### PR TITLE
disable long line breaks in unified ymls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [1]: https://pypi.org/project/demisto-sdk/#history
 
+### 0.3.8
+* Fixed an issue where *unify* broke long lines in script section causing syntax errors
+
+
 ### 0.3.7
 * Added *generate-docs* command to generate documentation file for integration, playbook or script.
 * Fixed an issue where *unify* created a malformed integration yml.

--- a/demisto_sdk/commands/unify/unifier.py
+++ b/demisto_sdk/commands/unify/unifier.py
@@ -50,6 +50,7 @@ class Unifier:
 
         self.ryaml = YAML()
         self.ryaml.preserve_quotes = True
+        self.ryaml.width = 400  # make sure long lines will not break (relevant for code section)
         if self.yml_path:
             with open(self.yml_path, 'r') as yml_file:
                 self.yml_data = self.ryaml.load(yml_file)


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Description
fixed an issue where long lines in unified yml caused syntax error due to automatic line breaks of ruamel dump.

## Screenshots
see attached files
[with_bug.txt](https://github.com/demisto/demisto-sdk/files/4193391/with_bug.txt)
[without_bug.txt](https://github.com/demisto/demisto-sdk/files/4193393/without_bug.txt)
