### PR TITLE
use pip3 and not pip in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ The library uses python 3.7+.
 
 ### Installation
 
-1. **Install** - `pip install demisto-sdk`
+1. **Install** - `pip3 install demisto-sdk`
 
-2. **Upgrade** - `pip install --upgrade demisto-sdk`
+2. **Upgrade** - `pip3 install --upgrade demisto-sdk`
 
 3. **Demisto server demisto-sdk integration** - In order that demisto-sdk and Demisto server communicate, perfrom the following steps:
 
@@ -338,7 +338,7 @@ We build for python 3.7 and 3.8. We use [tox](https://github.com/tox-dev/tox) fo
 
 4) Install `tox`:
     ```
-    pip install tox
+    pip3 install tox
     ```
     Then setup dev virtual envs for python 3 (will also install all necessary requirements):
     ```

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -59,7 +59,7 @@ def main(config, version, env_dir):
     last_release = get_last_remote_release_version()
     if last_release and cur_version != last_release:
         print_warning(f'You are using demisto-sdk {cur_version}, however version {last_release} is available.\n'
-                      f'You should consider upgrading via "pip install --upgrade demisto-sdk" command.')
+                      f'You should consider upgrading via "pip3 install --upgrade demisto-sdk" command.')
     if version:
         version = get_distribution('demisto-sdk').version
         print(version)


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Description
We should use `pip3` in our docs as on systems that have both py 2 and 3, using pip will fail.

## Screenshots
Paste here any images that will help the reviewer
