### PR TITLE
Format - avoid duplicate feed param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Changelog
-* Added validation for approved content pack usecases and tags.
+* Added validation for approved content pack use-cases and tags.
 * Added new code validations for *CommonServerPython* import to `XSOAR-linter`.
 * Added *default value* and *predefined values* to argument description in **generate-docs** command.
-* Added a new validation that checks if *get-mapping-fields* command exists if the intgeration schema has *{ismappable: true}* in **validate** command.
+* Added a new validation that checks if *get-mapping-fields* command exists if the integration schema has *{ismappable: true}* in **validate** command.
 * Fixed an issue where the *--staged* flag recognised added files as modified in the **validate** command.
 * Fixed an issue where a backwards compatibility warning was raised for all added files in the **validate** command.
 * Fixed an issue where **validate** command failed when no tests were given for a partner supported pack.
 * Updated the **download** command to support mappers.
+* Fixed an issue where the ***format*** command added a duplicate parameter.
 
 # v1.2.9
 * Fixed an issue in the **openapi_codegen** command where it created duplicate functions name from the swagger file.

--- a/demisto_sdk/commands/format/update_integration.py
+++ b/demisto_sdk/commands/format/update_integration.py
@@ -117,7 +117,7 @@ class IntegrationYMLFormat(BaseUpdateYML):
             # popped from the original configuration params.
             params = [dict(config) for config in self.data.get('configuration', [])]
             for counter, param in enumerate(params):
-                if 'defaultvalue' in param:
+                if 'defaultvalue' in param and param.get('name') != 'feed':
                     params[counter].pop('defaultvalue')
             for param in FEED_REQUIRED_PARAMS:
                 if param not in params:


### PR DESCRIPTION
## Status
- [x] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/30748

## Description
Don't remove the default value from the `feed` param.
