### PR TITLE
Changing exit method and adding error message for no RN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 [1]: https://pypi.org/project/demisto-sdk/#history
 
+### 0.2.2
+
+* Fixing bug where **lint** did not return exit code 1 on failure.
+* Fixing bug where **validate** did not print error message in case no release notes were give.
+
 ### 0.2.1
 
 * **Validate** now checks that the id and name fields are identical in yml files.

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -1,9 +1,9 @@
-import sys
+import os
 from demisto_sdk.main import main
 
 
 def console_entry() -> None:
-    sys.exit(main())
+    os._exit(main())
 
 
 if __name__ == '__main__':

--- a/demisto_sdk/common/hook_validations/base_validator.py
+++ b/demisto_sdk/common/hook_validations/base_validator.py
@@ -61,6 +61,7 @@ class BaseValidator:
             # check release_notes file exists and contain text
             if release_notes is None:
                 self.is_valid = False
+                print_error("Missing release notes for: {}".format(self.file_path))
                 return False
         return True
 

--- a/demisto_sdk/core.py
+++ b/demisto_sdk/core.py
@@ -4,7 +4,7 @@
 # Python client that invokes functions in the Demisto SDK.
 #
 # Author:       Demisto
-# Version:      0.1.8
+# Version:      0.2.2
 #
 
 import sys


### PR DESCRIPTION
Changing exit method and adding error message for no RN

sys.exit doesnt seem to break the build on failure.
A search brought up the option to use os__exit instead