### PR TITLE
demisto/etc#23400: printing file path instead of file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-
+* Fixed secretes validations for files with the same name in a different directory
 [PyPI History][1]
 
 [1]: https://pypi.org/project/demisto-sdk/#history

--- a/demisto_sdk/commands/secrets/secrets.py
+++ b/demisto_sdk/commands/secrets/secrets.py
@@ -206,7 +206,7 @@ class SecretsValidator(object):
             if high_entropy_strings or secrets_found_with_regex:
                 # uniquify identical matches between lists
                 file_secrets = list(set(high_entropy_strings + secrets_found_with_regex))
-                secrets_found[file_name] = file_secrets
+                secrets_found[file_path] = file_secrets
 
         return secrets_found
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: demisto/etc#23400

## Description
There are lots of README.md files in. content repo, at least one per pack.
When messing with lots of README files it is not enough to know the base name of the file, the full path must be included.

In addition- when there are multiple files with the same names such as README.md it only shows secrets for the last one checked

