### PR TITLE
Sort changed_items dict by value in update_rn.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * *Format* command now adds *feedBypassExclusionList*, *Fetch indicators*, *feedReputation*, *feedReliability*,
      *feedExpirationPolicy*, *feedExpirationInterval* and *feedFetchInterval* fields to integration yml.
 * Fixed an issue in the playbooks schema.
+* Fixed an issue where generated release notes were out of order.
 
 #### 1.1.3
 * Added a validation for invalid id fields in indicators types files in **validate** command.

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -19,18 +19,19 @@ class TestRNUpdate(unittest.TestCase):
             Then:
                 - return a markdown string
         """
-        expected_result = "\n#### Integrations\n##### Hello World Integration\n- %%UPDATE_RN%%\n" \
-                          "\n#### Playbooks\n##### Hello World Playbook\n- %%UPDATE_RN%%\n" \
-                          "\n#### Scripts\n##### Hello World Script\n- %%UPDATE_RN%%\n" \
-                          "\n#### Incident Fields\n##### Hello World IncidentField\n- %%UPDATE_RN%%\n" \
-                          "\n#### Classifiers\n##### Hello World Classifier\n- %%UPDATE_RN%%\n" \
-                          "\n#### Layouts\n##### Hello World Layout\n- %%UPDATE_RN%%\n" \
-                          "\n#### Incident Types\n##### Hello World Incident Type\n- %%UPDATE_RN%%\n" \
-                          "\n#### Indicator Types\n##### Hello World Indicator Type\n- %%UPDATE_RN%%\n" \
-                          "\n#### Widgets\n##### Hello World Widget\n- %%UPDATE_RN%%\n" \
-                          "\n#### Dashboards\n##### Hello World Dashboard\n- %%UPDATE_RN%%\n" \
-                          "\n#### Connections\n##### Hello World Connection\n- %%UPDATE_RN%%\n" \
-                          "\n#### Reports\n##### Hello World Report\n- %%UPDATE_RN%%\n"
+        expected_result = \
+            "\n#### Classifiers\n##### Hello World Classifier\n- %%UPDATE_RN%%\n" \
+            "\n#### Connections\n##### Hello World Connection\n- %%UPDATE_RN%%\n" \
+            "\n#### Dashboards\n##### Hello World Dashboard\n- %%UPDATE_RN%%\n" \
+            "\n#### Incident Fields\n##### Hello World IncidentField\n- %%UPDATE_RN%%\n" \
+            "\n#### Incident Types\n##### Hello World Incident Type\n- %%UPDATE_RN%%\n" \
+            "\n#### Indicator Types\n##### Hello World Indicator Type\n- %%UPDATE_RN%%\n" \
+            "\n#### Integrations\n##### Hello World Integration\n- %%UPDATE_RN%%\n" \
+            "\n#### Layouts\n##### Hello World Layout\n- %%UPDATE_RN%%\n" \
+            "\n#### Playbooks\n##### Hello World Playbook\n- %%UPDATE_RN%%\n" \
+            "\n#### Reports\n##### Hello World Report\n- %%UPDATE_RN%%\n" \
+            "\n#### Scripts\n##### Hello World Script\n- %%UPDATE_RN%%\n" \
+            "\n#### Widgets\n##### Hello World Widget\n- %%UPDATE_RN%%\n"
 
         from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         update_rn = UpdateRN(pack="HelloWorld", update_type='minor', pack_files={'HelloWorld'}, added_files=set())

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -28,6 +28,7 @@ class TestRNUpdate(unittest.TestCase):
             "\n#### Indicator Types\n##### Hello World Indicator Type\n- %%UPDATE_RN%%\n" \
             "\n#### Integrations\n##### Hello World Integration\n- %%UPDATE_RN%%\n" \
             "\n#### Layouts\n##### Hello World Layout\n- %%UPDATE_RN%%\n" \
+            "##### Second Hello World Layout\n- %%UPDATE_RN%%\n" \
             "\n#### Playbooks\n##### Hello World Playbook\n- %%UPDATE_RN%%\n" \
             "\n#### Reports\n##### Hello World Report\n- %%UPDATE_RN%%\n" \
             "\n#### Scripts\n##### Hello World Script\n- %%UPDATE_RN%%\n" \
@@ -45,6 +46,7 @@ class TestRNUpdate(unittest.TestCase):
             "Hello World Layout": "Layouts",
             "Hello World Incident Type": "Incident Types",
             "Hello World Indicator Type": "Indicator Types",
+            "Second Hello World Layout": "Layouts",
             "Hello World Widget": "Widgets",
             "Hello World Dashboard": "Dashboards",
             "Hello World Connection": "Connections",

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -297,7 +297,7 @@ class TestRNUpdateUnit:
 - %%UPDATE_RN%%
 """
 
-    diff_package = [('Layouts/VulnDB/VulnDB.json', ('VulnDB', 'Layout')),
+    diff_package = [('Layouts/VulnDB/VulnDB.json', ('VulnDB', 'Layouts')),
                     ('Classifiers/VulnDB/VulnDB.json', ('VulnDB', 'Classifiers')),
                     ('IncidentTypes/VulnDB/VulnDB.json', ('VulnDB', 'Incident Types')),
                     ('IncidentFields/VulnDB/VulnDB.json', ('VulnDB', 'Incident Fields')),

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -160,7 +160,7 @@ class UpdateRN:
             elif 'Classifiers' in file_path:
                 _file_type = 'Classifiers'
             elif 'Layouts' in file_path:
-                _file_type = 'Layout'
+                _file_type = 'Layouts'
             elif 'Reports' in file_path:
                 _file_type = 'Reports'
             elif 'Widgets' in file_path:
@@ -255,7 +255,7 @@ class UpdateRN:
         widgets_header = False
         dashboards_header = False
         connections_header = False
-        for k, v in sorted(changed_items.items(), key=lambda x: x[1], reverse=True):
+        for k, v in sorted(changed_items.items(), key=lambda x: x[1]):
             if k == 'N/A':
                 continue
             elif v == 'Integration':
@@ -283,7 +283,7 @@ class UpdateRN:
                     rn_string += '\n#### Classifiers\n'
                     classifier_header = True
                 rn_string += f'##### {k}\n- %%UPDATE_RN%%\n'
-            elif v == 'Layout':
+            elif v == 'Layouts':
                 if not layout_header:
                     rn_string += '\n#### Layouts\n'
                     layout_header = True

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -255,7 +255,7 @@ class UpdateRN:
         widgets_header = False
         dashboards_header = False
         connections_header = False
-        for k, v in changed_items.items():
+        for k, v in sorted(changed_items.items(), key=lambda x: x[1], reverse=True):
             if k == 'N/A':
                 continue
             elif v == 'Integration':
@@ -283,7 +283,7 @@ class UpdateRN:
                     rn_string += '\n#### Classifiers\n'
                     classifier_header = True
                 rn_string += f'##### {k}\n- %%UPDATE_RN%%\n'
-            elif v == 'Layouts':
+            elif v == 'Layout':
                 if not layout_header:
                     rn_string += '\n#### Layouts\n'
                     layout_header = True


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/25925

## Description
Dict of identified items was unsorted, so when iterating over the dict, if a value was repeated with another value in between the two, it would break the order of the generated release notes.