### PR TITLE
add env var to allow skip version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 [PyPI History][1]
 
 [1]: https://pypi.org/project/demisto-sdk/#history
+### 0.4.5
+* Added support for env var: *DEMISTO_SDK_SKIP_VERSION_CHECK*. When set version checks are skipped.
+
 ### 0.4.4
 * Added a validator for IncidentTypes (incidenttype-*.json).
 * Fixed an issue where the -p flag in the validate was not working.

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -200,20 +200,21 @@ def get_last_remote_release_version():
 
     :return: tag
     """
-    try:
-        releases_request = requests.get(SDK_API_GITHUB_RELEASES, verify=False, timeout=5)
-        releases_request.raise_for_status()
-        releases = releases_request.json()
-        if isinstance(releases, list) and isinstance(releases[0], dict):
-            latest_release = releases[0].get('tag_name')
-            if isinstance(latest_release, str):
-                # remove v prefix
-                return latest_release[1:]
-    except Exception as exc:
-        exc_msg = str(exc)
-        if isinstance(exc, requests.exceptions.ConnectionError):
-            exc_msg = f'{exc_msg[exc_msg.find(">") + 3:-3]}.\nThis may happen if you are not connected to the internet.'
-        print_warning(f'Could not get latest demisto-sdk version.\nEncountered error: {exc_msg}')
+    if not os.environ.get('DEMISTO_SDK_SKIP_VERSION_CHECK') and not os.environ.get('CI'):
+        try:
+            releases_request = requests.get(SDK_API_GITHUB_RELEASES, verify=False, timeout=5)
+            releases_request.raise_for_status()
+            releases = releases_request.json()
+            if isinstance(releases, list) and isinstance(releases[0], dict):
+                latest_release = releases[0].get('tag_name')
+                if isinstance(latest_release, str):
+                    # remove v prefix
+                    return latest_release[1:]
+        except Exception as exc:
+            exc_msg = str(exc)
+            if isinstance(exc, requests.exceptions.ConnectionError):
+                exc_msg = f'{exc_msg[exc_msg.find(">") + 3:-3]}.\nThis may happen if you are not connected to the internet.'
+            print_warning(f'Could not get latest demisto-sdk version.\nEncountered error: {exc_msg}')
     return ''
 
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Description
When working off-line or with a slow internet the version check can really slow things down for simple tasks. Added an env var `DEMISTO_SDK_SKIP_VERSION_CHECK` if it is set then version check is skipped. Additionally if `CI` is set then we skip. 

## Screenshots
Paste here any images that will help the reviewer
