### PR TITLE
Coverage support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,8 @@ jobs:
             name: tox build
             command: |
               pip install tox
-              tox -v demisto_sdk
+              tox -e py37 -v -- --cov=demisto_sdk --cov-report=html
+              tox -e py38 -v
         - run:
             name: pre-commit
             command: |
@@ -24,6 +25,8 @@ jobs:
               pre-commit --version
               pre-commit run -a
               deactivate
+        - store_artifacts:
+            path: coverage_html_report
         - run:
             name: deploy
             command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,10 @@ jobs:
         - store_artifacts:
             path: coverage_html_report
         - run:
+            name: coveralls upload
+              pip install coveralls
+              coveralls
+        - run:
             name: deploy
             command: |
               ./demisto_sdk/utils/deploy.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
             path: coverage_html_report
         - run:
             name: coveralls upload
+            command: |
               pip install coveralls
               coveralls
         - run:

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+omit =
+    **/tests/**
+    **/__init__.py
+
+[html]
+directory = coverage_html_report

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,4 @@ git_push.sh
 .pytest_cache
 .idea
 .mypy_cache
+coverage_html_report

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![PyPI version](https://badge.fury.io/py/demisto-sdk.svg)](https://badge.fury.io/py/demisto-sdk)
 [![CircleCI](https://circleci.com/gh/demisto/demisto-sdk/tree/master.svg?style=svg)](https://circleci.com/gh/demisto/demisto-sdk/tree/master)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/ppwwyyxx/OpenPano.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/demisto/demisto-sdk/context:python)
-[![Coverage Status](https://coveralls.io/repos/github/demisto/demisto-sdk/badge.svg?branch=coverage)](https://coveralls.io/github/demisto/demisto-sdk?branch=coverage)
+[![Coverage Status](https://coveralls.io/repos/github/demisto/demisto-sdk/badge.svg)](https://coveralls.io/github/demisto/demisto-sdk)
 
 # Demisto SDK
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --ignore=demisto_sdk/commands/init/templates

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 mock
 pre-commit
 pytest
+pytest-cov
 pytest-mock
 requests_mock
 tox-pyenv

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,11 @@
 [tox]
-envlist = py37,py38,flake8,mypy
+envlist = py37,py38,mypy
 
 [testenv]
 passenv = *
 deps = -r {toxinidir}/requirements.txt
        -r {toxinidir}/requirements-dev.txt
-commands = pytest -p no:warnings -v {posargs} --ignore=demisto_sdk/commands/init/templates
-
-[testenv:flake8]
-basepython = python3
-skip_install = true
-deps = flake8
-commands = flake8 demisto_sdk/ setup.py
+commands = pytest -p no:warnings -v {posargs}
 
 [testenv:mypy]
 basepython = python3


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Description
Adding code coverage support for our unit tests. A few changes to the build:
* add pytest.ini file to exclude: `demisto_sdk/commands/init/templates`
* removed flake8 from tox (it is run via pre-commit)
* coverage support (including upload to coveralls.io and to circleci artifacts)

## Screenshots
Paste here any images that will help the reviewer
