### PR TITLE
Build improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,14 +8,15 @@ references:
       filters:
         tags:
           only: /^v\d+\.\d+\.\d+$/
-    
+
     reqs_tox: &reqs_tox
       requires:
-        - tox3-8
+        - tox3-7
 
     reqs_content_checkout: &reqs_content_checkout
       requires:
         - checkout-content
+        - tox3-7
 
 jobs:
   tox3-7:
@@ -33,7 +34,11 @@ jobs:
             name: Tox build
             command: |
               pip install tox
-              tox -e py37 -v
+              tox -e py37 -v -- -n 4 --dist loadfile
+        - persist_to_workspace:
+            root: ~/project
+            paths:
+              - .tox
   tox3-8:
       docker:
         - image: circleci/python:3.8.3-buster-node
@@ -48,15 +53,18 @@ jobs:
             name: Tox build
             command: |
               pip install tox
-              tox -e py38 -v -- --cov=demisto_sdk --cov-report=html
+              tox -e py38 -v -- -n 4 --dist loadfile --cov=demisto_sdk --cov-report=html
         - store_artifacts:
             path: coverage_html_report
-        - persist_to_workspace:
-            root: ~/project
-            paths:
-              - coverage_html_report
-              - .coverage
-              - .tox
+        - run:
+            name: Coveralls upload
+            command: |
+              if [ -n "$COVERALLS_REPO_TOKEN" ]; then
+                pip install coveralls
+                coveralls
+              else
+                echo "Skipping coveralls"
+              fi
   precommit-checks:
       docker:
         - image: circleci/python:3.8.3-buster
@@ -67,26 +75,10 @@ jobs:
         - run:
             name: Pre-commit
             command: |
-              . .tox/py38/bin/activate
+              . .tox/py37/bin/activate
               pre-commit --version
               pre-commit run -a
               deactivate
-  coveralls-upload:
-      docker:
-        - image: circleci/python:3.8.3-buster
-      steps:
-        - checkout
-        - attach_workspace:
-            at: ~/project
-        - run:
-            name: Coveralls upload
-            command: |
-              if [ -n "$COVERALLS_REPO_TOKEN" ]; then
-                pip install coveralls
-                coveralls
-              else
-                echo "Skipping coveralls"
-              fi
   checkout-content:
       docker:
         - image: circleci/python:3.8.3-buster
@@ -94,7 +86,7 @@ jobs:
         - checkout
         - run:
             name: Checkout the Content Repo
-            command: |              
+            command: |
               git clone --depth 1 https://github.com/demisto/content.git
               cd content
               git config diff.renameLimit 5000
@@ -114,11 +106,11 @@ jobs:
             name: Test validate files and yaml
             when: always
             command: |
-              . .tox/py38/bin/activate
+              . .tox/py37/bin/activate
 
               cd content
               npm ci
-              
+
               CIRCLE_BRANCH="master" python3 ./Tests/scripts/update_conf_json.py
               CIRCLE_BRANCH="master" ./Tests/scripts/validate.sh
   create-id-set:
@@ -132,8 +124,8 @@ jobs:
             name: Test create ID set
             when: always
             command: |
-              . .tox/py38/bin/activate
-              
+              . .tox/py37/bin/activate
+
               cd content
               CIRCLE_BRANCH="master" demisto-sdk create-id-set -o ./Tests/id_set.json
   create-content-artifacts:
@@ -147,7 +139,7 @@ jobs:
             name: Test Create Content Artifacts
             when: always
             command: |
-              . .tox/py38/bin/activate
+              . .tox/py37/bin/activate
 
               cd content
               mkdir ./tmp
@@ -170,16 +162,12 @@ workflows:
   build_and_release:
     jobs:
       - tox3-7:
-          <<: *tag_filter          
+          <<: *tag_filter
       - tox3-8:
-          <<: *tag_filter          
+          <<: *tag_filter
       - checkout-content:
           <<: *tag_filter
-          <<: *reqs_tox
       - precommit-checks:
-          <<: *tag_filter
-          <<: *reqs_tox
-      - coveralls-upload:
           <<: *tag_filter
           <<: *reqs_tox
       - validate-files:
@@ -194,9 +182,8 @@ workflows:
       - deploy:
           <<: *tag_filter
           requires:
-            - tox3-7
+            - tox3-8
             - precommit-checks
-            - coveralls-upload
             - validate-files
             - create-id-set
             - create-content-artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
             name: Tox build
             command: |
               pip install tox
-              tox -e py37 -v -- -n 4 --dist loadfile
+              tox -e py37 -v
         - persist_to_workspace:
             root: ~/project
             paths:
@@ -53,7 +53,7 @@ jobs:
             name: Tox build
             command: |
               pip install tox
-              tox -e py38 -v -- -n 4 --dist loadfile --cov=demisto_sdk --cov-report=html
+              tox -e py38 -v -- --cov=demisto_sdk --cov-report=html
         - store_artifacts:
             path: coverage_html_report
         - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,16 +25,25 @@ jobs:
         - image: circleci/python:3.8.3-buster-node
       steps:
         - checkout
+        - restore_cache:
+            key: tox-3-7-cache-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
         - run:
             # install npm modules so readme tests run with mdx verification
             name: npm install
             command: |
               npm ci
         - run:
-            name: Tox build
+            name: Setup Tox
             command: |
               pip install tox
+        - run:
+            name: Tox build
+            command: |              
               tox -e py37 -v
+        - save_cache:
+            key: tox-3-7-cache-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+            paths:
+              - .tox/py38
         - persist_to_workspace:
             root: ~/project
             paths:
@@ -44,18 +53,27 @@ jobs:
         - image: circleci/python:3.8.3-buster-node
       steps:
         - checkout
+        - restore_cache:
+            key: tox-3-8-cache-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
         - run:
             # install npm modules so readme tests run with mdx verification
             name: npm install
             command: |
               npm ci
         - run:
-            name: Tox build
+            name: Setup Tox
             command: |
               pip install tox
+        - run:
+            name: Tox build
+            command: |              
               tox -e py38 -v -- --cov=demisto_sdk --cov-report=html
+        - save_cache:
+            key: tox-3-8-cache-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+            paths:
+              - .tox/py38
         - store_artifacts:
-            path: coverage_html_report
+            path: coverage_html_report        
         - run:
             name: Coveralls upload
             command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
         - save_cache:
             key: tox-3-7-cache-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
             paths:
-              - .tox/py38
+              - .tox/py37
         - persist_to_workspace:
             root: ~/project
             paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       steps:
         - checkout
         - restore_cache:
-            key: tox-3-7-cache-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+            key: tox-37-cache-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
         - run:
             # install npm modules so readme tests run with mdx verification
             name: npm install
@@ -41,7 +41,7 @@ jobs:
             command: |              
               tox -e py37 -v
         - save_cache:
-            key: tox-3-7-cache-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+            key: tox-37-cache-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
             paths:
               - .tox/py37
         - persist_to_workspace:
@@ -54,7 +54,7 @@ jobs:
       steps:
         - checkout
         - restore_cache:
-            key: tox-3-8-cache-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+            key: tox-38-cache-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
         - run:
             # install npm modules so readme tests run with mdx verification
             name: npm install
@@ -69,7 +69,7 @@ jobs:
             command: |              
               tox -e py38 -v -- --cov=demisto_sdk --cov-report=html
         - save_cache:
-            key: tox-3-8-cache-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+            key: tox-38-cache-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
             paths:
               - .tox/py38
         - store_artifacts:

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -459,6 +459,7 @@ class TestRNUpdate(unittest.TestCase):
 
 
 class TestRNUpdateUnit:
+    META_BACKUP = ""
     FILES_PATH = os.path.normpath(os.path.join(__file__, f'{git_path()}/demisto_sdk/tests', 'test_files'))
     CURRENT_RN = """
 #### Incident Types
@@ -514,6 +515,21 @@ class TestRNUpdateUnit:
                     ('Packs/VulnDB', 'Packs/VulnDB/TestPlaybooks/VulnDB/VulnDB.yml', ('N/A', None)),
                     ('Packs/CommonScripts', 'Packs/CommonScripts/TestPlaybooks/VulnDB/VulnDB.yml', ('N/A', None)),
                     ]
+
+    @pytest.fixture(autouse=True)
+    def setup(self, tmp_path):
+        """Tests below modify the file: 'demisto_sdk/commands/update_release_notes/tests_data/Packs/Test/pack_metadata.json'
+        We back it up and restore when done.
+
+        """
+        self.meta_backup = str(tmp_path / 'pack_metadata-backup.json')
+        shutil.copy('demisto_sdk/commands/update_release_notes/tests_data/Packs/Test/pack_metadata.json', self.meta_backup)
+
+    def teardown(self):
+        if self.meta_backup:
+            shutil.copy(self.meta_backup, 'demisto_sdk/commands/update_release_notes/tests_data/Packs/Test/pack_metadata.json')
+        else:
+            raise Exception('Expecting self.meta_backup to be set inorder to restore pack_metadata.json file')
 
     @pytest.mark.parametrize('pack_name, path, expected_result', diff_package)
     def test_ident_changed_file_type(self, pack_name, path, expected_result, mocker):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,5 @@ pytest
 pytest-cov
 pytest-datadir-ng
 pytest-mock
-pytest-xdist
 requests_mock
 tox-pyenv

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,5 +5,6 @@ pytest
 pytest-cov
 pytest-datadir-ng
 pytest-mock
+pytest-xdist
 requests_mock
 tox-pyenv


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Changed order of build steps to reduce build time. Build is down to under 20 minutes (before was over 25).

Main change is that tox-3-7 is used as dependency for the content repo tests instead of tox-3-8. tox 3-8 which is with coverage is run in paralel.

See the build in circleci for visual flow of the jobs.

## Additional
Added a small fix so unit test update rn doesn't modify files in the repo.

