### PR TITLE
Fix for mypy error for files which name starts with E

### DIFF
--- a/demisto_sdk/commands/lint/helpers.py
+++ b/demisto_sdk/commands/lint/helpers.py
@@ -429,9 +429,9 @@ def split_warnings_errors(output: str):
     error_list = []
     other_msg_list = []
     for msg in output_lst:
-        if msg.startswith('W') or 'W90' in msg:
+        if (msg.startswith('W') and msg[1].isdigit()) or 'W90' in msg:
             warnings_list.append(msg)
-        elif msg.startswith('E') or 'E90' in msg:
+        elif (msg.startswith('E') and msg[1].isdigit()) or 'E90' in msg:
             error_list.append(msg)
         else:
             other_msg_list.append(msg)

--- a/demisto_sdk/commands/lint/helpers.py
+++ b/demisto_sdk/commands/lint/helpers.py
@@ -425,8 +425,10 @@ def split_warnings_errors(output: str):
             list of error messags, list of warnings messages, list of all undetected messages
         """
     output_lst = output.split('\n')
+    # Warnings and errors lists currently relevant for XSOAR Linter
     warnings_list = []
     error_list = []
+    # Others list is relevant for mypy and flake8.
     other_msg_list = []
     for msg in output_lst:
         if (msg.startswith('W') and msg[1].isdigit()) or 'W90' in msg:

--- a/demisto_sdk/commands/lint/tests/helper_test.py
+++ b/demisto_sdk/commands/lint/tests/helper_test.py
@@ -113,7 +113,15 @@ MSG = [('flake8',
         "return-value]     \nreturn params^\n    Found 1 error in 1 file (checked 1 source file)",
         [], [], ["Maltiverse.py:31:12: error: Incompatible return value type (got",
                  "Dict[Any, Any]', expected 'str')[return-value]     ", "return params^",
-                 "    Found 1 error in 1 file (checked 1 source file)"])]
+                 "    Found 1 error in 1 file (checked 1 source file)"]),
+       ('mypy',
+        "Ebox.py:31:12: error: Incompatible return value type (got\nDict[Any, Any]', expected 'str')["
+        "return-value]     \nreturn params^\n    Found 1 error in 1 file (checked 1 source file)",
+        [], [], ["Ebox.py:31:12: error: Incompatible return value type (got",
+                 "Dict[Any, Any]', expected 'str')[return-value]     ", "return params^",
+                 "    Found 1 error in 1 file (checked 1 source file)"]),
+
+       ]
 
 
 @pytest.mark.parametrize('linter_name, input_msg, output_error, output_warning, output_other', MSG)


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues

## Description
added additional check in the split function. check not only if msg starts with E but also if there is the error number right after.

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
