### PR TITLE
Init Author Option and Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+* Updated the **init** command. Relevant only when passing the *--contribution* argument.
+   * Added the *--author* option.
+   * The *support* field of the pack's metadata is set to *community*.
 * Added a proper error message in the **Validate** command upon a missing description in the root of the yml.
 * **Format** now works with a relative path.
 * **Validate** now fails when all release notes have been excluded.

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -666,12 +666,18 @@ def generate_test_playbook(**kwargs):
     "This will format the contents of the zip file to a pack format ready for contribution "
     "in the content repository on your local machine. The command should be executed from the "
     "content repository's base directory. When this option is passed, the only other options "
-    "that are considered are \"name\" and \"description\" - all others are ignored.")
+    "that are considered are \"name\", \"description\" and \"author\" - all others are ignored.")
 @click.option(
     '-d', '--description',
     type=click.STRING,
     default='',
     help="The description to attach to the converted contribution pack. Used when the \"contribution\" "
+    "option is passed.")
+@click.option(
+    '--author',
+    type=click.STRING,
+    default='',
+    help="The author to attach to the converted contribution pack. Used when the \"contribution\" "
     "option is passed.")
 def init(**kwargs):
     initiator = Initiator(**kwargs)


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Add the `--author` option to `init` command's cli arguments. Update the changelog to reflect the updates made to the `init` command relevant to contribution zip file conversion.

## Must have
- [ ] Tests
- [x] Documentation
