### PR TITLE
Lint - Fix Rerun handling

### DIFF
--- a/demisto_sdk/commands/lint/linter.py
+++ b/demisto_sdk/commands/lint/linter.py
@@ -467,7 +467,8 @@ class Linter:
                             elif not no_pwsh_test and check == "pwsh_test":
                                 exit_code, output = self._docker_run_pwsh_test(test_image=image_id,
                                                                                keep_container=keep_container)
-
+                        # If lint check perfrom and failed on reason related to enviorment will run twice,
+                        # But it failing in second time it will count as test failure.
                         if exit_code == RERUN and trial == 1:
                             self._pkg_lint_status["exit_code"] |= EXIT_CODES[check]
                             status[f"{check}_errors"] = output

--- a/demisto_sdk/commands/lint/linter.py
+++ b/demisto_sdk/commands/lint/linter.py
@@ -468,11 +468,11 @@ class Linter:
                                 exit_code, output = self._docker_run_pwsh_test(test_image=image_id,
                                                                                keep_container=keep_container)
 
-                        if (exit_code != RERUN or trial == 2) and exit_code:
+                        if exit_code == RERUN and trial == 1:
                             self._pkg_lint_status["exit_code"] |= EXIT_CODES[check]
                             status[f"{check}_errors"] = output
                             break
-                        elif exit_code != RERUN:
+                        elif exit_code == FAIL or exit_code == SUCCESS:
                             break
             else:
                 status["image_errors"] = str(errors)


### PR DESCRIPTION
FYI - @glicht @yaakovi 

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Fix wrong handling when rerun should be done.

Build for validation (Excepted behavior - Fail on Pytest) - https://app.circleci.com/pipelines/github/demisto/content/23877/workflows/eebf4734-131f-4afa-ae9a-6c5415c43322/jobs/95383
