### PR TITLE
Fixed an issue where single changed files did not required release no…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
-* Fixed an issue were doc_images required release-notes and validations.
+* Fixed an issue where single changed files did not required release notes update.
+* Fixed an issue where doc_images required release-notes and validations.
 
 # 1.2.0
 * Fixed an issue where **format** did not update the test playbook from its pack.

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -188,12 +188,14 @@ class TestRNUpdate(unittest.TestCase):
             - case 1: only the readme was added/modified
             - case 2: other files except the readme were added/modified
             - case 3: only docs images were added/modified
+            - case 4: readme and py files were added/modified
         When:
             - calling the function that check if only the readme changed
         Then:
             - case 1: validate that the output of the function is True
             - case 2: validate that the output of the function is False
             - case 3: validate that the output of the function is True
+            - case 4: validate that the output of the function is False
         """
         from demisto_sdk.commands.update_release_notes.update_rn import \
             UpdateRN
@@ -224,6 +226,16 @@ class TestRNUpdate(unittest.TestCase):
         update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='minor', modified_files_in_pack={'HelloWorld/README.md'},
                              added_files={'HelloWorld/doc_files/added_params.png'})
         assert update_rn.only_docs_changed()
+
+        # case 4:
+        update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='minor', modified_files_in_pack=set(),
+                             added_files={'HelloWorld/doc_files/added_params.png', 'HelloWorld/HelloWorld.yml'})
+        assert not update_rn.only_docs_changed()
+
+        update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='minor',
+                             modified_files_in_pack={'HelloWorld/README.md', 'HelloWorld/HelloWorld.yml'},
+                             added_files=set())
+        assert not update_rn.only_docs_changed()
 
     def test_find_corresponding_yml(self):
         """

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -155,7 +155,7 @@ class UpdateRN:
 
     def only_docs_changed(self):
         changed_files = self.added_files.union(self.modified_files_in_pack)
-        if (len(changed_files) == 1 and 'README' in changed_files) or \
+        if (len(changed_files) == 1 and 'README' in changed_files[0]) or \
                 (all('README' in file or ('.png' in file and '_image.png' not in file) for file in changed_files)):
             return True
         return False

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -155,7 +155,7 @@ class UpdateRN:
 
     def only_docs_changed(self):
         changed_files = self.added_files.union(self.modified_files_in_pack)
-        if (len(changed_files) == 1 and 'README' in changed_files[0]) or \
+        if (len(changed_files) == 1 and 'README' in changed_files) or \
                 (all('README' in file or ('.png' in file and '_image.png' not in file) for file in changed_files)):
             return True
         return False

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -155,7 +155,8 @@ class UpdateRN:
 
     def only_docs_changed(self):
         changed_files = self.added_files.union(self.modified_files_in_pack)
-        if (len(changed_files) == 1 and 'README' in changed_files) or \
+        changed_files_copy = changed_files  # copying as pop will leave the file out of the set
+        if (len(changed_files) == 1 and 'README' in changed_files_copy.pop()) or \
                 (all('README' in file or ('.png' in file and '_image.png' not in file) for file in changed_files)):
             return True
         return False

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -1,7 +1,7 @@
 """
 This script is used to create a release notes template
 """
-
+import copy
 import errno
 import json
 import os
@@ -155,7 +155,7 @@ class UpdateRN:
 
     def only_docs_changed(self):
         changed_files = self.added_files.union(self.modified_files_in_pack)
-        changed_files_copy = changed_files  # copying as pop will leave the file out of the set
+        changed_files_copy = copy.deepcopy(changed_files)  # copying as pop will leave the file out of the set
         if (len(changed_files) == 1 and 'README' in changed_files_copy.pop()) or \
                 (all('README' in file or ('.png' in file and '_image.png' not in file) for file in changed_files)):
             return True

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -155,7 +155,7 @@ class UpdateRN:
 
     def only_docs_changed(self):
         changed_files = self.added_files.union(self.modified_files_in_pack)
-        if (len(changed_files) == 1 and 'README' in changed_files.pop()) or \
+        if (len(changed_files) == 1 and 'README' in changed_files) or \
                 (all('README' in file or ('.png' in file and '_image.png' not in file) for file in changed_files)):
             return True
         return False


### PR DESCRIPTION
…tes update

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/28143

## Description
```
/Users/bkatzir/dev/demisto/demisto-sdk/.tox/py37/bin/python /Users/bkatzir/dev/demisto/demisto-sdk/demisto_sdk/__main__.py update-release-notes -i Packs/CommonScripts/ -u revision
You are using demisto-sdk 1.1.7.dev52, however version 1.2.0 is available.
You should consider upgrading via "pip3 install --upgrade demisto-sdk" command.
Starting to update release notes.
Collecting all committed files
Collecting all local changed files against the content master
Finished updating release notes for CommonScripts.
Next Steps:
 - Please review the created release notes found at Packs/CommonScripts/ReleaseNotes/1_2_41.md and document any changes you made by replacing '%%UPDATE_RN%%'.
 - Commit the new release notes to your branch.
For information regarding proper format of the release notes, please refer to https://xsoar.pan.dev/docs/integrations/changelog

Process finished with exit code 0

```

## Must have
- [x] Tests
- [x] Documentation
