### PR TITLE
Hide extract-code and create-content-artifacts from help

### DIFF
--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -102,8 +102,10 @@ def extract(config, **kwargs):
 
 
 # ====================== extract-code ====================== #
-@main.command(name="extract-code",
-              short_help="Extract code from a Demisto integration or script yaml file.")
+@main.command(
+    name="extract-code",
+    hidden=True,
+    short_help="Extract code from a Demisto integration or script yaml file.")
 @click.help_option(
     '-h', '--help'
 )
@@ -208,10 +210,13 @@ def validate(config, **kwargs):
 
 
 # ====================== create ====================== #
-@main.command(name="create-content-artifacts",
-              short_help='Create content artifacts. This will generate content_new.zip file which can be used to '
-                         'upload to your server in order to upload a whole new content version to your Demisto '
-                         'instance.')
+@main.command(
+    name="create-content-artifacts",
+    hidden=True,
+    short_help='Create content artifacts. This will generate content_new.zip file which can be used to '
+    'upload to your server in order to upload a whole new content version to your Demisto '
+    'instance.',
+)
 @click.help_option(
     '-h', '--help'
 )


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/22551

## Screenshots
![image](https://user-images.githubusercontent.com/11165655/77844244-bf3dca00-71ad-11ea-804a-7f00ef876f6d.png)

Running commands after hiding them:
![image](https://user-images.githubusercontent.com/11165655/77844327-90742380-71ae-11ea-8d88-6d6e89838a80.png)
![image](https://user-images.githubusercontent.com/11165655/77844331-98cc5e80-71ae-11ea-936a-9d0752b6a1e3.png)

![image](https://user-images.githubusercontent.com/11165655/77844336-a5e94d80-71ae-11ea-963d-93f06ced97bb.png)
![image](https://user-images.githubusercontent.com/11165655/77844344-b994b400-71ae-11ea-9880-8b6ade162fdd.png)
