### PR TITLE
Generate Docs Bug Fixes

### DIFF
--- a/demisto_sdk/commands/generate_docs/common.py
+++ b/demisto_sdk/commands/generate_docs/common.py
@@ -138,7 +138,7 @@ def add_lines(line):
     return output if output else [line]
 
 
-def stringEscapeMD(st, minimal_escaping=False, escape_multiline=False, escape_html=True):
+def string_escape_md(st, minimal_escaping=False, escape_multiline=False, escape_html=True):
     """
        Escape any chars that might break a markdown string
 

--- a/demisto_sdk/commands/generate_docs/common.py
+++ b/demisto_sdk/commands/generate_docs/common.py
@@ -159,7 +159,7 @@ def stringEscapeMD(st, minimal_escaping=False, escape_multiline=False, escape_ht
        :rtype: ``str``
     """
     if escape_html:
-        st = html.escape(st)
+        st = html.escape(st, quote=False)
 
     if escape_multiline:
         st = st.replace('\r\n', '<br/>')  # Windows

--- a/demisto_sdk/commands/generate_docs/generate_integration_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_integration_doc.py
@@ -250,7 +250,7 @@ def generate_single_command_section(cmd: dict, example_dict: dict, command_permi
                     'Error! You are missing description in input {} of command {}'.format(arg['name'], cmd['name']))
             required_status = 'Required' if arg.get('required') else 'Optional'
             section.append('| {} | {} | {} | '.format(arg['name'], string_escape_md(arg.get('description', ''),
-                                                                                  True, True), required_status))
+                                                                                    True, True), required_status))
         section.append('')
 
     # Context output

--- a/demisto_sdk/commands/generate_docs/generate_integration_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_integration_doc.py
@@ -8,7 +8,7 @@ from demisto_sdk.commands.common.tools import (LOG_COLORS, get_yaml,
                                                print_warning)
 from demisto_sdk.commands.generate_docs.common import (
     add_lines, build_example_dict, generate_numbered_section, generate_section,
-    generate_table_section, save_output, stringEscapeMD)
+    generate_table_section, save_output, string_escape_md)
 
 
 def append_or_replace_command_in_docs(old_docs: str, new_doc_section: str, command_name: str) -> Tuple[str, list]:
@@ -160,7 +160,7 @@ def generate_setup_section(yaml_data: dict):
     for conf in yaml_data['configuration']:
         access_data.append(
             {'Parameter': conf.get('name', ''),
-             'Description': stringEscapeMD(conf.get('display', '')),
+             'Description': string_escape_md(conf.get('display', '')),
              'Required': conf.get('required', '')})
 
     section.extend(generate_table_section(access_data, '', horizontal_rule=False))
@@ -249,7 +249,7 @@ def generate_single_command_section(cmd: dict, example_dict: dict, command_permi
                 errors.append(
                     'Error! You are missing description in input {} of command {}'.format(arg['name'], cmd['name']))
             required_status = 'Required' if arg.get('required') else 'Optional'
-            section.append('| {} | {} | {} | '.format(arg['name'], stringEscapeMD(arg.get('description', ''),
+            section.append('| {} | {} | {} | '.format(arg['name'], string_escape_md(arg.get('description', ''),
                                                                                   True, True), required_status))
         section.append('')
 
@@ -274,7 +274,7 @@ def generate_single_command_section(cmd: dict, example_dict: dict, command_permi
                                                                                            cmd['name']))
             section.append(
                 '| {} | {} | {} | '.format(output['contextPath'], output.get('type', 'unknown'),
-                                           stringEscapeMD(output.get('description'))))
+                                           string_escape_md(output.get('description'))))
         section.append('')
 
     # Raw output:

--- a/demisto_sdk/commands/generate_docs/generate_playbook_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_playbook_doc.py
@@ -120,13 +120,12 @@ def get_inputs(playbook):
                 'Error! You are missing description in playbook input {}'.format(_input.get('key')))
 
         required_status = 'Required' if _input.get('required') else 'Optional'
-        _value, source = get_input_data(_input)
+        _value = get_input_data(_input)
 
         inputs.append({
             'Name': _input.get('key'),
             'Description': stringEscapeMD(_input.get('description', '')),
             'Default Value': _value,
-            'Source': source,
             'Required': required_status,
         })
 
@@ -171,12 +170,12 @@ def get_input_data(input_section):
     """
     default_value = input_section.get('value')
     if isinstance(default_value, str):
-        return default_value, ''
+        return default_value
 
     if default_value:
         complex = default_value.get('complex')
         if complex:
-            return complex.get('accessor'), complex.get('root')
-        return default_value.get('simple'), ''
+            return f"{complex.get('root')}.{complex.get('accessor')}"
+        return default_value.get('simple')
 
-    return '', ''
+    return ''

--- a/demisto_sdk/commands/generate_docs/generate_playbook_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_playbook_doc.py
@@ -1,5 +1,5 @@
 import os
-
+from typing import Tuple, List, Dict
 from demisto_sdk.commands.common.tools import (get_yaml, print_error,
                                                print_warning)
 from demisto_sdk.commands.generate_docs.common import (
@@ -102,11 +102,14 @@ def get_playbook_dependencies(playbook):
     return list(playbooks), list(integrations), list(scripts), list(commands)
 
 
-def get_inputs(playbook):
-    """
-    Gets playbook inputs.
-    :param playbook: the playbook object.
-    :return: list of inputs and list of errors.
+def get_inputs(playbook: Dict) -> Tuple[List[Dict], List[str]]:
+    """Gets playbook inputs.
+
+    Args:
+        playbook (dict): the playbook object.
+
+    Returns:
+        (tuple): list of inputs and list of errors.
     """
     errors = []
     inputs = []
@@ -170,11 +173,14 @@ def get_outputs(playbook):
     return outputs, errors
 
 
-def get_input_data(input_section):
-    """
-    Gets playbook single input item - support simple and complex input.
-    :param input_section: playbook input item.
-    :return: The input default value(accessor) and the input source(root).
+def get_input_data(input_section: Dict) -> str:
+    """Gets playbook single input item - support simple and complex input.
+
+    Args:
+        input_section (dict): playbook input item.
+
+    Returns:
+        (str): The playbook input item's value.
     """
     default_value = input_section.get('value')
     if isinstance(default_value, str):

--- a/demisto_sdk/commands/generate_docs/generate_playbook_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_playbook_doc.py
@@ -115,16 +115,24 @@ def get_inputs(playbook):
         return {}, []
 
     for _input in playbook.get('inputs'):
-        if not _input.get('description'):
-            errors.append(
-                'Error! You are missing description in playbook input {}'.format(_input.get('key')))
-
+        name = _input.get('key')
+        description = stringEscapeMD(_input.get('description', ''))
         required_status = 'Required' if _input.get('required') else 'Optional'
         _value = get_input_data(_input)
 
+        playbook_input_query = _input.get('playbookInputQuery')
+        if not name and isinstance(playbook_input_query, dict):
+            name = 'Indicator Query'
+            _value = playbook_input_query.get('query')
+            default_description = 'Indicators matching the indicator query will be used as playbook input'
+            description = description if description else default_description
+
+        if not description:
+            errors.append('Error! You are missing description in playbook input {}'.format(name))
+
         inputs.append({
-            'Name': _input.get('key'),
-            'Description': stringEscapeMD(_input.get('description', '')),
+            'Name': name,
+            'Description': description,
             'Default Value': _value,
             'Required': required_status,
         })

--- a/demisto_sdk/commands/generate_docs/generate_playbook_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_playbook_doc.py
@@ -1,5 +1,6 @@
 import os
-from typing import Tuple, List, Dict
+from typing import Dict, List, Tuple
+
 from demisto_sdk.commands.common.tools import (get_yaml, print_error,
                                                print_warning)
 from demisto_sdk.commands.generate_docs.common import (

--- a/demisto_sdk/commands/generate_docs/generate_playbook_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_playbook_doc.py
@@ -181,9 +181,9 @@ def get_input_data(input_section):
         return default_value
 
     if default_value:
-        complex = default_value.get('complex')
-        if complex:
-            return f"{complex.get('root')}.{complex.get('accessor')}"
+        complex_field = default_value.get('complex')
+        if complex_field:
+            return f"{complex_field.get('root')}.{complex_field.get('accessor')}"
         return default_value.get('simple')
 
     return ''

--- a/demisto_sdk/commands/generate_docs/generate_playbook_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_playbook_doc.py
@@ -4,7 +4,7 @@ from demisto_sdk.commands.common.tools import (get_yaml, print_error,
                                                print_warning)
 from demisto_sdk.commands.generate_docs.common import (
     HEADER_TYPE, generate_list_section, generate_numbered_section,
-    generate_section, generate_table_section, save_output, stringEscapeMD)
+    generate_section, generate_table_section, save_output, string_escape_md)
 
 
 def generate_playbook_doc(input, output: str = None, permissions: str = None, limitations: str = None,
@@ -119,7 +119,7 @@ def get_inputs(playbook: Dict) -> Tuple[List[Dict], List[str]]:
 
     for _input in playbook.get('inputs'):
         name = _input.get('key')
-        description = stringEscapeMD(_input.get('description', ''))
+        description = string_escape_md(_input.get('description', ''))
         required_status = 'Required' if _input.get('required') else 'Optional'
         _value = get_input_data(_input)
 
@@ -166,7 +166,7 @@ def get_outputs(playbook):
 
         outputs.append({
             'Path': output.get('contextPath'),
-            'Description': stringEscapeMD(output.get('description', '')),
+            'Description': string_escape_md(output.get('description', '')),
             'Type': output_type
         })
 

--- a/demisto_sdk/commands/generate_docs/generate_playbook_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_playbook_doc.py
@@ -124,6 +124,8 @@ def get_inputs(playbook: Dict) -> Tuple[List[Dict], List[str]]:
         _value = get_input_data(_input)
 
         playbook_input_query = _input.get('playbookInputQuery')
+        # a playbook input section whose 'key' key is empty and whose 'playbookInputQuery' key is a dict
+        # is an Indicators Query input section
         if not name and isinstance(playbook_input_query, dict):
             name = 'Indicator Query'
             _value = playbook_input_query.get('query')

--- a/demisto_sdk/commands/generate_docs/generate_script_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_script_doc.py
@@ -6,7 +6,7 @@ from demisto_sdk.commands.common.update_id_set import get_depends_on
 from demisto_sdk.commands.create_id_set.create_id_set import IDSetCreator
 from demisto_sdk.commands.generate_docs.common import (
     build_example_dict, generate_list_section, generate_numbered_section,
-    generate_section, generate_table_section, save_output, stringEscapeMD)
+    generate_section, generate_table_section, save_output, string_escape_md)
 
 
 def generate_script_doc(input, examples, output: str = None, permissions: str = None,
@@ -145,7 +145,7 @@ def get_inputs(script):
 
         inputs.append({
             'Argument Name': arg.get('name'),
-            'Description': stringEscapeMD(arg.get('description', ''))
+            'Description': string_escape_md(arg.get('description', ''))
         })
 
     return inputs, errors
@@ -170,7 +170,7 @@ def get_outputs(script):
 
         outputs.append({
             'Path': arg.get('contextPath'),
-            'Description': stringEscapeMD(arg.get('description', '')),
+            'Description': string_escape_md(arg.get('description', '')),
             'Type': arg.get('type', 'Unknown')
         })
 

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -17,16 +17,16 @@ TEST_INTEGRATION_PATH = os.path.join(FILES_PATH, 'fake_integration/fake_integrat
 
 
 def test_stringEscapeMD():
-    from demisto_sdk.commands.generate_docs.common import stringEscapeMD
-    res = stringEscapeMD('First fetch timestamp (<number> <time unit>, e.g., 12 hours, 7 days)')
+    from demisto_sdk.commands.generate_docs.common import string_escape_md
+    res = string_escape_md('First fetch timestamp (<number> <time unit>, e.g., 12 hours, 7 days)')
     assert '<' not in res
     assert '>' not in res
-    res = stringEscapeMD("new line test \n", escape_multiline=True)
+    res = string_escape_md("new line test \n", escape_multiline=True)
     assert '\n' not in res
     assert '<br/>' in res
-    res = stringEscapeMD('Here are "Double Quotation" marks')
+    res = string_escape_md('Here are "Double Quotation" marks')
     assert '"' in res
-    res = stringEscapeMD("Here are 'Single Quotation' marks")
+    res = string_escape_md("Here are 'Single Quotation' marks")
     assert "'" in res
 
 

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -24,6 +24,10 @@ def test_stringEscapeMD():
     res = stringEscapeMD("new line test \n", escape_multiline=True)
     assert '\n' not in res
     assert '<br/>' in res
+    res = stringEscapeMD('Here are "Double Quotation" marks')
+    assert '"' in res
+    res = stringEscapeMD("Here are 'Single Quotation' marks")
+    assert "'" in res
 
 
 def test_generate_list_section_empty():

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -107,10 +107,22 @@ def test_get_inputs():
 
     inputs, errors = get_inputs(playbook)
 
-    expected_inputs = [{'Name': 'InputA', 'Description': '', 'Default Value': 'File.Name',
-                        'Required': 'Optional'},
-                       {'Name': 'InputB', 'Description': 'This is input b', 'Default Value': 'johnnydepp@gmail.com',
-                        'Required': 'Required'}]
+    expected_query = '(type:ip or type:file or type:Domain or type:URL) -tags:pending_review ' \
+        'and (tags:approved_black or tags:approved_white or tags:approved_watchlist)'
+    expected_inputs = [
+        {
+            'Name': 'InputA', 'Description': '', 'Default Value': 'File.Name', 'Required': 'Optional'
+        },
+        {
+            'Name': 'InputB', 'Description': 'This is input b',
+            'Default Value': 'johnnydepp@gmail.com', 'Required': 'Required'
+        },
+        {
+            'Name': 'Indicator Query',
+            'Description': 'Indicators matching the indicator query will be used as playbook input',
+            'Default Value': expected_query, 'Required': 'Optional'
+        }
+    ]
 
     assert inputs == expected_inputs
     assert errors[0] == 'Error! You are missing description in playbook input InputA'

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -107,10 +107,10 @@ def test_get_inputs():
 
     inputs, errors = get_inputs(playbook)
 
-    expected_inputs = [{'Name': 'InputA', 'Description': '', 'Default Value': 'Name',
-                        'Source': 'File', 'Required': 'Optional'},
+    expected_inputs = [{'Name': 'InputA', 'Description': '', 'Default Value': 'File.Name',
+                        'Required': 'Optional'},
                        {'Name': 'InputB', 'Description': 'This is input b', 'Default Value': 'johnnydepp@gmail.com',
-                        'Source': '', 'Required': 'Required'}]
+                        'Required': 'Required'}]
 
     assert inputs == expected_inputs
     assert errors[0] == 'Error! You are missing description in playbook input InputA'
@@ -145,24 +145,22 @@ def test_get_input_data_simple():
     from demisto_sdk.commands.generate_docs.generate_playbook_doc import get_input_data
     playbook = get_yaml(TEST_PLAYBOOK_PATH)
 
-    input = playbook.get('inputs')[1]
+    sample_input = playbook.get('inputs')[1]
 
-    _value, source = get_input_data(input)
+    _value = get_input_data(sample_input)
 
     assert _value == 'johnnydepp@gmail.com'
-    assert source == ''
 
 
 def test_get_input_data_complex():
     from demisto_sdk.commands.generate_docs.generate_playbook_doc import get_input_data
     playbook = get_yaml(TEST_PLAYBOOK_PATH)
 
-    input = playbook.get('inputs')[0]
+    sample_input = playbook.get('inputs')[0]
 
-    _value, source = get_input_data(input)
+    _value = get_input_data(sample_input)
 
-    assert _value == 'Name'
-    assert source == 'File'
+    assert _value == 'File.Name'
 
 
 # script tests

--- a/demisto_sdk/tests/integration_tests/generate_docs_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/generate_docs_integration_test.py
@@ -1,0 +1,95 @@
+import pytest
+from demisto_sdk.commands.common.git_tools import git_path
+from os.path import join
+from pathlib import Path
+
+from click.testing import CliRunner
+from demisto_sdk.__main__ import main
+
+GENERATE_DOCS_CMD = "generate-docs"
+DEMISTO_SDK_PATH = join(git_path(), "demisto_sdk")
+VALID_PLAYBOOK_WITH_IO = join(DEMISTO_SDK_PATH, "tests/test_files/playbook-Test_playbook.yml")
+VALID_PLAYBOOK_NO_IO = join(DEMISTO_SDK_PATH, "tests/test_files/Playbooks.playbook-test.yml")
+
+
+class TestPlaybooks():
+    def test_integration_generate_docs_playbook_positive_with_io(self, tmpdir):
+        """
+        Given
+        - Path to valid playbook yml file to generate docs for.
+        - Path to directory to write the README.md file.
+        - The playbook has inputs.
+        - The playbook has outputs.
+
+        When
+        - Running the generate-docs command.
+
+        Then
+        - Ensure README.md is created.
+        - Ensure README.md has an inputs section.
+        - Ensure README.md has an outputs section.
+        """
+
+        runner = CliRunner(mix_stderr=False)
+        arguments = [
+            GENERATE_DOCS_CMD,
+            '-i', VALID_PLAYBOOK_WITH_IO,
+            '-o', tmpdir
+        ]
+        _ = runner.invoke(main, arguments)
+        readme_path = join(tmpdir, 'README.md')
+
+        assert Path(readme_path).exists()
+        with open(readme_path, 'r') as readme_file:
+            contents = readme_file.read()
+            assert '| **Name** | **Description** | **Default Value** | **Required** |' in contents
+            assert '| **Path** | **Description** | **Type** |' in contents
+
+    def test_integration_generate_docs_playbook_positive_no_io(self, tmpdir):
+        """
+        Given
+        - Path to valid playbook yml file to generate docs for.
+        - Path to directory to write the README.md file.
+        - The playbook does not have inputs.
+        - The playbook does not have outputs.
+
+        When
+        - Running the generate-docs command.
+
+        Then
+        - Ensure README.md is created.
+        - Ensure README.md does not have an inputs section.
+        - Ensure README.md does not have an outputs section.
+        """
+        runner = CliRunner(mix_stderr=False)
+        arguments = [
+            GENERATE_DOCS_CMD,
+            '-i', VALID_PLAYBOOK_NO_IO,
+            '-o', tmpdir
+        ]
+        _ = runner.invoke(main, arguments)
+        readme_path = join(tmpdir, 'README.md')
+
+        assert Path(readme_path).exists()
+        with open(readme_path, 'r') as readme_file:
+            contents = readme_file.read()
+            assert 'There are no inputs for this playbook.' in contents
+            assert 'There are no outputs for this playbook.' in contents
+
+
+@pytest.mark.skip(reason='Just place-holder stubs for later implementation')
+class TestScripts():
+    def test_integration_generate_docs_script_positive(self):
+        pass
+
+    def test_integration_generate_docs_script_negative(self):
+        pass
+
+
+@pytest.mark.skip(reason='Just place-holder stubs for later implementation')
+class TestIntegrations():
+    def test_integration_generate_docs_integration_positive(self):
+        pass
+
+    def test_integration_generate_docs_integration_negative(self):
+        pass

--- a/demisto_sdk/tests/integration_tests/generate_docs_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/generate_docs_integration_test.py
@@ -8,8 +8,6 @@ from demisto_sdk.__main__ import main
 
 GENERATE_DOCS_CMD = "generate-docs"
 DEMISTO_SDK_PATH = join(git_path(), "demisto_sdk")
-VALID_PLAYBOOK_WITH_IO = join(DEMISTO_SDK_PATH, "tests/test_files/playbook-Test_playbook.yml")
-VALID_PLAYBOOK_NO_IO = join(DEMISTO_SDK_PATH, "tests/test_files/Playbooks.playbook-test.yml")
 
 
 class TestPlaybooks():
@@ -29,16 +27,19 @@ class TestPlaybooks():
         - Ensure README.md has an inputs section.
         - Ensure README.md has an outputs section.
         """
-
+        valid_playbook_with_io = join(DEMISTO_SDK_PATH, "tests/test_files/playbook-Test_playbook.yml")
         runner = CliRunner(mix_stderr=False)
         arguments = [
             GENERATE_DOCS_CMD,
-            '-i', VALID_PLAYBOOK_WITH_IO,
+            '-i', valid_playbook_with_io,
             '-o', tmpdir
         ]
-        _ = runner.invoke(main, arguments)
+        result = runner.invoke(main, arguments)
         readme_path = join(tmpdir, 'README.md')
 
+        assert result.exit_code == 0
+        assert not result.stderr
+        assert not result.exception
         assert Path(readme_path).exists()
         with open(readme_path, 'r') as readme_file:
             contents = readme_file.read()
@@ -61,15 +62,19 @@ class TestPlaybooks():
         - Ensure README.md does not have an inputs section.
         - Ensure README.md does not have an outputs section.
         """
+        valid_playbook_no_io = join(DEMISTO_SDK_PATH, "tests/test_files/Playbooks.playbook-test.yml")
         runner = CliRunner(mix_stderr=False)
         arguments = [
             GENERATE_DOCS_CMD,
-            '-i', VALID_PLAYBOOK_NO_IO,
+            '-i', valid_playbook_no_io,
             '-o', tmpdir
         ]
-        _ = runner.invoke(main, arguments)
+        result = runner.invoke(main, arguments)
         readme_path = join(tmpdir, 'README.md')
 
+        assert result.exit_code == 0
+        assert not result.stderr
+        assert not result.exception
         assert Path(readme_path).exists()
         with open(readme_path, 'r') as readme_file:
             contents = readme_file.read()

--- a/demisto_sdk/tests/integration_tests/generate_docs_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/generate_docs_integration_test.py
@@ -1,10 +1,10 @@
-import pytest
-from demisto_sdk.commands.common.git_tools import git_path
 from os.path import join
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 from demisto_sdk.__main__ import main
+from demisto_sdk.commands.common.git_tools import git_path
 
 GENERATE_DOCS_CMD = "generate-docs"
 DEMISTO_SDK_PATH = join(git_path(), "demisto_sdk")

--- a/demisto_sdk/tests/integration_tests/generate_docs_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/generate_docs_integration_test.py
@@ -38,6 +38,7 @@ class TestPlaybooks():
         readme_path = join(tmpdir, 'README.md')
 
         assert result.exit_code == 0
+        assert 'Start generating playbook documentation...' in result.stdout
         assert not result.stderr
         assert not result.exception
         assert Path(readme_path).exists()
@@ -73,6 +74,7 @@ class TestPlaybooks():
         readme_path = join(tmpdir, 'README.md')
 
         assert result.exit_code == 0
+        assert 'Start generating playbook documentation...' in result.stdout
         assert not result.stderr
         assert not result.exception
         assert Path(readme_path).exists()

--- a/demisto_sdk/tests/test_files/fake_integration/fake_README.md
+++ b/demisto_sdk/tests/test_files/fake_integration/fake_README.md
@@ -68,7 +68,7 @@ Create a new zoom meeting (scheduled or instant)
 | user | email address or id of user for meeting | Required | 
 | topic | The topic of the meeting | Required | 
 | auto-record-meeting | Record zoom meeting?  | Optional | 
-| start-time | Meeting start time. When using a format like “yyyy-MM-dd’T&#x27;HH:mm:ss&#x27;Z’”, always use GMT time. When using a format like “yyyy-MM-dd’T&#x27;HH:mm:ss”, you should use local time and you will need to specify the time zone. Only used for scheduled meetings and recurring meetings with fixed time. | Optional | 
+| start-time | Meeting start time. When using a format like “yyyy-MM-dd’T'HH:mm:ss'Z’”, always use GMT time. When using a format like “yyyy-MM-dd’T'HH:mm:ss”, you should use local time and you will need to specify the time zone. Only used for scheduled meetings and recurring meetings with fixed time. | Optional | 
 | timezone | Timezone to format start_time. For example, “America/Los_Angeles”. For scheduled meetings only.  | Optional | 
 
 
@@ -106,16 +106,16 @@ Get meeting record and save as file in the warroom
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| File.SHA256 | unknown | Attachment&\#x27;s SHA256 | 
-| File.SHA1 | unknown | Attachment&\#x27;s SHA1 | 
-| File.MD5 | unknown | Attachment&\#x27;s MD5 | 
-| File.Name | unknown | Attachment&\#x27;s Name | 
-| File.Info | unknown | Attachment&\#x27;s Info | 
-| File.Size | unknown | Attachment&\#x27;s Size \(In Bytes\) | 
-| File.Extension | unknown | Attachment&\#x27;s Extension | 
-| File.Type | unknown | Attachment&\#x27;s Type | 
-| File.EntryID | unknown | Attachment&\#x27;s EntryID | 
-| File.SSDeep | unknown | Attachment&\#x27;s SSDeep hash | 
+| File.SHA256 | unknown | Attachment's SHA256 | 
+| File.SHA1 | unknown | Attachment's SHA1 | 
+| File.MD5 | unknown | Attachment's MD5 | 
+| File.Name | unknown | Attachment's Name | 
+| File.Info | unknown | Attachment's Info | 
+| File.Size | unknown | Attachment's Size \(In Bytes\) | 
+| File.Extension | unknown | Attachment's Extension | 
+| File.Type | unknown | Attachment's Type | 
+| File.EntryID | unknown | Attachment's EntryID | 
+| File.SSDeep | unknown | Attachment's SSDeep hash | 
 
 
 ##### Command Example

--- a/demisto_sdk/tests/test_files/playbook-Test_playbook.yml
+++ b/demisto_sdk/tests/test_files/playbook-Test_playbook.yml
@@ -176,6 +176,27 @@ inputs:
     simple: johnnydepp@gmail.com
   required: true
   description: This is input b
+- key: ""
+  value: {}
+  required: false
+  description: ""
+  playbookInputQuery:
+    query: (type:ip or type:file or type:Domain or type:URL) -tags:pending_review
+      and (tags:approved_black or tags:approved_white or tags:approved_watchlist)
+    queryEntity: indicators
+    results: null
+    daterange:
+      fromdate: 0001-01-01T00:00:00Z
+      todate: 0001-01-01T00:00:00Z
+      period:
+        by: ""
+        byto: ""
+        byfrom: ""
+        tovalue: null
+        fromvalue: null
+        field: ""
+      fromdatelicenseval: 0001-01-01T00:00:00Z
+    runFromLastJobTime: false
 outputs:
 - contextPath: Email.To
   description: The recipient of the email.


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/23824
fixes: https://github.com/demisto/etc/issues/23914
fixes: https://github.com/demisto/etc/issues/23931

## Description
1. Removes the `Source` column of the inputs table of the docs generated for playbooks by the `generate-docs` command.
2. The row for the inputs table generated for a playbook that accepted a `playbookInputQuery` as input was practically empty. Added default values for the `Name` and `Description` columns for inputs of this type to playbooks.
3. Quotation marks (single and double) were accidentally escaped if they appeared in the `Description` column. Fixed.
4. Updated the `Default Value` column to be the combined `root` and `accessor` (separated by a period) where applicable.

## Must have
- [x] Tests
- [ ] Documentation
