### PR TITLE
add star import lgtm ignore to the demisto-sdk templates

### DIFF
--- a/demisto_sdk/commands/init/templates/HelloWorld/HelloWorld.py
+++ b/demisto_sdk/commands/init/templates/HelloWorld/HelloWorld.py
@@ -1,6 +1,6 @@
 import demistomock as demisto
-from CommonServerPython import *  # lgtm [py/polluting-import]
-from CommonServerUserPython import *  # lgtm [py/polluting-import]
+from CommonServerPython import *  # lgtm [py/polluting-import] pylint: disable=wildcard-import
+from CommonServerUserPython import *  # lgtm [py/polluting-import] pylint: disable=wildcard-import
 # IMPORTS
 
 import json

--- a/demisto_sdk/commands/init/templates/HelloWorld/HelloWorld.py
+++ b/demisto_sdk/commands/init/templates/HelloWorld/HelloWorld.py
@@ -1,6 +1,6 @@
 import demistomock as demisto
-from CommonServerPython import *  # lgtm [py/polluting-import] pylint: disable=wildcard-import
-from CommonServerUserPython import *  # lgtm [py/polluting-import] pylint: disable=wildcard-import
+from CommonServerPython import *  # noqa: E402 lgtm [py/polluting-import]
+from CommonServerUserPython import *  # noqa: E402 lgtm [py/polluting-import]
 # IMPORTS
 
 import json

--- a/demisto_sdk/commands/init/templates/HelloWorld/HelloWorld.py
+++ b/demisto_sdk/commands/init/templates/HelloWorld/HelloWorld.py
@@ -1,6 +1,6 @@
 import demistomock as demisto
-from CommonServerPython import *
-from CommonServerUserPython import *
+from CommonServerPython import *  # lgtm [py/polluting-import]
+from CommonServerUserPython import *  # lgtm [py/polluting-import]
 # IMPORTS
 
 import json

--- a/demisto_sdk/commands/init/templates/HelloWorldScript/HelloWorldScript.py
+++ b/demisto_sdk/commands/init/templates/HelloWorldScript/HelloWorldScript.py
@@ -1,6 +1,6 @@
 import demistomock as demisto
-from CommonServerPython import *  # lgtm [py/polluting-import] pylint: disable=wildcard-import
-from CommonServerUserPython import *  # lgtm [py/polluting-import] pylint: disable=wildcard-import
+from CommonServerPython import *  # noqa: E402 lgtm [py/polluting-import]
+from CommonServerUserPython import *  # noqa: E402 lgtm [py/polluting-import]
 
 
 def say_hello(name):

--- a/demisto_sdk/commands/init/templates/HelloWorldScript/HelloWorldScript.py
+++ b/demisto_sdk/commands/init/templates/HelloWorldScript/HelloWorldScript.py
@@ -1,6 +1,6 @@
 import demistomock as demisto
-from CommonServerPython import *  # lgtm [py/polluting-import]
-from CommonServerUserPython import *  # lgtm [py/polluting-import]
+from CommonServerPython import *  # lgtm [py/polluting-import] pylint: disable=wildcard-import
+from CommonServerUserPython import *  # lgtm [py/polluting-import] pylint: disable=wildcard-import
 
 
 def say_hello(name):

--- a/demisto_sdk/commands/init/templates/HelloWorldScript/HelloWorldScript.py
+++ b/demisto_sdk/commands/init/templates/HelloWorldScript/HelloWorldScript.py
@@ -1,6 +1,6 @@
 import demistomock as demisto
-from CommonServerPython import *
-from CommonServerUserPython import *
+from CommonServerPython import *  # lgtm [py/polluting-import]
+from CommonServerUserPython import *  # lgtm [py/polluting-import]
 
 
 def say_hello(name):


### PR DESCRIPTION
## Status
Ready

## Description
We are getting `Import pollutes the enclosing namespace` errors on our PRs from LGTM. Adding an ignore comment to our star imports in the templates to not have this error anymore.

## Screenshots
![image](https://user-images.githubusercontent.com/46294017/74106636-2c9b8a00-4b71-11ea-813d-4b27e782e013.png)

## Notes
@yaakovi what other ignore comments did you want to add to these lines?
