### PR TITLE
fix typo and print to stdout generate docs

### DIFF
--- a/demisto_sdk/commands/common/update_id_set.py
+++ b/demisto_sdk/commands/common/update_id_set.py
@@ -1268,7 +1268,9 @@ def re_create_id_set(id_set_path: str = "./Tests/id_set.json", objects_to_create
 
     duplicates = find_duplicates(new_ids_dict, print_logs)
     if any(duplicates) and print_logs:
-        print_error('The following duplicates were found: {}'.format(duplicates))
+        print_error(
+            f'The following duplicates ids were found: {json.dumps(duplicates, indent=4)}\n'
+        )
 
     return new_ids_dict
 
@@ -1291,7 +1293,7 @@ def find_duplicates(id_set, print_logs):
         lists_to_return.append(dup_list)
 
     if print_logs:
-        print_color("Checking diff for Incident and Idicator Fields", LOG_COLORS.GREEN)
+        print_color("Checking diff for Incident and Indicator Fields", LOG_COLORS.GREEN)
 
     fields = id_set['IncidentFields'] + id_set['IndicatorFields']
     field_ids = {list(field.keys())[0] for field in fields}

--- a/demisto_sdk/commands/common/update_id_set.py
+++ b/demisto_sdk/commands/common/update_id_set.py
@@ -1269,7 +1269,7 @@ def re_create_id_set(id_set_path: str = "./Tests/id_set.json", objects_to_create
     duplicates = find_duplicates(new_ids_dict, print_logs)
     if any(duplicates) and print_logs:
         print_error(
-            f'The following duplicates ids were found: {json.dumps(duplicates, indent=4)}\n'
+            f'The following ids were found duplicates\n{json.dumps(duplicates, indent=4)}\n'
         )
 
     return new_ids_dict

--- a/demisto_sdk/commands/generate_docs/generate_script_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_script_doc.py
@@ -42,7 +42,7 @@ def generate_script_doc(input, examples, output: str = None, permissions: str = 
         dependencies, _ = get_depends_on(script)
 
         # get the script usages by the id set
-        id_set_creator = IDSetCreator()
+        id_set_creator = IDSetCreator(output=None, print_logs=False)
         id_set = id_set_creator.create_id_set()
         used_in = get_used_in(id_set, script_id)
 


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/23650

## Description
Fixed typo and turned off the output of id_set in generate_script_doc

