### PR TITLE
error out if install module fails on pwsh image create

### DIFF
--- a/demisto_sdk/commands/lint/templates/dockerfile.jinja2
+++ b/demisto_sdk/commands/lint/templates/dockerfile.jinja2
@@ -20,8 +20,8 @@ ENTRYPOINT ["/bin/sh", "-c"]
 {# Build for python based image #}
 {% elif pack_type == "powershell" %}
 {#  Install powershell requirements for analyze and tests  #}
-RUN pwsh -Command Set-PSRepository -name PSGallery -installationpolicy trusted
-RUN pwsh -Command Install-Module -Name Pester -Scope AllUsers -Force | pwsh -Command Out-Null
-RUN pwsh -Command Install-Module -Name PSScriptAnalyzer -Scope AllUsers -Force | pwsh -Command Out-Null
+RUN pwsh -Command Set-PSRepository -name PSGallery -installationpolicy trusted -ErrorAction Stop
+RUN pwsh -Command Install-Module -Name Pester -Scope AllUsers -Force -ErrorAction Stop
+RUN pwsh -Command Install-Module -Name PSScriptAnalyzer -Scope AllUsers -Force -ErrorAction Stop
 {# Container entry point (Every command will start with /bin/sh) #}
 {% endif %}


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Change powershell command to error out if it fails installing a module. Sdk image build step still lacks printout but at leat we fail on the image creation step and don't continue to try to run the tests/lint:
```
demisto-sdk lint -vvvv -i Packs/Infocyte/Integrations/Infocyte
Content path /Users/glichtman/dev/demisto/content
Test requirements successfully collected for python 2:
 ['apipkg==1.5', 'astroid==1.6.6', 'atomicwrites==1.3.0', 'attrs==19.3.0', 'backports.functools-lru-cache==1.6.1', 'certifi==2019.11.28', 'chardet==3.0.4', 'configparser==4.0.2', 'contextlib2==0.6.0.post1', 'enum34==1.1.9', 'execnet==1.7.1', 'funcsigs==1.0.2', 'futures==3.3.0', 'idna==2.9', 'importlib-metadata==1.5.0', 'isort==4.3.21', 'lazy-object-proxy==1.4.3', 'mccabe==0.6.1', 'mock==3.0.5', 'more-itertools==5.0.0', 'packaging==20.1', 'pathlib2==2.3.5', 'pluggy==0.13.1', 'py==1.8.1', 'pylint==1.9.5', 'pyparsing==2.4.6', 'pytest==4.6.9', 'pytest-forked==1.1.3', 'pytest-json==0.4.0', 'pytest-mock==2.0.0', 'pytest-xdist==1.31.0', 'requests==2.23.0', 'requests-mock==1.7.0', 'scandir==1.10.0', 'singledispatch==3.4.0.3', 'six==1.14.0', 'urllib3==1.25.8', 'wcwidth==0.1.8', 'wrapt==1.12.0', 'zipp==1.2.0']
Test requirements successfully collected for python 3:
 ['apipkg==1.5', 'astroid==2.3.3', 'atomicwrites==1.3.0', 'attrs==19.3.0', 'certifi==2019.11.28', 'chardet==3.0.4', 'execnet==1.7.1', 'freezegun==0.3.15', 'idna==2.9', 'importlib-metadata==1.5.0', 'isort==4.3.21', 'lazy-object-proxy==1.4.3', 'mccabe==0.6.1', 'more-itertools==8.2.0', 'packaging==20.1', 'pluggy==0.13.1', 'py==1.8.1', 'pylint==2.4.4', 'pyparsing==2.4.6', 'pytest==5.0.1', 'pytest-asyncio==0.10.0', 'pytest-datadir-ng==1.1.1', 'pytest-forked==1.1.3', 'pytest-json==0.4.0', 'pytest-mock==2.0.0', 'pytest-xdist==1.31.0', 'python-dateutil==2.8.1', 'requests==2.23.0', 'requests-mock==1.7.0', 'six==1.14.0', 'typed-ast==1.4.1', 'urllib3==1.25.8', 'wcwidth==0.1.8', 'wrapt==1.11.2', 'zipp==3.0.0']
Test mandatory modules successfully collected
Docker daemon test passed
Execute lint and test on 1/1 packages
Infocyte - Facts - Using yaml file /Users/glichtman/dev/demisto/content/Packs/Infocyte/Integrations/Infocyte/Infocyte.yml
Infocyte - Facts - Pulling docker images, can take up to 1-2 minutes if not exists locally 
Infocyte - Facts - Lint file /Users/glichtman/dev/demisto/content/Packs/Infocyte/Integrations/Infocyte/Infocyte.tests.ps1
Infocyte - Facts - Lint file /Users/glichtman/dev/demisto/content/Packs/Infocyte/Integrations/Infocyte/Infocyte.ps1
Infocyte - Image create - Trying to pull existing image devtestdemisto/pwsh-infocyte:1.0.3.8726-d253d8f1f64afe3cfb661a45978a3168
Infocyte - Image create - Unable to find image devtestdemisto/pwsh-infocyte:1.0.3.8726-d253d8f1f64afe3cfb661a45978a3168
Infocyte - Image create - Creating image based on demisto/pwsh-infocyte:1.0.3.8726 - Could take 2-3 minutes at first time
Infocyte - Image create - Build errors occurred The command '/bin/sh -c pwsh -Command Install-Module -Name Pester -Scope AllUsers -Force -ErrorAction Stop' returned a non-zero code: 1
Infocyte - Image create - Copy pack dir to image devtestdemisto/pwsh-infocyte:1.0.3.8726-d253d8f1f64afe3cfb661a45978a3168
Infocyte - Image create - errors occurred when copy pack dir 404 Client Error: Not Found ("No such image: devtestdemisto/pwsh-infocyte:1.0.3.8726-d253d8f1f64afe3cfb661a45978a3168")
Infocyte - Image create - Copy pack dir to image devtestdemisto/pwsh-infocyte:1.0.3.8726-d253d8f1f64afe3cfb661a45978a3168
Infocyte - Image create - errors occurred when copy pack dir 404 Client Error: Not Found ("No such image: devtestdemisto/pwsh-infocyte:1.0.3.8726-d253d8f1f64afe3cfb661a45978a3168")
Infocyte - Image create - Trying to pull existing image devtestdemisto/pwsh-infocyte:1.0.3.8726-d253d8f1f64afe3cfb661a45978a3168
Infocyte - Image create - Unable to find image devtestdemisto/pwsh-infocyte:1.0.3.8726-d253d8f1f64afe3cfb661a45978a3168
Infocyte - Image create - Creating image based on demisto/pwsh-infocyte:1.0.3.8726 - Could take 2-3 minutes at first time
Infocyte - Image create - Build errors occurred The command '/bin/sh -c pwsh -Command Install-Module -Name Pester -Scope AllUsers -Force -ErrorAction Stop' returned a non-zero code: 1
Infocyte - Image create - Copy pack dir to image devtestdemisto/pwsh-infocyte:1.0.3.8726-d253d8f1f64afe3cfb661a45978a3168
Infocyte - Image create - errors occurred when copy pack dir 404 Client Error: Not Found ("No such image: devtestdemisto/pwsh-infocyte:1.0.3.8726-d253d8f1f64afe3cfb661a45978a3168")
Infocyte - Image create - Copy pack dir to image devtestdemisto/pwsh-infocyte:1.0.3.8726-d253d8f1f64afe3cfb661a45978a3168
Infocyte - Image create - errors occurred when copy pack dir 404 Client Error: Not Found ("No such image: devtestdemisto/pwsh-infocyte:1.0.3.8726-d253d8f1f64afe3cfb661a45978a3168")
Resource ID was not provided
Flake8       - [SKIPPED]
Bandit       - [SKIPPED]
Mypy         - [SKIPPED]
Vulture      - [SKIPPED]
Pytest       - [SKIPPED]
Pylint       - [SKIPPED]
Pwsh analyze - [PASS]

```

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
