### PR TITLE
When Context Example is empty don't generate the section in generate-docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 * Updated **generate-docs** command to take the parameters names in setup section from display field and to use additionalinfo field when exist.
 * Using the *verbose* argument in the **find-dependencies** command will now log to the console.
 * Improved the deprecated message validation required from integrations.
+* Fixed an issue in the **generate-docs** command where **Context Example** section was created when it was empty.
+
 
 # 1.2.16
 * Added allowed ignore errors to the *IDSetValidator*.

--- a/demisto_sdk/commands/generate_docs/generate_integration_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_integration_doc.py
@@ -319,7 +319,7 @@ def generate_command_example(cmd, cmd_example=None):
         '```{}```'.format(cmd_example),
         '',
     ]
-    if context_example:
+    if context_example and context_example != '{}':
         example.extend([
             '#### Context Example',
             '```json',

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -392,7 +392,7 @@ def test_generate_commands_section():
 
 def test_generate_command_section_with_empty_cotext_example():
     """
-    When an string represent an emmpty dict '{}' is the context output
+    When an string representד an empty dict '{}' is the context output
     the 'Context Example' sections should be empty
     """
     example_dict = {

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -7,7 +7,8 @@ from demisto_sdk.commands.common.tools import get_json, get_yaml
 from demisto_sdk.commands.create_id_set.create_id_set import IDSetCreator
 from demisto_sdk.commands.generate_docs.generate_integration_doc import (
     append_or_replace_command_in_docs, generate_commands_section,
-    generate_integration_doc, generate_setup_section, generate_single_command_section)
+    generate_integration_doc, generate_setup_section,
+    generate_single_command_section)
 from demisto_sdk.commands.generate_docs.generate_script_doc import \
     generate_script_doc
 
@@ -392,7 +393,7 @@ def test_generate_commands_section():
 
 def test_generate_command_section_with_empty_cotext_example():
     """
-    When an string representד an empty dict '{}' is the context output
+    When an string represents an empty dict '{}' is the context output
     the 'Context Example' sections should be empty
     """
     example_dict = {

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -7,7 +7,7 @@ from demisto_sdk.commands.common.tools import get_json, get_yaml
 from demisto_sdk.commands.create_id_set.create_id_set import IDSetCreator
 from demisto_sdk.commands.generate_docs.generate_integration_doc import (
     append_or_replace_command_in_docs, generate_commands_section,
-    generate_integration_doc, generate_setup_section)
+    generate_integration_doc, generate_setup_section, generate_single_command_section)
 from demisto_sdk.commands.generate_docs.generate_script_doc import \
     generate_script_doc
 
@@ -386,6 +386,27 @@ def test_generate_commands_section():
         'There are no input arguments for this command.', '', '#### Context Output', '',
         'There is no context output for this command.', '', '#### Command Example', '``` ```', '',
         '#### Human Readable Output', '\n', '']
+
+    assert '\n'.join(section) == '\n'.join(expected_section)
+
+
+def test_generate_command_section_with_empty_cotext_example():
+    """
+    When an string represent an emmpty dict '{}' is the context output
+    the 'Context Example' sections should be empty
+    """
+    example_dict = {
+        'test1': (None, None, '{}')
+    }
+    command = {'deprecated': False, 'name': 'test1'}
+
+    section, errors = generate_single_command_section(command, example_dict=example_dict, command_permissions_dict={})
+
+    expected_section = ['### test1', '***', ' ', '#### Required Permissions', '**FILL IN REQUIRED PERMISSIONS HERE**',
+                        '#### Base Command', '', '`test1`', '#### Input', '',
+                        'There are no input arguments for this command.', '', '#### Context Output', '',
+                        'There is no context output for this command.', '', '#### Command Example', '```None```', '',
+                        '#### Human Readable Output', '\n>None', '']
 
     assert '\n'.join(section) == '\n'.join(expected_section)
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/32937

## Description
We didn't consider an string that contain an empty dict = '{}' as empty output, therefor a section was created.

## Must have
- [x] Tests
- [x] Documentation
