### PR TITLE
remove deprecated argument from executor

### DIFF
--- a/demisto_sdk/commands/lint/lint_manager.py
+++ b/demisto_sdk/commands/lint/lint_manager.py
@@ -297,7 +297,7 @@ class LintManager:
                                         req_2=self._facts["requirements_2"],
                                         req_3=self._facts["requirements_3"],
                                         docker_engine=self._facts["docker_engine"])
-                results.append(executor.submit(fn=linter.run_dev_packages,
+                results.append(executor.submit(linter.run_dev_packages,
                                                no_flake8=no_flake8,
                                                no_bandit=no_bandit,
                                                no_mypy=no_mypy,


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)


## Description
Remove deprecated `fn` argument. Will not work on py3.8

