### PR TITLE
Use Non-Interactive Format Command in the init Command

### DIFF
--- a/demisto_sdk/commands/init/initiator.py
+++ b/demisto_sdk/commands/init/initiator.py
@@ -244,7 +244,10 @@ class Initiator:
             # remove metadata.json file
             os.remove(os.path.join(pack_dir, 'metadata.json'))
             click.echo(f'Executing \'format\' on the restructured contribution zip files at "{pack_dir}"')
-            format_manager(input=pack_dir)
+            from_version = '6.0.0'
+            format_manager(
+                input=pack_dir, from_version=from_version, no_validate=True, update_docker=True, assume_yes=True
+            )
         except Exception as e:
             click.echo(
                 f'Creating a Pack from the contribution zip failed with error: {e}\n {traceback.format_exc()}',


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: link to the issue

## Description
Updates the `init` command's conversion flow of a contribution zip file to use the non-interactive version of the `demisto-sdk format` command.

## Must have
- [ ] Tests
- [ ] Documentation
