### PR TITLE
Format - skip unnecessary files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 * Fixed an issue in the **unify** command where it crashed on an integration without an image file.
+* Fixed an issue in the **format** command where unnecessary files were not skipped.
 
 # 1.2.6
 * No longer require setting `DEMISTO_README_VALIDATION` env var to enable README mdx validation. Validation will now run automatically if all necessary node modules are available.

--- a/TestSuite/pack.py
+++ b/TestSuite/pack.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import List, Optional
 
+from TestSuite.file import File
 from TestSuite.integration import Integration
 from TestSuite.json_based import JSONBased
 from TestSuite.playbook import Playbook
@@ -347,3 +348,8 @@ class Pack:
         rn = self._create_text_based(f'{version}.md', content, dir_path=self._release_notes)
         self.release_notes.append(rn)
         return rn
+
+    def create_doc_file(self, name: str = 'image') -> File:
+        doc_file_dir = self._pack_path / 'doc_files'
+        doc_file_dir.mkdir()
+        return File(doc_file_dir / f'{name}.png', self._repo.path)

--- a/demisto_sdk/commands/format/format_module.py
+++ b/demisto_sdk/commands/format/format_module.py
@@ -27,6 +27,7 @@ from demisto_sdk.commands.format.update_pythonfile import PythonFileFormat
 from demisto_sdk.commands.format.update_report import ReportJSONFormat
 from demisto_sdk.commands.format.update_script import ScriptYMLFormat
 from demisto_sdk.commands.format.update_widget import WidgetJSONFormat
+from demisto_sdk.commands.lint.commands_builder import excluded_files
 
 FILE_TYPE_AND_LINKED_CLASS = {
     'integration': IntegrationYMLFormat,
@@ -57,6 +58,7 @@ UNFORMATTED_FILES = ['readme',
                      'javascriptfile',
                      'powershellfile',
                      'betaintegration',
+                     'doc_image',
                      ]
 
 VALIDATE_RES_SKIPPED_CODE = 2
@@ -95,9 +97,18 @@ def format_manager(input: str = None,
     log_list = []
     error_list = []
     if files:
+        format_excluded_file = excluded_files + ['pack_metadata.json']
         for file in files:
             file_path = file.replace('\\', '/')
             file_type = find_type(file_path)
+
+            current_excluded_files = format_excluded_file[:]
+            dirname = os.path.dirname(file_path)
+            if dirname.endswith('CommonServerPython'):
+                current_excluded_files.remove('CommonServerPython.py')
+            if os.path.basename(file_path) in current_excluded_files:
+                continue
+
             if file_type and file_type.value not in UNFORMATTED_FILES:
                 file_type = file_type.value
                 info_res, err_res, skip_res = run_format_on_file(input=file_path,


### PR DESCRIPTION

## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/29696

## Description
- skipping files that are added to the dir when running lint
    - handling commonserverpython
    - not handling commonserverpowershell as we dont run format on it
- skipping doc image files

## Must have
- [x] Tests
