### PR TITLE
added an exception if Dockerfile exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added support for *prev-ver* flag in **update-release-notes** command.
 * Improved retry support when building docker images for linting.
 * Added the *--skip-id-set-creation* flag to **validate** command in order to add the capability to run validate command without creating id_set validation.
+* Fixed an issue with existing Dockerfile in the **lint** command.
 
 # 1.2.11
 * Fixed an issue where the ***generate-docs*** command reset the enumeration of line numbering after an MD table.


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes:  

## Description
The problem was that if a Dockerfile exists in content repo we exit with an exception which is written under flake8 while flake8 had nothing to do with the exception.
After this fix flake8 wont be changed, and also lint wont fail on existing docker file.
It will write an error in the traceback regarding an existing file and will run on that file instead of a new file

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
