### PR TITLE
Don't restore cache in validate files step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,8 +121,6 @@ jobs:
         - checkout
         - attach_workspace:
             at: ~/project
-        - restore_cache:
-            key: tox-38-cache-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
         - run:
             name: Test validate files and yaml
             when: always


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/31320

## Description
No need to restore cache when using tox
The tox has it's own caching and it appears like the cache we have saves also the sdk version and prevents it from changing until the next change in the requirements.txt. 

