### PR TITLE
Contribution Convert Refactor

### DIFF
--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -649,7 +649,7 @@ def generate_test_playbook(**kwargs):
     '-h', '--help'
 )
 @click.option(
-    "-n", "--name", help="The name of the directory and file you want to create")
+    "-n", "--name", help="The name of the directory and file you want to create", required=True)
 @click.option(
     "--id", help="The id used in the yml file of the integration or script"
 )
@@ -668,27 +668,6 @@ def generate_test_playbook(**kwargs):
 @click.option(
     '--common_server', is_flag=True,
     help="Copy the CommonServerPython. Relevant for initialization of Scripts and Integrations within a Pack.")
-@click.option(
-    '-c', '--contribution',
-    type=click.Path(exists=True, file_okay=True, dir_okay=True, readable=True),
-    required=False,
-    help="The path to the zip file downloaded via the Marketplace contribution UI. "
-    "This will format the contents of the zip file to a pack format ready for contribution "
-    "in the content repository on your local machine. The command should be executed from the "
-    "content repository's base directory. When this option is passed, the only other options "
-    "that are considered are \"name\", \"description\" and \"author\" - all others are ignored.")
-@click.option(
-    '-d', '--description',
-    type=click.STRING,
-    default='',
-    help="The description to attach to the converted contribution pack. Used when the \"contribution\" "
-    "option is passed.")
-@click.option(
-    '--author',
-    type=click.STRING,
-    default='',
-    help="The author to attach to the converted contribution pack. Used when the \"contribution\" "
-    "option is passed.")
 def init(**kwargs):
     initiator = Initiator(**kwargs)
     initiator.init()

--- a/demisto_sdk/commands/init/README.md
+++ b/demisto_sdk/commands/init/README.md
@@ -1,9 +1,8 @@
 ## init
-Create a pack, integration or script template _or_ create a pack from a contribution ZIP file.
+Create a pack, integration or script template.
 
 **Use-Cases**
 * This command is used to ease the initial creation of a pack, integration or a script.
-* Create a pack from a contribution ZIP file downloaded from the Cortex XSOAR marketplace.
 
 **Arguments**:
 * **-n, --name** The name given to the files and directories of new pack/integration/script being created
@@ -12,9 +11,6 @@ Create a pack, integration or script template _or_ create a pack from a contribu
 * **--integration** Create an integration
 * **--script** Create a script
 * **--pack** Create a pack
-* **-c, --contribution** The path to the contribution zip file to convert to a pack in the content repo
-* **-d, --description** The description to attach to the pack created from a contribution zip file
-* **--author** The author to attach to the pack created from a contribution zip file
 
 **Notes**
 * If `integration` or `script` not set - the command will automatically create a pack, even if `pack` was not set.
@@ -30,23 +26,15 @@ An integration will be created in the "Integrations" directory and a script will
 * If no `output` given and the command is not activated from content repo nor a pack directory -
 The pack/integration/script will be created in your current working directory.
 * The templates are based on "Integrations/HelloWorld" and "Scripts/HelloWorldScript" found in content repo.
-* If the `contribution` parameter is passed, all additional parameters other than `name`, `description` and `author`
-will be ignored.
-* When creating a pack from a contribution zip file, the `email` field in the pack's `pack_metadata.json` file will
-be left empty _even_ if the zip file's metadata file included an email address.
-* When creating a pack from a contribution zip file, the `support` field in the pack's `pack_metadata.json` file will
-be set to `community`.
-* When passing the `contribution` parameter, the command should be executed from within the content repository,
-otherwise the command will fail.
 
 **Examples**
 
 *Note: the below example commands and explanations are given as though the command is activated from the content repo directory.*
 
 
-`demisto-sdk init`
+`demisto-sdk init -n My_Pack`
 
-This will prompt a message asking for a name for the pack, once given a pack will be created under the "Packs" directory.
+This will create a new pack named "My_Pack" under the "Packs" directory in content repo.
 
 
 `demisto-sdk init --integration -n MyNewIntegration -o path/to/my/dir`
@@ -54,25 +42,11 @@ This will prompt a message asking for a name for the pack, once given a pack wil
 This will create a new integration template named MyNewIntegration within "path/to/my/dir" directory.
 
 
-`demisto-sdk init --script --id "My Script ID"`
+`demisto-sdk init --script --id "My Script ID" -n MyScript`
 
-This will prompt a message asking for a name for the script's directory and file name,
-once given a script will be created under "Scripts" directory and the yml file will have the id "My Script ID".
+This will create a named "MyScript" under the "Scripts" directory and the yml file will have the id "My Script ID".
 
 
 `demisto-sdk init --pack -n My_Pack`
 
 This will create a new pack named "My_Pack" under the "Packs" directory in content repo.
-
-
-`demisto-sdk init --contribution ~/Downloads/my_contribution.zip`
-
-This will use the data and content items in the zip file "my_contribution.zip" to construct a pack in the "Packs"
-directory in the content repo which will contain the content items from the zip file formatted to the content repo's
-conventions and expected file and directory structure.
-
-
-`demisto-sdk init -n "My New Pack" -c ~/Downloads/my_contribution.zip -d "This pack introduces the 'My Example' Integration allowing you to execute commands on 'My Example' product directly from Cortex XSOAR" --author "Octocat Smith"`
-
-This will do the same as in the previous example except that it will use the passed name, description and author
-for the converted contribution pack metadata.

--- a/demisto_sdk/commands/init/contribution_converter.py
+++ b/demisto_sdk/commands/init/contribution_converter.py
@@ -225,7 +225,7 @@ class ContributionConverter:
     def format_converted_pack(self) -> None:
         """Runs the demisto-sdk's format command on the pack converted from the contribution zipfile"""
         click.echo(f'Executing \'format\' on the restructured contribution zip files at "{self.pack_dir_path}"')
-        from_version = '6.0.0'
+        from_version = '6.0.0' if self.create_new else ''
         format_manager(
             input=self.pack_dir_path, from_version=from_version, no_validate=True, update_docker=True, assume_yes=True
         )

--- a/demisto_sdk/commands/init/contribution_converter.py
+++ b/demisto_sdk/commands/init/contribution_converter.py
@@ -1,0 +1,361 @@
+import json
+import os
+import re
+import shutil
+import textwrap
+import traceback
+import zipfile
+from datetime import datetime
+from string import punctuation
+from typing import Dict, List, Union
+
+import click
+from demisto_sdk.commands.common.configuration import Configuration
+from demisto_sdk.commands.common.constants import (
+    AUTOMATION, ENTITY_TYPE_TO_DIR, INTEGRATION, MARKETPLACE_LIVE_DISCUSSIONS,
+    PACK_INITIAL_VERSION, SCRIPT, XSOAR_AUTHOR, XSOAR_SUPPORT,
+    XSOAR_SUPPORT_URL)
+from demisto_sdk.commands.common.tools import (LOG_COLORS, capital_case,
+                                               find_type,
+                                               get_child_directories,
+                                               get_child_files,
+                                               get_content_path)
+from demisto_sdk.commands.format.format_module import format_manager
+from demisto_sdk.commands.split_yml.extractor import Extractor
+
+
+class ContributionConverter:
+    """ContributionConverter converts contribution zip files to valid pack formats
+
+    Class Variables:
+        DATE_FORMAT (str): The date format to use in the pack metadata
+
+    Instance Variables:
+        name (str): The name for the pack
+        configuration (Configuration): Configuration instance
+        contribution (str|Nonetype): The path to a contribution zip file
+        description (str): Description to attach to a converted contribution pack (in pack_metadata.json)
+        author (str): Author to ascribe to a pack converted from a contribution zip (in pack_metadata.json)
+        contrib_conversion_errs (List[str]): Messages of errors that occurred during a contribution conversion process
+        packs_dir_path (str): The path to the 'Packs' subdirectory of the local content repo
+        pack_dir_path (str): The path to the specific pack directory being created or updated, e.g. .../Packs/AbuseDB
+        dir_name (str): The directory name of a pack's containing folder
+        create_new (bool): True if creating a new pack (default), False if updating an existing pack
+    """
+    DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
+
+    def __init__(self, name: str = '', contribution: Union[str] = None, description: str = '', author: str = '',
+                 create_new: bool = True, pack_dir_name: Union[str] = None, base_dir: Union[str] = None):
+        """Initializes a ContributionConverter instance
+
+        Note that when recieving a contribution that is an update to an existing pack that the values of 'name',
+        'description' and 'author' will be those of the existing pack.
+
+        Args:
+            name (str, optional): The name of the pack. Defaults to ''.
+            contribution (Union[str], optional): The path to the contribution zipfile. Defaults to None.
+            description (str, optional): The description for the contribution. Defaults to ''.
+            author (str, optional): The author of the contribution. Defaults to ''.
+            create_new (bool, optional): Whether the contribution is intended as a new pack. When the contribution is
+                intended as an update to an existing pack, the value passed should be False. Defaults to True.
+            pack_dir_name (Union[str], optional): Explicitly pass the name of the pack directory. Only useful when
+                updating an existing pack and the pack's directory is not equivalent to the value returned from
+                running `self.format_pack_dir_name(name)`
+            base_dir (Union[str], optional): Used to explicitly pass the path to the top-level directory of the
+                local content repo. If no value is passed, the `get_content_path()` function is used to determine
+                the path. Defaults to None.
+        """
+        self.configuration = Configuration()
+        self.contribution = contribution
+        self.description = description
+        self.author = author
+        self.contrib_conversion_errs: List[str] = []
+        self.create_new = create_new
+        base_dir = base_dir or get_content_path()
+        self.packs_dir_path = os.path.join(base_dir, 'Packs')
+        if not os.path.isdir(self.packs_dir_path):
+            os.makedirs(self.packs_dir_path)
+
+        self.name = name
+        self.dir_name = pack_dir_name or ContributionConverter.format_pack_dir_name(name)
+        if create_new:
+            # make sure that it doesn't conflict with an existing pack directory
+            self.dir_name = self.ensure_unique_pack_dir_name(self.dir_name)
+        self.pack_dir_path = os.path.join(self.packs_dir_path, self.dir_name)
+        if not os.path.isdir(self.pack_dir_path):
+            os.makedirs(self.pack_dir_path)
+
+    @staticmethod
+    def format_pack_dir_name(name: str) -> str:
+        """Formats a (pack) name to a valid value
+
+        Specification:
+            A valid pack name does not contain any whitespace and may only contain alphanumeric, underscore, and
+            dash characters. The name must begin and end with an alphanumeric character. If it begins with an
+            alphabetical character, that character must be capitalized.
+
+        Behavior:
+            Individual words are titlecased, whitespace is stripped, and disallowed punctuation and space
+            characters are replaced with underscores.
+
+        Args:
+            name (str): The proposed pack name to convert to valid pack name format
+
+        Returns:
+            str: The reformatted pack name
+        """
+        temp = capital_case(name.strip().strip('-_'))
+        punctuation_to_replace = punctuation.replace('-', '').replace('_', '')
+        translation_dict = {x: '_' for x in punctuation_to_replace}
+        translation_table = str.maketrans(translation_dict)
+        temp = temp.translate(translation_table).strip('-_')
+        temp = re.sub(r'-+', '-', re.sub(r'_+', '_', temp))
+        comparator = capital_case(temp.replace('_', ' ').replace('-', ' '))
+        result = ''
+        i = j = 0
+        while i < len(temp):
+            temp_char = temp[i]
+            comp_char = comparator[j]
+            if temp_char.casefold() != comp_char.casefold():
+                while temp_char in {' ', '_', '-'}:
+                    result += f'{temp_char}'
+                    i += 1
+                    temp_char = temp[i]
+                while comp_char in {' '}:
+                    j += 1
+                    comp_char = comparator[j]
+            else:
+                result += comparator[j]
+                i += 1
+                j += 1
+        result = result.replace(' ', '')
+        result = re.sub(r'-+', '-', re.sub(r'_+', '_', result))
+        return result
+
+    def ensure_unique_pack_dir_name(self, pack_dir: str) -> str:
+        """When creating a brand new pack, ensures the name used for the pack directory is unique
+
+        If the proposed pack directory name already exists under the 'content/Packs' directory, then
+        a 'V2' is appended to the proposed name. If the proposed name already ends with a digit, the
+        digit is incremented. The adjusted pack directory name (if the name wasn't already unique)
+        is returned.
+
+        Args:
+            pack_dir (str): The proposed name of the pack directory
+
+        Returns:
+            str: A unique pack directory name
+        """
+        while os.path.exists(os.path.join(self.packs_dir_path, pack_dir)):
+            click.echo(
+                f'Modifying pack name because pack {pack_dir} already exists in the content repo',
+                color=LOG_COLORS.NATIVE
+            )
+            if len(pack_dir) >= 2 and pack_dir[-2].lower() == 'v' and pack_dir[-1].isdigit():
+                # increment by one
+                pack_dir = pack_dir[:-1] + str(int(pack_dir[-1]) + 1)
+            else:
+                pack_dir += 'V2'
+            click.echo(f'New pack name is "{pack_dir}"', color=LOG_COLORS.NATIVE)
+        return pack_dir
+
+    def unpack_contribution_to_dst_pack_directory(self) -> None:
+        """Unpacks the contribution zip's contents to the destination pack directory and performs some cleanup"""
+        shutil.unpack_archive(filename=self.contribution, extract_dir=self.pack_dir_path)
+        # remove metadata.json file
+        os.remove(os.path.join(self.pack_dir_path, 'metadata.json'))
+
+    def convert_contribution_dir_to_pack_contents(self, unpacked_contribution_dir: str) -> None:
+        """Converts a directory and its contents unpacked from the contribution zip file to the appropriate structure
+
+        Example:
+            The pack directory after `unpack_contribution_to_dst_pack_directory` has been executed:
+
+            ExamplePack
+            ├── automation
+            │   └── automation-ExampleAutomation.yml
+            ├── integration
+            │   └── integration-ExampleIntegration.yml
+            ├── playbook
+            │   └── playbook-ExamplePlaybook.yml
+            ├── report
+            │   └── report-ExampleReport.json
+            └── reputation
+                └── reputation-ExampleReputation.json
+
+            The updated pack directory structure after `convert_contribution_dir_to_pack_contents` has been
+            executed, passing the path of .../ExamplePack/integration as the argument, would appear as so:
+
+            ExamplePack
+            ├── automation
+            │   └── automation-ExampleAutomation.yml
+            ├── Integrations
+            │   └── ExampleIntegration
+            │       ├── ExampleIntegration.py
+            │       ├── ExampleIntegration.yml
+            │       ├── ExampleIntegration_description.md
+            │       └── ExampleIntegration_image.png
+            ├── playbook
+            │   └── playbook-ExamplePlaybook.yml
+            ├── report
+            │   └── report-ExampleReport.json
+            └── reputation
+                └── reputation-ExampleReputation.json
+
+        Args:
+            unpacked_contribution_dir (str): The directory to convert
+        """
+        basename = os.path.basename(unpacked_contribution_dir)
+        if basename in ENTITY_TYPE_TO_DIR:
+            dst_name = ENTITY_TYPE_TO_DIR.get(basename)
+            src_path = os.path.join(self.pack_dir_path, basename)
+            dst_path = os.path.join(self.pack_dir_path, dst_name)
+            if os.path.exists(dst_path):
+                # move src folder files to dst folder
+                content_item_dir = dst_path
+                for _, _, files in os.walk(src_path, topdown=False):
+                    for name in files:
+                        src_file_path = os.path.join(src_path, name)
+                        shutil.move(src_file_path, dst_path)
+            else:
+                # replace dst folder with src folder
+                content_item_dir = shutil.move(src_path, dst_path)
+            if basename in {SCRIPT, AUTOMATION, INTEGRATION}:
+                self.content_item_to_package_format(content_item_dir, del_unified=True)
+
+    def format_converted_pack(self) -> None:
+        """Runs the demisto-sdk's format command on the pack converted from the contribution zipfile"""
+        click.echo(f'Executing \'format\' on the restructured contribution zip files at "{self.pack_dir_path}"')
+        from_version = '6.0.0'
+        format_manager(
+            input=self.pack_dir_path, from_version=from_version, no_validate=True, update_docker=True, assume_yes=True
+        )
+
+    def convert_contribution_to_pack(self):
+        """Create a Pack in the content repo from the contents of a contribution zipfile"""
+        try:
+            with zipfile.ZipFile(self.contribution) as zipped_contrib:
+                with zipped_contrib.open('metadata.json') as metadata_file:
+                    click.echo(f'Pulling relevant information from {metadata_file.name}', color=LOG_COLORS.NATIVE)
+                    metadata = json.loads(metadata_file.read())
+                    self.create_metadata_file(metadata)
+            # unpack
+            self.unpack_contribution_to_dst_pack_directory()
+            # convert
+            unpacked_contribution_dirs = get_child_directories(self.pack_dir_path)
+            for unpacked_contribution_dir in unpacked_contribution_dirs:
+                self.convert_contribution_dir_to_pack_contents(unpacked_contribution_dir)
+            # create base files
+            if self.create_new:
+                self.create_pack_base_files()
+            # format
+            self.format_converted_pack()
+        except Exception as e:
+            click.echo(
+                f'Creating a Pack from the contribution zip failed with error: {e}\n {traceback.format_exc()}',
+                color=LOG_COLORS.RED
+            )
+        finally:
+            if self.contrib_conversion_errs:
+                click.echo(
+                    'The following errors occurred while converting unified content YAMLs to package structure:'
+                )
+                click.echo(
+                    textwrap.indent('\n'.join(self.contrib_conversion_errs), '\t')
+                )
+
+    def content_item_to_package_format(self, content_item_dir: str, del_unified: bool = True):
+        """
+        Iterate over the YAML files in a directory and create packages (a containing directory and
+        component files) from the YAMLs of integrations and scripts
+
+        Args:
+            content_item_dir (str): Path to the directory containing the content item YAML file(s)
+            del_unified (bool): Whether to delete the unified yaml the package was extracted from
+        """
+        child_files = get_child_files(content_item_dir)
+        content_item_file_path = ''
+        for child_file in child_files:
+            cf_name_lower = os.path.basename(child_file).lower()
+            if cf_name_lower.startswith((SCRIPT, AUTOMATION, INTEGRATION)) and cf_name_lower.endswith('yml'):
+                content_item_file_path = child_file
+                file_type = find_type(content_item_file_path)
+                file_type = file_type.value if file_type else file_type
+                try:
+                    extractor = Extractor(input=content_item_file_path, file_type=file_type, output=content_item_dir)
+                    extractor.extract_to_package_format()
+                except Exception as e:
+                    err_msg = f'Error occurred while trying to split the unified YAML "{content_item_file_path}" ' \
+                              f'into its component parts.\nError: "{e}"'
+                    self.contrib_conversion_errs.append(err_msg)
+                if del_unified:
+                    os.remove(content_item_file_path)
+
+    def create_pack_base_files(self):
+        """
+        Create empty 'README.md', '.secrets-ignore', and '.pack-ignore' files that are expected
+        to be in the base directory of a pack
+        """
+        click.echo('Creating pack base files', color=LOG_COLORS.NATIVE)
+        fp = open(os.path.join(self.pack_dir_path, 'README.md'), 'a')
+        fp.close()
+
+        fp = open(os.path.join(self.pack_dir_path, '.secrets-ignore'), 'a')
+        fp.close()
+
+        fp = open(os.path.join(self.pack_dir_path, '.pack-ignore'), 'a')
+        fp.close()
+
+    def create_metadata_file(self, zipped_metadata: Dict) -> None:
+        """Create the pack_metadata.json file in the base directory of the pack
+
+        Args:
+            zipped_metadata (Dict): The metadata that came in the zipfile
+        """
+        metadata_dict = {}
+
+        # a description passed on the cmd line should take precedence over one pulled
+        # from contribution metadata
+        metadata_dict['description'] = self.description or zipped_metadata.get('description')
+        metadata_dict['name'] = self.name
+        metadata_dict['author'] = self.author or zipped_metadata.get('author', '')
+        metadata_dict['support'] = 'community'
+        metadata_dict['url'] = zipped_metadata.get('supportDetails', {}).get('url', MARKETPLACE_LIVE_DISCUSSIONS)
+        metadata_dict['categories'] = zipped_metadata.get('categories') if zipped_metadata.get('categories') else []
+        metadata_dict['tags'] = zipped_metadata.get('tags') if zipped_metadata.get('tags') else []
+        metadata_dict['useCases'] = zipped_metadata.get('useCases') if zipped_metadata.get('useCases') else []
+        metadata_dict['keywords'] = zipped_metadata.get('keywords') if zipped_metadata.get('keywords') else []
+        metadata_dict = ContributionConverter.create_pack_metadata(data=metadata_dict)
+        metadata_path = os.path.join(self.pack_dir_path, 'pack_metadata.json')
+        with open(metadata_path, 'w') as pack_metadata_file:
+            json.dump(metadata_dict, pack_metadata_file, indent=4)
+
+    @staticmethod
+    def create_pack_metadata(data: Dict = {}) -> Dict:
+        """Builds pack metadata JSON content.
+
+        Args:
+            data (dict): Dictionary keys and value to insert into the pack metadata.
+
+        Returns:
+            Dict. Pack metadata JSON content.
+        """
+        pack_metadata = {
+            'name': '## FILL MANDATORY FIELD ##',
+            'description': '## FILL MANDATORY FIELD ##',
+            'support': XSOAR_SUPPORT,
+            'currentVersion': PACK_INITIAL_VERSION,
+            'author': XSOAR_AUTHOR,
+            'url': XSOAR_SUPPORT_URL,
+            'email': '',
+            'created': datetime.utcnow().strftime(ContributionConverter.DATE_FORMAT),
+            'categories': [],
+            'tags': [],
+            'useCases': [],
+            'keywords': []
+        }
+
+        if data:
+            pack_metadata.update(data)
+
+        return pack_metadata

--- a/demisto_sdk/commands/init/contribution_converter.py
+++ b/demisto_sdk/commands/init/contribution_converter.py
@@ -12,9 +12,9 @@ from typing import Dict, List, Union
 import click
 from demisto_sdk.commands.common.configuration import Configuration
 from demisto_sdk.commands.common.constants import (
-    AUTOMATION, ENTITY_TYPE_TO_DIR, INTEGRATION, INTEGRATIONS_DIR, MARKETPLACE_LIVE_DISCUSSIONS,
-    PACK_INITIAL_VERSION, SCRIPT, SCRIPTS_DIR, XSOAR_AUTHOR, XSOAR_SUPPORT,
-    XSOAR_SUPPORT_URL)
+    AUTOMATION, ENTITY_TYPE_TO_DIR, INTEGRATION, INTEGRATIONS_DIR,
+    MARKETPLACE_LIVE_DISCUSSIONS, PACK_INITIAL_VERSION, SCRIPT, SCRIPTS_DIR,
+    XSOAR_AUTHOR, XSOAR_SUPPORT, XSOAR_SUPPORT_URL)
 from demisto_sdk.commands.common.tools import (LOG_COLORS, capital_case,
                                                find_type,
                                                get_child_directories,
@@ -161,9 +161,15 @@ class ContributionConverter:
 
     def unpack_contribution_to_dst_pack_directory(self) -> None:
         """Unpacks the contribution zip's contents to the destination pack directory and performs some cleanup"""
-        shutil.unpack_archive(filename=self.contribution, extract_dir=self.pack_dir_path)
-        # remove metadata.json file
-        os.remove(os.path.join(self.pack_dir_path, 'metadata.json'))
+        if self.contribution:
+            shutil.unpack_archive(filename=self.contribution, extract_dir=self.pack_dir_path)
+            # remove metadata.json file
+            os.remove(os.path.join(self.pack_dir_path, 'metadata.json'))
+        else:
+            err_msg = ('Tried unpacking contribution to destination directory but the instance variable'
+                       ' "contribution" is "None" - Make sure "contribution" is set before trying to unpack'
+                       ' the contribution.')
+            raise TypeError(err_msg)
 
     def convert_contribution_dir_to_pack_contents(self, unpacked_contribution_dir: str) -> None:
         """Converts a directory and its contents unpacked from the contribution zip file to the appropriate structure
@@ -203,7 +209,7 @@ class ContributionConverter:
         """
         basename = os.path.basename(unpacked_contribution_dir)
         if basename in ENTITY_TYPE_TO_DIR:
-            dst_name = ENTITY_TYPE_TO_DIR.get(basename)
+            dst_name = ENTITY_TYPE_TO_DIR.get(basename, '')
             src_path = os.path.join(self.pack_dir_path, basename)
             dst_path = os.path.join(self.pack_dir_path, dst_name)
             if os.path.exists(dst_path):
@@ -289,7 +295,7 @@ class ContributionConverter:
                 try:
                     child_file_name = os.path.basename(child_file)
                     if file_dir_mapping and child_file_name in file_dir_mapping.keys():
-                        base_name = file_dir_mapping.get(child_file_name)
+                        base_name = file_dir_mapping.get(child_file_name, '')
                         extractor = Extractor(input=content_item_file_path, file_type=file_type,
                                               output=content_item_dir, base_name=base_name)
                     else:

--- a/demisto_sdk/commands/init/contribution_converter.py
+++ b/demisto_sdk/commands/init/contribution_converter.py
@@ -311,12 +311,18 @@ class ContributionConverter:
                         child_file_mapping = source_mapping.get(child_file_name, {})
                         base_name = child_file_mapping.get('base_name', '')
                         containing_dir_name = child_file_mapping.get('containing_dir_name', '')
-                        output_dir = os.path.join(
-                            self.pack_dir_path, ENTITY_TYPE_TO_DIR.get(file_type, ''), containing_dir_name
-                        )
-                        os.makedirs(output_dir)
-                        extractor = Extractor(input=content_item_file_path, file_type=file_type,
-                                              output=output_dir, base_name=base_name, no_auto_create_dir=True)
+                        # for legacy unified yamls in the repo, their containing directory will be that of their
+                        # entity type directly instead of the typical package format. For those cases, we need the
+                        # extractor to auto create the containing directory. An example would be -
+                        # 'content/Packs/AbuseDB/Scripts/script-AbuseIPDBPopulateIndicators.yml'
+                        autocreate_dir = containing_dir_name == ENTITY_TYPE_TO_DIR.get(file_type, '')
+                        output_dir = os.path.join(self.pack_dir_path, ENTITY_TYPE_TO_DIR.get(file_type, ''))
+                        if not autocreate_dir:
+                            output_dir = os.path.join(output_dir, containing_dir_name)
+                        os.makedirs(output_dir, exist_ok=True)
+                        extractor = Extractor(input=content_item_file_path, file_type=file_type, output=output_dir,
+                                              base_name=base_name, no_auto_create_dir=(not autocreate_dir))
+
                     else:
                         extractor = Extractor(input=content_item_file_path,
                                               file_type=file_type, output=content_item_dir)

--- a/demisto_sdk/commands/init/contribution_converter.py
+++ b/demisto_sdk/commands/init/contribution_converter.py
@@ -321,7 +321,8 @@ class ContributionConverter:
                             output_dir = os.path.join(output_dir, containing_dir_name)
                         os.makedirs(output_dir, exist_ok=True)
                         extractor = Extractor(input=content_item_file_path, file_type=file_type, output=output_dir,
-                                              base_name=base_name, no_auto_create_dir=(not autocreate_dir))
+                                              no_readme=True, base_name=base_name,
+                                              no_auto_create_dir=(not autocreate_dir))
 
                     else:
                         extractor = Extractor(input=content_item_file_path,

--- a/demisto_sdk/commands/init/initiator.py
+++ b/demisto_sdk/commands/init/initiator.py
@@ -1,14 +1,9 @@
 import json
 import os
-import re
 import shutil
-import textwrap
-import traceback
-import zipfile
 from datetime import datetime
 from distutils.dir_util import copy_tree
-from string import punctuation
-from typing import Dict, List, Union
+from typing import Dict, List
 
 import click
 import yaml
@@ -16,22 +11,15 @@ import yamlordereddictloader
 from demisto_sdk.commands.common import tools
 from demisto_sdk.commands.common.configuration import Configuration
 from demisto_sdk.commands.common.constants import (
-    AUTOMATION, CLASSIFIERS_DIR, CONNECTIONS_DIR, DASHBOARDS_DIR,
-    DOC_FILES_DIR, ENTITY_TYPE_TO_DIR, INCIDENT_FIELDS_DIR, INCIDENT_TYPES_DIR,
-    INDICATOR_FIELDS_DIR, INDICATOR_TYPES_DIR, INTEGRATION,
-    INTEGRATION_CATEGORIES, INTEGRATIONS_DIR, LAYOUTS_DIR,
+    CLASSIFIERS_DIR, CONNECTIONS_DIR, DASHBOARDS_DIR,
+    DOC_FILES_DIR, INCIDENT_FIELDS_DIR, INCIDENT_TYPES_DIR,
+    INDICATOR_FIELDS_DIR, INDICATOR_TYPES_DIR, INTEGRATION_CATEGORIES, INTEGRATIONS_DIR, LAYOUTS_DIR,
     MARKETPLACE_LIVE_DISCUSSIONS, PACK_INITIAL_VERSION, PACK_SUPPORT_OPTIONS,
-    PLAYBOOKS_DIR, REPORTS_DIR, SCRIPT, SCRIPTS_DIR, TEST_PLAYBOOKS_DIR,
+    PLAYBOOKS_DIR, REPORTS_DIR, SCRIPTS_DIR, TEST_PLAYBOOKS_DIR,
     WIDGETS_DIR, XSOAR_AUTHOR, XSOAR_SUPPORT, XSOAR_SUPPORT_URL)
-from demisto_sdk.commands.common.tools import (LOG_COLORS, capital_case,
-                                               find_type,
-                                               get_child_directories,
-                                               get_child_files,
-                                               get_common_server_path,
-                                               get_content_path, print_error,
+from demisto_sdk.commands.common.tools import (LOG_COLORS, get_common_server_path,
+                                               print_error,
                                                print_v, print_warning)
-from demisto_sdk.commands.format.format_module import format_manager
-from demisto_sdk.commands.split_yml.extractor import Extractor
 
 
 class Initiator:
@@ -44,14 +32,10 @@ class Initiator:
            integration (bool): Indicates whether to create an integration.
            script (bool): Indicates whether to create a script.
            full_output_path (str): The full path to the newly created pack/integration/script
-           contribution (str|Nonetype): The path to a contribution zip file
-           description (str): Description to attach to a converted contribution pack
-           author (str): Author to ascribe to a pack converted from a contribution zip
     """
 
     def __init__(self, output: str, name: str = '', id: str = '', integration: bool = False, script: bool = False,
-                 pack: bool = False, demisto_mock: bool = False, common_server: bool = False,
-                 contribution: Union[str] = None, description: str = '', author: str = ''):
+                 pack: bool = False, demisto_mock: bool = False, common_server: bool = False):
         self.output = output if output else ''
         self.id = id
 
@@ -61,10 +45,6 @@ class Initiator:
         self.demisto_mock = demisto_mock
         self.common_server = common_server
         self.configuration = Configuration()
-        self.contribution = contribution
-        self.description = description
-        self.author = author
-        self.contrib_conversion_errs: List[str] = []
 
         # if no flag given automatically create a pack.
         if not integration and not script and not pack:
@@ -72,15 +52,11 @@ class Initiator:
 
         self.full_output_path = ''
 
-        self.name = name
-        if name and not self.contribution:
-            while ' ' in name:
-                name = str(input("The directory and file name cannot have spaces in it, Enter a different name: "))
+        while ' ' in name:
+            name = str(input("The directory and file name cannot have spaces in it, Enter a different name: "))
 
-        if self.contribution:
-            self.dir_name = self.format_pack_dir_name(name)
-        else:
-            self.dir_name = name
+        self.dir_name = name
+
         self.is_pack_creation = not all([self.is_script, self.is_integration])
 
     HELLO_WORLD_INTEGRATION = 'HelloWorld'
@@ -107,9 +83,7 @@ class Initiator:
         """Starts the init command process.
 
         """
-        if self.contribution:
-            self.convert_contribution_to_pack()
-        elif self.is_integration:
+        if self.is_integration:
             self.get_created_dir_name(created_object="integration")
             self.get_object_id(created_object="integration")
             return self.integration_init()
@@ -122,172 +96,6 @@ class Initiator:
         elif self.is_pack:
             self.get_created_dir_name(created_object="pack")
             return self.pack_init()
-
-    @staticmethod
-    def format_pack_dir_name(name: str) -> str:
-        """Formats a (pack) name to a valid value
-
-        Specification:
-            A valid pack name does not contain any whitespace and may only contain alphanumeric, underscore, and
-            dash characters. The name must begin and end with an alphanumeric character. If it begins with an
-            alphabetical character, that character must be capitalized.
-
-        Behavior:
-            Individual words are titlecased, whitespace is stripped, and disallowed punctuation and space
-            characters are replaced with underscores.
-
-        Args:
-            name (str): The proposed pack name to convert to valid pack name format
-
-        Returns:
-            str: The reformatted pack name
-        """
-        temp = capital_case(name.strip().strip('-_'))
-        punctuation_to_replace = punctuation.replace('-', '').replace('_', '')
-        translation_dict = {x: '_' for x in punctuation_to_replace}
-        translation_table = str.maketrans(translation_dict)
-        temp = temp.translate(translation_table).strip('-_')
-        temp = re.sub(r'-+', '-', re.sub(r'_+', '_', temp))
-        comparator = capital_case(temp.replace('_', ' ').replace('-', ' '))
-        result = ''
-        i = j = 0
-        while i < len(temp):
-            temp_char = temp[i]
-            comp_char = comparator[j]
-            if temp_char.casefold() != comp_char.casefold():
-                while temp_char in {' ', '_', '-'}:
-                    result += f'{temp_char}'
-                    i += 1
-                    temp_char = temp[i]
-                while comp_char in {' '}:
-                    j += 1
-                    comp_char = comparator[j]
-            else:
-                result += comparator[j]
-                i += 1
-                j += 1
-        result = result.replace(' ', '')
-        result = re.sub(r'-+', '-', re.sub(r'_+', '_', result))
-        return result
-
-    def convert_contribution_to_pack(self):
-        """Create a Pack in the content repo from the contents of a contribution zipfile"""
-        try:
-            packs_dir = os.path.join(get_content_path(), 'Packs')
-            metadata_dict = {}
-            with zipfile.ZipFile(self.contribution) as zipped_contrib:
-                with zipped_contrib.open('metadata.json') as metadata_file:
-                    click.echo(f'Pulling relevant information from {metadata_file.name}', color=LOG_COLORS.NATIVE)
-                    metadata = json.loads(metadata_file.read())
-                    # a name passed on the cmd line should take precedence over one pulled
-                    # from contribution metadata
-                    pack_display_name = self.name or metadata.get('name', 'ContributionPack')
-                    # Strip 'Pack' suffix from pack display name if present
-                    pack_display_name = pack_display_name.strip()
-                    if pack_display_name.casefold().endswith('pack') > len(pack_display_name) > 4:
-                        stripped_pack_display_name = pack_display_name[:-4].strip()
-                        pack_display_name = stripped_pack_display_name or pack_display_name
-                    pack_name = self.dir_name or self.format_pack_dir_name(
-                        metadata.get('name', 'ContributionPack')
-                    )
-                    # a description passed on the cmd line should take precedence over one pulled
-                    # from contribution metadata
-                    metadata_dict['description'] = self.description or metadata.get('description')
-                    metadata_dict['name'] = pack_display_name
-                    metadata_dict['author'] = self.author or metadata.get('author', '')
-                    metadata_dict['support'] = 'community'
-                    metadata_dict['url'] = metadata.get('supportDetails', {}).get('url', MARKETPLACE_LIVE_DISCUSSIONS)
-                    metadata_dict['categories'] = metadata.get('categories') if metadata.get('categories') else []
-                    metadata_dict['tags'] = metadata.get('tags') if metadata.get('tags') else []
-                    metadata_dict['useCases'] = metadata.get('useCases') if metadata.get('useCases') else []
-                    metadata_dict['keywords'] = metadata.get('keywords') if metadata.get('keywords') else []
-            while os.path.exists(os.path.join(packs_dir, pack_name)):
-                click.echo(
-                    f'Modifying pack name because pack {pack_name} already exists in the content repo',
-                    color=LOG_COLORS.NATIVE
-                )
-                if len(pack_name) >= 2 and pack_name[-2].lower() == 'v' and pack_name[-1].isdigit():
-                    # increment by one
-                    pack_name = pack_name[:-1] + str(int(pack_name[-1]) + 1)
-                else:
-                    pack_name += 'V2'
-                click.echo(f'New pack name is "{pack_name}"', color=LOG_COLORS.NATIVE)
-            pack_dir = os.path.join(packs_dir, pack_name)
-            os.mkdir(pack_dir)
-            shutil.unpack_archive(filename=self.contribution, extract_dir=pack_dir)
-            pack_subdirectories = get_child_directories(pack_dir)
-            for pack_subdir in pack_subdirectories:
-                basename = os.path.basename(pack_subdir)
-                if basename in ENTITY_TYPE_TO_DIR:
-                    dst_name = ENTITY_TYPE_TO_DIR.get(basename)
-                    src_path = os.path.join(pack_dir, basename)
-                    dst_path = os.path.join(pack_dir, dst_name)
-                    if os.path.exists(dst_path):
-                        # move src folder files to dst folder
-                        content_item_dir = dst_path
-                        for _, _, files in os.walk(src_path, topdown=False):
-                            for name in files:
-                                src_file_path = os.path.join(src_path, name)
-                                shutil.move(src_file_path, dst_path)
-                    else:
-                        # replace dst folder with src folder
-                        content_item_dir = shutil.move(src_path, dst_path)
-                    if basename in {SCRIPT, AUTOMATION, INTEGRATION}:
-                        self.content_item_to_package_format(content_item_dir, del_unified=True)
-            # create pack's base files
-            self.full_output_path = pack_dir
-            self.create_pack_base_files()
-            metadata_dict = Initiator.create_metadata(fill_manually=False, data=metadata_dict)
-            metadata_path = os.path.join(self.full_output_path, 'pack_metadata.json')
-            with open(metadata_path, 'w') as pack_metadata_file:
-                json.dump(metadata_dict, pack_metadata_file, indent=4)
-            # remove metadata.json file
-            os.remove(os.path.join(pack_dir, 'metadata.json'))
-            click.echo(f'Executing \'format\' on the restructured contribution zip files at "{pack_dir}"')
-            from_version = '6.0.0'
-            format_manager(
-                input=pack_dir, from_version=from_version, no_validate=True, update_docker=True, assume_yes=True
-            )
-        except Exception as e:
-            click.echo(
-                f'Creating a Pack from the contribution zip failed with error: {e}\n {traceback.format_exc()}',
-                color=LOG_COLORS.RED
-            )
-        finally:
-            if self.contrib_conversion_errs:
-                click.echo(
-                    'The following errors occurred while converting unified content YAMLs to package structure:'
-                )
-                click.echo(
-                    textwrap.indent('\n'.join(self.contrib_conversion_errs), '\t')
-                )
-
-    def content_item_to_package_format(self, content_item_dir: str, del_unified: bool = True):
-        """
-        Iterate over the YAML files in a directory and create packages (a containing directory and
-        component files) from the YAMLs of integrations and scripts
-
-        Args:
-            content_item_dir (str): Path to the directory containing the content item YAML file(s)
-            del_unified (bool): Whether to delete the unified yaml the package was extracted from
-        """
-        child_files = get_child_files(content_item_dir)
-        content_item_file_path = ''
-        for child_file in child_files:
-            cf_name_lower = os.path.basename(child_file).lower()
-            if cf_name_lower.startswith((SCRIPT, AUTOMATION, INTEGRATION)) and cf_name_lower.endswith('yml'):
-                content_item_file_path = child_file
-                file_type = find_type(content_item_file_path)
-                file_type = file_type.value if file_type else file_type
-                try:
-                    extractor = Extractor(input=content_item_file_path, file_type=file_type, output=content_item_dir)
-                    extractor.extract_to_package_format()
-                except Exception as e:
-                    err_msg = f'Error occurred while trying to split the unified YAML "{content_item_file_path}" ' \
-                              f'into its component parts.\nError: "{e}"'
-                    self.contrib_conversion_errs.append(err_msg)
-                if del_unified:
-                    os.remove(content_item_file_path)
 
     def get_created_dir_name(self, created_object: str):
         """Makes sure a name is given for the created object

--- a/demisto_sdk/commands/init/initiator.py
+++ b/demisto_sdk/commands/init/initiator.py
@@ -11,15 +11,16 @@ import yamlordereddictloader
 from demisto_sdk.commands.common import tools
 from demisto_sdk.commands.common.configuration import Configuration
 from demisto_sdk.commands.common.constants import (
-    CLASSIFIERS_DIR, CONNECTIONS_DIR, DASHBOARDS_DIR,
-    DOC_FILES_DIR, INCIDENT_FIELDS_DIR, INCIDENT_TYPES_DIR,
-    INDICATOR_FIELDS_DIR, INDICATOR_TYPES_DIR, INTEGRATION_CATEGORIES, INTEGRATIONS_DIR, LAYOUTS_DIR,
+    CLASSIFIERS_DIR, CONNECTIONS_DIR, DASHBOARDS_DIR, DOC_FILES_DIR,
+    INCIDENT_FIELDS_DIR, INCIDENT_TYPES_DIR, INDICATOR_FIELDS_DIR,
+    INDICATOR_TYPES_DIR, INTEGRATION_CATEGORIES, INTEGRATIONS_DIR, LAYOUTS_DIR,
     MARKETPLACE_LIVE_DISCUSSIONS, PACK_INITIAL_VERSION, PACK_SUPPORT_OPTIONS,
-    PLAYBOOKS_DIR, REPORTS_DIR, SCRIPTS_DIR, TEST_PLAYBOOKS_DIR,
-    WIDGETS_DIR, XSOAR_AUTHOR, XSOAR_SUPPORT, XSOAR_SUPPORT_URL)
-from demisto_sdk.commands.common.tools import (LOG_COLORS, get_common_server_path,
-                                               print_error,
-                                               print_v, print_warning)
+    PLAYBOOKS_DIR, REPORTS_DIR, SCRIPTS_DIR, TEST_PLAYBOOKS_DIR, WIDGETS_DIR,
+    XSOAR_AUTHOR, XSOAR_SUPPORT, XSOAR_SUPPORT_URL)
+from demisto_sdk.commands.common.tools import (LOG_COLORS,
+                                               get_common_server_path,
+                                               print_error, print_v,
+                                               print_warning)
 
 
 class Initiator:

--- a/demisto_sdk/commands/init/tests/contribution_converter_test.py
+++ b/demisto_sdk/commands/init/tests/contribution_converter_test.py
@@ -53,7 +53,7 @@ def test_convert_contribution_zip(get_content_path_mock, get_python_version_mock
         get_python_version_mock (MagicMock): Patch of the 'get_python_version' function to return the "3.7"
         tmp_path (fixture): Temporary Path used for the unit test and cleaned up afterwards
 
-    Scenario: Simulate executing the 'init' command with the 'contribution' option passed
+    Scenario: Simulate converting a contribution zip file
 
     Given
     - A contribution zip file
@@ -137,7 +137,7 @@ def test_convert_contribution_zip_with_args(get_content_path_mock, get_python_ve
         get_python_version_mock (MagicMock): Patch of the 'get_python_version' function to return the "3.7"
         tmp_path (fixture): Temporary Path used for the unit test and cleaned up afterwards
 
-    Scenario: Simulate executing the 'init' command with the 'contribution' option passed
+    Scenario: Simulate converting a contribution zip file
 
     Given
     - A contribution zip file

--- a/demisto_sdk/commands/init/tests/contribution_converter_test.py
+++ b/demisto_sdk/commands/init/tests/contribution_converter_test.py
@@ -1,0 +1,218 @@
+import json
+import re
+
+import pytest
+from demisto_sdk.commands.common.constants import LAYOUT, LAYOUTS_CONTAINER
+from demisto_sdk.commands.init.contribution_converter import \
+    ContributionConverter
+from mock import patch
+from TestSuite.contribution import Contribution
+from TestSuite.repo import Repo
+
+name_reformatting_test_examples = [
+    ('PACKYAYOK', 'PACKYAYOK'),
+    ('PackYayOK', 'PackYayOK'),
+    ('pack yay ok!', 'PackYayOk'),
+    ('PackYayOK', 'PackYayOK'),
+    ('-pack-yay-ok--', 'Pack-Yay-Ok'),
+    ('PackYayOK', 'PackYayOK'),
+    ('The quick brown fox, jumps over the lazy dog!', 'TheQuickBrownFox_JumpsOverTheLazyDog'),
+    ('The quick`*+.brown fox, ;jumps over @@the lazy dog!', 'TheQuick_BrownFox_JumpsOver_TheLazyDog'),
+    ('ThE quIck`*+.brown fox, ;jumps ovER @@the lazy dog!', 'ThEQuIck_BrownFox_JumpsOvER_TheLazyDog')
+]
+
+
+@pytest.fixture
+def contrib_converter():
+    return ContributionConverter('')
+
+
+@patch('demisto_sdk.commands.split_yml.extractor.get_python_version')
+@patch('demisto_sdk.commands.init.contribution_converter.get_content_path')
+def test_convert_contribution_zip(get_content_path_mock, get_python_version_mock, tmp_path):
+    '''Create a fake contribution zip file and test that it is converted to a Pack correctly
+
+    Args:
+        get_content_path_mock (MagicMock): Patch of the 'get_content_path' function to return the fake repo directory
+            used in the test
+        get_python_version_mock (MagicMock): Patch of the 'get_python_version' function to return the "3.7"
+        tmp_path (fixture): Temporary Path used for the unit test and cleaned up afterwards
+
+    Scenario: Simulate executing the 'init' command with the 'contribution' option passed
+
+    Given
+    - A contribution zip file
+    - The zipfile contains a unified script file
+    - The zipfile contains a unified integration file
+    When
+    - Converting the zipfile to a valid Pack structure
+    Then
+    - Ensure script and integration are componentized and in valid directory structure
+    '''
+    # Create all Necessary Temporary directories
+    # create temp directory for the repo
+    repo_dir = tmp_path / 'content_repo'
+    repo_dir.mkdir()
+    get_content_path_mock.return_value = repo_dir
+    get_python_version_mock.return_value = 3.7
+    # create temp target dir in which we will create all the TestSuite content items to use in the contribution zip and
+    # that will be deleted after
+    target_dir = repo_dir / 'target_dir'
+    target_dir.mkdir()
+    # create temp directory in which the contribution zip will reside
+    contribution_zip_dir = tmp_path / 'contrib_zip'
+    contribution_zip_dir.mkdir()
+    # Create fake content repo and contribution zip
+    repo = Repo(repo_dir)
+    contrib_zip = Contribution(target_dir, 'ContribTestPack', repo)
+    # contrib_zip.create_zip(contribution_zip_dir)
+    contrib_zip.create_zip(contribution_zip_dir)
+
+    # target_dir should have been deleted after creation of the zip file
+    assert not target_dir.exists()
+
+    name = 'Contrib Test Pack'
+    contribution_path = contrib_zip.created_zip_filepath
+    description = 'test pack description here'
+    author = 'Octocat Smith'
+    contrib_converter_inst = ContributionConverter(
+        name=name, contribution=contribution_path, description=description, author=author)
+    contrib_converter_inst.convert_contribution_to_pack()
+
+    converted_pack_path = repo_dir / 'Packs' / 'ContribTestPack'
+    assert converted_pack_path.exists()
+
+    scripts_path = converted_pack_path / 'Scripts'
+    sample_script_path = scripts_path / 'SampleScript'
+    script_yml = sample_script_path / 'SampleScript.yml'
+    script_py = sample_script_path / 'SampleScript.py'
+
+    assert scripts_path.exists()
+    assert sample_script_path.exists()
+    assert script_yml.exists()
+    assert script_py.exists()
+
+    integrations_path = converted_pack_path / 'Integrations'
+    sample_integration_path = integrations_path / 'Sample'
+    integration_yml = sample_integration_path / 'Sample.yml'
+    integration_py = sample_integration_path / 'Sample.py'
+    integration_description = sample_integration_path / 'Sample_description.md'
+    integration_image = sample_integration_path / 'Sample_image.png'
+    integration_files = [integration_yml, integration_py, integration_description, integration_image]
+    for integration_file in integration_files:
+        assert integration_file.exists()
+
+    layouts_path = converted_pack_path / 'Layouts'
+    sample_layoutscontainer = layouts_path / f'{LAYOUTS_CONTAINER}-fakelayoutscontainer.json'
+    sample_layout = layouts_path / f'{LAYOUT}-fakelayout.json'
+
+    assert layouts_path.exists()
+    assert sample_layoutscontainer.exists()
+    assert sample_layout.exists()
+
+
+@patch('demisto_sdk.commands.split_yml.extractor.get_python_version')
+@patch('demisto_sdk.commands.init.contribution_converter.get_content_path')
+def test_convert_contribution_zip_with_args(get_content_path_mock, get_python_version_mock, tmp_path):
+    '''Convert a contribution zip to a pack and test that the converted pack's 'pack_metadata.json' is correct
+
+    Args:
+        get_content_path_mock (MagicMock): Patch of the 'get_content_path' function to return the fake repo directory
+            used in the test
+        get_python_version_mock (MagicMock): Patch of the 'get_python_version' function to return the "3.7"
+        tmp_path (fixture): Temporary Path used for the unit test and cleaned up afterwards
+
+    Scenario: Simulate executing the 'init' command with the 'contribution' option passed
+
+    Given
+    - A contribution zip file
+    When
+    - The contrib_converter class instance is instantiated with the 'name' argument of 'Test Pack'
+    - The contrib_converter class instance is instantiated with the 'description' argument
+      of 'test pack description here'
+    - The contrib_converter class instance is instantiated with the 'author' argument of 'Octocat Smith'
+    Then
+    - Ensure pack with directory name of 'TestPack' is created
+    - Ensure that the pack's 'pack_metadata.json' file's 'name' field is 'Test Pack'
+    - Ensure that the pack's 'pack_metadata.json' file's 'description' field is 'test pack description here'
+    - Ensure that the pack's 'pack_metadata.json' file's 'author' field is 'Octocat Smith'
+    - Ensure that the pack's 'pack_metadata.json' file's 'email' field is the empty string
+    '''
+    # Create all Necessary Temporary directories
+    # create temp directory for the repo
+    repo_dir = tmp_path / 'content_repo'
+    repo_dir.mkdir()
+    get_content_path_mock.return_value = repo_dir
+    get_python_version_mock.return_value = 3.7
+    # create temp target dir in which we will create all the TestSuite content items to use in the contribution zip and
+    # that will be deleted after
+    target_dir = repo_dir / 'target_dir'
+    target_dir.mkdir()
+    # create temp directory in which the contribution zip will reside
+    contribution_zip_dir = tmp_path / 'contrib_zip'
+    contribution_zip_dir.mkdir()
+    # Create fake content repo and contribution zip
+    repo = Repo(repo_dir)
+    contrib_zip = Contribution(target_dir, 'ContribTestPack', repo)
+    # contrib_zip.create_zip(contribution_zip_dir)
+    contrib_zip.create_zip(contribution_zip_dir)
+
+    # target_dir should have been deleted after creation of the zip file
+    assert not target_dir.exists()
+
+    name = 'Test Pack'
+    contribution_path = contrib_zip.created_zip_filepath
+    description = 'test pack description here'
+    author = 'Octocat Smith'
+    contrib_converter_inst = ContributionConverter(
+        name=name, contribution=contribution_path, description=description, author=author)
+    contrib_converter_inst.convert_contribution_to_pack()
+
+    converted_pack_path = repo_dir / 'Packs' / 'TestPack'
+    assert converted_pack_path.exists()
+
+    pack_metadata_path = converted_pack_path / 'pack_metadata.json'
+    assert pack_metadata_path.exists()
+    with open(pack_metadata_path, 'r') as pack_metadata:
+        metadata = json.load(pack_metadata)
+        assert metadata.get('name', '') == name
+        assert metadata.get('description', '') == description
+        assert metadata.get('author', '') == author
+        assert not metadata.get('email')
+
+
+@pytest.mark.parametrize('input_name,expected_output_name', name_reformatting_test_examples)
+def test_format_pack_dir_name(contrib_converter, input_name, expected_output_name):
+    '''Test the 'format_pack_dir_name' method with various inputs
+
+    Args:
+        contrib_converter (fixture): An instance of the ContributionConverter class
+        input_name (str): A 'name' argument value to test
+        expected_output_name (str): The value expected to be returned by passing 'input_name'
+            to the 'format_pack_dir_name' method
+
+    Scenario: The demisto-sdk 'init' command is executed with the 'contribution' option
+
+    Given
+    - A pack name (taken from the contribution metadata or explicitly passed as a command option)
+
+    When
+    - The pack name is passed to the 'format_pack_dir_name' method
+
+    Then
+    - Ensure the reformatted pack name returned by the method matches the expected output
+    - Ensure the reformatted pack name returned by the method contains only valid characters
+        (alphanumeric, underscore, and dash with no whitespace)
+    '''
+    output_name = contrib_converter.format_pack_dir_name(input_name)
+    assert output_name == expected_output_name
+    assert not re.search(
+        r'\s', output_name), 'Whitespace was found in the returned value from executing "format_pack_dir_name"'
+    err_msg = 'Characters other than alphanumeric, underscore, and dash were found in the output'
+    assert all([char.isalnum() or char in {'_', '-'} for char in output_name]), err_msg
+    if len(output_name) > 1:
+        first_char = output_name[0]
+        if first_char.isalpha():
+            assert first_char.isupper(), 'The output\'s first character should be capitalized'
+    assert not output_name.startswith(('-', '_')), 'The output\'s first character must be alphanumeric'
+    assert not output_name.endswith(('-', '_')), 'The output\'s last character must be alphanumeric'

--- a/demisto_sdk/commands/init/tests/initiator_test.py
+++ b/demisto_sdk/commands/init/tests/initiator_test.py
@@ -79,157 +79,188 @@ def test_get_object_id_custom_name(monkeypatch, initiator):
     assert given_id == initiator.id
 
 
-def test_create_metadata_non_filled_manually(initiator):
-    """Create a non filled manually pack metadata
+class TestCreateMetadata:
+    def test_create_metadata_non_filled_manually(self, initiator):
+        """Create a non filled manually pack metadata
 
-    Args:
-        initiator (fixture): Initializes an instance of the 'Initiator' class
+        Args:
+            initiator (fixture): Initializes an instance of the 'Initiator' class
 
-    Given
-    - a non filled manually pack metadata.
-    When
-    - Creating the pack metadata file.
-    Then
-    - Ensure pack metadata is created with the expected attributes.
-    """
-    pack_metadata = initiator.create_metadata(False)
-    assert pack_metadata == {
-        'name': '## FILL MANDATORY FIELD ##',
-        'description': '## FILL MANDATORY FIELD ##',
-        'support': XSOAR_SUPPORT,
-        'currentVersion': PACK_INITIAL_VERSION,
-        'author': XSOAR_AUTHOR,
-        'url': XSOAR_SUPPORT_URL,
-        'email': '',
-        'created': datetime.utcnow().strftime(Initiator.DATE_FORMAT),
-        'categories': [],
-        'tags': [],
-        'useCases': [],
-        'keywords': []
-    }
+        Given
+        - a non filled manually pack metadata.
+        When
+        - Creating the pack metadata file.
+        Then
+        - Ensure pack metadata is created with the expected attributes.
+        """
+        pack_metadata = initiator.create_metadata(False)
+        assert pack_metadata == {
+            'name': '## FILL MANDATORY FIELD ##',
+            'description': '## FILL MANDATORY FIELD ##',
+            'support': XSOAR_SUPPORT,
+            'currentVersion': PACK_INITIAL_VERSION,
+            'author': XSOAR_AUTHOR,
+            'url': XSOAR_SUPPORT_URL,
+            'email': '',
+            'created': datetime.utcnow().strftime(Initiator.DATE_FORMAT),
+            'categories': [],
+            'tags': [],
+            'useCases': [],
+            'keywords': []
+        }
 
+    def test_create_metadata_non_filled_manually_with_data(self, initiator):
+        """Create a non filled manually pack metadata updated with pre-existing data
 
-def test_create_metadata_partner(monkeypatch, initiator):
-    """Create a fake partner init inputs and test that it is converted to a metadata file correctly
+        Args:
+            initiator (fixture): Initializes an instance of the 'Initiator' class
 
-    Args:
-        monkeypatch (MagicMock): Patch of the user inputs
-        initiator (fixture): Initializes an instance of the 'Initiator' class
+        Given
+        - a non filled manually pack metadata.
+        - pre-existing data that should be included in the metadata
+        When
+        - Creating the pack metadata file.
+        Then
+        - Ensure pack metadata is created with the expected attributes.
+        """
+        name = 'Test Pack'
+        description = 'Test Pack description'
+        data = {'name': name, 'description': description}
+        pack_metadata = initiator.create_metadata(False, data)
+        assert pack_metadata == {
+            'name': name,
+            'description': description,
+            'support': XSOAR_SUPPORT,
+            'currentVersion': PACK_INITIAL_VERSION,
+            'author': XSOAR_AUTHOR,
+            'url': XSOAR_SUPPORT_URL,
+            'email': '',
+            'created': datetime.utcnow().strftime(Initiator.DATE_FORMAT),
+            'categories': [],
+            'tags': [],
+            'useCases': [],
+            'keywords': []
+        }
 
-    Given
-    - init inputs of a partner supported packs.
-    When
-    - Creating the pack metadata file.
-    Then
-    - Ensure inputs are converted correctly to the pack metadata.
-    """
-    monkeypatch.setattr(
-        'builtins.input',
-        generate_multiple_inputs(
-            deque([
-                PACK_NAME, PACK_DESC, '2', '1', PACK_AUTHOR,
-                PACK_URL, PACK_EMAIL, PACK_TAGS, PACK_GITHUB_USERS
-            ])
+    def test_create_metadata_partner(self, monkeypatch, initiator):
+        """Create a fake partner init inputs and test that it is converted to a metadata file correctly
+
+        Args:
+            monkeypatch (MagicMock): Patch of the user inputs
+            initiator (fixture): Initializes an instance of the 'Initiator' class
+
+        Given
+        - init inputs of a partner supported packs.
+        When
+        - Creating the pack metadata file.
+        Then
+        - Ensure inputs are converted correctly to the pack metadata.
+        """
+        monkeypatch.setattr(
+            'builtins.input',
+            generate_multiple_inputs(
+                deque([
+                    PACK_NAME, PACK_DESC, '2', '1', PACK_AUTHOR,
+                    PACK_URL, PACK_EMAIL, PACK_TAGS, PACK_GITHUB_USERS
+                ])
+            )
         )
-    )
-    pack_metadata = initiator.create_metadata(True)
-    assert pack_metadata == {
-        'author': PACK_AUTHOR,
-        'categories': [INTEGRATION_CATEGORIES[0]],
-        'currentVersion': '1.0.0',
-        'description': PACK_DESC,
-        'email': PACK_EMAIL,
-        'keywords': [],
-        'name': PACK_NAME,
-        'support': PACK_SUPPORT_OPTIONS[1],
-        'tags': ['Tag1', 'Tag2'],
-        'created': datetime.utcnow().strftime(Initiator.DATE_FORMAT),
-        'url': PACK_URL,
-        'useCases': [],
-        'githubUser': []
-    }
+        pack_metadata = initiator.create_metadata(True)
+        assert pack_metadata == {
+            'author': PACK_AUTHOR,
+            'categories': [INTEGRATION_CATEGORIES[0]],
+            'currentVersion': '1.0.0',
+            'description': PACK_DESC,
+            'email': PACK_EMAIL,
+            'keywords': [],
+            'name': PACK_NAME,
+            'support': PACK_SUPPORT_OPTIONS[1],
+            'tags': ['Tag1', 'Tag2'],
+            'created': datetime.utcnow().strftime(Initiator.DATE_FORMAT),
+            'url': PACK_URL,
+            'useCases': [],
+            'githubUser': []
+        }
 
+    def test_create_metadata_partner_wrong_url(self, monkeypatch, initiator):
+        """Create a fake partner init inputs and test that it is converted to a metadata file correctly
 
-def test_create_metadata_partner_wrong_url(monkeypatch, initiator):
-    """Create a fake partner init inputs and test that it is converted to a metadata file correctly
+        Args:
+            monkeypatch (MagicMock): Patch of the user inputs
+            initiator (fixture): Initializes an instance of the 'Initiator' class
 
-    Args:
-        monkeypatch (MagicMock): Patch of the user inputs
-        initiator (fixture): Initializes an instance of the 'Initiator' class
-
-    Given
-    - init inputs of a partner supported packs with a non valid PACK_URL(gave a value which does not contain http).
-    When
-    - Creating the pack metadata file.
-    Then
-    - Ensure inputs are converted correctly to the pack metadata.
-    """
-    monkeypatch.setattr(
-        'builtins.input',
-        generate_multiple_inputs(
-            deque([
-                PACK_NAME, PACK_DESC, '2', '1', PACK_AUTHOR,
-                'no_h[t][t]p', PACK_URL, PACK_EMAIL, PACK_TAGS, PACK_GITHUB_USERS
-            ])
+        Given
+        - init inputs of a partner supported packs with a non valid PACK_URL(gave a value which does not contain http).
+        When
+        - Creating the pack metadata file.
+        Then
+        - Ensure inputs are converted correctly to the pack metadata.
+        """
+        monkeypatch.setattr(
+            'builtins.input',
+            generate_multiple_inputs(
+                deque([
+                    PACK_NAME, PACK_DESC, '2', '1', PACK_AUTHOR,
+                    'no_h[t][t]p', PACK_URL, PACK_EMAIL, PACK_TAGS, PACK_GITHUB_USERS
+                ])
+            )
         )
-    )
-    pack_metadata = initiator.create_metadata(True)
-    assert pack_metadata == {
-        'author': PACK_AUTHOR,
-        'categories': [INTEGRATION_CATEGORIES[0]],
-        'currentVersion': '1.0.0',
-        'description': PACK_DESC,
-        'email': PACK_EMAIL,
-        'keywords': [],
-        'name': PACK_NAME,
-        'support': PACK_SUPPORT_OPTIONS[1],
-        'tags': ['Tag1', 'Tag2'],
-        'created': datetime.utcnow().strftime(Initiator.DATE_FORMAT),
-        'url': PACK_URL,
-        'useCases': [],
-        'githubUser': []
-    }
+        pack_metadata = initiator.create_metadata(True)
+        assert pack_metadata == {
+            'author': PACK_AUTHOR,
+            'categories': [INTEGRATION_CATEGORIES[0]],
+            'currentVersion': '1.0.0',
+            'description': PACK_DESC,
+            'email': PACK_EMAIL,
+            'keywords': [],
+            'name': PACK_NAME,
+            'support': PACK_SUPPORT_OPTIONS[1],
+            'tags': ['Tag1', 'Tag2'],
+            'created': datetime.utcnow().strftime(Initiator.DATE_FORMAT),
+            'url': PACK_URL,
+            'useCases': [],
+            'githubUser': []
+        }
 
+    def test_create_metadata_community(self, monkeypatch, initiator):
+        """Create a fake community init inputs and test that it is converted to a metadata file correctly
 
-def test_create_metadata_community(monkeypatch, initiator):
-    """Create a fake community init inputs and test that it is converted to a metadata file correctly
+        Args:
+            monkeypatch (MagicMock): Patch of the user inputs
+            initiator (fixture): Initializes an instance of the 'Initiator' class
 
-    Args:
-        monkeypatch (MagicMock): Patch of the user inputs
-        initiator (fixture): Initializes an instance of the 'Initiator' class
-
-    Given
-    - init inputs of a community supported packs.
-    When
-    - Creating the pack metadata file.
-    Then
-    - Ensure inputs are converted correctly to the pack metadata.
-    """
-    monkeypatch.setattr(
-        'builtins.input',
-        generate_multiple_inputs(
-            deque([
-                PACK_NAME, PACK_DESC, '4', '1', PACK_AUTHOR,
-                PACK_TAGS, PACK_GITHUB_USERS
-            ])
+        Given
+        - init inputs of a community supported packs.
+        When
+        - Creating the pack metadata file.
+        Then
+        - Ensure inputs are converted correctly to the pack metadata.
+        """
+        monkeypatch.setattr(
+            'builtins.input',
+            generate_multiple_inputs(
+                deque([
+                    PACK_NAME, PACK_DESC, '4', '1', PACK_AUTHOR,
+                    PACK_TAGS, PACK_GITHUB_USERS
+                ])
+            )
         )
-    )
-    pack_metadata = initiator.create_metadata(True)
-    assert pack_metadata == {
-        'author': PACK_AUTHOR,
-        'categories': [INTEGRATION_CATEGORIES[0]],
-        'currentVersion': '1.0.0',
-        'description': PACK_DESC,
-        'email': '',
-        'keywords': [],
-        'name': PACK_NAME,
-        'support': PACK_SUPPORT_OPTIONS[3],
-        'tags': ['Tag1', 'Tag2'],
-        'created': datetime.utcnow().strftime(Initiator.DATE_FORMAT),
-        'url': MARKETPLACE_LIVE_DISCUSSIONS,
-        'useCases': [],
-        'githubUser': []
-    }
+        pack_metadata = initiator.create_metadata(True)
+        assert pack_metadata == {
+            'author': PACK_AUTHOR,
+            'categories': [INTEGRATION_CATEGORIES[0]],
+            'currentVersion': '1.0.0',
+            'description': PACK_DESC,
+            'email': '',
+            'keywords': [],
+            'name': PACK_NAME,
+            'support': PACK_SUPPORT_OPTIONS[3],
+            'tags': ['Tag1', 'Tag2'],
+            'created': datetime.utcnow().strftime(Initiator.DATE_FORMAT),
+            'url': MARKETPLACE_LIVE_DISCUSSIONS,
+            'useCases': [],
+            'githubUser': []
+        }
 
 
 def test_get_valid_user_input(monkeypatch, initiator):

--- a/demisto_sdk/tests/integration_tests/init_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/init_integration_test.py
@@ -34,7 +34,7 @@ def test_integration_init_integration_positive(tmp_path):
     create_integration = 'Y'
     integration_name = "SuperIntegration"
     use_dir_name_as_id = 'Y'
-    inputs = [pack_name, fill_pack_metadata, pack_display_name, pack_desc, support_type, pack_category,
+    inputs = [fill_pack_metadata, pack_display_name, pack_desc, support_type, pack_category,
               pack_author, pack_url, pack_email, pack_tags, pack_reviewers, create_integration, integration_name,
               use_dir_name_as_id]
 
@@ -46,7 +46,7 @@ def test_integration_init_integration_positive(tmp_path):
     tmp_integration_path = tmp_pack_path / 'Integrations' / integration_name
 
     runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(main, [INIT_CMD, '-o', tmp_dir_path], input='\n'.join(inputs))
+    result = runner.invoke(main, [INIT_CMD, '-o', tmp_dir_path, '-n', pack_name], input='\n'.join(inputs))
 
     assert result.exit_code == 0
     assert f"Successfully created the pack SuperPack in: {tmp_pack_path}" in result.stdout


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Contribution conversion has been split out into its own file/class under the `init` command directory. Furthermore the `init` command arguments related to contribution zip file conversion have been removed as this functionality is not intended to be used from the command line but rather only as an import to other code. While the convenience function of `convert_contribution_to_pack` has been left (in the new class `ContributionConverter`) for the simple case of creating a new pack from a contribution, the functionality has been broken down into multiple functions which allow for code that imports this class to handle different cases (such as when updating an existing pack) by invoking those functions as per their own requirements.

## Must have
- [ ] Tests
- [ ] Documentation
