### PR TITLE
fixed old and new classifiers regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+* Fixed an issue where new and old classifiers where mixed on validate command.
 
 #### 1.1.1
 * fixed and issue where file types were not recognized correctly in **validate** command.

--- a/demisto_sdk/commands/common/constants.py
+++ b/demisto_sdk/commands/common/constants.py
@@ -361,11 +361,11 @@ DASHBOARD_CHANGELOG_REGEX = r'{}{}.*_CHANGELOG.md$'.format(CAN_START_WITH_DOT_SL
 
 CONNECTIONS_REGEX = r'{}{}.*canvas-context-connections.*\.json$'.format(CAN_START_WITH_DOT_SLASH, CONNECTIONS_DIR)
 
-CLASSIFIER_REGEX = r'{}{}.*classifier-(?!mapper).*\.json$'.format(CAN_START_WITH_DOT_SLASH, CLASSIFIERS_DIR)
+CLASSIFIER_REGEX = r'{}{}.*classifier-(?!mapper).*(?<!5_9_9)\.json$'.format(CAN_START_WITH_DOT_SLASH, CLASSIFIERS_DIR)
 CLASSIFIER_CHANGELOG_REGEX = r'{}{}.*classifier-(?!mapper).*_CHANGELOG.md$'.format(CAN_START_WITH_DOT_SLASH,
                                                                                    CLASSIFIERS_DIR)
 
-CLASSIFIER_REGEX_5_9_9 = r'{}{}.*classifier-.*_5_9_9\.json$'.format(CAN_START_WITH_DOT_SLASH, CLASSIFIERS_DIR)
+CLASSIFIER_REGEX_5_9_9 = r'{}{}.*classifier-(?!mapper).*_5_9_9\.json$'.format(CAN_START_WITH_DOT_SLASH, CLASSIFIERS_DIR)
 CLASSIFIER_CHANGELOG_REGEX_5_9_9 = r'{}{}.*_CHANGELOG_5_9_9.md$'.format(CAN_START_WITH_DOT_SLASH, CLASSIFIERS_DIR)
 
 MAPPER_REGEX = r'{}{}.*classifier-(?=mapper).*\.json$'.format(CAN_START_WITH_DOT_SLASH, CLASSIFIERS_DIR)

--- a/demisto_sdk/commands/common/tests/constants_regex_test.py
+++ b/demisto_sdk/commands/common/tests/constants_regex_test.py
@@ -30,48 +30,48 @@ def verify(acceptable, unacceptable, matched_regex):
 
 
 def get_test_new_classifiers_paths(folder):
-    acceptable_code_files = {
+    acceptable_new_classifiers_paths = {
         os.path.join(folder, 'classifier-A.json'),
     }
 
-    unacceptable_code_files = {
+    unacceptable_new_classifiers_paths = {
         os.path.join(folder, 'classifier-A_5_9_9.json'),
         os.path.join(folder, 'classifier-mapper-test.json'),
 
     }
 
-    return acceptable_code_files, unacceptable_code_files
+    return acceptable_new_classifiers_paths, unacceptable_new_classifiers_paths
 
 
 def get_test_old_classifiers_paths(folder):
-    acceptable_code_files = {
+    acceptable_old_classifier_paths = {
         os.path.join(folder, 'classifier-A_5_9_9.json'),
 
     }
 
-    unacceptable_code_files = {
+    unacceptable_old_classifiers_paths = {
         os.path.join(folder, 'classifier-A.json'),
         os.path.join(folder, 'classifier-mapper-test.json'),
         os.path.join(folder, 'classifier-mapper-test_5_9_9.json'),
 
     }
 
-    return acceptable_code_files, unacceptable_code_files
+    return acceptable_old_classifier_paths, unacceptable_old_classifiers_paths
 
 
 def get_test_mapper_paths(folder):
-    acceptable_code_files = {
+    acceptable_mapper_paths = {
         os.path.join(folder, 'classifier-mapper-A.json'),
 
     }
 
-    unacceptable_code_files = {
+    unacceptable_mapper_paths = {
         os.path.join(folder, 'classifierA.json'),
         os.path.join(folder, 'classifier-test_5_9_9.json'),
 
     }
 
-    return acceptable_code_files, unacceptable_code_files
+    return acceptable_mapper_paths, unacceptable_mapper_paths
 
 
 def get_test_code_file_paths(folder):
@@ -131,31 +131,31 @@ def test_script_code_files():
 
 
 def test_new_classifier_files():
-    acceptable_script_code_files, unacceptable_script_code_files = get_test_new_classifiers_paths(CLASSIFIERS_DIR)
+    acceptable_new_classifier_paths, unacceptable_new_classifier_paths = get_test_new_classifiers_paths(CLASSIFIERS_DIR)
 
     verify(
-        acceptable_script_code_files,
-        unacceptable_script_code_files,
+        acceptable_new_classifier_paths,
+        unacceptable_new_classifier_paths,
         (CLASSIFIER_REGEX, ),
     )
 
 
 def test_old_classifier_files():
-    acceptable_script_code_files, unacceptable_script_code_files = get_test_old_classifiers_paths(CLASSIFIERS_DIR)
+    acceptable_old_classifier_paths, unacceptable_old_classifier_paths = get_test_old_classifiers_paths(CLASSIFIERS_DIR)
 
     verify(
-        acceptable_script_code_files,
-        unacceptable_script_code_files,
+        acceptable_old_classifier_paths,
+        unacceptable_old_classifier_paths,
         (CLASSIFIER_REGEX_5_9_9, ),
     )
 
 
 def test_mapper_files():
-    acceptable_script_code_files, unacceptable_script_code_files = get_test_mapper_paths(CLASSIFIERS_DIR)
+    acceptable_mapper_paths, unacceptable_mapper_paths = get_test_mapper_paths(CLASSIFIERS_DIR)
 
     verify(
-        acceptable_script_code_files,
-        unacceptable_script_code_files,
+        acceptable_mapper_paths,
+        unacceptable_mapper_paths,
         (MAPPER_REGEX, ),
     )
 

--- a/demisto_sdk/commands/common/tests/constants_regex_test.py
+++ b/demisto_sdk/commands/common/tests/constants_regex_test.py
@@ -3,10 +3,11 @@ import os
 import pytest
 from demisto_sdk.commands.common.constants import (
     BETA_INTEGRATION_REGEX, BETA_INTEGRATION_YML_REGEX, BETA_INTEGRATIONS_DIR,
-    BETA_SCRIPT_REGEX, INCIDENT_TYPE_REGEX, INDICATOR_FIELDS_REGEX,
+    BETA_SCRIPT_REGEX, CLASSIFIER_REGEX, CLASSIFIER_REGEX_5_9_9,
+    CLASSIFIERS_DIR, INCIDENT_TYPE_REGEX, INDICATOR_FIELDS_REGEX,
     INTEGRATION_JS_REGEX, INTEGRATION_PY_REGEX, INTEGRATION_REGEX,
     INTEGRATION_TEST_PY_REGEX, INTEGRATION_YML_REGEX, INTEGRATIONS_DIR,
-    PACKAGE_YML_FILE_REGEX, PACKS_CHANGELOG_REGEX,
+    MAPPER_REGEX, PACKAGE_YML_FILE_REGEX, PACKS_CHANGELOG_REGEX,
     PACKS_CLASSIFIERS_5_9_9_REGEX, PACKS_CLASSIFIERS_REGEX,
     PACKS_DASHBOARDS_REGEX, PACKS_INCIDENT_FIELDS_REGEX,
     PACKS_INCIDENT_TYPES_REGEX, PACKS_INTEGRATION_JS_REGEX,
@@ -26,6 +27,51 @@ def verify(acceptable, unacceptable, matched_regex):
 
     for test_path in unacceptable:
         assert not checked_type(test_path, compared_regexes=matched_regex)
+
+
+def get_test_new_classifiers_paths(folder):
+    acceptable_code_files = {
+        os.path.join(folder, 'classifier-A.json'),
+    }
+
+    unacceptable_code_files = {
+        os.path.join(folder, 'classifier-A_5_9_9.json'),
+        os.path.join(folder, 'classifier-mapper-test.json'),
+
+    }
+
+    return acceptable_code_files, unacceptable_code_files
+
+
+def get_test_old_classifiers_paths(folder):
+    acceptable_code_files = {
+        os.path.join(folder, 'classifier-A_5_9_9.json'),
+
+    }
+
+    unacceptable_code_files = {
+        os.path.join(folder, 'classifier-A.json'),
+        os.path.join(folder, 'classifier-mapper-test.json'),
+        os.path.join(folder, 'classifier-mapper-test_5_9_9.json'),
+
+    }
+
+    return acceptable_code_files, unacceptable_code_files
+
+
+def get_test_mapper_paths(folder):
+    acceptable_code_files = {
+        os.path.join(folder, 'classifier-mapper-A.json'),
+
+    }
+
+    unacceptable_code_files = {
+        os.path.join(folder, 'classifierA.json'),
+        os.path.join(folder, 'classifier-test_5_9_9.json'),
+
+    }
+
+    return acceptable_code_files, unacceptable_code_files
 
 
 def get_test_code_file_paths(folder):
@@ -81,6 +127,36 @@ def test_script_code_files():
         acceptable_script_code_files,
         unacceptable_script_code_files,
         (SCRIPT_PY_REGEX, SCRIPT_JS_REGEX)
+    )
+
+
+def test_new_classifier_files():
+    acceptable_script_code_files, unacceptable_script_code_files = get_test_new_classifiers_paths(CLASSIFIERS_DIR)
+
+    verify(
+        acceptable_script_code_files,
+        unacceptable_script_code_files,
+        (CLASSIFIER_REGEX, ),
+    )
+
+
+def test_old_classifier_files():
+    acceptable_script_code_files, unacceptable_script_code_files = get_test_old_classifiers_paths(CLASSIFIERS_DIR)
+
+    verify(
+        acceptable_script_code_files,
+        unacceptable_script_code_files,
+        (CLASSIFIER_REGEX_5_9_9, ),
+    )
+
+
+def test_mapper_files():
+    acceptable_script_code_files, unacceptable_script_code_files = get_test_mapper_paths(CLASSIFIERS_DIR)
+
+    verify(
+        acceptable_script_code_files,
+        unacceptable_script_code_files,
+        (MAPPER_REGEX, ),
     )
 
 

--- a/demisto_sdk/commands/validate/file_validator.py
+++ b/demisto_sdk/commands/validate/file_validator.py
@@ -811,15 +811,15 @@ class FilesValidator:
             if not mapper_validator.is_valid_mapper(validate_rn=False):
                 self._is_valid = False
 
-        elif checked_type(file_path, JSON_ALL_CLASSIFIER_REGEXES) or file_type == 'classifier':
-            classifier_validator = ClassifierValidator(structure_validator, ignored_errors=ignored_errors_list,
+        elif checked_type(file_path, JSON_ALL_CLASSIFIER_REGEXES_5_9_9) or file_type == 'classifier_5_9_9':
+            classifier_validator = ClassifierValidator(structure_validator, new_classifier_version=False,
+                                                       ignored_errors=ignored_errors_list,
                                                        print_as_warnings=self.print_ignored_errors)
             if not classifier_validator.is_valid_classifier(validate_rn=False):
                 self._is_valid = False
 
-        elif checked_type(file_path, JSON_ALL_CLASSIFIER_REGEXES_5_9_9) or file_type == 'classifier_5_9_9':
-            classifier_validator = ClassifierValidator(structure_validator, new_classifier_version=False,
-                                                       ignored_errors=ignored_errors_list,
+        elif checked_type(file_path, JSON_ALL_CLASSIFIER_REGEXES) or file_type == 'classifier':
+            classifier_validator = ClassifierValidator(structure_validator, ignored_errors=ignored_errors_list,
                                                        print_as_warnings=self.print_ignored_errors)
             if not classifier_validator.is_valid_classifier(validate_rn=False):
                 self._is_valid = False


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/25204

## Description
Fixed an issue where new and old classifiers where mixed on validate command by editing their regex.

## Must have
- [x] Tests
- [x] Documentation
