### PR TITLE
Fixing a case where empty filtered tests makes all tests be executed

### DIFF
--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -168,7 +168,7 @@ class TestPlaybook:
     def should_test_run(self):
         skipped_tests_collected = self.build_context.tests_data_keeper.skipped_tests
         # If There are a list of filtered tests and the playbook is not in them
-        if self.build_context.filtered_tests and self.configuration.playbook_id not in self.build_context.filtered_tests:
+        if not self.build_context.filtered_tests or self.configuration.playbook_id not in self.build_context.filtered_tests:
             self.build_context.logging_module.debug(f'Skipping {self} because it\'s not in filtered tests')
             skipped_tests_collected[self.configuration.playbook_id] = 'not in filtered tests'
             return False
@@ -183,7 +183,7 @@ class TestPlaybook:
         # skipped test
         if self.configuration.playbook_id in self.build_context.conf.skipped_tests:
             # If the playbook supposed to run according to the filters but it's skipped - warning log
-            if self.build_context.filtered_tests and self.configuration.playbook_id in self.build_context.filtered_tests:
+            if self.configuration.playbook_id in self.build_context.filtered_tests:
                 self.build_context.logging_module.warning(f'Skipping test {self} because it\'s in skipped test list')
             else:
                 self.build_context.logging_module.debug(f'Skipping test {self} because it\'s in skipped test list')

--- a/demisto_sdk/commands/test_content/mock_server.py
+++ b/demisto_sdk/commands/test_content/mock_server.py
@@ -414,23 +414,12 @@ class MITMProxy:
             self.logging_module.debug(f'Proxy service started in {self.get_script_mode(is_record)} mode')
         else:
             self.logging_module.error(f'Proxy failed to start after {self.TIME_TO_WAIT_FOR_PROXY_SECONDS} seconds')
-            self.get_mitmdump_service_status()
 
     def _start_mitmdump_service(self) -> None:
         """
         Starts mitmdump service on the remote service
         """
         self.ami.call(['sudo', 'systemctl', 'start', 'mitmdump'])
-
-    def get_mitmdump_service_status(self) -> None:
-        """
-        Safely extract the current mitmdump status and last 50 log lines
-        """
-        try:
-            output = self.ami.check_output('systemctl status mitmdump -n 50 -l'.split(), stderr=STDOUT)
-            self.logging_module.debug(f'mitmdump service status output:\n{output.decode()}')
-        except CalledProcessError as exc:
-            self.logging_module.debug(f'mitmdump service status output:\n{exc.output.decode()}')
 
     def prepare_proxy_start(self,
                             path: str,
@@ -525,7 +514,6 @@ class MITMProxy:
         self.logging_module.debug('Stopping mitmdump service')
         if not self.is_proxy_listening():
             self.logging_module.debug('proxy service was already down.')
-            self.get_mitmdump_service_status()
         else:
             self.ami.call(['sudo', 'systemctl', 'stop', 'mitmdump'])
         self.ami.call(["rm", "-rf", "/tmp/_MEI*"])  # Clean up temp files

--- a/demisto_sdk/commands/test_content/tests/BuildContext_test.py
+++ b/demisto_sdk/commands/test_content/tests/BuildContext_test.py
@@ -207,6 +207,24 @@ def test_non_filtered_tests_are_skipped(mocker, tmp_path):
     assert 'test_that_should_run' not in build_context.tests_data_keeper.skipped_tests
 
 
+def test_no_tests_are_executed_when_filtered_tests_is_empty(mocker, tmp_path):
+    """
+    Given:
+        - A build context with empty filtered tests list
+    When:
+        - Initializing the BuildContext instance
+    Then:
+        - Ensure that all tests that are skipped
+    """
+    tests = [generate_test_configuration(playbook_id='test_that_should_be_skipped')]
+    content_conf_json = generate_content_conf_json(tests=tests)
+    build_context = get_mocked_build_context(mocker,
+                                             tmp_path,
+                                             content_conf_json=content_conf_json,
+                                             filtered_tests_content=[])
+    assert 'test_that_should_be_skipped' in build_context.tests_data_keeper.skipped_tests
+
+
 def test_playbook_with_skipped_integrations_is_skipped(mocker, tmp_path):
     """
     Given:


### PR DESCRIPTION
In case filtered tests is empty - the test should be skipped.
