### PR TITLE
check if commands exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+# 1.2.15
+* Added the *ID101* to the allowed ignored errors.
 
 # 1.2.14
 * SDK repository is now mypy check_untyped_defs complaint.

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -10,7 +10,7 @@ FOUND_FILES_AND_ERRORS: list = []
 FOUND_FILES_AND_IGNORED_ERRORS: list = []
 
 ALLOWED_IGNORE_ERRORS = ['BA101', 'BA106', 'RP102', 'RP104', 'SC100', 'IF106', 'PA113', 'PA116', 'IN126', 'PB105',
-                         'PB106', 'IN109', 'IN110', 'IN122']
+                         'PB106', 'IN109', 'IN110', 'IN122', 'ID101']
 
 PRESET_ERROR_TO_IGNORE = {
     'community': ['BC', 'CJ', 'DS', 'IN125', 'IN126'],

--- a/demisto_sdk/commands/common/hook_validations/id.py
+++ b/demisto_sdk/commands/common/hook_validations/id.py
@@ -106,13 +106,14 @@ class IDSetValidator(BaseValidator):
         """
         is_valid = True
         depends_on_commands = script_data.get('depends_on')
-        for command in depends_on_commands:
-            if command != 'test-module':
-                if command.endswith('dev') or command.endswith('copy'):
-                    error_message, error_code = Errors.invalid_command_name_in_script(script_data.get('name'),
-                                                                                      command)
-                    self.handle_error(error_message, error_code, file_path="id_set.json")
-                    return not is_valid
+        if depends_on_commands:
+            for command in depends_on_commands:
+                if command != 'test-module':
+                    if command.endswith('dev') or command.endswith('copy'):
+                        error_message, error_code = Errors.invalid_command_name_in_script(script_data.get('name'),
+                                                                                          command)
+                        self.handle_error(error_message, error_code, file_path="id_set.json")
+                        return not is_valid
         return is_valid
 
     def _is_valid_in_id_set(self, file_path: str, obj_data: OrderedDict, obj_set: list):

--- a/demisto_sdk/commands/common/tests/id_test.py
+++ b/demisto_sdk/commands/common/tests/id_test.py
@@ -166,3 +166,27 @@ def test_is_non_real_command_found__bad_command_name():
 
     assert validator._is_non_real_command_found(script_data=script_data) is False, \
         "The script has a non real command"
+
+
+def test_is_non_real_command_found__no_depend_on_name():
+    """
+    Given
+        - script which has no executeCommand.
+
+    When
+        - is_non_real_command_found is called
+
+    Then
+        - Ensure that the scripts depend-on commands are valid.
+    """
+    validator = IDSetValidator(is_circle=False, is_test_run=True, configuration=CONFIG)
+
+    script_data = {
+        'name': 'OktaUpdateUser',
+        'fidepends-le_path': 'Packs/CommonScripts/Scripts/NoExecuteCommand.yml',
+        'fromversion': '5.0.0', 'deprecated': True,
+        'tests': ['No test'], 'pack': 'CommonScripts'
+    }
+
+    assert validator._is_non_real_command_found(script_data=script_data) is True, \
+        "The script has a non real command"


### PR DESCRIPTION
When running on an automation which has no `depends-on`, it fails.
see: fix: https://app.circleci.com/pipelines/github/demisto/content/58736/workflows/127bc7e7-b183-45f8-a2b3-b178df38521d/jobs/245342

handled and added ut.
