### PR TITLE
Test Suite: Playbook path is wrong 

### DIFF
--- a/TestSuite/pack.py
+++ b/TestSuite/pack.py
@@ -315,7 +315,7 @@ class Pack:
             readme: Optional[str] = None,
     ) -> Playbook:
         if name is None:
-            name = f'playbook-{len(self.playbooks)}.yml'
+            name = f'playbook-{len(self.playbooks)}'
         if yml is None:
             yml = {}
         playbook = Playbook(self._playbooks_path, name, self._repo)


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Playbook path end with .yml.yml unstead of .yml
## Must have
- [ ] Tests
- [ ] Documentation
