### PR TITLE
Support running with REHL using podman

### DIFF
--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -1564,6 +1564,8 @@ class TestContext:
             test_message += f' with integration(s): {self.playbook.integrations}'
         else:
             test_message += ' with no integrations'
+        if not self.is_instance_using_docker:
+            test_message += ', RedHat instance'
         return test_message
 
     def __repr__(self):

--- a/demisto_sdk/commands/test_content/mock_server.py
+++ b/demisto_sdk/commands/test_content/mock_server.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import ast
 import os
+import re
 import string
 import time
 import unicodedata
@@ -78,7 +79,7 @@ class AMIConnection:
 
     Attributes:
         public_ip (string): The public IP of the AMI instance.
-        docker_ip (string): The IP of the AMI on the docker bridge (to direct traffic from docker to the AMI).
+        internal_ip (string): The  internal IP of the instance.
     """
 
     REMOTE_MACHINE_USER = 'ec2-user'
@@ -87,22 +88,23 @@ class AMIConnection:
 
     def __init__(self, public_ip):
         self.public_ip = public_ip
-        self.docker_ip = self._get_docker_ip()
+        self.internal_ip = self._get_internal_ip()
 
-    def _get_docker_ip(self):
-        """Get the IP of the AMI on the docker bridge.
-        Used to configure the docker host (AMI machine, in this case) as the proxy server.
+    def _get_internal_ip(self):
+        """Get the internal IP of the instance.
+        Used to configure the host (AMI machine, in this case) as the proxy server.
 
         Returns:
-            string. The IP of the AMI on the docker bridge.
+            string. The internal IP of the instance.
         """
-        out = self.check_output(['/usr/sbin/ip', 'addr', 'show', 'docker0']).decode().split('\n')
-        lines_of_words = map(lambda y: y.strip().split(' '), out)  # Split output to lines[words[]]
-        address_lines = list(filter(lambda x: x[0] == 'inet', lines_of_words))  # Take only lines with ipv4 addresses
-        if len(address_lines) != 1:
-            raise Exception("docker bridge interface has {} ipv4 addresses, should only have one."
-                            .format(len(address_lines)))
-        return address_lines[0][1].split('/')[0]  # Return only the IP Address (without mask)
+        out = self.check_output("/usr/sbin/ifconfig eth0".split()).decode()
+        pattern = re.compile(r'inet ([^ ]+)')
+        pattern_findall_result = pattern.findall(out)
+        if not pattern_findall_result:
+            raise Exception(f'Could not find internal IP for instance {self.public_ip}')
+        internal_ip = pattern.findall(out)[0]
+
+        return internal_ip
 
     def add_ssh_prefix(self, command, ssh_options=""):
         """Add necessary text before a command in order to run it on the AMI instance via SSH.

--- a/demisto_sdk/commands/test_content/tests/BuildContext_test.py
+++ b/demisto_sdk/commands/test_content/tests/BuildContext_test.py
@@ -14,7 +14,8 @@ def generate_test_configuration(playbook_id: str,
                                 timeout: int = None,
                                 memory_threshold: int = None,
                                 pid_threshold: int = None,
-                                is_mockable: bool = None
+                                is_mockable: bool = None,
+                                runnable_on_docker_only: bool = None
                                 ) -> dict:
     playbook_config = {
         'playbookID': playbook_id,
@@ -35,6 +36,8 @@ def generate_test_configuration(playbook_id: str,
         playbook_config['memory_threshold'] = memory_threshold
     if pid_threshold:
         playbook_config['pid_threshold'] = pid_threshold
+    if runnable_on_docker_only is not None:
+        playbook_config['runnable_on_docker_only'] = runnable_on_docker_only
     if is_mockable is not None:
         playbook_config['is_mockable'] = is_mockable
     return playbook_config

--- a/demisto_sdk/commands/test_content/tests/TestContext_test.py
+++ b/demisto_sdk/commands/test_content/tests/TestContext_test.py
@@ -1,0 +1,31 @@
+from functools import partial
+
+from demisto_sdk.commands.test_content.TestContentClasses import (
+    TestConfiguration, TestContext, TestPlaybook)
+from demisto_sdk.commands.test_content.tests.BuildContext_test import \
+    generate_test_configuration
+
+
+def test_is_runnable_on_this_instance(mocker):
+    """
+    Given:
+        - A test configuration configured to run only on instances that uses docker as container engine
+    When:
+        - The method _is_runnable_on_current_server_instance is invoked from the TestContext class
+    Then:
+        - Ensure that it returns False when the test is running on REHL instance that uses podman
+        - Ensure that it returns True when the test is running on a regular Linux instance that uses docker
+    """
+    test_playbook_configuration = TestConfiguration(
+        generate_test_configuration(playbook_id='playbook_runnable_only_on_docker',
+                                    runnable_on_docker_only=True), default_test_timeout=30)
+    test_context_builder = partial(TestContext,
+                                   build_context=mocker.MagicMock(),
+                                   playbook=TestPlaybook(mocker.MagicMock(),
+                                                         test_playbook_configuration),
+                                   client=mocker.MagicMock())
+
+    test_context = test_context_builder(is_instance_using_docker=False)
+    assert not test_context._is_runnable_on_current_server_instance()
+    test_context = test_context_builder(is_instance_using_docker=True)
+    assert test_context._is_runnable_on_current_server_instance()

--- a/demisto_sdk/commands/test_content/tests/mock_unit_test.py
+++ b/demisto_sdk/commands/test_content/tests/mock_unit_test.py
@@ -25,15 +25,21 @@ def test_get_paths():
     assert get_folder_path(test_playbook_id) == 'test_playbook/'
 
 
-# TODO: Maybe mock subprocess functions??
-with patch('demisto_sdk.commands.test_content.mock_server.AMIConnection._get_docker_ip') as mock:
-    mock.return_value = "2.2.2.2"
+def test_ami():
+    with patch('demisto_sdk.commands.test_content.mock_server.AMIConnection.check_output') as mock:
+        mock.return_value = b"""
+        eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9001
+            inet 2.2.2.2  netmask 255.255.240.0  broadcast 172.31.63.255
+            inet6 fe80::c9d:ccff:fe7f:1e91  prefixlen 64  scopeid 0x20<link>
+            ether 0e:9d:cc:7f:1e:91  txqueuelen 1000  (Ethernet)
+            RX packets 37051  bytes 47117967 (44.9 MiB)
+            RX errors 0  dropped 0  overruns 0  frame 0
+            TX packets 26025  bytes 28722186 (27.3 MiB)
+            TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0"""
 
-    ami = AMIConnection('1.1.1.1')
-
-    def test_ami():
+        ami = AMIConnection('1.1.1.1')
         assert ami.public_ip == '1.1.1.1'
-        assert ami.docker_ip == '2.2.2.2'
+        assert ami.internal_ip == '2.2.2.2'
 
 
 def test_push_mock_files_thread_safety(mocker):

--- a/demisto_sdk/commands/test_content/tests/test_tools.py
+++ b/demisto_sdk/commands/test_content/tests/test_tools.py
@@ -1,0 +1,21 @@
+from subprocess import CalledProcessError
+
+from demisto_sdk.commands.test_content.tools import is_redhat_instance
+
+
+def raise_exception():
+    raise CalledProcessError(1, 'ls -l /home/ec2-user/rhel_ami'.split())
+
+
+class CheckOutputMock:
+    stdout = 'output'
+
+
+def test_is_redhat_instance_positive(mocker):
+    mocker.patch('subprocess.run', return_value=CheckOutputMock)
+    assert is_redhat_instance('instance_ip')
+
+
+def test_is_redhat_instance_negative(mocker):
+    mocker.patch('subprocess.check_output', side_effect=raise_exception)
+    assert not is_redhat_instance('instance_ip')

--- a/demisto_sdk/commands/test_content/tools.py
+++ b/demisto_sdk/commands/test_content/tools.py
@@ -1,6 +1,7 @@
 import ast
 import logging
 from pprint import pformat
+from subprocess import STDOUT, CalledProcessError, check_output
 
 import demisto_client
 
@@ -61,3 +62,22 @@ def update_server_configuration(client, server_configuration, error_msg, logging
         else:
             logging.error(f'{error_msg} {status_code}\n{message}')
     return response_data, status_code
+
+
+def is_redhat_instance(instance_ip: str) -> bool:
+    """
+    As part of the AMI creation - in case the AMI is RHEL a file named '/home/ec2-user/rhel_ami' is created as
+    an indication.
+    If not
+    Args:
+        instance_ip: The instance IP to check.
+
+    Returns:
+        True if the file '/home/ec2-user/rhel_ami' exists on the instance, else False
+    """
+    try:
+        check_output(f'ssh -o StrictHostKeyChecking=no ec2-user@{instance_ip} ls -l /home/ec2-user/rhel_ami'.split(),
+                     stderr=STDOUT)
+        return True
+    except CalledProcessError:
+        return False


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://github.com/demisto/etc/issues/29360

## Description
- Using the internal IP of the instance instead of the default docker bridge's IP.
- Added a method that will query the instance and check if this is a RHEL instance or not and return a boolean accordingly.
- Not running docker threshold tests on RHEL instance

