### PR TITLE
Api module release notes support to validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Added handling of dependent packs when running **update-release-notes** on changed *APIModules*.
     * Added new argument *--id-set-path* for id_set.json path.
     * When changes to *APIModule* is detected and an id_set.json is available - the command will update the dependent pack as well.
+* Added handling of dependent packs when running **validate** on changed *APIModules*.
+    * Added new argument *--id-set-path* for id_set.json path.
+    * When changes to *APIModule* is detected and an id_set.json is available - the command will validate that the dependent pack has release notes as well.
 * Fixed an issue where the find_type function didn't recognize file types correctly.
 
 # 1.2.0

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -273,6 +273,9 @@ def unify(**kwargs):
 @click.option(
     '--skip-pack-dependencies', is_flag=True,
     help='Skip validation of pack dependencies.')
+@click.option(
+    "-idp", "--id-set-path", help="The path of the id-set.json used for validations.",
+    type=click.Path(resolve_path=True))
 @pass_config
 def validate(config, **kwargs):
     sys.path.append(config.configuration.env_dir)
@@ -296,7 +299,8 @@ def validate(config, **kwargs):
                                     print_ignored_files=kwargs['print_ignored_files'],
                                     no_docker_checks=kwargs['no_docker_checks'],
                                     silence_init_prints=kwargs['silence_init_prints'],
-                                    skip_dependencies=kwargs['skip_pack_dependencies'])
+                                    skip_dependencies=kwargs['skip_pack_dependencies'],
+                                    id_set_path=kwargs.get('id_set_path'))
         return validator.run_validation()
 
 

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -11,7 +11,7 @@ import click
 from demisto_sdk.commands.common import tools
 from demisto_sdk.commands.common.configuration import Configuration
 # Common tools
-from demisto_sdk.commands.common.constants import FileType
+from demisto_sdk.commands.common.constants import API_MODULES_PACK, FileType
 from demisto_sdk.commands.common.tools import (find_type,
                                                get_last_remote_release_version,
                                                get_pack_name,
@@ -900,7 +900,7 @@ def update_pack_releasenotes(**kwargs):
                                           added_files=added, specific_version=specific_version)
                 update_pack_rn.execute_update()
 
-    if 'ApiModules' in _pack:
+    if API_MODULES_PACK in _pack:
         # case: ApiModules
         update_api_modules_dependents_rn(_pack, pre_release, update_type, added, modified, id_set_path)
 

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -19,7 +19,7 @@ import requests
 import urllib3
 import yaml
 from demisto_sdk.commands.common.constants import (
-    ALL_FILES_VALIDATION_IGNORE_WHITELIST, CLASSIFIERS_DIR,
+    ALL_FILES_VALIDATION_IGNORE_WHITELIST, API_MODULES_PACK, CLASSIFIERS_DIR,
     CONTENT_GITHUB_LINK, CONTENT_GITHUB_ORIGIN, CONTENT_GITHUB_UPSTREAM,
     DASHBOARDS_DIR, DEF_DOCKER, DEF_DOCKER_PWSH, DOC_FILES_DIR,
     ID_IN_COMMONFIELDS, ID_IN_ROOT, INCIDENT_FIELDS_DIR, INCIDENT_TYPES_DIR,
@@ -394,9 +394,9 @@ def get_api_module_ids(file_list):
     if file_list:
         for pf in file_list:
             parent = pf
-            while '/ApiModules/Scripts/' in parent:
+            while f'/{API_MODULES_PACK}/Scripts/' in parent:
                 parent = get_parent_directory_name(parent, abs_path=True)
-                if '/ApiModules/Scripts/' in parent:
+                if f'/{API_MODULES_PACK}/Scripts/' in parent:
                     pf = parent
             if parent != pf:
                 api_module_set.add(os.path.basename(pf))

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -674,6 +674,44 @@ class TestValidators:
                                                                       old_format_files=set(),
                                                                       added_files=added_files) is False
 
+    def test_validate_no_missing_release_notes__happy_rn_dependent_on_api_module(self, repo, mocker, tmpdir):
+        """
+            Given:
+                - APIModule pack has a change relevant for another pack
+                - APIModule modified files and release notes present
+                - dependent pack has NO CHANGES
+                - dependent pack has release notes
+            When:
+                - running validate_no_missing_release_notes on the file
+            Then:
+                - return a True as there are no release notes missing
+        """
+        mocker.patch.object(BaseValidator, "update_checked_flags_by_support_level", return_value="")
+        pack1 = repo.create_pack('ApiModules')
+        api_script1 = pack1.create_script('APIScript')
+        pack2_name = 'ApiDependent'
+        pack2 = repo.create_pack(pack2_name)
+        integration2 = pack2.create_integration(pack2_name)
+        id_set_content = {'integrations':
+                          [
+                              {'ApiDependent':
+                               {'name': integration2.name,
+                                'file_path': integration2.path,
+                                'pack': pack2_name,
+                                'api_modules': api_script1.name
+                                }
+                               }
+                          ]}
+        id_set_f = tmpdir / "id_set.json"
+        id_set_f.write(json.dumps(id_set_content))
+        validate_manager = ValidateManager(id_set_path=id_set_f.strpath)
+        modified_files = {api_script1.yml_path}
+        added_files = {'Packs/ApiModules/ReleaseNotes/1_0_0.md', 'Packs/ApiDependent/ReleaseNotes/1_0_0.md'}
+        with ChangeCWD(repo.path):
+            assert validate_manager.validate_no_missing_release_notes(modified_files=modified_files,
+                                                                      old_format_files=set(),
+                                                                      added_files=added_files) is True
+
     def test_validate_no_missing_release_notes__missing_rn_in_old_format_files(self, repo, mocker):
         """
             Given:

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -8,7 +8,7 @@ import click
 from demisto_sdk.commands.common import tools
 from demisto_sdk.commands.common.configuration import Configuration
 from demisto_sdk.commands.common.constants import (
-    CONTENT_ENTITIES_DIRS, KNOWN_FILE_STATUSES, PACKS_DIR,
+    API_MODULES_PACK, CONTENT_ENTITIES_DIRS, KNOWN_FILE_STATUSES, PACKS_DIR,
     PACKS_INTEGRATION_NON_SPLIT_YML_REGEX, PACKS_PACK_IGNORE_FILE_NAME,
     PACKS_PACK_META_FILE_NAME, PACKS_SCRIPT_NON_SPLIT_YML_REGEX, FileType)
 from demisto_sdk.commands.common.errors import (ALLOWED_IGNORE_ERRORS,

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -63,7 +63,7 @@ class ValidateManager:
     def __init__(self, is_backward_check=True, prev_ver=None, use_git=False, only_committed_files=False,
                  print_ignored_files=False, skip_conf_json=True, validate_id_set=False, file_path=None,
                  validate_all=False, is_external_repo=False, skip_pack_rn_validation=False, print_ignored_errors=False,
-                 silence_init_prints=False, no_docker_checks=False, skip_dependencies=False):
+                 silence_init_prints=False, no_docker_checks=False, skip_dependencies=False, id_set_path=None):
         # General configuration
         self.skip_docker_checks = False
         self.no_configuration_prints = silence_init_prints
@@ -83,6 +83,9 @@ class ValidateManager:
         # Class constants
         self.handle_error = BaseValidator(print_as_warnings=print_ignored_errors).handle_error
         self.file_path = file_path
+        if not id_set_path:
+            id_set_path = 'Tests/id_set.json'
+        self.id_set_path = id_set_path
         self.branch_name = ''
         self.changes_in_schema = False
         self.check_only_schema = False
@@ -614,8 +617,8 @@ class ValidateManager:
 
         changed_packs = modified_packs.union(added_packs).union(changed_meta_packs)
 
-        if not os.path.isfile('Tests/id_set.json'):
-            IDSetCreator(print_logs=False, output='Tests/id_set.json').create_id_set()
+        if not os.path.isfile(self.id_set_path):
+            IDSetCreator(print_logs=False, output=self.id_set_path).create_id_set()
 
         for pack in changed_packs:
             raise_version = False
@@ -624,7 +627,7 @@ class ValidateManager:
                 raise_version = True
             valid_pack_files.add(self.validate_pack_unique_files(
                 pack_path, self.get_error_ignore_list(pack), should_version_raise=raise_version,
-                id_set_path='Tests/id_set.json'))
+                id_set_path=self.id_set_path))
 
         return all(valid_pack_files)
 


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/24157
continues PR: https://github.com/demisto/demisto-sdk/pull/744

## Description
Add the following behavior:
* demisto-sdk validate validates that the APIModule change is accompanied by release notes for all related packs.

## Screenshots
Paste here any images that will help the reviewer
![image](https://user-images.githubusercontent.com/20818773/93217358-a03def00-f771-11ea-8132-7c60af9f65e3.png)

## Must have
- [x] Tests

