### PR TITLE
increase line width limit in scripts

### DIFF
--- a/demisto_sdk/commands/unify/unifier.py
+++ b/demisto_sdk/commands/unify/unifier.py
@@ -51,7 +51,7 @@ class Unifier:
 
         self.ryaml = YAML()
         self.ryaml.preserve_quotes = True
-        self.ryaml.width = 3000  # make sure long lines will not break (relevant for code section)
+        self.ryaml.width = 50000  # make sure long lines will not break (relevant for code section)
         if self.yml_path:
             with open(self.yml_path, 'r') as yml_file:
                 self.yml_data = self.ryaml.load(yml_file)

--- a/demisto_sdk/commands/unify/unifier.py
+++ b/demisto_sdk/commands/unify/unifier.py
@@ -51,7 +51,7 @@ class Unifier:
 
         self.ryaml = YAML()
         self.ryaml.preserve_quotes = True
-        self.ryaml.width = 400  # make sure long lines will not break (relevant for code section)
+        self.ryaml.width = 3000  # make sure long lines will not break (relevant for code section)
         if self.yml_path:
             with open(self.yml_path, 'r') as yml_file:
                 self.yml_data = self.ryaml.load(yml_file)


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Description
some scripts / integrations contains very long lines (like `WhoIs` below).
this is causing the sdk to split those lines in the unified yaml creating SyntaxErrors in code.

## Screenshots
![image (7)](https://user-images.githubusercontent.com/30797606/75802951-4b62fa00-5d86-11ea-887e-aa157cc75352.png)
