### PR TITLE
Added the *max* field to the Playbook schema, allowing to define it i…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 [PyPI History][1]
 
 [1]: https://pypi.org/project/demisto-sdk/#history
+### 0.4.8
+* Added the *max* field to the Playbook schema, allowing to define it in tasks loop.
+
 ### 0.4.7
 * Added the *slareminder* field to the Playbook schema.
 * Added the *common_server*, *demisto_mock* arguments to the *init* command.

--- a/demisto_sdk/commands/common/schemas/playbook.yml
+++ b/demisto_sdk/commands/common/schemas/playbook.yml
@@ -159,6 +159,8 @@ mapping:
                 allowempty: True
               exitCondition:
                 type: str
+              max:
+                type: int
               wait:
                 type: int
           conditions:


### PR DESCRIPTION
…n tasks loop

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: Added the *max* field to the Playbook schema, allowing to define it in tasks loop.

## Description
in the referenced issue