### PR TITLE
[Fix] update-release-notes failing with exception when no path is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 * Added support for layoutscontainer in **init** contribution flow.
 * Added a validation for tlp_color param in feeds in **validate** command.
-* Fixed and issue where **update-release-notes** was failing with wrong error message if no pack or input was given.
+* Fixed an issue where **update-release-notes** was failing with a wrong error message if no pack or input was given.
 
 # 1.2.1
 * Added an additional linter `XSOAR-linter` to the **lint** command which custom validates py files. currently checks for:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 * Added support for layoutscontainer in **init** contribution flow.
 * Added a validation for tlp_color param in feeds in **validate** command.
+* Fixed and issue where **update-release-notes** was failing with wrong error message if no pack or input was given.
 
 # 1.2.1
 * Added an additional linter `XSOAR-linter` to the **lint** command which custom validates py files. currently checks for:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 * Added support for layoutscontainer in **init** contribution flow.
 * Added a validation for tlp_color param in feeds in **validate** command.
-* Fixed an issue where **update-release-notes** was failing with a wrong error message if no pack or input was given.
+* Fixed an issue where **update-release-notes** was failing with a wrong error message when no pack or input was given.
 
 # 1.2.1
 * Added an additional linter `XSOAR-linter` to the **lint** command which custom validates py files. currently checks for:

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -902,7 +902,7 @@ def update_pack_releasenotes(**kwargs):
                                           added_files=added, specific_version=specific_version)
                 update_pack_rn.execute_update()
 
-    if API_MODULES_PACK in _pack:
+    if _pack and API_MODULES_PACK in _pack:
         # case: ApiModules
         update_api_modules_dependents_rn(_pack, pre_release, update_type, added, modified, id_set_path)
 


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Fixed an issue where **update-release-notes** was failing with a wrong error message if no pack or input was given.

```
Starting to update release notes.
Collecting all committed files
Collecting all local changed files against the content master
Traceback (most recent call last):
  File "/Users/darbel/.pyenv/versions/3.8.0/bin/demisto-sdk", line 11, in <module>
    load_entry_point('demisto-sdk==1.2.1', 'console_scripts', 'demisto-sdk')()
  File "/Users/darbel/.pyenv/versions/3.8.0/lib/python3.8/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/Users/darbel/.pyenv/versions/3.8.0/lib/python3.8/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/Users/darbel/.pyenv/versions/3.8.0/lib/python3.8/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/darbel/.pyenv/versions/3.8.0/lib/python3.8/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/darbel/.pyenv/versions/3.8.0/lib/python3.8/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/Users/darbel/.pyenv/versions/3.8.0/lib/python3.8/site-packages/demisto_sdk/__main__.py", line 901, in update_pack_releasenotes
    if 'ApiModules' in _pack:
TypeError: argument of type 'NoneType' is not iterable
```