### PR TITLE
Fix lint duplicate log message

### DIFF
--- a/demisto_sdk/commands/create_artifacts/content_artifacts_creator.py
+++ b/demisto_sdk/commands/create_artifacts/content_artifacts_creator.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import logging
 import os
 import re
 import sys
@@ -36,7 +37,7 @@ FIRST_MARKETPLACE_VERSION = parse('6.0.0')
 IGNORED_PACKS = ['ApiModules']
 IGNORED_TEST_PLAYBOOKS_DIR = 'Deprecated'
 ContentObject = Union[YAMLContentUnifiedObject, YAMLContentObject, JSONContentObject, TextObject]
-logger = logging_setup(3)
+logger: logging.Logger
 EX_SUCCESS = 0
 EX_FAIL = 1
 
@@ -75,6 +76,9 @@ class ArtifactsManager:
 
 
 def create_content_artifacts(artifact_manager: ArtifactsManager) -> int:
+    global logger
+    logger = logging_setup(3)
+
     with ArtifactsDirsHandler(artifact_manager), ProcessPoolHandler(artifact_manager) as pool:
         futures: List[ProcessFuture] = []
         # content/Packs


### PR DESCRIPTION
FYI - @yaakovi @bakatzir @orhovy @roysagi 

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/28546

## Description
Fixing duplicate lint log messages, I produced this bug when I rewrite the `content-create-artifacts` command, However I believe that we should develop a better mechanism for logging in our code (Singleton or any other solution) so it will not happen again.

## Screenshots
After fix:
![image](https://user-images.githubusercontent.com/53563021/93448931-d2b82b00-f8dc-11ea-8189-cfc1a5ffae7d.png)