### PR TITLE
extracting the name property from layoutscontainer data (#1006)

### DIFF
--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -451,7 +451,7 @@ def get_entity_name_by_entity_type(data: dict, content_entity: str):
     :return: The file name
     """
     if content_entity == LAYOUTS_DIR:
-        return data.get('typeId', '')
+        return data.get('typeId', data.get('name', ''))
     else:
         return data.get('name', '')
 


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
Fixes #1006

## Description

### What happened?

1. I added an indicator layout to one of our instances manually via the layout editor (6.0.1, both SDK versions 1.2.11 and current master)
2. I wanted to download the custom content via the SDK in order to add it to my content pack but it wouldn't even list the content
  * `$ demisto-sdk download -lf` would not show the content
3. So obviously I could not download the layout JSON via the SDK

### Why?

After adding some debug statements to the SDK's source code I was able to see that it indeed got the custom content from the instance *but was not listing it because it was not able to derive the content's name from the JSON file*. It tries to look for a property called `typeId` in layout files which does not exist for this particular content I created.

## Must have
- [ ] Tests
- [ ] Documentation
