### PR TITLE
fixed imports in templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 0.3.6
 * Fixed an issue where demisto-sdk **validate** failed on modified scripts without error message.
+* Fixed an issue where demisto-sdk **init** creates unit-test file with invalid import.
 
 ### 0.3.5
 * Fixed an issue with docker tag validation for integrations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,18 @@
 
 [1]: https://pypi.org/project/demisto-sdk/#history
 
+### 0.3.7
+* Fixed an issue where demisto-sdk **init** creates unit-test file with invalid import.
+
+
 ### 0.3.6
 * Fixed an issue where demisto-sdk **validate** failed on modified scripts without error message.
-* Fixed an issue where demisto-sdk **init** creates unit-test file with invalid import.
+
 
 ### 0.3.5
 * Fixed an issue with docker tag validation for integrations.
 * Restructured repo source code.
+
 
 ### 0.3.4
 * Saved failing unit tests as a file.

--- a/demisto_sdk/commands/init/initiator.py
+++ b/demisto_sdk/commands/init/initiator.py
@@ -84,7 +84,7 @@ class Initiator:
         if not self.id:
             if self.is_pack_creation:  # There was no option to enter the ID in this process.
                 use_dir_name = str(input(f"Do you want to use the directory name as an "
-                                         f"ID for the {created_object}? Y/N"))
+                                         f"ID for the {created_object}? Y/N "))
             else:
                 use_dir_name = str(input(f"No ID given for the {created_object}'s yml file. "
                                          f"Do you want to use the directory name? Y/N "))

--- a/demisto_sdk/commands/init/initiator.py
+++ b/demisto_sdk/commands/init/initiator.py
@@ -297,7 +297,8 @@ class Initiator:
         """
         with open(os.path.join(self.full_output_path, f"{self.dir_name}_test.py"), 'r') as fp:
             file_contents = fp.read()
-            file_contents = file_contents.replace(name_to_change, self.dir_name)
+
+        file_contents = file_contents.replace(f'.{name_to_change}', self.dir_name)
 
         with open(os.path.join(self.full_output_path, f"{self.dir_name}_test.py"), 'w') as fp:
             fp.write(file_contents)

--- a/demisto_sdk/commands/init/templates/HelloWorld/HelloWorld_test.py
+++ b/demisto_sdk/commands/init/templates/HelloWorld/HelloWorld_test.py
@@ -1,4 +1,4 @@
-from demisto_sdk.commands.init.templates.HelloWorld.HelloWorld import Client, say_hello_command,\
+from HelloWorld import Client, say_hello_command,\
     say_hello_over_http_command
 
 

--- a/demisto_sdk/commands/init/templates/HelloWorld/HelloWorld_test.py
+++ b/demisto_sdk/commands/init/templates/HelloWorld/HelloWorld_test.py
@@ -1,4 +1,4 @@
-from HelloWorld import Client, say_hello_command,\
+from .HelloWorld import Client, say_hello_command,\
     say_hello_over_http_command
 
 

--- a/demisto_sdk/commands/init/templates/HelloWorldScript/HelloWorldScript_test.py
+++ b/demisto_sdk/commands/init/templates/HelloWorldScript/HelloWorldScript_test.py
@@ -1,4 +1,4 @@
-from HelloWorldScript import say_hello, say_hello_command
+from .HelloWorldScript import say_hello, say_hello_command
 
 
 def test_say_hello():

--- a/demisto_sdk/commands/init/templates/HelloWorldScript/HelloWorldScript_test.py
+++ b/demisto_sdk/commands/init/templates/HelloWorldScript/HelloWorldScript_test.py
@@ -1,4 +1,4 @@
-from demisto_sdk.commands.init.templates.HelloWorldScript.HelloWorldScript import say_hello, say_hello_command
+from HelloWorldScript import say_hello, say_hello_command
 
 
 def test_say_hello():


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/21827

## Description
switched full path import to relative import.

## Screenshots
after running:
1. `demisto-sdk init --script -n Shai --id shai -o .` or `demisto-sdk init --integration -n Shai --id shai -o .`
2. `demisto-sdk lint -d Shai`
both options return success
![image](https://user-images.githubusercontent.com/30797606/74097078-786a1700-4b10-11ea-94fc-63cdd50f1ca7.png)

when initializing a pack:
1. `demisto-sdk init --pack -n Shai -o .`
2. `demisto-sdk lint -d Shai/Integrations/Shai`
also return success
![image](https://user-images.githubusercontent.com/30797606/74097133-58872300-4b11-11ea-8789-96856fc0a7b8.png)
