### PR TITLE
Fixed an issue where **update-release-notes** was crushing on `--all`…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+* Fixed an issue where **update-release-notes** was crushing on `--all` flag.
 * Fixed an issue where running **validate**, **update-release-notes** outside of content repo crushed without a meaningful error message.
 * Added support for layoutscontainer in **init** contribution flow.
 * Added a validation for tlp_color param in feeds in **validate** command.

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -881,7 +881,7 @@ def update_pack_releasenotes(**kwargs):
                             f"To update release notes in a specific pack, please use the -i parameter "
                             f"along with the pack name.")
                 sys.exit(0)
-    if (len(modified) < 1) and (len(added) < 1) and (len(old) < 1):
+    if not is_all and (len(modified) < 1) and (len(added) < 1) and (len(old) < 1):
         # case: changed_meta_files
         if len(changed_meta_files) < 1:
             print_warning('No changes were detected. If changes were made, please commit the changes '
@@ -899,7 +899,7 @@ def update_pack_releasenotes(**kwargs):
         packs_list = ''.join(f"{p}, " for p in packs)
         print_warning(f"Adding release notes to the following packs: {packs_list.rstrip(', ')}")
         for pack in packs:
-            update_pack_rn = UpdateRN(pack_path=pack, update_type=update_type,
+            update_pack_rn = UpdateRN(pack_path='', pack=pack, update_type=update_type,
                                       modified_files_in_pack=modified.union(old), pre_release=pre_release,
                                       added_files=added, specific_version=specific_version, text=text)
             update_pack_rn.execute_update()

--- a/demisto_sdk/tests/integration_tests/update_release_notes_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/update_release_notes_integration_test.py
@@ -40,7 +40,7 @@ def test_update_release_notes_new_integration(demisto_client, mocker):
     - Ensure the release motes content is valid and as expected.
     """
 
-    expected_rn = '\n' + '#### Integrations\n' +\
+    expected_rn = '\n' + '#### Integrations\n' + \
                   '##### New: Azure Feed\n' + \
                   '- Azure.CloudIPs Feed Integration.\n'
 
@@ -83,7 +83,7 @@ def test_update_release_notes_modified_integration(demisto_client, mocker):
     - Ensure the release motes content is valid and as expected.
     """
 
-    expected_rn = '\n' + '#### Integrations\n' +\
+    expected_rn = '\n' + '#### Integrations\n' + \
                   '##### Azure Feed\n' + \
                   '- %%UPDATE_RN%%\n'
     modified_files = {join(AZURE_FEED_PACK_PATH, 'Integrations', 'FeedAzureValid', 'FeedAzureValid.yml')}
@@ -126,7 +126,7 @@ def test_update_release_notes_incident_field(demisto_client, mocker):
     - Ensure the release motes content is valid and as expected.
     """
 
-    expected_rn = '\n' + '#### Incident Fields\n' +\
+    expected_rn = '\n' + '#### Incident Fields\n' + \
                   '- **City**\n'
 
     runner = CliRunner(mix_stderr=False)
@@ -230,13 +230,13 @@ def test_update_release_notes_existing(demisto_client, mocker):
     - Ensure message is printed when update release notes process finished.
     - Ensure the release motes content is valid and as expected.
     """
-    expected_rn = '\n' + '#### Integrations\n' +\
+    expected_rn = '\n' + '#### Integrations\n' + \
                   '##### New: Azure Feed\n' + \
                   '- Azure.CloudIPs Feed Integration.\n' + \
                   '\n' + '#### Incident Fields\n' + \
                   '- **City**'
 
-    input_rn = '\n' + '#### Integrations\n' +\
+    input_rn = '\n' + '#### Integrations\n' + \
                '##### New: Azure Feed\n' + \
                '- Azure.CloudIPs Feed Integration.\n'
 
@@ -323,3 +323,27 @@ def test_update_release_notes_modified_apimodule(demisto_client, repo, mocker):
     assert not result.exception
     assert 'Changes were detected. Bumping ApiModules to version: 1.0.1' in result.stdout
     assert 'Changes were detected. Bumping FeedTAXII to version: 1.0.2' in result.stdout
+
+
+def test_update_release_notes_all(demisto_client, mocker):
+    """
+    Given
+    - --all flag
+
+    When
+    - Running demisto-sdk update-release-notes command.
+
+    Then
+    - Ensure release notes are detected.
+    """
+    runner = CliRunner(mix_stderr=False)
+
+    mocker.patch.object(UpdateRN, 'is_bump_required', return_value=True)
+    mocker.patch.object(ValidateManager, 'get_modified_and_added_files', return_value=(set(), set(), set(), set(),
+                                                                                       {'FeedAzureValid'}))
+    mocker.patch.object(UpdateRN, 'get_pack_metadata', return_value={'currentVersion': '1.0.0'})
+
+    result = runner.invoke(main, [UPDATE_RN_COMMAND, "--all"])
+
+    assert result.exit_code == 0
+    assert 'Changes were detected. Bumping FeedAzureValid to version: 1.0.1' in result.stdout


### PR DESCRIPTION
… flag

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/28496

## Must have
- [x] Tests
