### PR TITLE
small fix in content creator

### DIFF
--- a/demisto_sdk/commands/create_artifacts/content_creator.py
+++ b/demisto_sdk/commands/create_artifacts/content_creator.py
@@ -307,8 +307,9 @@ class ContentCreator:
             if os.path.isdir(path):
                 non_circle_tests = glob.glob(os.path.join(path, '*'))
                 for new_path in non_circle_tests:
-                    print(f'copying path {new_path}')
-                    shutil.copyfile(new_path, os.path.join(self.test_bundle, os.path.basename(new_path)))
+                    if os.path.isfile(new_path):
+                        print(f'copying path {new_path}')
+                        shutil.copyfile(new_path, os.path.join(self.test_bundle, os.path.basename(new_path)))
 
             else:
                 # test playbooks in test_playbooks_dir in packs can start without playbook* prefix


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Description
Fixed a small issue in create-content-artifacts where uploading directories inside NonCircleTests dir raised an exception.

See an example [here](https://app.circleci.com/pipelines/github/demisto/content/16868/workflows/65f89bc9-71ba-4514-8ba2-1ae0afb396d5/jobs/59293/steps).
![image](https://user-images.githubusercontent.com/38749041/85265971-cf4b0a00-b47b-11ea-81b7-0699c0fe701f.png)
