### PR TITLE
Reset containers before mockable tests as well

### DIFF
--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -1579,7 +1579,6 @@ class ServerContext:
         Args:
             queue: The queue to fetch tests to execute from
         """
-
         self._reset_containers()
         while queue.unfinished_tasks:
             try:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
When the demisto server initializes it starts the default python2 container without any proxy configurations (because they are not configured on the server yet)

Therefore, when running unmockable tests playbooks with integrations that uses that container (such as Mimecast v2, BigFix etc.) some of the commands can go to the old non-configured container and the requests will be routed to the integration instance itself instead of using the proxy playback.

The solution is to reset all containers before starting to run mockable tests and reset it again when starting to run unmockable tests.
