### PR TITLE
fixed a bug in update-release-notes command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-
+* Fixed an issue where **update-release-notes** crashed when a file was renamed.
 
 # 1.1.11
 * Added line number to secrets' path in **secrets** command report.

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -839,6 +839,7 @@ def update_pack_releasenotes(**kwargs):
     validate_manager = ValidateManager(skip_pack_rn_validation=True)
     validate_manager.setup_git_params()
     modified, added, old, changed_meta_files, _packs = validate_manager.get_modified_and_added_files('...', 'origin/master')
+    modified = [file_[1] if isinstance(file_, tuple) else file_ for file_ in modified]
 
     packs_existing_rn = set()
     for pf in added:

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -839,7 +839,6 @@ def update_pack_releasenotes(**kwargs):
     validate_manager = ValidateManager(skip_pack_rn_validation=True)
     validate_manager.setup_git_params()
     modified, added, old, changed_meta_files, _packs = validate_manager.get_modified_and_added_files('...', 'origin/master')
-    modified = [file_[1] if isinstance(file_, tuple) else file_ for file_ in modified]
 
     packs_existing_rn = set()
     for pf in added:

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -598,3 +598,26 @@ class TestRNUpdateUnit:
         mocker.patch('sys.exit', return_value=None)
         bump_result = update_rn.is_bump_required()
         assert bump_result is expected_result
+
+    def test_renamed_files(self):
+        """
+        Given:
+            A file was renamed
+        When:
+            Bumping release notes with update-release-notes command.
+        Then:
+            file list should contain the new file path and ignore the old path.
+        """
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
+        modified_files = {
+            'file1',
+            ('file2', 'file2_new'),
+            'file3'
+        }
+        update_rn = UpdateRN(pack_path="Packs/Base", update_type='minor', pack_files=modified_files,
+                             added_files=set())
+
+        assert 'file1' in update_rn.pack_files
+        assert 'file2_new' in update_rn.pack_files
+        assert ('file2', 'file2_new') not in update_rn.pack_files
+        assert 'file3' in update_rn.pack_files

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -30,7 +30,8 @@ class UpdateRN:
         self.update_type = update_type
         self.pack_meta_file = PACKS_PACK_META_FILE_NAME
         self.pack_path = pack_name_to_path(self.pack)
-        self.pack_files = pack_files
+        # renamed files will appear in the modified list as a tuple: (old path, new path)
+        self.pack_files = {file_[1] if isinstance(file_, tuple) else file_ for file_ in pack_files}
         self.added_files = added_files
         self.pre_release = pre_release
         self.specific_version = specific_version


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
fixed an issue where update release notes crash when a file was renamed.

## Screenshots
before:
![image](https://user-images.githubusercontent.com/30797606/91974133-019fa000-ed26-11ea-9d6d-7dac6dd69227.png)

after:
![image](https://user-images.githubusercontent.com/30797606/91974161-0f552580-ed26-11ea-8d78-8776d93d350c.png)


## Must have
- [ ] Tests
- [ ] Documentation
