### PR TITLE
incidenttype validator - if field is 0 than failed

### DIFF
--- a/demisto_sdk/commands/common/hook_validations/incident_type.py
+++ b/demisto_sdk/commands/common/hook_validations/incident_type.py
@@ -101,7 +101,7 @@ class IncidentTypeValidator(BaseValidator):
         # type: () -> bool
         """Check if including required fields, only from 5.0.0.
         Returns:
-            bool. Whether the included fields are of type int.
+            bool. Whether the included fields have a positive integer value.
         """
         is_valid = True
         fields_to_include = ['hours', 'days', 'weeks', 'hoursR', 'daysR', 'weeksR']
@@ -113,7 +113,7 @@ class IncidentTypeValidator(BaseValidator):
                     int_field = self.current_file.get(field, -1)
                     if not isinstance(int_field, int) or int_field < 0:
                         is_valid = False
-                        print_error(f'{self.file_path}: the field {field} needs to be included as an integer.'
+                        print_error(f'{self.file_path}: the field {field} needs to be a positive integer.'
                                     f' Please add it.\n')
         except (AttributeError, ValueError):
             print_error(f'{self.file_path}: "fromVersion" has an invalid value.')

--- a/demisto_sdk/commands/common/hook_validations/incident_type.py
+++ b/demisto_sdk/commands/common/hook_validations/incident_type.py
@@ -111,7 +111,7 @@ class IncidentTypeValidator(BaseValidator):
             if LooseVersion(from_version) >= LooseVersion("5.0.0"):
                 for field in fields_to_include:
                     int_field = self.current_file.get(field, -1)
-                    if int_field < 0 or not isinstance(int_field, int):
+                    if not isinstance(int_field, int) or int_field < 0:
                         is_valid = False
                         print_error(f'{self.file_path}: the field {field} needs to be included as an integer.'
                                     f' Please add it.\n')

--- a/demisto_sdk/commands/common/hook_validations/incident_type.py
+++ b/demisto_sdk/commands/common/hook_validations/incident_type.py
@@ -110,8 +110,8 @@ class IncidentTypeValidator(BaseValidator):
             from_version = self.current_file.get("fromVersion", "0.0.0")
             if LooseVersion(from_version) >= LooseVersion("5.0.0"):
                 for field in fields_to_include:
-                    int_field = self.current_file.get(field)
-                    if not int_field or not isinstance(int_field, int):
+                    int_field = self.current_file.get(field, -1)
+                    if int_field < 0 or not isinstance(int_field, int):
                         is_valid = False
                         print_error(f'{self.file_path}: the field {field} needs to be included as an integer.'
                                     f' Please add it.\n')

--- a/demisto_sdk/commands/common/hook_validations/incident_type.py
+++ b/demisto_sdk/commands/common/hook_validations/incident_type.py
@@ -101,7 +101,7 @@ class IncidentTypeValidator(BaseValidator):
         # type: () -> bool
         """Check if including required fields, only from 5.0.0.
         Returns:
-            bool. Whether the fields .
+            bool. Whether the included fields are of type int.
         """
         is_valid = True
         fields_to_include = ['hours', 'days', 'weeks', 'hoursR', 'daysR', 'weeksR']


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready
@mayagoldb FYI

## Related Issues

fixes: https://github.com/demisto/etc/issues/23024

## Description
run on files from https://github.com/demisto/content/pull/6145 locally
```
(py37) ➜  content git:(pb_with_loop_keys) ✗ demisto-sdk validate -g
You are using demisto-sdk 0.4.8.dev2, however version 0.4.7 is available.
You should consider upgrading via “pip3 install --upgrade demisto-sdk” command.
Using git
Running validation on branch pb_with_loop_keys
Starting validating files structure
Validates only committed files
Validating IncidentTypes/incidenttype-mayag.json
Starting validation against origin/master
The files are valid
```

## Screenshots
Paste here any images that will help the reviewer
