### PR TITLE
Added detection for and validation with upstream remotes for contributors

### DIFF
--- a/demisto_sdk/commands/common/constants.py
+++ b/demisto_sdk/commands/common/constants.py
@@ -691,6 +691,8 @@ PYTHON_SUBTYPES = {'python3', 'python2'}
 CONTENT_GITHUB_LINK = r'https://raw.githubusercontent.com/demisto/content'
 CONTENT_GITHUB_MASTER_LINK = CONTENT_GITHUB_LINK + '/master'
 SDK_API_GITHUB_RELEASES = r'https://api.github.com/repos/demisto/demisto-sdk/releases'
+CONTENT_GITHUB_UPSTREAM = r'upstream\s*https://github\.com/demisto/content\.git'
+CONTENT_GITHUB_ORIGIN = r'origin\s*https://github\.com/demisto/content\.git'
 
 # Run all test signal
 RUN_ALL_TESTS_FORMAT = 'Run all tests'

--- a/demisto_sdk/commands/common/tests/errors_test.py
+++ b/demisto_sdk/commands/common/tests/errors_test.py
@@ -5,43 +5,83 @@ from demisto_sdk.commands.common.errors import Errors
 
 class TestErrors(unittest.TestCase):
     def test_file_name_includes_spaces(self):
+        """
+        Given: File Name with spaces
+        When: Returning an error message
+        Then: Return error message with the input value as a tuple containing error and error code.
+        """
         file_name = "test file.gif"
         expected_result = ("Please remove spaces from the file's name: 'test file.gif'.", 'BA103')
         result = Errors.file_name_include_spaces_error(file_name)
         assert expected_result == result
 
     def test_wrong_required_value(self):
+        """
+        Given: Param value
+        When: Returning an error message
+        Then: Return error message with the input value as a tuple containing error and error code.
+        """
         param_name = "test param"
         expected_result = ("The required field of the test param parameter should be False", "IN102")
         result = Errors.wrong_required_value(param_name)
         assert result == expected_result
 
     def test_pack_metadata_empty(self):
+        """
+        Given: None
+        When: Returning an error message
+        Then: Return error message with the input value as a tuple containing error and error code.
+        """
         expected_result = ("Pack metadata is empty.", "PA105")
         result = Errors.pack_metadata_empty()
         assert result == expected_result
 
     def test_might_need_rns(self):
+        """
+        Given: None
+        When: Returning an error message
+        Then: Return error message with the input value as a tuple containing error and error code.
+        """
         expected_result = "You may need RN in this file, please verify if they are required."
         result = Errors.might_need_release_notes()
         assert result == expected_result
 
     def test_unknown_file(self):
+        """
+        Given: None
+        When: Returning an error message
+        Then: Return error message with the input value as a string containing error.
+        """
         expected_result = "File type is unknown, check it out."
         result = Errors.unknown_file()
         assert result == expected_result
 
     def test_id_change(self):
+        """
+        Given: None
+        When: Returning an error message
+        Then: Return error message with the input value as a string containing error.
+        """
         expected_result = "You've changed the ID of the file, please undo this change."
         result = Errors.id_changed()
         assert result == expected_result
 
     def test_id_might_change(self):
+        """
+        Given: None
+        When: Returning an error message
+        Then: Return error message with the input value as a string containing error.
+        """
         expected_result = "ID may have changed, please make sure to check you have the correct one."
         result = Errors.id_might_changed()
         assert result == expected_result
 
     def test_id_should_equal(self):
+        """
+        Given: File name and file ID
+        When: Returning an error message
+        Then: Return error message with the input value as a tuple containing error and error code.
+        """
         expected_result = ("The File's name, which is: 'FileName', should be equal to its ID, which "
                            "is: 'FileID'. please update the file.", "BA101")
         name = "FileName"
@@ -50,6 +90,11 @@ class TestErrors(unittest.TestCase):
         assert result == expected_result
 
     def test_file_type_not_supported(self):
+        """
+        Given: None
+        When: Returning an error message
+        Then: Return error message with the input value as a tuple containing error and error code.
+        """
         error_statement = "The file type is not supported in validate command\n " \
             "validate' command supports: Integrations, Scripts, Playbooks, " \
             "Incident fields, Indicator fields, Images, Release notes, Layouts and Descriptions"
@@ -58,6 +103,11 @@ class TestErrors(unittest.TestCase):
         assert result == expected_result
 
     def test_invalid_context_output(self):
+        """
+        Given: Command Name and Output Name
+        When: Returning an error message
+        Then: Return error message with the input value as a tuple containing error and error code.
+        """
         expected_result = ("Invalid context output for command TestCommand. Output is BadOutput",
                            "IN115")
         command_name = "TestCommand"
@@ -66,6 +116,11 @@ class TestErrors(unittest.TestCase):
         assert result == expected_result
 
     def test_wrong_display_name(self):
+        """
+        Given: Param Name and Param Display
+        When: Returning an error message
+        Then: Return error message with the input value as a tuple containing error and error code.
+        """
         expected_result = ('The display name of the ParamName parameter should be \'ParamDisplay\'',
                            "IN100")
         param_name = "ParamName"

--- a/demisto_sdk/commands/common/tests/errors_test.py
+++ b/demisto_sdk/commands/common/tests/errors_test.py
@@ -40,3 +40,35 @@ class TestErrors(unittest.TestCase):
         expected_result = "ID may have changed, please make sure to check you have the correct one."
         result = Errors.id_might_changed()
         assert result == expected_result
+
+    def test_id_should_equal(self):
+        expected_result = ("The File's name, which is: 'FileName', should be equal to its ID, which "
+                           "is: 'FileID'. please update the file.", "BA101")
+        name = "FileName"
+        file_id = "FileID"
+        result = Errors.id_should_equal_name(name, file_id)
+        assert result == expected_result
+
+    def test_file_type_not_supported(self):
+        error_statement = "The file type is not supported in validate command\n " \
+            "validate' command supports: Integrations, Scripts, Playbooks, " \
+            "Incident fields, Indicator fields, Images, Release notes, Layouts and Descriptions"
+        expected_result = (error_statement, "BA102")
+        result = Errors.file_type_not_supported()
+        assert result == expected_result
+
+    def test_invalid_context_output(self):
+        expected_result = ("Invalid context output for command TestCommand. Output is BadOutput",
+                           "IN115")
+        command_name = "TestCommand"
+        output_name = "BadOutput"
+        result = Errors.invalid_context_output(command_name, output_name)
+        assert result == expected_result
+
+    def test_wrong_display_name(self):
+        expected_result = ('The display name of the ParamName parameter should be \'ParamDisplay\'',
+                           "IN100")
+        param_name = "ParamName"
+        param_display = "ParamDisplay"
+        result = Errors.wrong_display_name(param_name, param_display)
+        assert result == expected_result

--- a/demisto_sdk/commands/common/tests/tools_test.py
+++ b/demisto_sdk/commands/common/tests/tools_test.py
@@ -357,6 +357,16 @@ remote_testbank = [
 
 @pytest.mark.parametrize('git_value, response', remote_testbank)
 def test_has_remote(mocker, git_value, response):
+    """
+    While: Testing if the remote upstream contains demisto/content
+    Given:
+      1. Origin string not containing demisto/content
+      2. Upstream string containing demisto/content
+    Expects:
+      1. Test condition fails
+      2. Test condition passes
+    :param git_value: Git string from `git remotes -v`
+    """
     mocker.patch('demisto_sdk.commands.common.tools.run_command', return_value=git_value)
     test_remote = has_remote_configured()
     assert response == test_remote
@@ -370,6 +380,16 @@ origin_testbank = [
 
 @pytest.mark.parametrize('git_value, response', origin_testbank)
 def test_origin_content(mocker, git_value, response):
+    """
+    While: Testing if the remote origin contains demisto/content
+    Given:
+      1. Origin string not containing demisto/content
+      2. Origin string containing demisto/content
+    Expects:
+      1. Test condition fails
+      2. Test condition passes
+    :param git_value: Git string from `git remotes -v`
+    """
     mocker.patch('demisto_sdk.commands.common.tools.run_command', return_value=git_value)
     test_remote = is_origin_content_repo()
     assert response == test_remote

--- a/demisto_sdk/commands/common/tests/tools_test.py
+++ b/demisto_sdk/commands/common/tests/tools_test.py
@@ -22,7 +22,10 @@ from demisto_sdk.commands.common.tools import (LOG_COLORS,
                                                get_latest_release_notes_text,
                                                get_matching_regex,
                                                get_release_notes_file_path,
-                                               get_ryaml, retrieve_file_ending,
+                                               get_ryaml,
+                                               has_remote_configured,
+                                               is_origin_content_repo,
+                                               retrieve_file_ending,
                                                run_command_os,
                                                server_version_compare)
 from demisto_sdk.tests.constants_test import (INDICATORFIELD_EXTRA_FIELDS,
@@ -344,3 +347,29 @@ def test_get_release_notes_file_path_invalid():
     """
     filepath = '/SomePack/1_1_1.json'
     assert get_release_notes_file_path(filepath) is None
+
+
+remote_testbank = [
+    ('origin  https://github.com/turbodog/content.git', False),
+    ('upstream  https://github.com/demisto/content.git', True)
+]
+
+
+@pytest.mark.parametrize('git_value, response', remote_testbank)
+def test_has_remote(mocker, git_value, response):
+    mocker.patch('demisto_sdk.commands.common.tools.run_command', return_value=git_value)
+    test_remote = has_remote_configured()
+    assert response == test_remote
+
+
+origin_testbank = [
+    ('origin  https://github.com/turbodog/content.git', False),
+    ('origin  https://github.com/demisto/content.git', True)
+]
+
+
+@pytest.mark.parametrize('git_value, response', origin_testbank)
+def test_origin_content(mocker, git_value, response):
+    mocker.patch('demisto_sdk.commands.common.tools.run_command', return_value=git_value)
+    test_remote = is_origin_content_repo()
+    assert response == test_remote

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -21,9 +21,10 @@ import urllib3
 import yaml
 from demisto_sdk.commands.common.constants import (
     ALL_FILES_VALIDATION_IGNORE_WHITELIST, CHECKED_TYPES_REGEXES,
-    CLASSIFIERS_DIR, CONTENT_GITHUB_LINK, DASHBOARDS_DIR, DEF_DOCKER,
-    DEF_DOCKER_PWSH, ID_IN_COMMONFIELDS, ID_IN_ROOT, INCIDENT_FIELDS_DIR,
-    INCIDENT_TYPES_DIR, INDICATOR_FIELDS_DIR, INTEGRATIONS_DIR, LAYOUTS_DIR,
+    CLASSIFIERS_DIR, CONTENT_GITHUB_LINK, CONTENT_GITHUB_ORIGIN,
+    CONTENT_GITHUB_UPSTREAM, DASHBOARDS_DIR, DEF_DOCKER, DEF_DOCKER_PWSH,
+    ID_IN_COMMONFIELDS, ID_IN_ROOT, INCIDENT_FIELDS_DIR, INCIDENT_TYPES_DIR,
+    INDICATOR_FIELDS_DIR, INTEGRATIONS_DIR, LAYOUTS_DIR,
     PACKAGE_SUPPORTING_DIRECTORIES, PACKAGE_YML_FILE_REGEX, PACKS_DIR,
     PACKS_DIR_REGEX, PACKS_README_FILE_NAME, PLAYBOOKS_DIR,
     RELEASE_NOTES_REGEX, REPORTS_DIR, SCRIPTS_DIR, SDK_API_GITHUB_RELEASES,
@@ -243,6 +244,33 @@ def get_child_files(directory):
         path in os.listdir(directory) if os.path.isfile(os.path.join(directory, path))
     ]
     return child_files
+
+
+def has_remote_configured():
+    """
+    Checks to see if a remote named "upstream" is configured. This is important for forked
+    repositories as it will allow validation against the demisto/content master branch as
+    opposed to the master branch of the fork.
+    :return: bool : True if remote is configured, False if not.
+    """
+    remotes = run_command('git remote -v')
+    if re.search(CONTENT_GITHUB_UPSTREAM, remotes):
+        return True
+    else:
+        return False
+
+
+def is_origin_content_repo():
+    """
+    Checks to see if a remote named "origin" is configured. This check helps to determine if
+    validation needs to be ran against the origin master branch or the upstream master branch
+    :return: bool : True if remote is configured, False if not.
+    """
+    remotes = run_command('git remote -v')
+    if re.search(CONTENT_GITHUB_ORIGIN, remotes):
+        return True
+    else:
+        return False
 
 
 def get_last_remote_release_version():

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -68,7 +68,7 @@ class UpdateRN:
                     print_color(f"Finished updating release notes for {self.pack}."
                                 f"\nNext Steps:\n - Please review the "
                                 f"created release notes found at {rn_path} and document any changes you "
-                                f"made by replacing '%%_UPDATE_RN%%'.\n - Commit "
+                                f"made by replacing '%%UPDATE_RN%%'.\n - Commit "
                                 f"the new release notes to your branch.\nFor information regarding proper"
                                 f" format of the release notes, please refer to "
                                 f"https://xsoar.pan.dev/docs/integrations/changelog", LOG_COLORS.GREEN)

--- a/demisto_sdk/commands/validate/file_validator.py
+++ b/demisto_sdk/commands/validate/file_validator.py
@@ -286,8 +286,6 @@ class FilesValidator:
                     self.get_modified_files(all_changed_files_string,
                                             print_ignored_files=self.print_ignored_files)
             else:
-                remote_configured = False
-                is_origin_demisto = False
                 if (not is_origin_demisto and not remote_configured) and self.silence_init_prints:
                     print_warning(
                         "Warning: The changes may fail validation once submitted via a "

--- a/demisto_sdk/commands/validate/file_validator.py
+++ b/demisto_sdk/commands/validate/file_validator.py
@@ -128,12 +128,6 @@ class FilesValidator:
         self.validate_id_set = validate_id_set
         self.file_path = file_path
         self.changed_pack_data = set()
-        if not self.is_circle:
-            self._remote_configured = has_remote_configured()
-            self._is_origin_demisto = is_origin_content_repo()
-        else:
-            self._remote_configure = False
-            self._is_origin_demisto = False
 
         self.is_external_repo = is_external_repo
         if is_external_repo:
@@ -279,7 +273,9 @@ class FilesValidator:
             print_ignored_files=self.print_ignored_files)
 
         if not self.is_circle:
-            if self._remote_configured and not self._is_origin_demisto:
+            remote_configured = has_remote_configured()
+            is_origin_demisto = is_origin_content_repo()
+            if remote_configured and not is_origin_demisto:
                 files_string = run_command('git diff --name-status --no-merges upstream/master...HEAD')
                 nc_modified_files, nc_added_files, nc_deleted_files, nc_old_format_files = \
                     self.get_modified_files(files_string, print_ignored_files=self.print_ignored_files)
@@ -290,7 +286,9 @@ class FilesValidator:
                     self.get_modified_files(all_changed_files_string,
                                             print_ignored_files=self.print_ignored_files)
             else:
-                if (not self._is_origin_demisto and not self._remote_configured) and self.silence_init_prints:
+                remote_configured = False
+                is_origin_demisto = False
+                if (not is_origin_demisto and not remote_configured) and self.silence_init_prints:
                     print_warning(
                         "Warning: The changes may fail validation once submitted via a "
                         "PR. To validate your changes, please make sure you have a git remote setup"

--- a/demisto_sdk/commands/validate/file_validator.py
+++ b/demisto_sdk/commands/validate/file_validator.py
@@ -128,8 +128,12 @@ class FilesValidator:
         self.validate_id_set = validate_id_set
         self.file_path = file_path
         self.changed_pack_data = set()
-        self._remote_configured = has_remote_configured()
-        self._is_origin_demisto = is_origin_content_repo()
+        if not self.is_circle:
+            self._remote_configured = has_remote_configured()
+            self._is_origin_demisto = is_origin_content_repo()
+        else:
+            self._remote_configure = False
+            self._is_origin_demisto = False
 
         self.is_external_repo = is_external_repo
         if is_external_repo:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/25737

## Description
We now check to see if an upstream is configured. If not and the origin is also not the content repo, we print a warning to explain how to configure an upstream. Git diffs will use the content master if the upstream is configured.

## Screenshots
![Screen Shot 2020-06-18 at 14 02 09](https://user-images.githubusercontent.com/42912128/85012848-52aee780-b16c-11ea-83cf-e5c31dab454f.png)

## Must have
- [ ] Tests
- [ ] Documentation
