### PR TITLE
Fix Content Creator's Copying of the `id_set.json` File

### DIFF
--- a/demisto_sdk/commands/create_artifacts/content_creator.py
+++ b/demisto_sdk/commands/create_artifacts/content_creator.py
@@ -654,7 +654,7 @@ class ContentCreator:
                 shutil.make_archive(self.content_zip, 'zip', self.content_bundle)
                 shutil.make_archive(self.test_zip, 'zip', self.test_bundle)
 
-                shutil.copyfile("./Tests/id_set.json", os.path.join(self.artifacts_path, "id_set.json"))
+                self.copy_file_to_artifacts("./Tests/id_set.json")
 
             shutil.make_archive(self.packs_zip, 'zip', self.packs_bundle)
 


### PR DESCRIPTION
## Status
- [x] Ready

## Description
The command would fail if `id_set.json` file was not present to be copied to the artifacts. Now it will copy it if the file is present, otherwise, it will continue.
