### PR TITLE
Always clean mock file after creation

### DIFF
--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -47,7 +47,7 @@ __all__ = ['BuildContext',
            'TestContext',
            'TestPlaybook',
            'TestResults',
-           'TestsExecution']
+           'ServerContext']
 
 
 class IntegrationConfiguration:
@@ -1502,7 +1502,7 @@ class TestContext:
         """
         Executes the test and return a boolean that indicates whether the test was executed or not.
         In case the test was not executed - it will be returned to the queue and will be collected later in the future
-        by some other TestsExecution instance.
+        by some other ServerContext instance.
         Args:
             proxy: The MITMProxy instance to use in the current test
 
@@ -1536,7 +1536,7 @@ class TestContext:
         return str(self)
 
 
-class TestsExecution:
+class ServerContext:
 
     def __init__(self, build_context: BuildContext, server_ip: str):
         self.build_context = build_context

--- a/demisto_sdk/commands/test_content/execute_test_content.py
+++ b/demisto_sdk/commands/test_content/execute_test_content.py
@@ -6,7 +6,7 @@ import requests
 from demisto_sdk.commands.test_content.ParallelLoggingManager import \
     ParallelLoggingManager
 from demisto_sdk.commands.test_content.TestContentClasses import (
-    BuildContext, TestsExecution)
+    BuildContext, ServerContext)
 
 
 def _handle_github_response(response, logging_module) -> dict:
@@ -45,7 +45,7 @@ def execute_test_content(**kwargs):
     build_context = BuildContext(kwargs, logging_manager)
     threads_list = []
     for server_ip in build_context.instances_ips:
-        tests_execution_instance = TestsExecution(build_context, server_ip)
+        tests_execution_instance = ServerContext(build_context, server_ip)
         threads_list.append(Thread(target=tests_execution_instance.execute_tests))
 
     for thread in threads_list:

--- a/demisto_sdk/commands/test_content/mock_server.py
+++ b/demisto_sdk/commands/test_content/mock_server.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
 import ast
-import json
 import os
 import string
 import time
@@ -312,8 +311,24 @@ class MITMProxy:
             self.ami.call(['mkdir', '--parents', dst_folder])
             self.ami.call(['mv', src_files, dst_folder])
 
-    def clean_mock_file(self, playbook_or_integration_id, path=None):
-        self.logging_module.debug(f'clean_mock_file was called for test "{playbook_or_integration_id}"')
+    def normalize_mock_file(self, playbook_or_integration_id: str, path: str = None):
+        """Normalize the mock file of a test playbook
+
+        Normalizes a mock file by doing the following:
+        1. Replaces the timestamp/variable data in a mock file as identified by
+        the keys provided in the mock file's associated 'problematic_keys.json'
+        file, with constant values.
+        2. Standardizes the query parameter data order for all requests.
+
+        Args:
+            playbook_or_integration_id: ID of the test playbook or
+                integration for which the associated mock file will be
+                normalized.
+            path: Path to the directory in which to search
+                for the required data (temp directory or repo). If not
+                provided, method will use the current directory.
+        """
+        self.logging_module.debug(f'normalize_mock_file was called for test "{playbook_or_integration_id}"')
         path = path or self.current_folder
         problem_keys_filepath = os.path.join(path, get_folder_path(playbook_or_integration_id), 'problematic_keys.json')
         self.logging_module.debug(f'problem_keys_filepath="{problem_keys_filepath}"')
@@ -323,65 +338,44 @@ class MITMProxy:
                                       f' "{problem_keys_filepath}" when recording '
                                       f'the "{playbook_or_integration_id}" test playbook')
             return
-        problem_keys = json.loads(self.ami.check_output(['cat', problem_keys_filepath]))
 
-        # is there data in problematic_keys.json that needs whitewashing?
-        self.logging_module.debug('checking if there is data to whitewash')
-        needs_whitewashing = False
-        for val in problem_keys.values():
-            if val:
-                needs_whitewashing = True
-                break
-
-        if problem_keys and needs_whitewashing:
-            mock_file_path = os.path.join(path, get_mock_file_path(playbook_or_integration_id))
-            cleaned_mock_filepath = mock_file_path.strip('.mock') + '_cleaned.mock'
-            # rewrite mock file with problematic key values replaced
-            command = 'mitmdump -ns ~/timestamp_replacer.py '
-            log_file = os.path.join(path, get_log_file_path(playbook_or_integration_id, record=True))
-            # Handle proxy log output
-            debug_opt = f' | sudo tee -a {log_file}'
-            options = f'--set script_mode=clean --set keys_filepath={problem_keys_filepath}'
-            if options.strip():
-                command += options
-            command += ' -r {} -w {}{}'.format(mock_file_path, cleaned_mock_filepath, debug_opt)
-            command = "source .bash_profile && {}".format(command)
-            self.logging_module.debug(f'command to clean mockfile:\n\t{command}')
-            split_command = command.split()
-            self.logging_module.debug('Let\'s try and clean the mockfile from timestamp data!')
-            try:
-                check_output(self.ami.add_ssh_prefix(split_command, ssh_options='-t'), stderr=STDOUT)
-            except CalledProcessError as e:
-                self.logging_module.debug(
-                    'There may have been a problem when filtering timestamp data from the mock file.')
-                err_msg = f'command `{command}` exited with return code [{e.returncode}]'
-                err_msg = f'{err_msg} and the output of "{e.output}"' if e.output else err_msg
-                if e.stderr:
-                    err_msg += f'STDERR: {e.stderr}'
-                self.logging_module.debug(err_msg)
-            else:
-                self.logging_module.debug('Success!')
-
-            # verify cleaned mock is different than original
-            self.logging_module.debug('verifying cleaned mock file is different than the original mock file')
-            diff_cmd = f'diff -sq {cleaned_mock_filepath} {mock_file_path}'
-            try:
-                diff_cmd_output = self.ami.check_output(diff_cmd.split()).decode().strip()
-                self.logging_module.debug(f'diff_cmd_output={diff_cmd_output}')
-                if diff_cmd_output.endswith('are identical'):
-                    self.logging_module.debug('cleaned mock file and original mock file are identical')
-                else:
-                    self.logging_module.debug('looks like the cleaning process did something!')
-
-            except CalledProcessError:
-                self.logging_module.debug('looks like the cleaning process did something!')
-
-            self.logging_module.debug('Replace old mock with cleaned one.')
-            mv_cmd = f'mv {cleaned_mock_filepath} {mock_file_path}'
-            self.ami.call(mv_cmd.split())
+        mock_file_path = os.path.join(path, get_mock_file_path(playbook_or_integration_id))
+        cleaned_mock_filepath = mock_file_path.strip('.mock') + '_cleaned.mock'
+        log_file = os.path.join(path, get_log_file_path(playbook_or_integration_id, record=True))
+        command = '/home/ec2-user/.local/bin/mitmdump -ns ~/timestamp_replacer.py ' \
+                  f'--set script_mode=clean --set keys_filepath={problem_keys_filepath}' \
+                  f' -r {mock_file_path} -w {cleaned_mock_filepath} | sudo tee -a {log_file}'
+        self.logging_module.debug(f'command to normalize mockfile:\n\t{command}')
+        self.logging_module.debug('Let\'s try and normalize the mockfile')
+        try:
+            check_output(self.ami.add_ssh_prefix(command.split(), ssh_options='-t'), stderr=STDOUT)
+        except CalledProcessError as e:
+            self.logging_module.debug(
+                'There may have been a problem while normalizing the mock file.')
+            err_msg = f'command `{command}` exited with return code [{e.returncode}]'
+            err_msg = f'{err_msg} and the output of "{e.output}"' if e.output else err_msg
+            if e.stderr:
+                err_msg += f'STDERR: {e.stderr}'
+            self.logging_module.debug(err_msg)
         else:
-            self.logging_module.debug('"problematic_keys.json" dictionary values were empty - '
-                                      'no data to whitewash from the mock file.')
+            self.logging_module.debug('Success!')
+
+        # verify cleaned mock is different than original
+        diff_cmd = f'diff -sq {cleaned_mock_filepath} {mock_file_path}'
+        try:
+            diff_cmd_output = self.ami.check_output(diff_cmd.split()).decode().strip()
+            self.logging_module.debug(f'diff_cmd_output={diff_cmd_output}')
+            if diff_cmd_output.endswith('are identical'):
+                self.logging_module.debug('normalized mock file and original mock file are identical')
+            else:
+                self.logging_module.debug('the normalized mock file differs from the original')
+
+        except CalledProcessError:
+            self.logging_module.debug('the normalized mock file differs from the original')
+
+        self.logging_module.debug('Replacing original mock file with the normalized one.')
+        mv_cmd = f'mv {cleaned_mock_filepath} {mock_file_path}'
+        self.ami.call(mv_cmd.split())
 
     def start(self, playbook_or_integration_id, path=None, record=False) -> None:
         """Start the proxy process and direct traffic through it.
@@ -565,7 +559,7 @@ def run_with_mock(proxy_instance: MITMProxy,
         proxy_instance.stop()
         if record:
             if result_holder.get(RESULT):
-                proxy_instance.clean_mock_file(playbook_or_integration_id)
+                proxy_instance.normalize_mock_file(playbook_or_integration_id)
                 proxy_instance.move_mock_file_to_repo(playbook_or_integration_id)
                 proxy_instance.successful_rerecord_count += 1
                 proxy_instance.rerecorded_tests.append(playbook_or_integration_id)


### PR DESCRIPTION

## Description
Since the query data is sorted - we need to always clean the newly created mock files and not only when problematic keys are set.

