### PR TITLE
Fixed Lint and Unit Test on master branch

### DIFF
--- a/demisto_sdk/commands/lint/lint_manager.py
+++ b/demisto_sdk/commands/lint/lint_manager.py
@@ -209,8 +209,11 @@ class LintManager:
               f"{content_repo.active_branch}{Colors.reset}")
         staged_files = {content_repo.working_dir / Path(item.b_path).parent for item in
                         content_repo.active_branch.commit.tree.diff(None, paths=pkgs)}
-        last_common_commit = content_repo.merge_base(content_repo.active_branch.commit,
-                                                     content_repo.remote().refs.master)
+        if content_repo.active_branch != content_repo.heads.master:
+            last_common_commit = content_repo.merge_base(content_repo.active_branch.commit,
+                                                         content_repo.remote().refs.master)
+        else:
+            last_common_commit = content_repo.remote().refs.master.commit.parents[0]
         changed_from_master = {content_repo.working_dir / Path(item.b_path).parent for item in
                                content_repo.active_branch.commit.tree.diff(last_common_commit, paths=pkgs)}
         all_changed = staged_files.union(changed_from_master)


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold 

## Related Issues
fixes: https://github.com/demisto/etc/issues/26869

## Description
In case active branch is master, `last_common_commit` will be set to previous master commit (equivalent to `'origin/master~1'`)