### PR TITLE
validate file type in RN creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-* Fixed an issue where **update-release-notes** command were not checked files type correctly.
+* Fixed an issue where **update-release-notes** command failed on invalid file types.
 
 # 1.1.8
 * Fixed a regression where **upload** command failed on test playbooks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+* Fixed an issue where **update-release-notes** command were not checked files type correctly.
 
 # 1.1.8
 * Fixed a regression where **upload** command failed on test playbooks.

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -51,6 +51,7 @@ class TestRNUpdate(unittest.TestCase):
             "Hello World Dashboard": {"type": "Dashboards", "description": "", "is_new_file": False},
             "Hello World Connection": {"type": "Connections", "description": "", "is_new_file": False},
             "Hello World Report": {"type": "Reports", "description": "", "is_new_file": False},
+            "N/A": {"type": None, "description": "", "is_new_file": True},
         }
         release_notes = update_rn.build_rn_template(changed_items)
         assert expected_result == release_notes

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -51,7 +51,7 @@ class TestRNUpdate(unittest.TestCase):
             "Hello World Dashboard": {"type": "Dashboards", "description": "", "is_new_file": False},
             "Hello World Connection": {"type": "Connections", "description": "", "is_new_file": False},
             "Hello World Report": {"type": "Reports", "description": "", "is_new_file": False},
-            "N/A": {"type": None, "description": "", "is_new_file": True},
+            "N/A2": {"type": None, "description": "", "is_new_file": True},
         }
         release_notes = update_rn.build_rn_template(changed_items)
         assert expected_result == release_notes

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -266,7 +266,7 @@ class UpdateRN:
         dashboards_header = False
         connections_header = False
         for content_name, data in sorted(changed_items.items(),
-                                         key=lambda x: x[1].get('type') if x[1].get('type') is not None else ''):
+                                         key=lambda x: x[1].get('type', '') if x[1].get('type') is not None else ''):
             desc = data.get('description', '')
             is_new_file = data.get('is_new_file', False)
             _type = data.get('type', '')

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -59,12 +59,13 @@ class UpdateRN:
             self.find_added_pack_files()
             for packfile in self.pack_files:
                 file_name, file_type = self.identify_changed_file_type(packfile)
-                if file_type:
-                    changed_files[file_name] = {
-                        'type': file_type,
-                        'description': get_file_description(packfile, file_type),
-                        'is_new_file': True if packfile in self.added_files else False
-                    }
+
+                changed_files[file_name] = {
+                    'type': file_type,
+                    'description': get_file_description(packfile, file_type),
+                    'is_new_file': True if packfile in self.added_files else False
+                }
+
             rn_string = self.build_rn_template(changed_files)
             if len(rn_string) > 0:
                 if self.is_bump_required():
@@ -264,7 +265,8 @@ class UpdateRN:
         widgets_header = False
         dashboards_header = False
         connections_header = False
-        for content_name, data in sorted(changed_items.items(), key=lambda x: x[1].get('type') if x[1] is not None else ''):
+        for content_name, data in sorted(changed_items.items(),
+                                         key=lambda x: x[1].get('type') if x[1].get('type') is not None else ''):
             desc = data.get('description', '')
             is_new_file = data.get('is_new_file', False)
             _type = data.get('type', '')

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -59,14 +59,12 @@ class UpdateRN:
             self.find_added_pack_files()
             for packfile in self.pack_files:
                 file_name, file_type = self.identify_changed_file_type(packfile)
-
-                changed_files[file_name] = {
-                    'type': file_type,
-                    'description': get_file_description(packfile, file_type),
-                    'is_new_file': True if packfile in self.added_files else False
-                }
-            print('==========')
-            print(changed_files)
+                if file_type:
+                    changed_files[file_name] = {
+                        'type': file_type,
+                        'description': get_file_description(packfile, file_type),
+                        'is_new_file': True if packfile in self.added_files else False
+                    }
             rn_string = self.build_rn_template(changed_files)
             if len(rn_string) > 0:
                 if self.is_bump_required():

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -270,7 +270,9 @@ class UpdateRN:
             desc = data.get('description', '')
             is_new_file = data.get('is_new_file', False)
             _type = data.get('type', '')
-            if not _type:
+
+            # Skipping the invalid files
+            if not _type or content_name == 'N/A':
                 continue
 
             if _type in ('Connections', 'Incident Types', 'Indicator Types', 'Layouts', 'Incident Fields'):
@@ -279,9 +281,7 @@ class UpdateRN:
                 rn_desc = f'##### New: {content_name}\n- {desc}\n' if is_new_file \
                     else f'##### {content_name}\n- %%UPDATE_RN%%\n'
 
-            if content_name == 'N/A':
-                continue
-            elif _type == 'Integration':
+            if _type == 'Integration':
                 if not integration_header:
                     rn_string += '\n#### Integrations\n'
                     integration_header = True

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -65,7 +65,8 @@ class UpdateRN:
                     'description': get_file_description(packfile, file_type),
                     'is_new_file': True if packfile in self.added_files else False
                 }
-
+            print('==========')
+            print(changed_files)
             rn_string = self.build_rn_template(changed_files)
             if len(rn_string) > 0:
                 if self.is_bump_required():
@@ -265,7 +266,7 @@ class UpdateRN:
         widgets_header = False
         dashboards_header = False
         connections_header = False
-        for content_name, data in sorted(changed_items.items(), key=lambda x: x[1]['type'] if x[1] is not None else ''):
+        for content_name, data in sorted(changed_items.items(), key=lambda x: x[1].get('type') if x[1] is not None else ''):
             desc = data.get('description', '')
             is_new_file = data.get('is_new_file', False)
             _type = data.get('type', '')


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/27382

## Description
Updated the method `build_rn_template` - make sure that file type is not None before build the release notes for this item.
