### PR TITLE
Adding useproxy key to mocked integrations to support LogRhythm

### DIFF
--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -846,7 +846,7 @@ class Integration:
             }
         if is_mockable:
             self.build_context.logging_module.debug(f'configuring {self} with proxy params')
-            for param in ('proxy', 'useProxy', 'insecure', 'unsecure'):
+            for param in ('proxy', 'useProxy', 'useproxy', 'insecure', 'unsecure'):
                 self.configuration.params[param] = True  # type: ignore
         return True
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
related: https://github.com/demisto/etc/issues/27164

## Description
The proxy key for `LogRhythm` is useproxy, we need to add that key to the configuration in order to let the integration to actually be mocked.

