### PR TITLE
handle wrong pack name in find dependencies

### DIFF
--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -869,8 +869,15 @@ def find_dependencies_command(**kwargs):
     id_set_path = kwargs.get('id_set_path')
     verbose = kwargs.get('verbose')
     update_pack_metadata = not kwargs.get('no_update')
-    PackDependencies.find_dependencies(pack_name=pack_name, id_set_path=id_set_path, debug_file_path=verbose,
-                                       update_pack_metadata=update_pack_metadata)
+
+    try:
+        PackDependencies.find_dependencies(pack_name=pack_name,
+                                           id_set_path=id_set_path,
+                                           debug_file_path=verbose,
+                                           update_pack_metadata=update_pack_metadata,
+                                           )
+    except ValueError as exp:
+        print_error(str(exp))
 
 
 @main.resultcallback()

--- a/demisto_sdk/commands/find_dependencies/find_dependencies.py
+++ b/demisto_sdk/commands/find_dependencies/find_dependencies.py
@@ -827,6 +827,9 @@ class PackDependencies:
         pack_items['classifiers'] = PackDependencies._search_for_pack_items(pack_id, id_set['Classifiers'])
         pack_items['mappers'] = PackDependencies._search_for_pack_items(pack_id, id_set['Mappers'])
 
+        if not sum(pack_items.values(), []):
+            raise ValueError(f"Couldn't find any items for pack '{pack_id}'. make sure your spelling is correct.")
+
         return pack_items
 
     @staticmethod
@@ -968,6 +971,7 @@ class PackDependencies:
         else:
             with open(id_set_path, 'r') as id_set_file:
                 id_set = json.load(id_set_file)
+
         with VerboseFile(debug_file_path) as verbose_file:
             dependency_graph = PackDependencies.build_dependency_graph(
                 pack_id=pack_name, id_set=id_set, verbose_file=verbose_file,

--- a/demisto_sdk/tests/integration_tests/find_dependencies_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/find_dependencies_integration_test.py
@@ -24,7 +24,7 @@ EMPTY_ID_SET = {
 }
 
 
-def test_integration_find_dependencies__sanity(repo):
+def test_integration_find_dependencies__sanity(mocker, repo):
     """
     Given
     - Valid pack folder
@@ -40,6 +40,9 @@ def test_integration_find_dependencies__sanity(repo):
     """
     pack = repo.create_pack('FindDependencyPack')
     integration = pack.create_integration('integration')
+    mocker.patch(
+        "demisto_sdk.commands.find_dependencies.find_dependencies.update_pack_metadata_with_dependencies",
+    )
 
     # Change working dir to repo
     with ChangeCWD(integration.repo_path):

--- a/demisto_sdk/tests/integration_tests/find_dependencies_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/find_dependencies_integration_test.py
@@ -47,7 +47,6 @@ def test_integration_find_dependencies__sanity(repo):
         result = runner.invoke(main, [FIND_DEPENDENCIES_CMD,
                                       '-p', os.path.basename(repo.packs[0].path),
                                       '-v', os.path.join(repo.path, 'debug.md'),
-                                      '--no-update',
                                       ])
     assert 'Found dependencies result for FindDependencyPack pack:' in result.output
     assert "{}" in result.output

--- a/demisto_sdk/tests/integration_tests/find_dependencies_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/find_dependencies_integration_test.py
@@ -98,6 +98,47 @@ def test_integration_find_dependencies__sanity_with_id_set(repo):
     assert result.stderr == ""
 
 
+def test_integration_find_dependencies__not_a_pack(repo):
+    """
+    Given
+    - Valid pack folder
+
+    When
+    - Running find-dependencies on it.
+
+    Then
+    - Ensure find-dependencies passes.
+    - Ensure no error occurs.
+    """
+    pack = repo.create_pack('FindDependencyPack')
+    integration = pack.create_integration('integration')
+    id_set = EMPTY_ID_SET.copy()
+    id_set['integrations'].append({
+        'integration': {
+            'name': integration.name,
+            'file_path': integration.path,
+            'commands': [
+                'test-command',
+            ],
+            'pack': 'FindDependencyPack',
+        }
+    })
+
+    repo.id_set.write_json(id_set)
+
+    # Change working dir to repo
+    with ChangeCWD(integration.repo_path):
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(main, [FIND_DEPENDENCIES_CMD,
+                                      '-p', 'NotValidPack',
+                                      '-i', repo.id_set.path,
+                                      '--no-update',
+                                      ])
+    assert "Couldn't find any items for pack" in result.output
+    assert result.exit_code == 0
+    assert result.stderr == ""
+
+
 def test_integration_find_dependencies__with_dependency(repo):
     """
     Given


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/26678

## Description
print an error message in case of misspelled pack name

## Screenshots
![image](https://user-images.githubusercontent.com/30797606/88488255-a6df8f80-cf94-11ea-9867-06450325e38e.png)


## Must have
- [ ] Tests
- [ ] Documentation
