### PR TITLE
improved message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+* Improved a **validate** command message for missing release notes of api module dependencies.
 * SDK repository is now mypy check_untyped_defs complaint.
 * The lint command will now ignore the unsubscriptable-object (E1136) pylint error in dockers based on python 3.9 - this will be removed once a new pylint version is released.
 * Added an option for **format** to run on a whole pack.


### PR DESCRIPTION
When updating an apimodule script, all the related integration should have release notes.
the command that updated all those integrations is `demisto-sdk update-release-notes -i Packs/ApiModules -u revision` and now is printed as the suggestion for all those packs.

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes:https://github.com/demisto/etc/issues/32119

## Description

## Screenshots
![image](https://user-images.githubusercontent.com/58938354/103813126-42a71880-5068-11eb-9924-7387c4a18784.png)

## Must have
- [ ] Tests
- [ ] Documentation
