### PR TITLE
handle_error better suggestion how to fix

### DIFF
--- a/demisto_sdk/commands/common/hook_validations/base_validator.py
+++ b/demisto_sdk/commands/common/hook_validations/base_validator.py
@@ -79,7 +79,10 @@ class BaseValidator:
         if should_print:
             if suggested_fix:
                 click.secho(formatted_error[:-1], fg="bright_red")
-                click.secho(suggested_fix + "\n", fg="bright_red")
+                if error_code == 'ST109':
+                    click.secho("Please add to the root of the yml a description.\n", fg="bright_red")
+                else:
+                    click.secho(suggested_fix + "\n", fg="bright_red")
 
             else:
                 click.secho(formatted_error, fg="bright_red")

--- a/demisto_sdk/commands/common/tests/base_validator_test.py
+++ b/demisto_sdk/commands/common/tests/base_validator_test.py
@@ -44,6 +44,10 @@ def test_handle_error():
     assert 'path/to/file_name - [BA101]' not in FOUND_FILES_AND_ERRORS
     assert 'path/to/file_name - [BA101]' in FOUND_FILES_AND_IGNORED_ERRORS
 
+    formatted_error = base_validator.handle_error("Error-message", "ST109", "path/to/file_name")
+    assert formatted_error == 'path/to/file_name: [ST109] - Error-message\n'
+    assert 'path/to/file_name - [ST109]' in FOUND_FILES_AND_ERRORS
+
 
 def test_check_deprecated_where_ignored_list_exists(repo):
     """


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/26881

## Screenshots
```
================= Validating file =================

Validating Packs/PcapAnalysis/Playbooks/playbook-PCAP_File_Carving.yml as playbook
Validating scheme for Packs/PcapAnalysis/Playbooks/playbook-PCAP_File_Carving.yml
ERROR:pykwalify.core:validation.invalid
ERROR:pykwalify.core: --- All found errors ---
ERROR:pykwalify.core:["Cannot find required key 'description'. Path: ''"]
Packs/PcapAnalysis/Playbooks/playbook-PCAP_File_Carving.yml: [ST109] - Missing description in root
Please add to the root of the yml a description.


=========== Found errors in the following files ===========

Packs/PcapAnalysis/Playbooks/playbook-PCAP_File_Carving.yml - [ST109]

The files were found as invalid, the exact error message can be located above
```

## Must have
- [x] Tests - no, as it is in click.secho
