### PR TITLE
Generate-docs command cp flag fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+* Fixed an issue were **generate-docs** command has failed if a command did not exist in commands permissions file.
 
 # 1.2.16
 * Added allowed ignore errors to the *IDSetValidator*.
@@ -13,7 +14,6 @@
 * Added new validation of unimplemented commands from yml in the code to `XSOAR-linter`.
 * Fixed an issue where Auto-Extract fields were only checked for newly added incident types in the **validate** command.
 * Added a new warning validation of direct access to args/params dicts to `XSOAR-linter`.
-* Fixed an issue were **generate-docs** command has failed if a command did not exist in commands permissions file.
 
 # 1.2.13
 * Added new validation of indicators usage in CommandResults to `XSOAR-linter`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added new validation of unimplemented commands from yml in the code to `XSOAR-linter`.
 * Fixed an issue where Auto-Extract fields were only checked for newly added incident types in the **validate** command.
 * Added a new warning validation of direct access to args/params dicts to `XSOAR-linter`.
+* Fixed an issue were **generate-docs** command has failed if a command did not exist in commands permissions file.
 
 # 1.2.13
 * Added new validation of indicators usage in CommandResults to `XSOAR-linter`.

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -728,7 +728,7 @@ def init(**kwargs):
 @click.option(
     "-cp", "--command_permissions", help="Path for file containing commands permissions"
                                          " Each command permissions should be in a separate line."
-                                         " (i.e. '!command-name Administrator READ-WRITE')", required=False)
+                                         " (i.e. 'command-name Administrator READ-WRITE')", required=False)
 @click.option(
     "-l", "--limitations", help="Known limitations. Number the steps by '*' (i.e. '* foo. * bar.')", required=False)
 @click.option(

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -728,7 +728,7 @@ def init(**kwargs):
 @click.option(
     "-cp", "--command_permissions", help="Path for file containing commands permissions"
                                          " Each command permissions should be in a separate line."
-                                         " (i.e. 'command-name Administrator READ-WRITE')", required=False)
+                                         " (i.e. '<command-name> Administrator READ-WRITE')", required=False)
 @click.option(
     "-l", "--limitations", help="Known limitations. Number the steps by '*' (i.e. '* foo. * bar.')", required=False)
 @click.option(

--- a/demisto_sdk/commands/generate_docs/README.md
+++ b/demisto_sdk/commands/generate_docs/README.md
@@ -11,7 +11,7 @@ This command is used to create a documentation file for Cortex XSOAR content fil
 * **-e, --examples** Integrations: path for file containing command examples. Each command should be in a separate line.
   Scripts: the script example surrounded by quotes. For example: `-e '!ConvertFile entry_id=<entry_id>'`
 * **-p, --permissions** permissions in the documentation.
-* **-cp, --command_permissions** Path for file containing commands permissions. Each command permissions should be in a separate line (i.e. '!command-name Administrator READ-WRITE').
+* **-cp, --command_permissions** Path for file containing commands permissions. Each command permissions should be in a separate line (i.e. 'command-name Administrator READ-WRITE').
 * **-l, --limitations** Known limitations. Number the steps by '*' (i.e. '\* foo. * bar.').
 * **-id, --id_set** Path of updated id_set.json file.
 * **--insecure** Skip certificate validation.

--- a/demisto_sdk/commands/generate_docs/generate_integration_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_integration_doc.py
@@ -213,15 +213,19 @@ def generate_commands_section(
 
 
 def generate_single_command_section(cmd: dict, example_dict: dict, command_permissions_dict):
+    errors = []
     cmd_example = example_dict.get(cmd['name'])
     if command_permissions_dict:
-        cmd_permission_example = ['#### Required Permissions', command_permissions_dict.get(cmd['name'])]
+        if command_permissions_dict.get(cmd['name']):
+            cmd_permission_example = ['#### Required Permissions', command_permissions_dict.get(cmd['name'])]
+        else:
+            errors.append(f"Error! Command Permissions were not found for command {cmd['name']}")
+            cmd_permission_example = ['#### Required Permissions', '']
     elif isinstance(command_permissions_dict, dict) and not command_permissions_dict:
         cmd_permission_example = ['#### Required Permissions', '**FILL IN REQUIRED PERMISSIONS HERE**']
     else:  # no permissions for this command
         cmd_permission_example = ['', '']
 
-    errors = []
     section = [
         '### {}'.format(cmd['name']),
         '***',

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -311,6 +311,7 @@ def test_get_input_data_complex():
 
     assert _value == 'File.Name'
 
+
 # script tests
 
 
@@ -443,6 +444,41 @@ def test_generate_commands_with_permissions_section():
         'There is no context output for this command.', '', '#### Command Example', '``` ```', '',
         '#### Human Readable Output', '\n', '']
 
+    assert '\n'.join(section) == '\n'.join(expected_section)
+
+
+def test_generate_commands_with_permissions_section_command_doesnt_exist():
+    """
+        Given
+            - Integration commands from yml file with command permission flag on.
+            - The commands from yml file do not exist in the given command permissions dict.
+        When
+            - Running the generate_table_section command.
+        Then
+            - Validate that in the #### Required Permissions section empty string is returned
+            - Validate that an error is returned in error list which indicated that for this command no permission were found.
+    """
+    yml_data = {
+        'script': {
+            'commands': [
+                {'deprecated': True,
+                 'name': 'deprecated-cmd'},
+                {'deprecated': False,
+                 'name': 'non-deprecated-cmd'}]}}
+    section, errors = generate_commands_section(yml_data, example_dict={}, command_permissions_dict={
+        '!non-deprecated-cmd': 'SUPERUSER'})
+
+    expected_section = [
+        '## Commands',
+        'You can execute these commands from the Cortex XSOAR CLI, as part of an automation, or in a playbook.',
+        'After you successfully execute a command, a DBot message appears in the War Room with the command details.',
+        '### non-deprecated-cmd', '***', ' ', '#### Required Permissions',
+        '', '#### Base Command', '', '`non-deprecated-cmd`', '#### Input', '',
+        'There are no input arguments for this command.', '', '#### Context Output', '',
+        'There is no context output for this command.', '', '#### Command Example', '``` ```', '',
+        '#### Human Readable Output', '\n', '']
+
+    assert 'Error! Command Permissions were not found for command non-deprecated-cmd' in errors
     assert '\n'.join(section) == '\n'.join(expected_section)
 
 


### PR DESCRIPTION

## Related Issues
fixes: https://github.com/demisto/etc/issues/32372

## Description
edited the readme and help section for the correct usage of command permissions file
return an empty list and an error in the end of the generate-docs run if the command does not exist in permission file.

## Screenshots
![image](https://user-images.githubusercontent.com/58938354/103801766-dec82400-5056-11eb-98d0-d77274a88bfc.png)

## Must have
- [x] Tests
- [ ] Documentation
