### PR TITLE
fix verify ssl in uploader to use DEMISTO_VERIFY_SSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Removed supported version message from the documentation when running **generate_docs**.
 * Added a print to indicate backwards compatibility is being checked in **validate** command.
 * Added a percent print when running the **validate** command with the *-a* flag.
+* Fixed a regression in the `upload` command where it was ignoring `DEMISTO_VERIFY_SSL` env var.
 
 # 1.2.12
 * Bandit now reports also on medium severity issues.

--- a/demisto_sdk/commands/upload/uploader.py
+++ b/demisto_sdk/commands/upload/uploader.py
@@ -67,7 +67,8 @@ class Uploader:
     def __init__(self, input: str, insecure: bool = False, verbose: bool = False):
         self.path = input
         self.log_verbose = verbose
-        self.client = demisto_client.configure(verify_ssl=not insecure)
+        verify = (not insecure) if insecure else None  # set to None so demisto_client will use env var DEMISTO_VERIFY_SSL
+        self.client = demisto_client.configure(verify_ssl=verify)
         self.successfully_uploaded_files: List[Tuple[str, str]] = []
         self.failed_uploaded_files: List[Tuple[str, str, str]] = []
         self.unuploaded_due_to_version: List[Tuple[str, str, Version, Version, Version]] = []


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)


## Description
For some reason this PR: https://github.com/demisto/demisto-sdk/pull/806/files?file-filters%5B%5D=.py#diff-4a64a8945d641acadd958e216f57f9227715f81df3fbeb7a98de88c563fd6538L35

Broke support for DEMISTO_VERIFY_SSL env variable in uploader

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
