### PR TITLE
fixing auto extract validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * The lint command will now ignore the unsubscriptable-object (E1136) pylint error in dockers based on python 3.9 - this will be removed once a new pylint version is released.
 * Added an option for **format** to run on a whole pack.
 * Added new validation of unimplemented commands from yml in the code to `XSOAR-linter`.
+* Fixed an issue where Auto-Extract fields were only checked for newly added incident types in the **validate** command.
 
 # 1.2.13
 * Added new validation of indicators usage in CommandResults to `XSOAR-linter`.

--- a/demisto_sdk/commands/common/hook_validations/incident_type.py
+++ b/demisto_sdk/commands/common/hook_validations/incident_type.py
@@ -33,7 +33,8 @@ class IncidentTypeValidator(ContentEntityValidator):
         """
         is_incident_type__valid = all([
             super().is_valid_file(validate_rn),
-            self.is_valid_version()
+            self.is_valid_version(),
+            self.is_valid_autoextract()
         ])
 
         # check only on added files
@@ -42,8 +43,7 @@ class IncidentTypeValidator(ContentEntityValidator):
                 is_incident_type__valid,
                 self.is_id_equals_name(),
                 self.is_including_int_fields(),
-                self.is_valid_playbook_id(),
-                self.is_valid_autoextract()
+                self.is_valid_playbook_id()
             ])
 
         return is_incident_type__valid


### PR DESCRIPTION
Fixed an issue where Auto-Extract fields were only checked for newly added incident types in the **validate** command.