### PR TITLE
fixing flaky tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
               pip install tox
         - run:
             name: Tox build
+            no_output_timeout: 30m
             command: |
               tox -e py37 -v
         - save_cache:
@@ -63,6 +64,7 @@ jobs:
               pip install tox
         - run:
             name: Tox build
+            no_output_timeout: 30m
             command: |
               tox -e py38 -v -- --cov=demisto_sdk --cov-report=html
         - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,6 @@ jobs:
               pip install tox
         - run:
             name: Tox build
-            no_output_timeout: 30m
             command: |
               tox -e py37 -v
         - save_cache:
@@ -64,7 +63,6 @@ jobs:
               pip install tox
         - run:
             name: Tox build
-            no_output_timeout: 30m
             command: |
               tox -e py38 -v -- --cov=demisto_sdk --cov-report=html
         - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
               pip install tox
         - run:
             name: Tox build
+            no_output_timeout: 15m
             command: |
               tox -e py37 -v
         - save_cache:
@@ -63,6 +64,7 @@ jobs:
               pip install tox
         - run:
             name: Tox build
+            no_output_timeout: 15m
             command: |
               tox -e py38 -v -- --cov=demisto_sdk --cov-report=html
         - store_artifacts:

--- a/TestSuite/repo.py
+++ b/TestSuite/repo.py
@@ -1,6 +1,7 @@
 """
 
 """
+import os
 import shutil
 from pathlib import Path
 from typing import List, Optional
@@ -180,3 +181,10 @@ class Repo:
 
     def working_dir(self):
         return self.path
+
+    def make_dir(self, dir_name: str = ''):
+        if not dir_name:
+            dir_name = "NewDir"
+        dir_path = os.path.join(self.path, dir_name)
+        os.mkdir(dir_path)
+        return dir_path

--- a/demisto_sdk/commands/common/update_id_set.py
+++ b/demisto_sdk/commands/common/update_id_set.py
@@ -1182,7 +1182,7 @@ def re_create_id_set(id_set_path: Optional[str] = DEFAULT_ID_SET_PATH, pack_to_c
     widgets_list = []
     mappers_list = []
 
-    pool = Pool(processes=int(cpu_count() * 1.5))
+    pool = Pool(processes=int(cpu_count()))
 
     print_color("Starting the creation of the id_set", LOG_COLORS.GREEN)
 

--- a/demisto_sdk/commands/init/contribution_converter.py
+++ b/demisto_sdk/commands/init/contribution_converter.py
@@ -53,7 +53,7 @@ class ContributionConverter:
 
     def __init__(self, name: str = '', contribution: Union[str] = None, description: str = '', author: str = '',
                  gh_user: str = '', create_new: bool = True, pack_dir_name: Union[str] = None,
-                 base_dir: Union[str] = None):
+                 base_dir: Union[str] = None, no_pipenv: bool = False):
         """Initializes a ContributionConverter instance
 
         Note that when recieving a contribution that is an update to an existing pack that the values of 'name',
@@ -81,6 +81,7 @@ class ContributionConverter:
         self.gh_user = gh_user
         self.contrib_conversion_errs: List[str] = []
         self.create_new = create_new
+        self.no_pipenv = no_pipenv
         base_dir = base_dir or get_content_path()
         self.packs_dir_path = os.path.join(base_dir, 'Packs')
         if not os.path.isdir(self.packs_dir_path):
@@ -374,11 +375,11 @@ class ContributionConverter:
                         os.makedirs(output_dir, exist_ok=True)
                         extractor = Extractor(input=content_item_file_path, file_type=file_type, output=output_dir,
                                               no_readme=True, base_name=base_name,
-                                              no_auto_create_dir=(not autocreate_dir))
+                                              no_auto_create_dir=(not autocreate_dir), no_pipenv=self.no_pipenv)
 
                     else:
                         extractor = Extractor(input=content_item_file_path, file_type=file_type,
-                                              output=content_item_dir)
+                                              output=content_item_dir, no_pipenv=self.no_pipenv)
                     extractor.extract_to_package_format()
                 except Exception as e:
                     err_msg = f'Error occurred while trying to split the unified YAML "{content_item_file_path}" ' \

--- a/demisto_sdk/commands/init/tests/contribution_converter_test.py
+++ b/demisto_sdk/commands/init/tests/contribution_converter_test.py
@@ -95,7 +95,8 @@ def test_convert_contribution_zip_updated_pack(get_content_path_mock, get_python
     description = 'test pack description here'
     author = 'Octocat Smith'
     contrib_converter_inst = ContributionConverter(
-        name=name, contribution=contribution_path, description=description, author=author, create_new=False)
+        name=name, contribution=contribution_path, description=description, author=author, create_new=False,
+        no_pipenv=True)
     contrib_converter_inst.convert_contribution_to_pack()
     converted_pack_path = repo_dir / 'Packs' / 'TestPack'
     assert converted_pack_path.exists()
@@ -167,7 +168,7 @@ def test_convert_contribution_zip(get_content_path_mock, get_python_version_mock
     description = 'test pack description here'
     author = 'Octocat Smith'
     contrib_converter_inst = ContributionConverter(
-        name=name, contribution=contribution_path, description=description, author=author)
+        name=name, contribution=contribution_path, description=description, author=author, no_pipenv=True)
     contrib_converter_inst.convert_contribution_to_pack()
 
     converted_pack_path = repo_dir / 'Packs' / 'ContribTestPack'
@@ -279,7 +280,8 @@ def test_convert_contribution_zip_with_args(get_content_path_mock, get_python_ve
     author = 'Octocat Smith'
     gh_user = 'octocat'
     contrib_converter_inst = ContributionConverter(
-        name=name, contribution=contribution_path, description=description, author=author, gh_user=gh_user)
+        name=name, contribution=contribution_path, description=description, author=author, gh_user=gh_user,
+        no_pipenv=True)
     contrib_converter_inst.convert_contribution_to_pack()
 
     converted_pack_path = repo_dir / 'Packs' / 'TestPack'

--- a/demisto_sdk/tests/integration_tests/content_create_artifacts_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/content_create_artifacts_integration_test.py
@@ -4,6 +4,7 @@ from demisto_sdk.__main__ import main
 from demisto_sdk.commands.common.tools import src_root
 from demisto_sdk.commands.create_artifacts.tests.content_artifacts_creator_test import (
     destroy_by_ext, duplicate_file, same_folders, temp_dir)
+from TestSuite.test_tools import ChangeCWD
 from wcmatch.pathlib import Path
 
 ARTIFACTS_CMD = 'create-content-artifacts'
@@ -23,26 +24,29 @@ def mock_git(mocker):
     yield
 
 
-def test_integration_create_content_artifacts_no_zip(mock_git):
+def test_integration_create_content_artifacts_no_zip(repo):
     expected_artifacts_path = ARTIFACTS_EXPEXTED_RESULTS / 'content'
 
-    with temp_dir() as temp:
+    with ChangeCWD(repo.path):
+        dir_path = repo.make_dir()
         runner = CliRunner()
-        result = runner.invoke(main, [ARTIFACTS_CMD, '-a', temp, '--no-zip'])
+        result = runner.invoke(main, [ARTIFACTS_CMD, '-a', dir_path, '--no-zip'])
 
-        assert same_folders(temp, expected_artifacts_path)
+        assert same_folders(dir_path, expected_artifacts_path)
         assert result.exit_code == 0
 
 
-def test_integration_create_content_artifacts_zip(mock_git):
-    with temp_dir() as temp:
+def test_integration_create_content_artifacts_zip(mock_git, repo):
+    with ChangeCWD(repo.path):
+        dir_path = repo.make_dir()
         runner = CliRunner(mix_stderr=False)
-        result = runner.invoke(main, [ARTIFACTS_CMD, '-a', temp])
+        result = runner.invoke(main, [ARTIFACTS_CMD, '-a', dir_path])
+        dir_path = Path(dir_path)
 
-        assert Path(temp / 'content_new.zip').exists()
-        assert Path(temp / 'all_content.zip').exists()
-        assert Path(temp / 'content_packs.zip').exists()
-        assert Path(temp / 'content_test.zip').exists()
+        assert Path(dir_path / 'content_new.zip').exists()
+        assert Path(dir_path / 'all_content.zip').exists()
+        assert Path(dir_path / 'content_packs.zip').exists()
+        assert Path(dir_path / 'content_test.zip').exists()
         assert result.exit_code == 0
 
 


### PR DESCRIPTION
slightly increased tox timeout.
adding no pipenv option for contribution converter - and implementing this in the unit tests.
improved implementation of `test_integration_create_content_artifacts_no_zip` and `test_integration_create_content_artifacts_zip` tests.
Decreased thread count in create_id_set to match cpu_count.