### PR TITLE
remove sort-can produce bug

### DIFF
--- a/demisto_sdk/commands/lint/lint_manager.py
+++ b/demisto_sdk/commands/lint/lint_manager.py
@@ -552,5 +552,4 @@ class LintManager:
             json_path = Path(path) / "lint_report.json"
             json.dump(fp=json_path.open(mode='w'),
                       obj=pkgs_status,
-                      indent=4,
-                      sort_keys=True)
+                      indent=4)


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/23880

## Description
The bug source is in the creation of - "lint_report.json", and I can't reproduce the bug, I checked old builds and didn't find similar.
From the traceback I see that we have None values in the dict I am creating, however, it seems to be a bug in JSON dumps, Because I verified the logs and I see that all tests have keys initialized and value initialized, However, I removed the sort-key for now, if it will be reproduced I will get the JSON, this will avoid the bug in the future.