### PR TITLE
Download bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-* Fixed a bug in the **download** command when file wasn't of content type.
+* Fixed a bug in the **download** command when custom content contained not supported content entity.
 * Fixed a bug in the **unify** command when output path was provided empty.
 * Improved error message for integration with no tests configured.
 * Improved the error message returned from the **validate** command when an integration is missing or contains malformed fetch incidents related parameters.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+* Fixed a bug in the **download** command when file wasn't of content type.
 * Fixed a bug in the **unify** command when output path was provided empty.
 * Improved error message for integration with no tests configured.
 * Improved the error message returned from the **validate** command when an integration is missing or contains malformed fetch incidents related parameters.

--- a/demisto_sdk/commands/download/downloader.py
+++ b/demisto_sdk/commands/download/downloader.py
@@ -69,7 +69,7 @@ class Downloader:
         self.all_custom_content = all_custom_content
         self.run_format = run_format
         self.client = None
-        self.custom_content_temp_dir = None
+        self.custom_content_temp_dir = mkdtemp()
         self.all_custom_content_objects = list()
         self.files_not_downloaded = list()
         self.custom_content = list()
@@ -130,7 +130,6 @@ class Downloader:
             io_bytes = io.BytesIO(body)
             # Demisto's custom content file is of type tar.gz
             tar = tarfile.open(fileobj=io_bytes, mode='r')
-            self.custom_content_temp_dir = mkdtemp()
 
             for member in tar.getmembers():
                 file_name: str = self.update_file_prefix(member.name.strip('/'))

--- a/demisto_sdk/commands/download/downloader.py
+++ b/demisto_sdk/commands/download/downloader.py
@@ -6,7 +6,7 @@ import os
 import shutil
 import tarfile
 from tempfile import mkdtemp
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 import demisto_client.demisto_api
 from demisto_client.demisto_api.rest import ApiException

--- a/demisto_sdk/commands/download/downloader.py
+++ b/demisto_sdk/commands/download/downloader.py
@@ -368,8 +368,6 @@ class Downloader:
         file_data, file_ending = get_dict_from_file(file_path)  # For example: yml, for integration files
         file_type: str = find_type(_dict=file_data, file_type=file_ending)  # For example: integration
         file_entity = ENTITY_TYPE_TO_DIR.get(file_type)  # For example: Integrations
-        if not file_entity:
-            raise KeyError(f'{file_path}: Could not find entity type in file.')
         file_id: str = get_entity_id_by_entity_type(file_data, file_entity)
         file_name: str = get_entity_name_by_entity_type(file_data, file_entity)
 

--- a/demisto_sdk/commands/download/tests/downloader_test.py
+++ b/demisto_sdk/commands/download/tests/downloader_test.py
@@ -257,6 +257,15 @@ class TestFlagHandlers:
                 assert file[1] in stdout
             assert answer
 
+    def test_handle_list_files_flag_error(self, mocker):
+        mocker.patch('demisto_sdk.commands.download.downloader.get_dict_from_file', return_value=({}, 'json'))
+        mocker.patch('demisto_sdk.commands.download.downloader.get_child_files', return_value=['path'])
+        with patch.object(Downloader, "__init__", lambda a, b, c: None):
+            downloader = Downloader('', '')
+            downloader.custom_content_temp_dir = INTEGRATION_INSTANCE_PATH
+            downloader.list_files = True
+            assert downloader.handle_list_files_flag()
+
 
 class TestBuildPackContent:
     def test_build_pack_content(self):

--- a/demisto_sdk/commands/download/tests/downloader_test.py
+++ b/demisto_sdk/commands/download/tests/downloader_test.py
@@ -258,6 +258,11 @@ class TestFlagHandlers:
             assert answer
 
     def test_handle_list_files_flag_error(self, mocker):
+        """
+        GIVEN a file contained in custom content of not supported type
+        WHEN the user runs demisto-sdk download -lf
+        THEN the handle_list_files_flag method should ignore the file
+        """
         mocker.patch('demisto_sdk.commands.download.downloader.get_dict_from_file', return_value=({}, 'json'))
         mocker.patch('demisto_sdk.commands.download.downloader.get_child_files', return_value=['path'])
         with patch.object(Downloader, "__init__", lambda a, b, c: None):


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/24107

## Description
The file was causing the error was of type `preprocessrule`, the `find_type` function doesn't handle files of this type. From now and so on files of this type will be ignored by the download command.

@ShahafBenYakir I'll update the docs in a different PR will be opened soon.