### PR TITLE
run command - fix when running non-existing command

### DIFF
--- a/demisto_sdk/commands/run_cmd/runner.py
+++ b/demisto_sdk/commands/run_cmd/runner.py
@@ -45,6 +45,7 @@ class Runner:
         try:
             log_ids = self._run_query(playground_id)
         except DemistoRunTimeError as err:
+            log_ids = None
             print_error(str(err))
 
         if self.debug:

--- a/demisto_sdk/tests/integration_tests/run_cmd_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/run_cmd_integration_test.py
@@ -1,0 +1,29 @@
+import pytest
+from click.testing import CliRunner
+from demisto_client.demisto_api import DefaultApi
+from demisto_sdk.__main__ import main
+from demisto_sdk.commands.run_cmd.runner import Runner
+
+
+@pytest.fixture
+def set_environment_variables(monkeypatch):
+    # Set environment variables required by runner
+    monkeypatch.setenv('DEMISTO_BASE_URL', 'http://demisto.instance.com:8080/')
+    monkeypatch.setenv('DEMISTO_API_KEY', 'API_KEY')
+
+
+def test_runner_with_wrong_query(mocker, set_environment_variables):
+    """
+    Given
+    - Non-existing query.
+
+    When
+    - Running `run` command.
+
+    Then
+    - Ensure output is the appropriate error.
+    """
+    mocker.patch.object(DefaultApi, 'investigation_add_entries_sync', return_value=None)
+    mocker.patch.object(Runner, '_get_playground_id', return_value='pg_id')
+    result = CliRunner(mix_stderr=False).invoke(main, ['run', '-q', '!non-existing-command'])
+    assert 'Command did not run, make sure it was written correctly.' in result.output

--- a/demisto_sdk/tests/integration_tests/run_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/run_integration_test.py
@@ -12,10 +12,10 @@ def set_environment_variables(monkeypatch):
     monkeypatch.setenv('DEMISTO_API_KEY', 'API_KEY')
 
 
-def test_runner_with_wrong_query(mocker, set_environment_variables):
+def test_integration_run_non_existing_command(mocker, set_environment_variables):
     """
     Given
-    - Non-existing query.
+    - Non-existing command to run.
 
     When
     - Running `run` command.
@@ -25,5 +25,7 @@ def test_runner_with_wrong_query(mocker, set_environment_variables):
     """
     mocker.patch.object(DefaultApi, 'investigation_add_entries_sync', return_value=None)
     mocker.patch.object(Runner, '_get_playground_id', return_value='pg_id')
-    result = CliRunner(mix_stderr=False).invoke(main, ['run', '-q', '!non-existing-command'])
+    result = CliRunner(mix_stderr=False, ).invoke(main, ['run', '-q', '!non-existing-command'], catch_exceptions=False)
+    assert result.exit_code == 0
     assert 'Command did not run, make sure it was written correctly.' in result.output
+    assert not result.stderr

--- a/demisto_sdk/tests/integration_tests/run_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/run_integration_test.py
@@ -16,6 +16,7 @@ def test_integration_run_non_existing_command(mocker, set_environment_variables)
     """
     Given
     - Non-existing command to run.
+    - Debug and Verbose option to increase coverage
 
     When
     - Running `run` command.
@@ -25,7 +26,8 @@ def test_integration_run_non_existing_command(mocker, set_environment_variables)
     """
     mocker.patch.object(DefaultApi, 'investigation_add_entries_sync', return_value=None)
     mocker.patch.object(Runner, '_get_playground_id', return_value='pg_id')
-    result = CliRunner(mix_stderr=False, ).invoke(main, ['run', '-q', '!non-existing-command'], catch_exceptions=False)
-    assert result.exit_code == 0
+    result = CliRunner(mix_stderr=False, ).invoke(main, ['run', '-q', '!non-existing-command', '-D', '-v'])
+    assert 0 == result.exit_code
+    assert not result.exception
     assert 'Command did not run, make sure it was written correctly.' in result.output
     assert not result.stderr


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/23611

## Description
There was a var that was not assigned but still used

## Must have
- [x] Tests
