### PR TITLE
is_docker_valid was misplaced in script.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/demisto-sdk/#history
 
+### 0.3.6
+* Fixed an issue where demisto-sdk **validate** failed on modified scripts without error message.
+
+### 0.3.5
+* Fixed an issue with docker tag validation for integrations.
+* Restructured repo source code.
+
 ### 0.3.4
 * Saved failing unit tests as a file.
 * Fixed an issue where "_test" file for scripts/integrations created using **init** would import the "HelloWorld" templates.

--- a/demisto_sdk/commands/common/hook_validations/script.py
+++ b/demisto_sdk/commands/common/hook_validations/script.py
@@ -38,7 +38,6 @@ class ScriptValidator(BaseValidator):
             self.is_arg_changed(),
             self.is_there_duplicates_args(),
             self.is_changed_subtype(),
-            self.is_docker_image_valid()
         ]
 
         # Add sane-doc-report exception
@@ -55,7 +54,8 @@ class ScriptValidator(BaseValidator):
         is_script_valid = all([
             super(ScriptValidator, self).is_valid_file(validate_rn),
             self.is_valid_subtype(),
-            self.is_id_equals_name()
+            self.is_id_equals_name(),
+            self.is_docker_image_valid(),
         ])
 
         return is_script_valid


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: https://circleci.com/gh/demisto/content/39317

## Description
is_docker_valid was misplaced in script.py as a BC check, causing it to fail
docker was valid -> `is_docker_valid` returned true -> `is_breaking_backwards` = true -> validation failed.

## Screenshots
last check
![image](https://user-images.githubusercontent.com/30797606/73169329-87aa9700-4104-11ea-8737-5b2b043ab8af.png)


circle with a fix here (first build with sdk 0.3.5, second build with sdk of this branch)
https://circleci.com/gh/demisto/content/tree/mypy-update_testing
