### PR TITLE
Add message to prompt users to commit their changes before running update RN command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Running `demisto-sdk validate` will run the **validate** command using git and only on committed files (same as using *-g --post-commit*).
 * Fixed an issue where release notes were not checked correctly in **validate** command.
 * Fixed an issue in the **create-id-set** command where optional playbook tasks were not taken into consideration.
+* Added a prompt to the `demisto-sdk update-release-notes` command to prompt users to commit changes before running the release notes command.
 
 #### 1.1.5
 * Fixed an issue in **find-dependencies** command.

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -820,7 +820,8 @@ def update_pack_releasenotes(**kwargs):
                             f"along with the pack name.")
                 sys.exit(0)
     if (len(modified) < 1) and (len(added) < 1):
-        print_warning('No changes were detected.')
+        print_warning('No changes were detected. If changes were made, please commit the changes '
+                      'and rerun the command')
         sys.exit(0)
     if is_all and not _pack:
         packs = list(_packs - packs_existing_rn)


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: internal

## Description
* Added a prompt to the `demisto-sdk update-release-notes` command to prompt users to commit changes before running the release notes command when no changes are detected.