### PR TITLE
Docker image change should not fail build

### DIFF
--- a/demisto_sdk/commands/common/hook_validations/docker.py
+++ b/demisto_sdk/commands/common/hook_validations/docker.py
@@ -62,7 +62,6 @@ class DockerImageValidator(object):
             self.is_latest_tag = False
 
         if not self.is_latest_tag:
-            self.is_latest_tag = False
             print_warning('The docker image tag is not the latest, please update it.\n'
                           'The docker image tag in the yml file is: {}\n'
                           'The latest docker image tag in docker hub is: {}\n'

--- a/demisto_sdk/commands/common/hook_validations/docker.py
+++ b/demisto_sdk/commands/common/hook_validations/docker.py
@@ -57,7 +57,8 @@ class DockerImageValidator(object):
             self.is_latest_tag = False
             return self.is_latest_tag
 
-        if not self.is_latest_tag:
+        if self.docker_image_latest_tag != self.docker_image_tag:
+            # If docker image tag is not the most updated one that exists in docker-hub
             print_warning('The docker image tag is not the latest, please update it.\n'
                           'The docker image tag in the yml file is: {}\n'
                           'The latest docker image tag in docker hub is: {}\n'

--- a/demisto_sdk/commands/common/hook_validations/docker.py
+++ b/demisto_sdk/commands/common/hook_validations/docker.py
@@ -57,10 +57,6 @@ class DockerImageValidator(object):
             self.is_latest_tag = False
             return self.is_latest_tag
 
-        if self.docker_image_latest_tag != self.docker_image_tag:
-            # If docker image tag is not the most updated one that exists in docker-hub
-            self.is_latest_tag = False
-
         if not self.is_latest_tag:
             print_warning('The docker image tag is not the latest, please update it.\n'
                           'The docker image tag in the yml file is: {}\n'

--- a/demisto_sdk/commands/common/tests/docker_test.py
+++ b/demisto_sdk/commands/common/tests/docker_test.py
@@ -217,6 +217,8 @@ def test_is_docker_image_latest_tag_with_numeric_but_not_most_updated():
    Then
    -  If the docker image is numeric and the most update one, it is Valid
    -  If the docker image is not numeric and labeled "latest", it is Invalid
+   - If the docker image is not the most updated one it is still valid
+        (however, a warning will be printed)
   """
     with mock.patch.object(DockerImageValidator, '__init__', lambda x, y, z, w: None):
         docker_image_validator = DockerImageValidator(None, None, None)
@@ -226,8 +228,8 @@ def test_is_docker_image_latest_tag_with_numeric_but_not_most_updated():
 
         docker_image_validator.is_latest_tag = True
         docker_image_validator.docker_image_tag = '1.0.2'
-        assert docker_image_validator.is_docker_image_latest_tag() is False
-        assert docker_image_validator.is_latest_tag is False
+        assert docker_image_validator.is_docker_image_latest_tag() is True
+        assert docker_image_validator.is_latest_tag is True
 
 
 def test_is_docker_image_latest_tag_without_tag():

--- a/demisto_sdk/commands/common/tests/docker_test.py
+++ b/demisto_sdk/commands/common/tests/docker_test.py
@@ -154,8 +154,11 @@ def test_is_docker_image_latest_tag_with_default_image():
         docker_image_validator.is_latest_tag = True
         docker_image_validator.is_modified_file = False
         docker_image_validator.docker_image_tag = '1.3-alpine'
+        docker_image_validator.is_valid = True
+
         assert docker_image_validator.is_docker_image_latest_tag() is False
         assert docker_image_validator.is_latest_tag is False
+        assert docker_image_validator.is_docker_image_valid() is False
 
 
 def test_is_docker_image_latest_tag_with_tag_labeled_latest():
@@ -177,9 +180,12 @@ def test_is_docker_image_latest_tag_with_tag_labeled_latest():
         docker_image_validator.docker_image_name = 'demisto/python'
 
         docker_image_validator.is_latest_tag = True
+        docker_image_validator.is_valid = True
         docker_image_validator.docker_image_tag = 'latest'
+
         assert docker_image_validator.is_docker_image_latest_tag() is False
         assert docker_image_validator.is_latest_tag is False
+        assert docker_image_validator.is_docker_image_valid() is False
 
 
 def test_is_docker_image_latest_tag_with_latest_tag():
@@ -201,9 +207,12 @@ def test_is_docker_image_latest_tag_with_latest_tag():
         docker_image_validator.docker_image_name = 'demisto/python'
 
         docker_image_validator.is_latest_tag = True
+        docker_image_validator.is_valid = True
         docker_image_validator.docker_image_tag = '1.0.3'
+
         assert docker_image_validator.is_docker_image_latest_tag() is True
         assert docker_image_validator.is_latest_tag is True
+        assert docker_image_validator.is_docker_image_valid() is True
 
 
 def test_is_docker_image_latest_tag_with_numeric_but_not_most_updated():
@@ -228,8 +237,11 @@ def test_is_docker_image_latest_tag_with_numeric_but_not_most_updated():
 
         docker_image_validator.is_latest_tag = True
         docker_image_validator.docker_image_tag = '1.0.2'
+        docker_image_validator.is_valid = True
+
         assert docker_image_validator.is_docker_image_latest_tag() is True
         assert docker_image_validator.is_latest_tag is True
+        assert docker_image_validator.is_docker_image_valid() is True
 
 
 def test_is_docker_image_latest_tag_without_tag():
@@ -252,5 +264,8 @@ def test_is_docker_image_latest_tag_without_tag():
 
         docker_image_validator.is_latest_tag = True
         docker_image_validator.docker_image_tag = '1.0.2'
+        docker_image_validator.is_valid = True
+
         assert docker_image_validator.is_docker_image_latest_tag() is False
         assert docker_image_validator.is_latest_tag is False
+        assert docker_image_validator.is_docker_image_valid() is False


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
When the docker image is not the latest we want to only return an error and not break build.
