### PR TITLE
fixed an issue where jsontooutptus determined bool as int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+* Fixed an issue where **json-to-outputs** determined bool values as int.
 * Fixed an issue where **update-release-notes** was crushing on `--all` flag.
 * Fixed an issue where running **validate**, **update-release-notes** outside of content repo crushed without a meaningful error message.
 * Added support for layoutscontainer in **init** contribution flow.

--- a/demisto_sdk/commands/json_to_outputs/json_to_outputs.py
+++ b/demisto_sdk/commands/json_to_outputs/json_to_outputs.py
@@ -142,11 +142,12 @@ def determine_type(val):
     if isinstance(val, str):
         return 'String'
 
-    if isinstance(val, (int, float)):
-        return 'Number'
-
+    # bool is an sub class of int, so the we should first check isinstance of bool and only afterwards int
     if isinstance(val, bool):
         return 'Boolean'
+
+    if isinstance(val, (int, float)):
+        return 'Number'
 
     return 'Unknown'
 

--- a/demisto_sdk/commands/json_to_outputs/tests/json_to_outputs_test.py
+++ b/demisto_sdk/commands/json_to_outputs/tests/json_to_outputs_test.py
@@ -1,4 +1,6 @@
-from demisto_sdk.commands.json_to_outputs.json_to_outputs import parse_json
+import pytest
+from demisto_sdk.commands.json_to_outputs.json_to_outputs import (
+    determine_type, parse_json)
 
 
 def test_json_to_outputs__json_from_file():
@@ -86,3 +88,23 @@ outputs:
   description: ''
   type: Date
 '''
+
+
+INPUT = [(True, 'Boolean'),
+         (0, 'Number'),
+         (1, 'Number'),
+         (False, 'Boolean'),
+         ("test string", 'String')]
+
+
+@pytest.mark.parametrize('value, type', INPUT)
+def test_determine_type(value, type):
+    """
+    Given
+        - value of the dict.
+    When
+        - determine type function runs
+    Then
+        - ensure the returned type is correct
+    """
+    assert determine_type(value) == type


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/28471

## Description
isinstance of int was. checked before bool . bool is a subclass of int and as a result true was determined as int. converted the if statements to insure the correct type.

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
