### PR TITLE
Gen docs small improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Added support for layoutscontainer in **init** contribution flow.
 * Added a validation for tlp_color param in feeds in **validate** command.
 * Fixed an issue where **update-release-notes** was failing with a wrong error message when no pack or input was given.
+* Improved formatting output of the **generate-docs** command.
 
 # 1.2.1
 * Added an additional linter `XSOAR-linter` to the **lint** command which custom validates py files. currently checks for:

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -807,7 +807,7 @@ def generate_doc(**kwargs):
     '-h', '--help'
 )
 @click.option(
-    "-o", "--output", help="Output file path, the default is the Tests directory.", required=False)
+    "-o", "--output", help="Output file path, the default is the Tests directory.", default='', required=False)
 def id_set_command(**kwargs):
     id_set_creator = IDSetCreator(**kwargs)
     id_set_creator.create_id_set()

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -717,9 +717,10 @@ def init(**kwargs):
     required=False
 )
 @click.option(
-    "-e", "--examples", help="Path for file containing command or script examples."
-                             " Each Command should be in a separate line."
-                             " For script - the script example surrounded by double quotes.")
+    "-e", "--examples", help="Integrations: path for file containing command examples."
+                             " Each command should be in a separate line."
+                             " Scripts: the script example surrounded by quotes."
+                             " For example: -e '!ConvertFile entry_id=<entry_id>'")
 @click.option(
     "-p", "--permissions", type=click.Choice(["none", "general", "per-command"]), help="Permissions needed.",
     required=True, default='none')

--- a/demisto_sdk/commands/common/update_id_set.py
+++ b/demisto_sdk/commands/common/update_id_set.py
@@ -1059,10 +1059,10 @@ def re_create_id_set(id_set_path: Optional[str] = DEFAULT_ID_SET_PATH, objects_t
         except ValueError:
             refresh_interval = -1
             print_color(
-                f"Re-creating id_set.\n"
-                f"DEMISTO_SDK_ID_SET_REFRESH_INTERVAL env var is set with value: "
+                "Re-creating id_set.\n"
+                "DEMISTO_SDK_ID_SET_REFRESH_INTERVAL env var is set with value: "
                 f"{os.getenv('DEMISTO_SDK_ID_SET_REFRESH_INTERVAL')} which is an illegal integer."
-                f"\nPlease modify or unset env var.", LOG_COLORS.YELLOW
+                "\nPlease modify or unset env var.", LOG_COLORS.YELLOW
             )
         if refresh_interval > 0:  # if file is newer than refersh interval use it as is
             mtime = os.path.getmtime(id_set_path)

--- a/demisto_sdk/commands/common/update_id_set.py
+++ b/demisto_sdk/commands/common/update_id_set.py
@@ -1054,7 +1054,16 @@ def re_create_id_set(id_set_path: Optional[str] = DEFAULT_ID_SET_PATH, objects_t
     if id_set_path == "":
         id_set_path = DEFAULT_ID_SET_PATH
     if id_set_path and os.path.exists(id_set_path):
-        refresh_interval = int(os.getenv('DEMISTO_SDK_ID_SET_REFRESH_INTERVAL', -1))
+        try:
+            refresh_interval = int(os.getenv('DEMISTO_SDK_ID_SET_REFRESH_INTERVAL', -1))
+        except ValueError:
+            refresh_interval = -1
+            print_color(
+                f"Re-creating id_set.\n"
+                f"DEMISTO_SDK_ID_SET_REFRESH_INTERVAL env var is set with value: "
+                f"{os.getenv('DEMISTO_SDK_ID_SET_REFRESH_INTERVAL')} which is an illegal integer."
+                f"\nPlease modify or unset env var.", LOG_COLORS.YELLOW
+            )
         if refresh_interval > 0:  # if file is newer than refersh interval use it as is
             mtime = os.path.getmtime(id_set_path)
             mtime_dt = datetime.fromtimestamp(mtime)

--- a/demisto_sdk/commands/create_id_set/create_id_set.py
+++ b/demisto_sdk/commands/create_id_set/create_id_set.py
@@ -7,7 +7,7 @@ class IDSetCreator:
 
         Args:
             output (str, optional): The output path. Set to None to avoid creation of a file. '' means the default path.
-             Defaults to ''.
+             Defaults to 'Tests/id_set.json'.
             print_logs (bool, optional): Print log output. Defaults to True.
         """
         self.output = output

--- a/demisto_sdk/commands/create_id_set/create_id_set.py
+++ b/demisto_sdk/commands/create_id_set/create_id_set.py
@@ -3,6 +3,13 @@ from demisto_sdk.commands.common.update_id_set import re_create_id_set
 
 class IDSetCreator:
     def __init__(self, output: str = '', print_logs: bool = True):
+        """IDSetCreator
+
+        Args:
+            output (str, optional): The output path. Set to None to avoid creation of a file. '' means the default path.
+             Defaults to ''.
+            print_logs (bool, optional): Print log output. Defaults to True.
+        """
         self.output = output
         self.print_logs = print_logs
 

--- a/demisto_sdk/commands/create_id_set/tests/update_id_set_test.py
+++ b/demisto_sdk/commands/create_id_set/tests/update_id_set_test.py
@@ -48,7 +48,7 @@ class TestIDSetCreator:
     def test_create_id_set_no_output(self, mocker):
         import demisto_sdk.commands.common.update_id_set as uis
         mocker.patch.object(uis, 'cpu_count', return_value=1)
-        id_set_creator = IDSetCreator()
+        id_set_creator = IDSetCreator(output=None)
 
         id_set = id_set_creator.create_id_set()
         assert not os.path.exists(self.file_path)

--- a/demisto_sdk/commands/generate_docs/README.md
+++ b/demisto_sdk/commands/generate_docs/README.md
@@ -8,7 +8,8 @@ This command is used to create a documentation file for Cortex XSOAR content fil
 * **-i, --input**Path of the yml file.
 * **-o, --output** The output dir to write the documentation file into, documentation file name is README.md. If not specified, will be in the yml dir.
 * **-u, --use_cases** For integration - Top use-cases. Number the steps by '*' (i.e. '\* foo. * bar.').
-* **-e, --examples** Path for file containing command or script examples. Each Command should be in a separate line. For script - the script example surrounded by double quotes.
+* **-e, --examples** Integrations: path for file containing command examples. Each command should be in a separate line.
+  Scripts: the script example surrounded by quotes. For example: `-e '!ConvertFile entry_id=<entry_id>'`
 * **-p, --permissions** permissions in the documentation.
 * **-cp, --command_permissions** Path for file containing commands permissions. Each command permissions should be in a separate line (i.e. '!command-name Administrator READ-WRITE').
 * **-l, --limitations** Known limitations. Number the steps by '*' (i.e. '\* foo. * bar.').

--- a/demisto_sdk/commands/generate_docs/generate_integration_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_integration_doc.py
@@ -304,7 +304,7 @@ def generate_command_example(cmd, cmd_example=None):
     if context_example:
         example.extend([
             '#### Context Example',
-            '```',
+            '```json',
             '{}'.format(context_example),
             '```',
             '',

--- a/demisto_sdk/commands/generate_docs/generate_script_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_script_doc.py
@@ -1,4 +1,5 @@
 import os
+import random
 
 from demisto_sdk.commands.common.tools import (get_from_version, get_yaml,
                                                print_error, print_warning)
@@ -70,8 +71,17 @@ def generate_script_doc(input, examples, output: str = None, permissions: str = 
             doc.extend(generate_section('Permissions', ''))
 
         if used_in:
-            doc.extend(generate_list_section('Used In', used_in, True,
-                                             text='This script is used in the following playbooks and scripts.'))
+            if len(used_in) <= 10:
+                doc.extend(generate_list_section('Used In', used_in, True,
+                                                 text='This script is used in the following playbooks and scripts.'))
+            else:  # if we have more than 10 use a sample
+                print_warning(f'"Used In" section found too many scripts/playbooks ({len(used_in)}). Will use a sample of 10.'
+                              ' Full list is available as a comment in the README file.')
+                sample_used_in = random.sample(used_in, 10)
+                doc.extend(generate_list_section('Used In', sorted(sample_used_in), True,
+                                                 text='Sample usage of this script can be found in the following playbooks and scripts.'))
+                used_in_str = '\n'.join(used_in)
+                doc.append(f"<!--\nUsed In: list was truncated. Full list commented out for reference:\n\n{used_in_str}\n -->\n")
 
         doc.extend(generate_table_section(inputs, 'Inputs', 'There are no inputs for this script.'))
 
@@ -226,7 +236,7 @@ def generate_script_example(script_name, example=None):
         if md_example:
             example.extend([
                 '## Human Readable Output',
-                '{}'.format(md_example),
+                '{}'.format('>'.join(f'\n{md_example}'.splitlines(True))),  # prefix human readable with quote
                 '',
             ])
 

--- a/demisto_sdk/commands/generate_docs/generate_script_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_script_doc.py
@@ -47,7 +47,6 @@ def generate_script_doc(input, examples, output: str = None, permissions: str = 
         used_in = get_used_in(id_set, script_id)
 
         description = script.get('comment', '')
-        deprecated = script.get('deprecated', False)
         # get inputs/outputs
         inputs, inputs_errors = get_inputs(script)
         outputs, outputs_errors = get_outputs(script)
@@ -56,12 +55,9 @@ def generate_script_doc(input, examples, output: str = None, permissions: str = 
         errors.extend(outputs_errors)
 
         if not description:
-            errors.append('Error! You are missing description for the playbook')
+            errors.append('Error! You are missing a description for the Script')
 
-        if deprecated:
-            doc.append('`Deprecated`')
-
-        doc.append(description)
+        doc.append(description + '\n')
 
         doc.extend(generate_table_section(secript_info, 'Script Data'))
 
@@ -121,9 +117,11 @@ def get_script_info(script_path):
 
     from_version = get_from_version(script_path)
 
-    return [{'Name': 'Script Type', 'Description': script_type},
-            {'Name': 'Tags', 'Description': tags},
-            {'Name': 'Demisto Version', 'Description': from_version}]
+    res = [{'Name': 'Script Type', 'Description': script_type},
+           {'Name': 'Tags', 'Description': tags}]
+    if from_version != '0.0.0':
+        res.append({'Name': 'Demisto Version', 'Description': from_version})
+    return res
 
 
 def get_inputs(script):
@@ -219,7 +217,7 @@ def generate_script_example(script_name, example=None):
     if context_example:
         example.extend([
             '## Context Example',
-            '```',
+            '```json',
             '{}'.format(context_example),
             '```',
             '',

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -6,6 +6,8 @@ from demisto_sdk.commands.common.tools import get_json, get_yaml
 from demisto_sdk.commands.generate_docs.generate_integration_doc import (
     append_or_replace_command_in_docs, generate_commands_section,
     generate_integration_doc)
+from demisto_sdk.commands.generate_docs.generate_script_doc import \
+    generate_script_doc
 
 FILES_PATH = os.path.normpath(os.path.join(__file__, git_path(), 'demisto_sdk', 'tests', 'test_files'))
 FAKE_ID_SET = get_json(os.path.join(FILES_PATH, 'fake_id_set.json'))
@@ -441,6 +443,17 @@ def test_generate_commands_with_permissions_section():
         '#### Human Readable Output', '\n', '']
 
     assert '\n'.join(section) == '\n'.join(expected_section)
+
+
+def test_generate_script_doc(tmp_path, mocker):
+    d = tmp_path / "script_doc_out"
+    d.mkdir()
+    in_script = os.path.join(FILES_PATH, 'docs_test', 'script-Set.yml')
+    generate_script_doc(in_script, '', str(d), verbose=True)
+    readme = d / "README.md"
+    with open(readme) as f:
+        text = f.read()
+        assert 'There are no outputs for this script.' in text
 
 
 class TestAppendOrReplaceCommandInDocs:

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+from demisto_sdk.commands.common import update_id_set
 from demisto_sdk.commands.common.git_tools import git_path
 from demisto_sdk.commands.common.tools import get_json, get_yaml
 from demisto_sdk.commands.generate_docs.generate_integration_doc import (
@@ -449,6 +450,7 @@ def test_generate_script_doc(tmp_path, mocker):
     d = tmp_path / "script_doc_out"
     d.mkdir()
     in_script = os.path.join(FILES_PATH, 'docs_test', 'script-Set.yml')
+    mocker.patch.object(update_id_set, 're_create_id_set', return_value={})
     generate_script_doc(in_script, '', str(d), verbose=True)
     readme = d / "README.md"
     with open(readme) as f:

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -1,9 +1,10 @@
+import json
 import os
 
 import pytest
-from demisto_sdk.commands.common import update_id_set
 from demisto_sdk.commands.common.git_tools import git_path
 from demisto_sdk.commands.common.tools import get_json, get_yaml
+from demisto_sdk.commands.create_id_set.create_id_set import IDSetCreator
 from demisto_sdk.commands.generate_docs.generate_integration_doc import (
     append_or_replace_command_in_docs, generate_commands_section,
     generate_integration_doc)
@@ -450,12 +451,16 @@ def test_generate_script_doc(tmp_path, mocker):
     d = tmp_path / "script_doc_out"
     d.mkdir()
     in_script = os.path.join(FILES_PATH, 'docs_test', 'script-Set.yml')
-    mocker.patch.object(update_id_set, 're_create_id_set', return_value={})
+    id_set_file = os.path.join(FILES_PATH, 'docs_test', 'id_set.json')
+    with open(id_set_file, 'r') as f:
+        id_set = json.load(f)
+    patched = mocker.patch.object(IDSetCreator, 'create_id_set', return_value=id_set)
     generate_script_doc(in_script, '', str(d), verbose=True)
+    patched.assert_called()
     readme = d / "README.md"
     with open(readme) as f:
         text = f.read()
-        assert 'There are no outputs for this script.' in text
+        assert 'Sample usage of this script can be found in the following playbooks and scripts' in text
 
 
 class TestAppendOrReplaceCommandInDocs:

--- a/demisto_sdk/tests/test_files/docs_test/script-Set.yml
+++ b/demisto_sdk/tests/test_files/docs_test/script-Set.yml
@@ -1,0 +1,77 @@
+commonfields:
+  id: Set
+  version: -1
+name: Set
+script: >-
+  var ec = {};
+
+  var value;
+
+  try {
+      if (args.stringify === 'true') {
+          if (typeof args.value === 'string') {
+              value = args.value
+          } else {
+              value = JSON.stringify(args.value)
+          }
+      } else {
+          value = JSON.parse(args.value);
+      }
+  } catch(err) {
+      value = args.value;
+  }
+
+
+  ec[args.key] = value;
+
+  var result = {
+      Type: entryTypes.note,
+      Contents: ec,
+      ContentsFormat: formats.json,
+      HumanReadable: 'Key ' + args.key + ' set'
+  };
+
+
+  if (!args.append || args.append === 'false') {
+      setContext(args.key, value);
+  } else {
+      result.EntryContext = ec;
+  }
+
+
+  return result;
+type: javascript
+tags:
+- Utility
+comment: Set a value in context under the key you entered.
+enabled: true
+args:
+- name: key
+  required: true
+  default: true
+  description: The key to set. Can be a full path such as "Key.ID". 
+    If using append=true can also use a DT selector such as "Data(val.ID == obj.ID)".
+- name: value
+  required: true
+  description: The value to set to the key. Can be an array.
+  isArray: true
+- name: append
+  auto: PREDEFINED
+  predefined:
+  - "true"
+  - "false"
+  description: If false then the context key will be overwritten. If set to true
+    then the script will append to existing context key.
+- name: stringify
+  auto: PREDEFINED
+  predefined:
+  - "true"
+  - "false"
+  description: Whether the argument should be saved as a string.
+  defaultValue: "false"
+scripttarget: 0
+runonce: false
+runas: DBotWeakRole
+tests:
+- Set - Test
+fromversion: 5.0.0


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Small improvements to generate docs:

* Clarification on -e arg
* Use json formatting for context data
* Remove `Deprecated` logic in Script docs as this is handled in the the docs site.
* Script "Used In" to include max 10 entries
* Ignore 0.0.0 version (probably less relevant after move for version branch in content repo)
* Human Readable in script to be quoted as we do in integration docs
* Add _DEMISTO_SDK_ID_SET_REFRESH_INTERVAL_ (see changelog)
 

Generate doc can be seen here: 
https://github.com/demisto/content/blob/e94f5d29972183d33458e8743ef5f7ef619a6796/Packs/CommonScripts/Scripts/script-Set_README.md

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
