### PR TITLE
Add a lock for pushing content-test-data commits

### DIFF
--- a/demisto_sdk/commands/test_content/tests/mock_unit_test.py
+++ b/demisto_sdk/commands/test_content/tests/mock_unit_test.py
@@ -1,8 +1,11 @@
 from __future__ import print_function
 
+import time
+from threading import Thread
 from unittest.mock import patch
 
 from demisto_sdk.commands.test_content.mock_server import (AMIConnection,
+                                                           MITMProxy,
                                                            clean_filename,
                                                            get_folder_path,
                                                            get_log_file_path,
@@ -31,3 +34,46 @@ with patch('demisto_sdk.commands.test_content.mock_server.AMIConnection._get_doc
     def test_ami():
         assert ami.public_ip == '1.1.1.1'
         assert ami.docker_ip == '2.2.2.2'
+
+
+def test_push_mock_files_thread_safety(mocker):
+    """
+    Given:
+        - A proxy instance
+    When:
+        - Mocking the subprocess's 'check_output' command with a method that increments a counter with 1
+        and running the 'push_mock_files' with 5 threads at the same time.
+    Then:
+        - Ensure thread safety is achieved and that the counter equals 5 at the end of the test
+        - Ensure that each thread has entered the 'increment_counter' method alone
+    """
+    class Counter:
+        counter = 0
+        modifying_dates = []
+
+    def increment_counter(*_, **__):
+        time.sleep(2)
+        Counter.counter += 1
+        Counter.modifying_dates.append(time.time())
+        return
+    # Mocking
+    mocker.patch.object(MITMProxy, '__init__', lambda *args, **kwargs: None)
+    proxy_instance = MITMProxy('public_ip', 'logging_module', 'build_number', 'branch_name')
+    # Replacing the ami instance with MagicMock instance so that the check_output command will be mocked as well
+    proxy_instance.ami = mocker.MagicMock()
+    proxy_instance.logging_module = mocker.MagicMock()
+    proxy_instance.counter = 0
+    proxy_instance.ami.check_output = increment_counter
+
+    # Creating 10 threads that will push together
+    threads = []
+    for i in range(5):
+        threads.append(Thread(target=proxy_instance.push_mock_files))
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    assert Counter.counter == 5
+    for i in range(4):
+        assert Counter.modifying_dates[i] < Counter.modifying_dates[i + 1]
+        assert Counter.modifying_dates[i + 1] - Counter.modifying_dates[i] > 1


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Description:

Since in the current flow, when running in nightly mode, all instances finishes their execution together and attempt to push their commits to the `content-test-data` repo together, some of them fail to do so.

For example in the latest nightly - only 3/10 managed to push the updated mock files, the rest received the following error:
```
! [remote rejected]     master -> master (cannot lock ref 'refs/heads/master': is at 2e6861f25cf3075ab1ebdfdfc94e663cefefb8fc but expected ed07a660dc4e53e22c694e4bb3725c8605f7e630)
error: failed to push some refs to 'git@github.com:demisto/content-test-data.git'
```
