### PR TITLE
fixed error handling in generate-docs for missing output descriptions

### DIFF
--- a/demisto_sdk/commands/generate_docs/generate_integration_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_integration_doc.py
@@ -274,7 +274,7 @@ def generate_single_command_section(cmd: dict, example_dict: dict, command_permi
                                                                                            cmd['name']))
             section.append(
                 '| {} | {} | {} | '.format(output['contextPath'], output.get('type', 'unknown'),
-                                           string_escape_md(output.get('description'))))
+                                           string_escape_md(output.get('description', ''))))
         section.append('')
 
     # Raw output:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes:
![image](https://user-images.githubusercontent.com/30797606/84650437-e7b5a480-af10-11ea-8d21-ad724956bc20.png)


## Description
in case there is output with no description.