### PR TITLE
set integration dependency of indicator types as optional

### DIFF
--- a/demisto_sdk/commands/find_dependencies/find_dependencies.py
+++ b/demisto_sdk/commands/find_dependencies/find_dependencies.py
@@ -238,7 +238,7 @@ class PackDependencies:
     @staticmethod
     def _label_as_optional(pack_ids):
         """
-        Sets pack as mandatory.
+        Sets pack as optional.
 
         Args:
             pack_ids (set): collection of pack ids to set as optional.

--- a/demisto_sdk/commands/find_dependencies/find_dependencies.py
+++ b/demisto_sdk/commands/find_dependencies/find_dependencies.py
@@ -236,6 +236,20 @@ class PackDependencies:
         return [(p, True) for p in pack_ids]
 
     @staticmethod
+    def _label_as_optional(pack_ids):
+        """
+        Sets pack as mandatory.
+
+        Args:
+            pack_ids (set): collection of pack ids to set as optional.
+
+        Returns:
+            list: collection of pack id and whether mandatory flag.
+
+        """
+        return [(p, False) for p in pack_ids]
+
+    @staticmethod
     def _collect_scripts_dependencies(pack_scripts, id_set):
         """
         Collects script pack dependencies.
@@ -437,7 +451,7 @@ class PackDependencies:
 
             if packs_found_from_integrations:
                 pack_dependencies_data = PackDependencies. \
-                    _label_as_mandatory(packs_found_from_integrations)
+                    _label_as_optional(packs_found_from_integrations)
                 dependencies_packs.update(pack_dependencies_data)
 
             related_scripts = incident_field_data.get('scripts', [])

--- a/demisto_sdk/commands/find_dependencies/tests/find_dependencies_test.py
+++ b/demisto_sdk/commands/find_dependencies/tests/find_dependencies_test.py
@@ -518,7 +518,12 @@ class TestDependsOnIndicatorType:
         Then
             - Extracting the packs that the indicator type depends on.
         """
-        expected_result = {("Feedsslabusech", True), ("AbuseDB", True), ("ActiveMQ", True), ("CommonScripts", True), ("Carbon_Black_Enterprise_Response", True)}
+        expected_result = {
+            # integration dependencies
+            ("Feedsslabusech", False), ("AbuseDB", False), ("ActiveMQ", False),
+            # script dependencies
+            ("CommonScripts", True), ("Carbon_Black_Enterprise_Response", True)
+        }
 
         test_input = [
             {


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
all integrations dependencies of indicator type are marked as optional.
need to add tests

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
