### PR TITLE
remove style props when formatting md (generate docs)

### DIFF
--- a/demisto_sdk/commands/generate_docs/common.py
+++ b/demisto_sdk/commands/generate_docs/common.py
@@ -196,11 +196,9 @@ def execute_command(command_example, insecure: bool):
             if entry.contents:
                 content: str = entry.contents
                 if isinstance(content, STRING_TYPES):
-                    md_example += content
+                    md_example = format_md(content)
                 else:
-                    md_example += json.dumps(content)
-
-            md_example = format_md(md_example)
+                    md_example = f'```\n{json.dumps(content, sort_keys=True, indent=4)}\n```'
 
     except RuntimeError:
         errors.append('The provided example for cmd {} has failed...'.format(cmd))
@@ -261,6 +259,7 @@ def build_example_dict(command_examples: list, insecure: bool):
 def format_md(md: str) -> str:
     """
     Formats a given md string by replacing <br> and <hr> tags with <br/> or <hr/>
+    Will also remove style tags such as: style="background:#eeeeee; border:1px solid #cccccc; padding:5px" which cause mdx to fail
     :param
         md (str): String representing mark down.
     :return:
@@ -269,6 +268,7 @@ def format_md(md: str) -> str:
     replace_tuples = [
         (r'<br>(</br>)?', '<br/>'),
         (r'<hr>(</hr>)?', '<hr/>'),
+        (r'style="[a-zA-Z0-9:;#\.\s\(\)\-\,]*?"', ''),
     ]
     if md:
         for old, new in replace_tuples:

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -51,6 +51,8 @@ def test_format_md():
     # these are a valid but we replace for completeness
     assert format_md('test<br></br>\nthis<br>again').count('<br/>') == 2
     assert format_md('test<hr></hr>\nthis<hr>again').count('<hr/>') == 2
+    # test removing style
+    assert 'style=' not in format_md('<div style="background:#eeeeee; border:1px solid #cccccc; padding:5px 10px">"this is a test"</div>')
 
 
 def test_stringEscapeMD():


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
If an html element contains a style prop it will cause mdx to fail rendering. Added regex to remove style prop. Also improved md example if receiving json.

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
