### PR TITLE
download rename file

### DIFF
--- a/demisto_sdk/commands/download/downloader.py
+++ b/demisto_sdk/commands/download/downloader.py
@@ -604,7 +604,7 @@ class Downloader:
         file_ending: str = custom_content_object['file_ending']
 
         dir_output_path: str = os.path.join(self.output_pack_path, file_entity)
-        file_output_name: str = os.path.basename(file_path)
+        file_output_name: str = os.path.basename(f'{file_name}.{file_ending}')
         file_output_path: str = os.path.join(dir_output_path, file_output_name)
         try:
             shutil.move(src=file_path, dst=file_output_path)

--- a/demisto_sdk/commands/download/tests/downloader_test.py
+++ b/demisto_sdk/commands/download/tests/downloader_test.py
@@ -643,8 +643,9 @@ class TestMergeNewFile:
             entity = param['custom_content_object']['entity']
             output_dir_path = f'{temp_dir}/{entity}'
             os.mkdir(output_dir_path)
-            old_file_path = param['custom_content_object']['path']
-            new_file_path = f'{output_dir_path}/{os.path.basename(old_file_path)}'
+            old_file_name = param['custom_content_object']['name']
+            old_file_type = param['custom_content_object']['type']
+            new_file_path = f'{output_dir_path}/{old_file_name}.{old_file_type}'
             downloader = Downloader(output=temp_dir, input='')
             downloader.merge_new_file(param['custom_content_object'])
             assert os.path.isfile(new_file_path)


### PR DESCRIPTION

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/issues/assigned

## Description
Currently when using the command to download a playbook it adds "playbook-" prefix.
Changing it, not needed anymore.

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
