### PR TITLE
Add fromversion when a new integration is released to the RN and readme.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added support for *prev-ver* flag in **update-release-notes** command.
 * Improved retry support when building docker images for linting.
 * Added the *--skip-id-set-creation* flag to **validate** command in order to add the capability to run validate command without creating id_set validation.
+* Added version of availability (fromversion) to the README and to the release notes, when a new integration is released, in **update-release-notes** and **generate_docs** command.
 
 # 1.2.11
 * Fixed an issue where the ***generate-docs*** command reset the enumeration of line numbering after an MD table.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Improved retry support when building docker images for linting.
 * Added the *--skip-id-set-creation* flag to **validate** command in order to add the capability to run validate command without creating id_set validation.
 * Fixed an issue where **validate** command checked docker image tag on ApiModules pack.
-* Added version of availability (fromversion) to the README and to the release notes, when a new integration is released, in **update-release-notes** and **generate_docs** command.
+* Added supported version message to the documentation and release notes files when running **generate_docs** and **update-release-notes** commands respectively.
 
 # 1.2.11
 * Fixed an issue where the ***generate-docs*** command reset the enumeration of line numbering after an MD table.

--- a/TestSuite/pack.py
+++ b/TestSuite/pack.py
@@ -315,7 +315,7 @@ class Pack:
             readme: Optional[str] = None,
     ) -> Playbook:
         if name is None:
-            name = f'playbook-{len(self.playbooks)}.yml'
+            name = f'playbook-{len(self.playbooks)}'
         if yml is None:
             yml = {}
         playbook = Playbook(self._playbooks_path, name, self._repo)

--- a/demisto_sdk/commands/generate_docs/generate_integration_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_integration_doc.py
@@ -110,7 +110,9 @@ def generate_integration_doc(
         else:
             docs = []  # type: list
             docs.extend(add_lines(yml_data.get('description')))
-            docs.extend(['This integration was integrated and tested with version xx of {}'.format(yml_data['name'])])
+            docs.extend(['This integration was integrated and tested with version xx of {}.'.format(yml_data['name'])])
+            if from_version := yml_data.get('fromversion'):
+                docs.append(f'Supported Cortex XSOAR versions: {from_version} and later.\n')
 
             # Integration use cases
             if use_cases:

--- a/demisto_sdk/commands/generate_docs/generate_integration_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_integration_doc.py
@@ -111,7 +111,9 @@ def generate_integration_doc(
             docs = []  # type: list
             docs.extend(add_lines(yml_data.get('description')))
             docs.extend(['This integration was integrated and tested with version xx of {}.'.format(yml_data['name'])])
-            if from_version := yml_data.get('fromversion'):
+
+            from_version = yml_data.get('fromversion')
+            if from_version:
                 docs.append(f'Supported Cortex XSOAR versions: {from_version} and later.\n')
 
             # Integration use cases

--- a/demisto_sdk/commands/generate_docs/generate_playbook_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_playbook_doc.py
@@ -22,7 +22,8 @@ def generate_playbook_doc(input, output: str = None, permissions: str = None, li
             errors.append('Error! You are missing description for the playbook')
         doc = [description]
 
-        if from_version := playbook.get('fromversion'):
+        from_version = playbook.get('fromversion')
+        if from_version:
             doc.append(f'Supported Cortex XSOAR versions: {from_version} and later.\n')
 
         doc.extend(['', '## Dependencies',

--- a/demisto_sdk/commands/generate_docs/generate_playbook_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_playbook_doc.py
@@ -20,9 +20,13 @@ def generate_playbook_doc(input, output: str = None, permissions: str = None, li
         _name = playbook.get('name', 'Unknown')
         if not description:
             errors.append('Error! You are missing description for the playbook')
+        doc = [description]
 
-        doc = [description, '', '## Dependencies',
-               'This playbook uses the following sub-playbooks, integrations, and scripts.', '']
+        if from_version := playbook.get('fromversion'):
+            doc.append(f'Supported Cortex XSOAR versions: {from_version} and later.\n')
+
+        doc.extend(['', '## Dependencies',
+                    'This playbook uses the following sub-playbooks, integrations, and scripts.', ''])
 
         playbooks, integrations, scripts, commands = get_playbook_dependencies(playbook, input)
         inputs, inputs_errors = get_inputs(playbook)

--- a/demisto_sdk/commands/generate_docs/generate_script_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_script_doc.py
@@ -60,7 +60,8 @@ def generate_script_doc(input, examples, output: str = None, permissions: str = 
 
         doc.append(description + '\n')
 
-        if from_version := script.get('fromversion'):
+        from_version = script.get('fromversion')
+        if from_version:
             doc.append(f'Supported Cortex XSOAR versions: {from_version} and later.\n')
 
         doc.extend(generate_table_section(secript_info, 'Script Data'))

--- a/demisto_sdk/commands/generate_docs/generate_script_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_script_doc.py
@@ -60,6 +60,9 @@ def generate_script_doc(input, examples, output: str = None, permissions: str = 
 
         doc.append(description + '\n')
 
+        if from_version := script.get('fromversion'):
+            doc.append(f'Supported Cortex XSOAR versions: {from_version} and later.\n')
+
         doc.extend(generate_table_section(secript_info, 'Script Data'))
 
         if dependencies:

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -328,7 +328,11 @@ def test_generate_playbook(playbook):
 
         generate_playbook_doc(input=playbook.yml.path)
 
-        readme_filename = os.path.basename(playbook.yml.path).replace('.yml', '_README.md')
+        # playbook_filename = os.path.basename(playbook.yml.path).replace('.yml', '')
+        # readme = playbook.path + '/' + playbook_filename + '_README.md'
+        playbook_path = playbook.yml.path
+
+        readme_filename = os.path.basename(playbook.yml.path).replace('.yml', '_README.md', 1)
         readme = playbook.path + '/' + readme_filename
         with open(readme) as f:
             text = f.read()

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -313,20 +313,30 @@ def test_get_input_data_complex():
 
 
 def test_generate_playbook(playbook):
+    """Unit test
+    Given
+        - generate_playbook_doc command
+        - playbook
+    When
+        - running the command generate_playbook_doc on playbook in order to generate documentation.
+    Then
+        - Validate That from-version added to the documentation.
+    """
     from demisto_sdk.commands.generate_docs.generate_playbook_doc import \
         generate_playbook_doc
 
-    playbook.create_default_playbook()
-    playbook.yml.write_dict({'fromversion': '5.0.0'})
+    try:
+        playbook.yml.write_dict({'fromversion': '5.0.0'})
 
-    generate_playbook_doc(input=playbook.yml.path)
+        generate_playbook_doc(input=playbook.yml.path)
 
-    playbook_filename = os.path.basename(playbook.yml.path).replace('.yml', '')
-    readme = playbook.path + '/' + playbook_filename + '_README.md'
-    with open(readme) as f:
-        text = f.read()
-        assert 'Supported Cortex XSOAR versions: 5.0.0 and later.' in text
-
+        playbook_filename = os.path.basename(playbook.yml.path).replace('.yml', '')
+        readme = playbook.path + '/' + playbook_filename + '_README.md'
+        with open(readme) as f:
+            text = f.read()
+            assert 'Supported Cortex XSOAR versions: 5.0.0 and later.' in text
+    finally:
+        os.remove(readme)
 
 # script tests
 

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -328,11 +328,7 @@ def test_generate_playbook(playbook):
 
         generate_playbook_doc(input=playbook.yml.path)
 
-        # playbook_filename = os.path.basename(playbook.yml.path).replace('.yml', '')
-        # readme = playbook.path + '/' + playbook_filename + '_README.md'
-        playbook_path = playbook.yml.path
-
-        readme_filename = os.path.basename(playbook.yml.path).replace('.yml', '_README.md', 1)
+        readme_filename = os.path.basename(playbook.yml.path).replace('.yml', '_README.md')
         readme = playbook.path + '/' + readme_filename
         with open(readme) as f:
             text = f.read()

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -322,7 +322,7 @@ def test_generate_playbook(playbook):
     generate_playbook_doc(input=playbook.yml.path)
 
     playbook_filename = os.path.basename(playbook.yml.path).replace('.yml', '')
-    readme = playbook.path+'/'+playbook_filename+'_README.md'
+    readme = playbook.path + '/' + playbook_filename + '_README.md'
     with open(readme) as f:
         text = f.read()
         assert 'Supported Cortex XSOAR versions: 5.0.0 and later.' in text

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -328,8 +328,8 @@ def test_generate_playbook(playbook):
 
         generate_playbook_doc(input=playbook.yml.path)
 
-        playbook_filename = os.path.basename(playbook.yml.path).replace('.yml', '')
-        readme = playbook.path + '/' + playbook_filename + '_README.md'
+        readme_filename = os.path.basename(playbook.yml.path).replace('.yml', '_README.md')
+        readme = playbook.path + '/' + readme_filename
         with open(readme) as f:
             text = f.read()
             assert 'Supported Cortex XSOAR versions: 5.0.0 and later.' in text

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -313,14 +313,12 @@ def test_get_input_data_complex():
 
 
 def test_generate_playbook(playbook):
-    """Unit test
     Given
-        - generate_playbook_doc command
-        - playbook
+        - A playbook path
     When
-        - running the command generate_playbook_doc on playbook in order to generate documentation.
+        - running the command generate_playbook_doc in order to generate documentation.
     Then
-        - Validate That from-version added to the documentation.
+        - Validate that from-version added to the documentation.
     """
     from demisto_sdk.commands.generate_docs.generate_playbook_doc import \
         generate_playbook_doc

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -312,7 +312,7 @@ def test_get_input_data_complex():
     assert _value == 'File.Name'
 
 
-def test_generate_playbook(playbook):
+def test_generate_playbook(playbook, tmp_path):
     """Given
         - A playbook path
     When
@@ -323,18 +323,15 @@ def test_generate_playbook(playbook):
     from demisto_sdk.commands.generate_docs.generate_playbook_doc import \
         generate_playbook_doc
 
-    try:
-        playbook.yml.write_dict({'fromversion': '5.0.0'})
+    playbook.yml.write_dict({'fromversion': '5.0.0'})
 
-        generate_playbook_doc(input=playbook.yml.path)
+    generate_playbook_doc(input=playbook.yml.path, output=tmp_path)
 
-        readme_filename = os.path.basename(playbook.yml.path).replace('.yml', '_README.md')
-        readme = playbook.path + '/' + readme_filename
-        with open(readme) as f:
-            text = f.read()
-            assert 'Supported Cortex XSOAR versions: 5.0.0 and later.' in text
-    finally:
-        os.remove(readme)
+    readme_filename = os.path.basename(playbook.yml.path).replace('.yml', '_README.md')
+    readme = str(tmp_path) + '/' + readme_filename
+    with open(readme) as f:
+        text = f.read()
+        assert 'Supported Cortex XSOAR versions: 5.0.0 and later.' in text
 
 # script tests
 

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -313,7 +313,7 @@ def test_get_input_data_complex():
 
 
 def test_generate_playbook(playbook):
-    Given
+    """Given
         - A playbook path
     When
         - running the command generate_playbook_doc in order to generate documentation.

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -312,6 +312,22 @@ def test_get_input_data_complex():
     assert _value == 'File.Name'
 
 
+def test_generate_playbook(playbook):
+    from demisto_sdk.commands.generate_docs.generate_playbook_doc import \
+        generate_playbook_doc
+
+    playbook.create_default_playbook()
+    playbook.yml.write_dict({'fromversion': '5.0.0'})
+
+    generate_playbook_doc(input=playbook.yml.path)
+
+    playbook_filename = os.path.basename(playbook.yml.path).replace('.yml', '')
+    readme = playbook.path+'/'+playbook_filename+'_README.md'
+    with open(readme) as f:
+        text = f.read()
+        assert 'Supported Cortex XSOAR versions: 5.0.0 and later.' in text
+
+
 # script tests
 
 
@@ -461,6 +477,7 @@ def test_generate_script_doc(tmp_path, mocker):
     with open(readme) as f:
         text = f.read()
         assert 'Sample usage of this script can be found in the following playbooks and scripts' in text
+        assert 'Supported Cortex XSOAR versions: 5.0.0 and later.' in text
 
 
 class TestAppendOrReplaceCommandInDocs:

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -458,12 +458,11 @@ class TestRNUpdate(unittest.TestCase):
         self.assertRaises(ValueError, update_rn.bump_version_number)
 
     def test_add_fromversion_to_new_file(self):
-        """Unit test
+        """
             Given
-                - build_rn_desc command
-                - pack
+                - A new file
             When
-                - running the command build_rn_desc on pack in order to generate rn description.
+                - Running the command build_rn_desc on a file in order to generate rn description.
             Then
                 - Validate That from-version added to the rn description.
             """
@@ -477,14 +476,13 @@ class TestRNUpdate(unittest.TestCase):
         assert '(Available from Cortex XSOAR 5.5.0).' in desc
 
     def test_build_rn_template_with_fromversion(self):
-        """Unit test
+        """
             Given
-                - build_rn_template command
-                - pack
+                - New playbook integration and script.
             When
-                - running the command build_rn_template on pack in order to generate rn description.
+                - running the command build_rn_template on this files in order to generate rn description.
             Then
-                - Validate That from-version added to the rn description.
+                - Validate That from-version added to each of rn descriptions.
             """
         from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
 
@@ -986,13 +984,13 @@ class TestRNUpdateUnit:
 def test_get_from_version_at_update_rn(integration):
     """
         Given
-            - integration
-            - get_from_version_at_update_rn command
+            - Case 1: An integration path
+            - Case 2: A fake integration path
         When
-            - Updating release notes for integration, trying to get fromversion
+            - Updating release notes for integration, trying to extract the 'fromversion' key from the integration yml.
         Then
-            - Successfully receiving fromversion if yml file path right,
-            - receiving '' if yml path wrong
+            - Case 1: Assert that the `fromverrsion` value is 5.0.0
+            - Case 2: Assert that the `fromverrsion` value is ''
         """
     from demisto_sdk.commands.update_release_notes.update_rn import get_from_version_at_update_rn
 

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -567,11 +567,13 @@ class TestRNUpdateUnit:
 
         """
         self.meta_backup = str(tmp_path / 'pack_metadata-backup.json')
-        shutil.copy('demisto_sdk/commands/update_release_notes/tests_data/Packs/Test/pack_metadata.json', self.meta_backup)
+        shutil.copy('demisto_sdk/commands/update_release_notes/tests_data/Packs/Test/pack_metadata.json',
+                    self.meta_backup)
 
     def teardown(self):
         if self.meta_backup:
-            shutil.copy(self.meta_backup, 'demisto_sdk/commands/update_release_notes/tests_data/Packs/Test/pack_metadata.json')
+            shutil.copy(self.meta_backup,
+                        'demisto_sdk/commands/update_release_notes/tests_data/Packs/Test/pack_metadata.json')
         else:
             raise Exception('Expecting self.meta_backup to be set inorder to restore pack_metadata.json file')
 
@@ -990,7 +992,7 @@ def test_get_from_version_at_update_rn(integration):
             - Updating release notes for integration, trying to extract the 'fromversion' key from the integration yml.
         Then
             - Case 1: Assert that the `fromversion` value is 5.0.0
-            - Case 2: Assert that the `fromversion` value is ''
+            - Case 2: Assert that the `fromversion` value is None
         """
     from demisto_sdk.commands.update_release_notes.update_rn import get_from_version_at_update_rn
 
@@ -998,4 +1000,4 @@ def test_get_from_version_at_update_rn(integration):
     fromversion = get_from_version_at_update_rn(integration.yml.path)
     assert fromversion == '5.0.0'
     fromversion = get_from_version_at_update_rn('fake_path.yml')
-    assert fromversion == ''
+    assert fromversion is None

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -981,3 +981,23 @@ class TestRNUpdateUnit:
             RN = file.read()
         os.remove('demisto_sdk/commands/update_release_notes/tests_data/Packs/release_notes/1_1_0.md')
         assert 'Upgraded the Docker image to dockerimage:python/test:1243' not in RN
+
+
+def test_get_from_version_at_update_rn(integration):
+    """
+        Given
+            - integration
+            - get_from_version_at_update_rn command
+        When
+            - Updating release notes for integration, trying to get fromversion
+        Then
+            - Successfully receiving fromversion if yml file path right,
+            - receiving '' if yml path wrong
+        """
+    from demisto_sdk.commands.update_release_notes.update_rn import get_from_version_at_update_rn
+
+    integration.yml.write_dict({'fromversion': '5.0.0'})
+    fromversion = get_from_version_at_update_rn(integration.yml.path)
+    assert fromversion == '5.0.0'
+    fromversion = get_from_version_at_update_rn('fake_path.yml')
+    assert fromversion == ''

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -478,11 +478,11 @@ class TestRNUpdate(unittest.TestCase):
     def test_build_rn_desc_old_file(self):
         """
             Given
-                - A new file
+                - An old file
             When
                 - Running the command build_rn_desc on a file in order to generate rn description.
             Then
-                - Validate That from-version added to the rn description.
+                - Validate That from-version was not added to the rn description.
             """
         from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
 

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -457,7 +457,7 @@ class TestRNUpdate(unittest.TestCase):
         update_rn.metadata_path = os.path.join(TestRNUpdate.FILES_PATH, 'fake_pack_invalid/pack_metadata.json')
         self.assertRaises(ValueError, update_rn.bump_version_number)
 
-    def test_ build_rn_desc_new_file(self):
+    def test_build_rn_desc_new_file(self):
         """
             Given
                 - A new file

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -457,6 +457,52 @@ class TestRNUpdate(unittest.TestCase):
         update_rn.metadata_path = os.path.join(TestRNUpdate.FILES_PATH, 'fake_pack_invalid/pack_metadata.json')
         self.assertRaises(ValueError, update_rn.bump_version_number)
 
+    def test_add_fromversion_to_new_file(self):
+        """Unit test
+            Given
+                - build_rn_desc command
+                - pack
+            When
+                - running the command build_rn_desc on pack in order to generate rn description.
+            Then
+                - Validate That from-version added to the rn description.
+            """
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
+
+        update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='minor', modified_files_in_pack={'HelloWorld'},
+                             added_files=set())
+
+        desc = update_rn.build_rn_desc(_type='Test_type', content_name='Hello World Test', desc='Test description',
+                                       is_new_file=True, text='', from_version='5.5.0')
+        assert '(Available from Cortex XSOAR 5.5.0).' in desc
+
+    def test_build_rn_template_with_fromversion(self):
+        """Unit test
+            Given
+                - build_rn_template command
+                - pack
+            When
+                - running the command build_rn_template on pack in order to generate rn description.
+            Then
+                - Validate That from-version added to the rn description.
+            """
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
+
+        changed_items = {
+            'Hello World Integration': {'type': 'Integration', 'description': "", 'is_new_file': True,
+                                        'fromversion': '5.0.0'},
+            'Hello World Playbook': {'type': 'Playbook', 'description': '', 'is_new_file': True,
+                                     'fromversion': '5.5.0'},
+            "Hello World Script": {'type': 'Script', 'description': '', 'is_new_file': True, 'fromversion': '6.0.0'},
+        }
+        update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='minor', modified_files_in_pack={'HelloWorld'},
+                             added_files=set())
+
+        desc = update_rn.build_rn_template(changed_items=changed_items)
+        assert '(Available from Cortex XSOAR 5.0.0).' in desc
+        assert '(Available from Cortex XSOAR 5.5.0).' in desc
+        assert '(Available from Cortex XSOAR 6.0.0).' in desc
+
 
 class TestRNUpdateUnit:
     META_BACKUP = ""

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -457,7 +457,7 @@ class TestRNUpdate(unittest.TestCase):
         update_rn.metadata_path = os.path.join(TestRNUpdate.FILES_PATH, 'fake_pack_invalid/pack_metadata.json')
         self.assertRaises(ValueError, update_rn.bump_version_number)
 
-    def test_add_fromversion_to_new_file(self):
+    def test_ build_rn_desc_new_file(self):
         """
             Given
                 - A new file

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -475,7 +475,7 @@ class TestRNUpdate(unittest.TestCase):
                                        is_new_file=True, text='', from_version='5.5.0')
         assert '(Available from Cortex XSOAR 5.5.0).' in desc
 
-    def test_build_rn_desc_new_file(self):
+    def test_build_rn_desc_old_file(self):
         """
             Given
                 - A new file

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -989,8 +989,8 @@ def test_get_from_version_at_update_rn(integration):
         When
             - Updating release notes for integration, trying to extract the 'fromversion' key from the integration yml.
         Then
-            - Case 1: Assert that the `fromverrsion` value is 5.0.0
-            - Case 2: Assert that the `fromverrsion` value is ''
+            - Case 1: Assert that the `fromversion` value is 5.0.0
+            - Case 2: Assert that the `fromversion` value is ''
         """
     from demisto_sdk.commands.update_release_notes.update_rn import get_from_version_at_update_rn
 

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -475,6 +475,24 @@ class TestRNUpdate(unittest.TestCase):
                                        is_new_file=True, text='', from_version='5.5.0')
         assert '(Available from Cortex XSOAR 5.5.0).' in desc
 
+    def test_build_rn_desc_new_file(self):
+        """
+            Given
+                - A new file
+            When
+                - Running the command build_rn_desc on a file in order to generate rn description.
+            Then
+                - Validate That from-version added to the rn description.
+            """
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
+
+        update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='minor', modified_files_in_pack={'HelloWorld'},
+                             added_files=set())
+
+        desc = update_rn.build_rn_desc(_type='Test_type', content_name='Hello World Test', desc='Test description',
+                                       is_new_file=False, text='', from_version='5.5.0')
+        assert '(Available from Cortex XSOAR 5.5.0).' not in desc
+
     def test_build_rn_template_with_fromversion(self):
         """
             Given

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -17,7 +17,7 @@ from demisto_sdk.commands.common.hook_validations.structure import \
     StructureValidator
 from demisto_sdk.commands.common.tools import (LOG_COLORS, get_api_module_ids,
                                                get_api_module_integrations_set,
-                                               get_json,
+                                               get_from_version, get_json,
                                                get_latest_release_notes_text,
                                                get_pack_name, get_yaml,
                                                pack_name_to_path, print_color,
@@ -96,7 +96,8 @@ class UpdateRN:
                 changed_files[file_name] = {
                     'type': file_type,
                     'description': get_file_description(packfile, file_type),
-                    'is_new_file': True if packfile in self.added_files else False
+                    'is_new_file': True if packfile in self.added_files else False,
+                    'fromversion': get_from_version(packfile)
                 }
 
             rn_string = self.build_rn_template(changed_files)
@@ -344,10 +345,12 @@ class UpdateRN:
             desc = data.get('description', '')
             is_new_file = data.get('is_new_file', False)
             _type = data.get('type', '')
+            from_version = data.get('fromversion')
             # Skipping the invalid files
             if not _type or content_name == 'N/A':
                 continue
-            rn_desc = self.build_rn_desc(_type, content_name, desc, is_new_file, self.text)
+            rn_desc = self.build_rn_desc(_type=_type, content_name=content_name, desc=desc, is_new_file=is_new_file,
+                                         text=self.text, from_version=from_version)
             if _type == 'Integration':
                 if not integration_header:
                     rn_string += '\n#### Integrations\n'
@@ -416,13 +419,16 @@ class UpdateRN:
 
         return rn_string
 
-    def build_rn_desc(self, _type, content_name, desc, is_new_file, text):
+    def build_rn_desc(self, _type, content_name, desc, is_new_file, text, from_version=None):
         if _type in ('Connections', 'Incident Types', 'Indicator Types', 'Layouts', 'Incident Fields',
                      'Indicator Fields'):
             rn_desc = f'- **{content_name}**\n'
         else:
             if is_new_file:
-                rn_desc = f'##### New: {content_name}\n- {desc}\n'
+                rn_desc = f'##### New: {content_name}\n- {desc}'
+                if from_version:
+                    rn_desc += f'(Available from Cortex XSOAR {from_version}).'
+                rn_desc += '\n'
             else:
                 rn_desc = f'##### {content_name}\n'
                 if self.update_type == 'maintenance':
@@ -447,7 +453,7 @@ class UpdateRN:
             if _type in ('Connections', 'Incident Types', 'Indicator Types', 'Layouts', 'Incident Fields'):
                 rn_desc = f'\n- **{content_name}**'
             else:
-                rn_desc = f'\n##### New: {content_name}\n- {desc}\n' if is_new_file\
+                rn_desc = f'\n##### New: {content_name}\n- {desc}\n' if is_new_file \
                     else f'\n##### {content_name}\n- %%UPDATE_RN%%\n'
 
             if _type in current_rn:

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -97,7 +97,7 @@ class UpdateRN:
                     'type': file_type,
                     'description': get_file_description(packfile, file_type),
                     'is_new_file': True if packfile in self.added_files else False,
-                    'fromversion': get_from_version(packfile)
+                    'fromversion': get_from_version_at_update_rn(packfile)
                 }
 
             rn_string = self.build_rn_template(changed_files)
@@ -345,7 +345,7 @@ class UpdateRN:
             desc = data.get('description', '')
             is_new_file = data.get('is_new_file', False)
             _type = data.get('type', '')
-            from_version = data.get('fromversion')
+            from_version = data.get('fromversion', '')
             # Skipping the invalid files
             if not _type or content_name == 'N/A':
                 continue
@@ -419,7 +419,7 @@ class UpdateRN:
 
         return rn_string
 
-    def build_rn_desc(self, _type, content_name, desc, is_new_file, text, from_version=None):
+    def build_rn_desc(self, _type, content_name, desc, is_new_file, text, from_version=''):
         if _type in ('Connections', 'Incident Types', 'Indicator Types', 'Layouts', 'Incident Fields',
                      'Indicator Fields'):
             rn_desc = f'- **{content_name}**\n'
@@ -563,3 +563,18 @@ def check_docker_image_changed(added_or_modified_yml):
                 # changed.
                 return True, diff_line.split()[-1]
         return False, ''
+
+
+def get_from_version_at_update_rn(path):
+    """
+    Args:
+        path: path to yml file, if exists
+
+    Returns: - '' if no such yml file,
+             - fromversion if there fromversion in the yml file
+
+    """
+    if not os.path.isfile(path):
+        print_warning(f'Cannot get file fromversion: "{path}" file does not exist')
+        return ''
+    return get_from_version(path)

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -570,7 +570,7 @@ def get_from_version_at_update_rn(path: str):
     Args:
         path (str): path to yml file, if exists
 
-    Returns: 
+    Returns:
             str. Fromversion if there fromversion key in the yml file.
 
     """

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -565,13 +565,13 @@ def check_docker_image_changed(added_or_modified_yml):
         return False, ''
 
 
-def get_from_version_at_update_rn(path):
+def get_from_version_at_update_rn(path: str):
     """
     Args:
-        path: path to yml file, if exists
+        path (str): path to yml file, if exists
 
-    Returns: - '' if no such yml file,
-             - fromversion if there fromversion in the yml file
+    Returns: 
+            str. Fromversion if there fromversion key in the yml file.
 
     """
     if not os.path.isfile(path):

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -427,7 +427,7 @@ class UpdateRN:
             if is_new_file:
                 rn_desc = f'##### New: {content_name}\n- {desc}'
                 if from_version:
-                    rn_desc += f'(Available from Cortex XSOAR {from_version}).'
+                    rn_desc += f' (Available from Cortex XSOAR {from_version}).'
                 rn_desc += '\n'
             else:
                 rn_desc = f'##### {content_name}\n'
@@ -576,5 +576,5 @@ def get_from_version_at_update_rn(path: str):
     """
     if not os.path.isfile(path):
         print_warning(f'Cannot get file fromversion: "{path}" file does not exist')
-        return ''
+        return
     return get_from_version(path)

--- a/demisto_sdk/tests/integration_tests/Packs/FeedAzureValid/ReleaseNotes/1_0_1.md
+++ b/demisto_sdk/tests/integration_tests/Packs/FeedAzureValid/ReleaseNotes/1_0_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### New: Azure Feed
+- Azure.CloudIPs Feed Integration.(Available from Cortex XSOAR 5.5.0).

--- a/demisto_sdk/tests/integration_tests/Packs/FeedAzureValid/ReleaseNotes/1_0_1.md
+++ b/demisto_sdk/tests/integration_tests/Packs/FeedAzureValid/ReleaseNotes/1_0_1.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### New: Azure Feed
-- Azure.CloudIPs Feed Integration.(Available from Cortex XSOAR 5.5.0).
+- Azure.CloudIPs Feed Integration. (Available from Cortex XSOAR 5.5.0).

--- a/demisto_sdk/tests/integration_tests/update_release_notes_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/update_release_notes_integration_test.py
@@ -42,7 +42,7 @@ def test_update_release_notes_new_integration(demisto_client, mocker):
 
     expected_rn = '\n' + '#### Integrations\n' + \
                   '##### New: Azure Feed\n' + \
-                  '- Azure.CloudIPs Feed Integration.(Available from Cortex XSOAR 5.5.0).\n'
+                  '- Azure.CloudIPs Feed Integration. (Available from Cortex XSOAR 5.5.0).\n'
 
     added_files = {join(AZURE_FEED_PACK_PATH, 'Integrations', 'FeedAzureValid', 'FeedAzureValid.yml')}
     rn_path = join(RN_FOLDER, '1_0_1.md')

--- a/demisto_sdk/tests/integration_tests/update_release_notes_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/update_release_notes_integration_test.py
@@ -42,7 +42,7 @@ def test_update_release_notes_new_integration(demisto_client, mocker):
 
     expected_rn = '\n' + '#### Integrations\n' + \
                   '##### New: Azure Feed\n' + \
-                  '- Azure.CloudIPs Feed Integration.\n'
+                  '- Azure.CloudIPs Feed Integration.(Available from Cortex XSOAR 5.5.0).\n'
 
     added_files = {join(AZURE_FEED_PACK_PATH, 'Integrations', 'FeedAzureValid', 'FeedAzureValid.yml')}
     rn_path = join(RN_FOLDER, '1_0_1.md')

--- a/demisto_sdk/tests/test_files/fake_integration/fake_README.md
+++ b/demisto_sdk/tests/test_files/fake_integration/fake_README.md
@@ -1,5 +1,7 @@
 Use the Zoom integration manage your Zoom users and meetings
-This integration was integrated and tested with version xx of Zoom
+This integration was integrated and tested with version xx of Zoom.
+Supported Cortex XSOAR versions: 5.0.0 and later.
+
 ## Configure Zoom on Cortex XSOAR
 
 1. Navigate to **Settings** > **Integrations** > **Servers & Services**.

--- a/demisto_sdk/tests/test_files/fake_integration/fake_integration.yml
+++ b/demisto_sdk/tests/test_files/fake_integration/fake_integration.yml
@@ -401,3 +401,4 @@ script:
     execution: true
   dockerimage: demisto/pyjwt:1.0
   runonce: false
+fromversion: 5.0.0


### PR DESCRIPTION

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/30648

## Description
Customers will able to know from which demisto version they can use new integration. 

## Must have
- [x] Tests
- [x] Documentation
