### PR TITLE
Performance improvement for all files validations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
 
               export CIRCLE_ARTIFACTS="/home/circleci/project/artifacts"
 
-              CIRCLE_BRANCH="master" demisto-sdk create-id-set -o ./Tests/id_set.json
+              gsutil cp gs://marketplace-dist/content/id_set.json ./Tests/id_set.json
               gsutil cp gs://marketplace-dist/content/private_id_set.json $CIRCLE_ARTIFACTS/unified_id_set.json
               CIRCLE_BRANCH="master" demisto-sdk merge-id-sets -i1 ./Tests/id_set.json -i2 $CIRCLE_ARTIFACTS/unified_id_set.json -o $CIRCLE_ARTIFACTS/unified_id_set.json
 

--- a/demisto_sdk/commands/common/hook_validations/id.py
+++ b/demisto_sdk/commands/common/hook_validations/id.py
@@ -235,6 +235,7 @@ class IDSetValidator(BaseValidator):
             bool. Whether the file is valid in the id_set or not.
         """
         is_valid = True
+
         if self.is_circle:  # No need to check on local env because the id_set will contain this info after the commit
             click.echo(f"id set validations for: {file_path}")
 

--- a/demisto_sdk/commands/common/hook_validations/id.py
+++ b/demisto_sdk/commands/common/hook_validations/id.py
@@ -44,14 +44,14 @@ class IDSetValidator(BaseValidator):
     ID_SET_PATH = "./Tests/id_set.json"
 
     def __init__(self, is_test_run=False, is_circle=False, configuration=Configuration(), ignored_errors=None,
-                 print_as_warnings=False, suppress_print=False):
+                 print_as_warnings=False, suppress_print=False, id_set_path: str = None):
         super().__init__(ignored_errors=ignored_errors, print_as_warnings=print_as_warnings,
                          suppress_print=suppress_print)
         self.is_circle = is_circle
         self.configuration = configuration
         if not is_test_run and self.is_circle:
+            self.id_set_path = id_set_path or self.ID_SET_PATH
             self.id_set = self.load_id_set()
-            self.id_set_path = os.path.join(self.configuration.env_dir, 'configs', 'id_set.json')
             self.script_set = self.id_set[self.SCRIPTS_SECTION]
             self.playbook_set = self.id_set[self.PLAYBOOK_SECTION]
             self.integration_set = self.id_set[self.INTEGRATION_SECTION]
@@ -62,7 +62,7 @@ class IDSetValidator(BaseValidator):
             self.incident_types_set = self.id_set[self.INCIDENT_TYPES_SECTION]
 
     def load_id_set(self):
-        with open(self.ID_SET_PATH, 'r') as id_set_file:
+        with open(self.id_set_path, 'r') as id_set_file:
             try:
                 id_set = json.load(id_set_file)
             except ValueError as ex:

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -79,7 +79,6 @@ class ValidateManager:
         self.no_configuration_prints = silence_init_prints
         self.skip_conf_json = skip_conf_json
         self.is_backward_check = is_backward_check
-        self.id_set_validations = validate_id_set
         self.is_circle = only_committed_files
         self.validate_all = validate_all
         self.use_git = use_git
@@ -98,6 +97,10 @@ class ValidateManager:
         if not id_set_path:
             id_set_path = 'Tests/id_set.json'
         self.id_set_path = id_set_path
+        # create the id_set only once per run.
+        self.id_set_validator = IDSetValidator(is_circle=self.is_circle, configuration=Configuration(),
+                                               ignored_errors=None, print_as_warnings=self.print_ignored_errors) \
+            if validate_id_set else None
         self.branch_name = ''
         self.changes_in_schema = False
         self.check_only_schema = False
@@ -333,12 +336,9 @@ class ValidateManager:
             return True
 
         # id_set validation
-        if self.id_set_validations:
-            id_set_validator = IDSetValidator(is_circle=self.is_circle, configuration=Configuration(),
-                                              ignored_errors=pack_error_ignore_list,
-                                              print_as_warnings=self.print_ignored_errors)
-            if not id_set_validator.is_file_valid_in_set(file_path, file_type):
-                return False
+        if self.id_set_validator and not \
+                self.id_set_validator.is_file_valid_in_set(file_path, file_type):
+            return False
 
         # Note: these file are not ignored but there are no additional validators for connections
         if file_type == FileType.CONNECTION:
@@ -793,7 +793,8 @@ class ValidateManager:
             integrations = get_api_module_integrations_set(api_module_set, self.id_set_file.get('integrations', []))
             packs_that_should_have_new_rn_api_module_related = set(map(lambda integration: integration.get('pack'),
                                                                        integrations))
-            packs_that_should_have_new_rn = packs_that_should_have_new_rn.union(packs_that_should_have_new_rn_api_module_related)
+            packs_that_should_have_new_rn = packs_that_should_have_new_rn.union(
+                packs_that_should_have_new_rn_api_module_related)
 
             # APIModules pack is without a version and should not have RN
             packs_that_should_have_new_rn.remove(API_MODULES_PACK)

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -94,12 +94,13 @@ class ValidateManager:
         # Class constants
         self.handle_error = BaseValidator(print_as_warnings=print_ignored_errors).handle_error
         self.file_path = file_path
-        if not id_set_path:
-            id_set_path = 'Tests/id_set.json'
-        self.id_set_path = id_set_path
+        self.id_set_path = id_set_path or IDSetValidator.ID_SET_PATH
         # create the id_set only once per run.
-        self.id_set_validator = IDSetValidator(is_circle=self.is_circle, configuration=Configuration(),
-                                               ignored_errors=None, print_as_warnings=self.print_ignored_errors) \
+        self.id_set_validator = IDSetValidator(is_circle=self.is_circle,
+                                               configuration=Configuration(),
+                                               ignored_errors=None,
+                                               print_as_warnings=self.print_ignored_errors,
+                                               id_set_path=self.id_set_path) \
             if validate_id_set else None
         self.branch_name = ''
         self.changes_in_schema = False


### PR DESCRIPTION
Recently the file's validation duration has increased significanly in the build.

Working with @bakatzir we profiled it and saw that at least 20% of the time it spends on opening the id_set file.

So an easy optimization is to open the id_set.json once and cache it for reuse.
This alone have decreased the duration in ~8 minutes.

In addition, instead of creating the content id_set, downloading it from the GCP bucket can also save additional ~2 minutes. 

All together - time reduction of ~9 minutes.
