### PR TITLE
support for DEMISTO_VERIFY_SSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-
+* Will use env var `DEMISTO_VERIFY_SSL` to determine if to use a secure connection for commands interacting with the Server when `--insecure` is not passed. If working with a local Server without a trusted certificate, you can set env var `DEMISTO_VERIFY_SSL=no` to avoid using `--insecure` on each command.
 
 # 1.2.5
 * Added support for special fields: *defaultclassifier*, *defaultmapperin*, *defaultmapperout* in **download** command.

--- a/demisto_sdk/commands/download/downloader.py
+++ b/demisto_sdk/commands/download/downloader.py
@@ -131,7 +131,8 @@ class Downloader:
         :return: True if fetched successfully, False otherwise
         """
         try:
-            self.client = demisto_client.configure(verify_ssl=not self.insecure)
+            verify = (not self.insecure) if self.insecure else None  # set to None so demisto_client will use env var DEMISTO_VERIFY_SSL
+            self.client = demisto_client.configure(verify_ssl=verify)
             api_response: tuple = demisto_client.generic_request_func(self.client, '/content/bundle', 'GET')
             body: bytes = ast.literal_eval(api_response[0])
             io_bytes = io.BytesIO(body)

--- a/demisto_sdk/commands/run_cmd/runner.py
+++ b/demisto_sdk/commands/run_cmd/runner.py
@@ -39,7 +39,8 @@ class Runner:
         self.log_verbose = verbose
         self.debug = debug
         self.debug_path = debug_path
-        self.client = demisto_client.configure(verify_ssl=not insecure)
+        verify = (not insecure) if insecure else None  # set to None so demisto_client will use env var DEMISTO_VERIFY_SSL
+        self.client = demisto_client.configure(verify_ssl=verify)
         self.json2outputs = json_to_outputs
         self.prefix = prefix
         self.raw_response = raw_response

--- a/demisto_sdk/commands/run_playbook/playbook_runner.py
+++ b/demisto_sdk/commands/run_playbook/playbook_runner.py
@@ -22,11 +22,11 @@ class PlaybookRunner:
         self.playbook_id = playbook_id
         self.should_wait = wait
         self.timeout = timeout
-
+        verify = (not insecure) if insecure else None  # we set to None so demisto_client will use env var DEMISTO_VERIFY_SSL
         # if url parameter is not provided, demisto_client will search the DEMISTO_BASE_URL env variable
         self.demisto_client = demisto_client.configure(
             base_url=url,
-            verify_ssl=not insecure)
+            verify_ssl=verify)
 
         self.base_link_to_workplan = self.get_base_link_to_workplan(url)
 

--- a/demisto_sdk/commands/upload/uploader.py
+++ b/demisto_sdk/commands/upload/uploader.py
@@ -32,7 +32,8 @@ class Uploader:
     def __init__(self, input: str, insecure: bool = False, verbose: bool = False):
         self.path = input
         self.log_verbose = verbose
-        self.client = demisto_client.configure(verify_ssl=not insecure)
+        verify = (not insecure) if insecure else None  # set to None so demisto_client will use env var DEMISTO_VERIFY_SSL
+        self.client = demisto_client.configure(verify_ssl=verify)
         self.status_code = 0
         self.successfully_uploaded_files: List[Tuple[str, str]] = []
         self.failed_uploaded_files: List[Tuple[str, str]] = []


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
In short: this PR allows setting the env var: `DEMISTO_VERIFY_SSL=no` and avoid passing `--insecure` every time.

We were ignoring the `DEMISTO_VERIFY_SSL` var when `--insecure` was not specified. This small PR changes this behaviour so the demisto-py client will use the env var when --insecure is not passed. if --insecure is passed then that will be used. If the var is not set we default to verify as before. 

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [x] Documentation (changelog)
