### PR TITLE
Bump PyYAML to 5.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ mypy>=0.761
 pipenv==2018.11.26
 pykwalify>=1.7.0
 PyPDF2>=1.26.0
-PyYAML>=5.1.2
+PyYAML>=5.3.1
 requests>=2.22.0
 ruamel.yaml>=0.16.5
 vulture>=1.3


### PR DESCRIPTION
## Status
Ready

## Description
Bump PyYAML newest release version 5.3.1 which contains a security fix for [CVE-2020-1747](https://bugzilla.redhat.com/show_bug.cgi?id=1807367)
