### PR TITLE
Fixed typo in bash completion setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ eval "$(_DEMISTO_SDK_COMPLETE=source_zsh demisto-sdk)"
 ```
 for regular bashrc users run in the terminal
 ```
-eval "$(_DEMISTO_SDK_COMPLETE=source demisto_sdk)"
+eval "$(_DEMISTO_SDK_COMPLETE=source demisto-sdk)"
 ```
 
 ## Commands


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
N/A

## Description
Fixes a typo in README.md in the bash completion setup instructions

## Screenshots
N/A
