### PR TITLE
fixed bug with validate on readme files when they are removed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
     * Removed the *-t yml_type* argument, the file type will be inferred.
     * Removed the *-g use_git* argument, running format without arguments will run automatically on git diff.
 * Fixed an issue in loading playbooks with '=' character.
+* Fixed an issue un *validate* failed on deleted README files.
 
 ### 0.4.8
 * Added the *max* field to the Playbook schema, allowing to define it in tasks loop.

--- a/demisto_sdk/commands/common/tests/tools_test.py
+++ b/demisto_sdk/commands/common/tests/tools_test.py
@@ -5,11 +5,11 @@ import pytest
 from demisto_sdk.commands.common.git_tools import git_path
 from demisto_sdk.commands.common import tools
 from demisto_sdk.commands.common.constants import PACKS_PLAYBOOK_YML_REGEX, PACKS_TEST_PLAYBOOKS_REGEX
-from demisto_sdk.commands.common.tools import get_matching_regex, server_version_compare, find_type,\
-    get_dict_from_file, LOG_COLORS, get_last_release_version
+from demisto_sdk.commands.common.tools import get_matching_regex, server_version_compare, find_type, \
+    get_dict_from_file, LOG_COLORS, get_last_release_version, filter_packagify_changes
 from demisto_sdk.tests.constants_test import VALID_REPUTATION_FILE, VALID_SCRIPT_PATH, VALID_INTEGRATION_TEST_PATH, \
     VALID_PLAYBOOK_ID_PATH, VALID_LAYOUT_PATH, VALID_WIDGET_PATH, VALID_INCIDENT_FIELD_PATH, VALID_DASHBOARD_PATH, \
-    INDICATORFIELD_EXTRA_FIELDS, VALID_INCIDENT_TYPE_PATH
+    INDICATORFIELD_EXTRA_FIELDS, VALID_INCIDENT_TYPE_PATH, VALID_MD
 
 
 class TestGenericFunctions:
@@ -63,6 +63,17 @@ class TestGenericFunctions:
     def test_find_type(self, path, _type):
         output = find_type(str(path))
         assert output == _type, f'find_type({path}) returns: {output} instead {_type}'
+
+    test_path_md = [
+        VALID_MD
+    ]
+
+    @pytest.mark.parametrize('path', test_path_md)
+    def test_filter_packagify_changes(self, path):
+        modified, added, removed = filter_packagify_changes(modified_files=[], added_files=[], removed_files=[path])
+        assert modified == []
+        assert added == set()
+        assert removed == [VALID_MD]
 
 
 class TestGetRemoteFile:

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -158,6 +158,8 @@ def filter_packagify_changes(modified_files, added_files, removed_files, tag='ma
     packagify_diff = {}  # type: dict
     for file_path in removed_files:
         if file_path.split("/")[0] in PACKAGE_SUPPORTING_DIRECTORIES:
+            if "README.md" in file_path:
+                continue
             details = get_remote_file(file_path, tag)
             if details:
                 uniq_identifier = '_'.join([

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -17,7 +17,7 @@ import requests
 
 from demisto_sdk.commands.common.constants import CHECKED_TYPES_REGEXES, PACKAGE_SUPPORTING_DIRECTORIES, \
     CONTENT_GITHUB_LINK, PACKAGE_YML_FILE_REGEX, UNRELEASE_HEADER, RELEASE_NOTES_REGEX, PACKS_DIR, PACKS_DIR_REGEX, \
-    DEF_DOCKER, DEF_DOCKER_PWSH, TYPE_PWSH, SDK_API_GITHUB_RELEASES, PACKS_CHANGELOG_REGEX
+    DEF_DOCKER, DEF_DOCKER_PWSH, TYPE_PWSH, SDK_API_GITHUB_RELEASES, PACKS_CHANGELOG_REGEX, PACKS_README_FILE_NAME
 
 # disable insecure warnings
 urllib3.disable_warnings()
@@ -158,7 +158,7 @@ def filter_packagify_changes(modified_files, added_files, removed_files, tag='ma
     packagify_diff = {}  # type: dict
     for file_path in removed_files:
         if file_path.split("/")[0] in PACKAGE_SUPPORTING_DIRECTORIES:
-            if "README.md" in file_path:
+            if PACKS_README_FILE_NAME in file_path:
                 continue
             details = get_remote_file(file_path, tag)
             if details:
@@ -172,7 +172,7 @@ def filter_packagify_changes(modified_files, added_files, removed_files, tag='ma
     updated_added_files = set()
     for file_path in added_files:
         if file_path.split("/")[0] in PACKAGE_SUPPORTING_DIRECTORIES:
-            if "README.md" in file_path:
+            if PACKS_README_FILE_NAME in file_path:
                 updated_added_files.add(file_path)
                 continue
             with open(file_path) as f:

--- a/demisto_sdk/tests/constants_test.py
+++ b/demisto_sdk/tests/constants_test.py
@@ -97,3 +97,5 @@ LAYOUT_PATH = f"Layouts"
 SOURCE_FORMAT_DASHBOARD_COPY = f"{GIT_ROOT}/demisto_sdk/tests/test_files/format_dashboard-copy.json"
 DESTINATION_FORMAT_DASHBOARD_COPY = f"Dashboards/dashboard-copy.json"
 DASHBOARD_PATH = f"Dashboards"
+VALID_MD = f'{git_path()}/demisto_sdk/tests/test_files/README-valid.md'
+INVALID_MD = f'{git_path()}/demisto_sdk/tests/test_files/README-invalid.md'


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Description
When deleting a readme file, the validator tried to load the file as yml to check details in it.