### PR TITLE
Catch meta_data join error when path is not found in RN command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 * Fixed an issue where **lint** did not run on circle when docker did not return ping.
 * Updated the missing release notes error message (RN106) in the **Validate** command.
+* Fixed an issue where a non-descriptive error would be returned when giving the **update-release-notes** command a pack which can not be found.
 
 # 1.1.10
 * Updated the **init** command. Relevant only when passing the *--contribution* argument.

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -39,7 +39,7 @@ class UpdateRN:
             self.metadata_path = os.path.join(self.pack_path, 'pack_metadata.json')
         except TypeError:
             print_error(f"pack_metadata.json was not found for the {self.pack} pack. Please verify "
-                        f"the pack name is correct.")
+                        f"the pack path is correct.")
             sys.exit(1)
 
     def execute_update(self):

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -38,8 +38,9 @@ class UpdateRN:
         try:
             self.metadata_path = os.path.join(self.pack_path, 'pack_metadata.json')
         except TypeError:
-            print_warning(f"pack_metadata.json was not found for the {self.pack} pack. Please verify "
-                          f"the pack name is correct.")
+            print_error(f"pack_metadata.json was not found for the {self.pack} pack. Please verify "
+                        f"the pack name is correct.")
+            sys.exit(1)
 
     def execute_update(self):
         if self.pack in IGNORED_PACK_NAMES:

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -29,13 +29,17 @@ class UpdateRN:
         self.update_type = update_type
         self.pack_meta_file = PACKS_PACK_META_FILE_NAME
         self.pack_path = pack_name_to_path(self.pack)
-        self.metadata_path = os.path.join(self.pack_path, 'pack_metadata.json')
         self.pack_files = pack_files
         self.added_files = added_files
         self.pre_release = pre_release
         self.specific_version = specific_version
         self.existing_rn_changed = False
         self.pack_metadata_only = pack_metadata_only
+        try:
+            self.metadata_path = os.path.join(self.pack_path, 'pack_metadata.json')
+        except TypeError:
+            print_warning(f"pack_metadata.json was not found for the {self.pack} pack. Please verify "
+                          f"the pack name is correct.")
 
     def execute_update(self):
         if self.pack in IGNORED_PACK_NAMES:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/27849

## Description
Error was caused when giving an incomplete path as an input.
