### PR TITLE
Generate-docs - need to add indentation to a table if it's a part of a list item.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * For partner supported content packs, added support for a list of emails.
 * Removed validation of README files from the ***validate*** command.
 * Fixed an issue where the ***validate*** command required release notes for ApiModules pack.
+* Fixed an issue where the ***generate-docs*** command resets the numbers of the list, after table.
 
 # v1.2.9
 * Fixed an issue in the **openapi_codegen** command where it created duplicate functions name from the swagger file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * For partner supported content packs, added support for a list of emails.
 * Removed validation of README files from the ***validate*** command.
 * Fixed an issue where the ***validate*** command required release notes for ApiModules pack.
-* Fixed an issue where the ***generate-docs*** command resets the numbers of the list, after table.
+* Fixed an issue where the ***generate-docs*** command reset the enumeration of line numbering after an MD table.
 
 # v1.2.9
 * Fixed an issue in the **openapi_codegen** command where it created duplicate functions name from the swagger file.

--- a/demisto_sdk/commands/generate_docs/common.py
+++ b/demisto_sdk/commands/generate_docs/common.py
@@ -96,7 +96,8 @@ def generate_list_section(title, data='', horizontal_rule=False, empty_message='
     return section
 
 
-def generate_table_section(data, title, empty_message='', text='', horizontal_rule=True, numbered_section=False):
+def generate_table_section(data: list, title: str, empty_message: str = '', text: str = '',
+                           horizontal_rule: bool = True, numbered_section: bool = False):
     """
     Generate table in markdown format.
     :param data: list of dicts contains the table data.
@@ -104,6 +105,7 @@ def generate_table_section(data, title, empty_message='', text='', horizontal_ru
     :param empty_message: message to print when there is no data.
     :param text: message to print after table header.
     :param horizontal_rule: add horizontal rule after title.
+    :param numbered_section: is the table part of numbered sections.
     :return: array of strings contains the table in markdown format.
     """
     section = []

--- a/demisto_sdk/commands/generate_docs/common.py
+++ b/demisto_sdk/commands/generate_docs/common.py
@@ -96,7 +96,7 @@ def generate_list_section(title, data='', horizontal_rule=False, empty_message='
     return section
 
 
-def generate_table_section(data, title, empty_message='', text='', horizontal_rule=True):
+def generate_table_section(data, title, empty_message='', text='', horizontal_rule=True, numbered_section=False):
     """
     Generate table in markdown format.
     :param data: list of dicts contains the table data.
@@ -117,14 +117,14 @@ def generate_table_section(data, title, empty_message='', text='', horizontal_ru
         section.extend([empty_message, ''])
         return section
 
-    section.extend([text, '|', '|'])
+    section.extend([text, '    |', '    |']) if numbered_section else section.extend([text, '|', '|'])
     header_index = len(section) - 2
     for key in data[0]:
         section[header_index] += f' **{key}** |'
         section[header_index + 1] += ' --- |'
 
     for item in data:
-        tmp_item = '|'
+        tmp_item = '    |' if numbered_section else '|'
         for key in item:
             tmp_item += f" {string_escape_md(str(item.get(key, '')), minimal_escaping=True, escape_multiline=True)} |"
         section.append(tmp_item)

--- a/demisto_sdk/commands/generate_docs/generate_integration_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_integration_doc.py
@@ -163,7 +163,7 @@ def generate_setup_section(yaml_data: dict):
              'Description': string_escape_md(conf.get('display', '')),
              'Required': conf.get('required', '')})
 
-    section.extend(generate_table_section(access_data, '', horizontal_rule=False))
+    section.extend(generate_table_section(access_data, '', horizontal_rule=False, numbered_section=True))
     section.append('4. Click **Test** to validate the URLs, token, and connection.')
 
     return section

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -510,6 +510,16 @@ class TestGenerateIntegrationDoc:
         assert "Number of users to return. Max 300. Default is 30." in open(fake_readme).read()
 
     def test_generate_numbered_section_with_table(self, pack):
+        """
+        Given
+            - generate_table_section command
+            - integration
+        When
+            - running generate_integration_doc command on the integration, generating setup section
+        Then
+            - Validate that the generating setup was created correctly, the numbers in the list are not being reset,
+             after a list item that contains a table
+    """
         fake_readme = os.path.join(os.path.dirname(TEST_INTEGRATION_PATH), 'fake_README.md')
         # Generate doc
         generate_integration_doc(TEST_INTEGRATION_PATH)
@@ -530,3 +540,22 @@ class TestGenerateIntegrationDoc:
 4. Click **Test** to validate the URLs, token, and connection."""
 
         assert table in open(os.path.join(os.path.dirname(TEST_INTEGRATION_PATH), 'README.md')).read()
+
+
+def test_generate_table_section_numbered_section():
+    """Unit test
+        Given
+            - generate_table_section command
+            - table, that part of numbered section.
+        When
+            - generating setup section of integration
+        Then
+            - Validate that the table has \t at all lines.
+        """
+    from demisto_sdk.commands.generate_docs.common import generate_table_section
+    expected_section = ['', '    | **Type** | **Docker Image** |', '    | --- | --- |',
+                        '    | python2 | demisto/python2 |', '']
+
+    section = generate_table_section(data=[{'Type': 'python2', 'Docker Image': 'demisto/python2'}],
+                                     title='', horizontal_rule=False, numbered_section=True)
+    assert section == expected_section

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -504,7 +504,8 @@ class TestGenerateIntegrationDoc:
         When
             - Running generate_integration_doc command on the integration.
         Then
-            - Validate that the generating setup was created correctly, specifically that the numbers in the lines are not being reset after a list item that contains a table.
+            - Validate that the generating setup was created correctly, specifically that the numbers in the
+            lines are not being reset after a list item that contains a table.
             - Test that the predefined values and default values are added to the README.
     """
         fake_readme = os.path.join(os.path.dirname(TEST_INTEGRATION_PATH), 'fake_README.md')
@@ -519,14 +520,17 @@ class TestGenerateIntegrationDoc:
 
 
 def test_generate_table_section_numbered_section():
+    """
         Given
             - A table that should be part of a numbered section (like the setup section of integration README).
         When
             - Running the generate_table_section command.
         Then
             - Validate that the generated table has \t at the beginning of each line.
-        """
+    """
+
     from demisto_sdk.commands.generate_docs.common import generate_table_section
+
     expected_section = ['', '    | **Type** | **Docker Image** |', '    | --- | --- |',
                         '    | python2 | demisto/python2 |', '']
 

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -498,18 +498,6 @@ class TestGenerateIntegrationDoc:
         cls.rm_readme()
 
     def test_generate_integration_doc(self):
-        fake_readme = os.path.join(os.path.dirname(TEST_INTEGRATION_PATH), 'fake_README.md')
-        # Generate doc
-        generate_integration_doc(TEST_INTEGRATION_PATH)
-        assert open(fake_readme).read() == open(
-            os.path.join(os.path.dirname(TEST_INTEGRATION_PATH), 'README.md')).read()
-
-        # Test that the predefined values and default values are added to the README.
-        assert "The type of the newly created user. Possible values are: Basic, Pro, Corporate. Default is Basic." \
-               in open(fake_readme).read()
-        assert "Number of users to return. Max 300. Default is 30." in open(fake_readme).read()
-
-    def test_generate_numbered_section_with_table(self, pack):
         """
         Given
             - generate_table_section command
@@ -519,6 +507,7 @@ class TestGenerateIntegrationDoc:
         Then
             - Validate that the generating setup was created correctly, the numbers in the list are not being reset,
              after a list item that contains a table
+            - Test that the predefined values and default values are added to the README.
     """
         fake_readme = os.path.join(os.path.dirname(TEST_INTEGRATION_PATH), 'fake_README.md')
         # Generate doc
@@ -526,20 +515,9 @@ class TestGenerateIntegrationDoc:
         assert open(fake_readme).read() == open(
             os.path.join(os.path.dirname(TEST_INTEGRATION_PATH), 'README.md')).read()
 
-        table = """
-1. Navigate to **Settings** > **Integrations** > **Servers & Services**.
-2. Search for Zoom.
-3. Click **Add instance** to create and configure a new integration instance.
-
-    | **Parameter** | **Description** | **Required** |
-    | --- | --- | --- |
-    | apiKey |  | True |
-    | apiSecret |  | True |
-    | proxy | Use system proxy settings | False |
-
-4. Click **Test** to validate the URLs, token, and connection."""
-
-        assert table in open(os.path.join(os.path.dirname(TEST_INTEGRATION_PATH), 'README.md')).read()
+        assert "The type of the newly created user. Possible values are: Basic, Pro, Corporate. Default is Basic." \
+               in open(fake_readme).read()
+        assert "Number of users to return. Max 300. Default is 30." in open(fake_readme).read()
 
 
 def test_generate_table_section_numbered_section():

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -504,8 +504,7 @@ class TestGenerateIntegrationDoc:
         When
             - Running generate_integration_doc command on the integration.
         Then
-            - Validate that the generating setup was created correctly, specifically that the numbers in the
-            lines are not being reset after a list item that contains a table.
+            - Validate that the integration README was created correctly, specifically that line numbers are not being reset after a table.
             - Test that the predefined values and default values are added to the README.
     """
         fake_readme = os.path.join(os.path.dirname(TEST_INTEGRATION_PATH), 'fake_README.md')

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -508,3 +508,25 @@ class TestGenerateIntegrationDoc:
         assert "The type of the newly created user. Possible values are: Basic, Pro, Corporate. Default is Basic." \
                in open(fake_readme).read()
         assert "Number of users to return. Max 300. Default is 30." in open(fake_readme).read()
+
+    def test_generate_numbered_section_with_table(self, pack):
+        fake_readme = os.path.join(os.path.dirname(TEST_INTEGRATION_PATH), 'fake_README.md')
+        # Generate doc
+        generate_integration_doc(TEST_INTEGRATION_PATH)
+        assert open(fake_readme).read() == open(
+            os.path.join(os.path.dirname(TEST_INTEGRATION_PATH), 'README.md')).read()
+
+        table = """
+1. Navigate to **Settings** > **Integrations** > **Servers & Services**.
+2. Search for Zoom.
+3. Click **Add instance** to create and configure a new integration instance.
+
+    | **Parameter** | **Description** | **Required** |
+    | --- | --- | --- |
+    | apiKey |  | True |
+    | apiSecret |  | True |
+    | proxy | Use system proxy settings | False |
+
+4. Click **Test** to validate the URLs, token, and connection."""
+
+        assert table in open(os.path.join(os.path.dirname(TEST_INTEGRATION_PATH), 'README.md')).read()

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -545,12 +545,11 @@ class TestGenerateIntegrationDoc:
 def test_generate_table_section_numbered_section():
     """Unit test
         Given
-            - generate_table_section command
-            - table, that part of numbered section.
+            - A table that should be part of a numbered section (like the setup section of integration README).
         When
-            - generating setup section of integration
+            - Running the generate_table_section command.
         Then
-            - Validate that the table has \t at all lines.
+            - Validate that the generated table has \t at the beginning of each line.
         """
     from demisto_sdk.commands.generate_docs.common import generate_table_section
     expected_section = ['', '    | **Type** | **Docker Image** |', '    | --- | --- |',

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -500,13 +500,11 @@ class TestGenerateIntegrationDoc:
     def test_generate_integration_doc(self):
         """
         Given
-            - generate_table_section command
-            - integration
+            - YML file representing an integration.
         When
-            - running generate_integration_doc command on the integration, generating setup section
+            - Running generate_integration_doc command on the integration.
         Then
-            - Validate that the generating setup was created correctly, the numbers in the list are not being reset,
-             after a list item that contains a table
+            - Validate that the generating setup was created correctly, specifically that the numbers in the lines are not being reset after a list item that contains a table.
             - Test that the predefined values and default values are added to the README.
     """
         fake_readme = os.path.join(os.path.dirname(TEST_INTEGRATION_PATH), 'fake_README.md')
@@ -521,7 +519,6 @@ class TestGenerateIntegrationDoc:
 
 
 def test_generate_table_section_numbered_section():
-    """Unit test
         Given
             - A table that should be part of a numbered section (like the setup section of integration README).
         When

--- a/demisto_sdk/tests/test_files/fake_integration/fake_README.md
+++ b/demisto_sdk/tests/test_files/fake_integration/fake_README.md
@@ -6,11 +6,11 @@ This integration was integrated and tested with version xx of Zoom
 2. Search for Zoom.
 3. Click **Add instance** to create and configure a new integration instance.
 
-| **Parameter** | **Description** | **Required** |
-| --- | --- | --- |
-| apiKey |  | True |
-| apiSecret |  | True |
-| proxy | Use system proxy settings | False |
+    | **Parameter** | **Description** | **Required** |
+    | --- | --- | --- |
+    | apiKey |  | True |
+    | apiSecret |  | True |
+    | proxy | Use system proxy settings | False |
 
 4. Click **Test** to validate the URLs, token, and connection.
 ## Commands


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/30814

## Description
When generating a README.md file, the numbers in a list are being reset after a list item that contains a table.

## Must have
- [x] Tests
- [ ] Documentation
