### PR TITLE
Fix README Generation for Scripts during Contribution Conversion

### DIFF
--- a/demisto_sdk/commands/common/update_id_set.py
+++ b/demisto_sdk/commands/common/update_id_set.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from distutils.version import LooseVersion
 from enum import Enum
 from functools import partial
+from genericpath import exists
 from multiprocessing import Pool, cpu_count
 from typing import Callable, Optional, Tuple
 
@@ -1396,6 +1397,9 @@ def re_create_id_set(id_set_path: Optional[str] = DEFAULT_ID_SET_PATH, pack_to_c
     new_ids_dict['Mappers'] = sort(mappers_list)
 
     if id_set_path:
+        if not exists(id_set_path):
+            intermediate_dirs = os.path.dirname(os.path.abspath(id_set_path))
+            os.makedirs(intermediate_dirs, exist_ok=True)
         with open(id_set_path, 'w+') as id_set_file:
             json.dump(new_ids_dict, id_set_file, indent=4)
     exec_time = time.time() - start_time

--- a/demisto_sdk/commands/generate_docs/generate_script_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_script_doc.py
@@ -11,7 +11,8 @@ from demisto_sdk.commands.generate_docs.common import (
 
 
 def generate_script_doc(input, examples, output: str = None, permissions: str = None,
-                        limitations: str = None, insecure: bool = False, verbose: bool = False):
+                        limitations: str = None, insecure: bool = False, verbose: bool = False,
+                        include_used_in: bool = True):
     try:
         doc: list = []
         errors: list = []
@@ -43,9 +44,12 @@ def generate_script_doc(input, examples, output: str = None, permissions: str = 
         dependencies, _ = get_depends_on(script)
 
         # get the script usages by the id set
-        id_set_creator = IDSetCreator(output='', print_logs=False)
-        id_set = id_set_creator.create_id_set()
-        used_in = get_used_in(id_set, script_id)
+        if include_used_in:
+            id_set_creator = IDSetCreator(output='', print_logs=False)
+            id_set = id_set_creator.create_id_set()
+            used_in = get_used_in(id_set, script_id)
+        else:
+            used_in = ''
 
         description = script.get('comment', '')
         # get inputs/outputs

--- a/demisto_sdk/commands/generate_docs/generate_script_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_script_doc.py
@@ -11,8 +11,7 @@ from demisto_sdk.commands.generate_docs.common import (
 
 
 def generate_script_doc(input, examples, output: str = None, permissions: str = None,
-                        limitations: str = None, insecure: bool = False, verbose: bool = False,
-                        include_used_in: bool = True):
+                        limitations: str = None, insecure: bool = False, verbose: bool = False):
     try:
         doc: list = []
         errors: list = []
@@ -44,12 +43,9 @@ def generate_script_doc(input, examples, output: str = None, permissions: str = 
         dependencies, _ = get_depends_on(script)
 
         # get the script usages by the id set
-        if include_used_in:
-            id_set_creator = IDSetCreator(output='', print_logs=False)
-            id_set = id_set_creator.create_id_set()
-            used_in = get_used_in(id_set, script_id)
-        else:
-            used_in = ''
+        id_set_creator = IDSetCreator(output='', print_logs=False)
+        id_set = id_set_creator.create_id_set()
+        used_in = get_used_in(id_set, script_id)
 
         description = script.get('comment', '')
         # get inputs/outputs

--- a/demisto_sdk/commands/init/contribution_converter.py
+++ b/demisto_sdk/commands/init/contribution_converter.py
@@ -252,7 +252,7 @@ class ContributionConverter:
         if file_type == 'integration':
             generate_integration_doc(yml_path)
         if file_type == 'script':
-            generate_script_doc(input=yml_path, examples=[], include_used_in=False)
+            generate_script_doc(input=yml_path, examples=[])
         if file_type == 'playbook':
             generate_playbook_doc(yml_path)
 

--- a/demisto_sdk/commands/init/contribution_converter.py
+++ b/demisto_sdk/commands/init/contribution_converter.py
@@ -268,7 +268,9 @@ class ContributionConverter:
                     files = get_child_files(directory)
                     for file in files:
                         file_name = os.path.basename(file)
-                        if file_name.startswith('integration') or file_name.startswith('script'):
+                        if file_name.startswith('integration-') \
+                           or file_name.startswith('script-') \
+                           or file_name.startswith('automation-'):
                             unified_file = file
                             self.generate_readme_for_pack_content_item(unified_file)
                             os.remove(unified_file)
@@ -314,8 +316,8 @@ class ContributionConverter:
                         pack_subdir, del_unified=(not self.create_new), source_mapping=files_to_source_mapping
                     )
 
-                    if self.create_new:
-                        self.generate_readmes_for_new_content_pack()
+            if self.create_new:
+                self.generate_readmes_for_new_content_pack()
 
             # format
             self.format_converted_pack()

--- a/demisto_sdk/commands/init/contribution_converter.py
+++ b/demisto_sdk/commands/init/contribution_converter.py
@@ -252,7 +252,7 @@ class ContributionConverter:
         if file_type == 'integration':
             generate_integration_doc(yml_path)
         if file_type == 'script':
-            generate_script_doc(input=yml_path, examples=[])
+            generate_script_doc(input=yml_path, examples=[], include_used_in=False)
         if file_type == 'playbook':
             generate_playbook_doc(yml_path)
 

--- a/demisto_sdk/commands/init/tests/contribution_converter_test.py
+++ b/demisto_sdk/commands/init/tests/contribution_converter_test.py
@@ -1,6 +1,8 @@
 import json
 import os
 import re
+from typing import Union
+from zipfile import ZipFile
 
 import pytest
 from _pytest.fixtures import FixtureRequest
@@ -40,6 +42,29 @@ def contribution_converter(request: FixtureRequest, tmp_path_factory: TempPathFa
     """Mocking tmp_path
     """
     return create_contribution_converter(request, tmp_path_factory)
+
+
+def rename_file_in_zip(path_to_zip: Union[os.PathLike, str], original_file_name: str, updated_file_name: str):
+    """Utility to rename a file in a zip file
+
+    Useful for renaming files in an example contribution zip file to test specific cases.
+    If the zipped file includes directories, make sure the filenames take that into account.
+
+    Args:
+        path_to_zip (Union[os.PathLike, str]): The zip file containing a file which needs renaming
+        original_file_name (str): The file which will be renamed
+        updated_file_name (str): The name the original file will be renamed to
+    """
+    modded_zip_file = os.path.join(os.path.dirname(path_to_zip), 'Edit' + os.path.basename(path_to_zip))
+    tmp_zf = ZipFile(modded_zip_file, 'w')
+    with ZipFile(path_to_zip, 'r') as zf:
+        for item in zf.infolist():
+            if item.filename == original_file_name:
+                with tmp_zf.open(updated_file_name, 'w') as out_file:
+                    out_file.write(zf.read(item.filename))
+            else:
+                tmp_zf.writestr(item, zf.read(item.filename))
+    os.replace(modded_zip_file, path_to_zip)
 
 
 @patch('demisto_sdk.commands.split_yml.extractor.get_python_version')
@@ -121,6 +146,103 @@ def test_convert_contribution_zip_updated_pack(get_content_path_mock, get_python
 
 @patch('demisto_sdk.commands.split_yml.extractor.get_python_version')
 @patch('demisto_sdk.commands.init.contribution_converter.get_content_path')
+def test_convert_contribution_zip_outputs_structure(get_content_path_mock, get_python_version_mock, tmp_path):
+    """Create a fake contribution zip file and test that it is converted to a Pack correctly
+
+    Args:
+        get_content_path_mock (MagicMock): Patch of the 'get_content_path' function to return the fake repo directory
+            used in the test
+        get_python_version_mock (MagicMock): Patch of the 'get_python_version' function to return the "3.7"
+        tmp_path (fixture): Temporary Path used for the unit test and cleaned up afterwards
+
+    Scenario: Simulate converting a contribution zip file
+
+    Given
+    - A contribution zip file
+    - The zipfile contains a unified script file
+    - The zipfile contains a unified integration file
+    When
+    - Converting the zipfile to a valid Pack structure
+    Then
+    - Ensure the unified yaml files of the integration and script have been removed from the output created by
+      converting the contribution zip file
+    """
+    # ### SETUP ### #
+    # Create all Necessary Temporary directories
+    # create temp directory for the repo
+    repo_dir = tmp_path / 'content_repo'
+    repo_dir.mkdir()
+    get_content_path_mock.return_value = repo_dir
+    get_python_version_mock.return_value = 3.7
+    # create temp target dir in which we will create all the TestSuite content items to use in the contribution zip and
+    # that will be deleted after
+    target_dir = repo_dir / 'target_dir'
+    target_dir.mkdir()
+    # create temp directory in which the contribution zip will reside
+    contribution_zip_dir = tmp_path / 'contrib_zip'
+    contribution_zip_dir.mkdir()
+    # Create fake content repo and contribution zip
+    repo = Repo(repo_dir)
+    contrib_zip = Contribution(target_dir, 'ContribTestPack', repo)
+    contrib_zip.create_zip(contribution_zip_dir)
+    # rename script-script0.yml unified to automation-script0.yml
+    # this naming is aligned to how the server exports scripts in contribution zips
+    rename_file_in_zip(
+        contrib_zip.created_zip_filepath, 'automation/script-script0.yml', 'automation/automation-script0.yml'
+    )
+
+    # Convert Zip
+    name = 'Contrib Test Pack'
+    contribution_path = contrib_zip.created_zip_filepath
+    description = 'test pack description here'
+    author = 'Octocat Smith'
+    contrib_converter_inst = ContributionConverter(
+        name=name, contribution=contribution_path, description=description, author=author, no_pipenv=True)
+    contrib_converter_inst.convert_contribution_to_pack()
+
+    # Ensure directory/file structure output by conversion meets expectations
+
+    # target_dir should have been deleted after creation of the zip file
+    assert not target_dir.exists()
+
+    converted_pack_path = repo_dir / 'Packs' / 'ContribTestPack'
+    assert converted_pack_path.exists()
+
+    scripts_path = converted_pack_path / 'Scripts'
+    sample_script_path = scripts_path / 'SampleScript'
+    script_yml = sample_script_path / 'SampleScript.yml'
+    script_py = sample_script_path / 'SampleScript.py'
+    script_readme_md = sample_script_path / 'README.md'
+    unified_script_in_sample = sample_script_path / 'automation-script0.yml'
+    unified_script = scripts_path / 'automation-script0.yml'
+
+    assert scripts_path.exists()
+    assert sample_script_path.exists()
+    assert script_yml.exists()
+    assert script_py.exists()
+    assert script_readme_md.exists()
+    assert not unified_script_in_sample.exists()
+    assert not unified_script.exists()
+
+    integrations_path = converted_pack_path / 'Integrations'
+    sample_integration_path = integrations_path / 'Sample'
+    integration_yml = sample_integration_path / 'Sample.yml'
+    integration_py = sample_integration_path / 'Sample.py'
+    integration_description = sample_integration_path / 'Sample_description.md'
+    integration_image = sample_integration_path / 'Sample_image.png'
+    integration_readme_md = sample_integration_path / 'README.md'
+    unified_yml = integrations_path / 'integration-integration0.yml'
+    unified_yml_in_sample = sample_integration_path / 'integration-integration0.yml'
+    integration_files = [integration_yml, integration_py, integration_description, integration_image,
+                         integration_readme_md]
+    for integration_file in integration_files:
+        assert integration_file.exists()
+    assert not unified_yml.exists()
+    assert not unified_yml_in_sample.exists()
+
+
+@patch('demisto_sdk.commands.split_yml.extractor.get_python_version')
+@patch('demisto_sdk.commands.init.contribution_converter.get_content_path')
 def test_convert_contribution_zip(get_content_path_mock, get_python_version_mock, tmp_path):
     """Create a fake contribution zip file and test that it is converted to a Pack correctly
 
@@ -157,11 +279,15 @@ def test_convert_contribution_zip(get_content_path_mock, get_python_version_mock
     # Create fake content repo and contribution zip
     repo = Repo(repo_dir)
     contrib_zip = Contribution(target_dir, 'ContribTestPack', repo)
-    # contrib_zip.create_zip(contribution_zip_dir)
     contrib_zip.create_zip(contribution_zip_dir)
-
     # target_dir should have been deleted after creation of the zip file
     assert not target_dir.exists()
+
+    # rename script-script0.yml unified to automation-script0.yml
+    # this naming is aligned to how the server exports scripts in contribution zips
+    rename_file_in_zip(
+        contrib_zip.created_zip_filepath, 'automation/script-script0.yml', 'automation/automation-script0.yml'
+    )
 
     name = 'Contrib Test Pack'
     contribution_path = contrib_zip.created_zip_filepath
@@ -179,8 +305,8 @@ def test_convert_contribution_zip(get_content_path_mock, get_python_version_mock
     script_yml = sample_script_path / 'SampleScript.yml'
     script_py = sample_script_path / 'SampleScript.py'
     script_readme_md = sample_script_path / 'README.md'
-    unified_script_in_sample = sample_script_path / 'script-script0.yml'
-    unified_script = scripts_path / 'script-script0.yml'
+    unified_script_in_sample = sample_script_path / 'automation-script0.yml'
+    unified_script = scripts_path / 'automation-script0.yml'
 
     assert scripts_path.exists()
     assert sample_script_path.exists()

--- a/demisto_sdk/commands/init/tests/contribution_converter_test.py
+++ b/demisto_sdk/commands/init/tests/contribution_converter_test.py
@@ -221,6 +221,11 @@ def test_convert_contribution_zip_outputs_structure(get_content_path_mock, get_p
     assert script_yml.exists()
     assert script_py.exists()
     assert script_readme_md.exists()
+
+    # generated script readme should not be empty
+    script_statinfo = os.stat(script_readme_md)
+    assert script_statinfo and script_statinfo.st_size > 0
+    # unified yaml of the script should have been deleted
     assert not unified_script_in_sample.exists()
     assert not unified_script.exists()
 
@@ -237,6 +242,11 @@ def test_convert_contribution_zip_outputs_structure(get_content_path_mock, get_p
                          integration_readme_md]
     for integration_file in integration_files:
         assert integration_file.exists()
+    # generated integration readme should not be empty
+    statinfo = os.stat(integration_readme_md)
+    assert statinfo and statinfo.st_size > 0
+
+    # unified yaml of the integration should have been deleted
     assert not unified_yml.exists()
     assert not unified_yml_in_sample.exists()
 


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: can see [here](https://github.com/demisto/content/pull/11061/files?file-filters%5B%5D=.json&file-filters%5B%5D=.lock&file-filters%5B%5D=.md&file-filters%5B%5D=.py&file-filters%5B%5D=.yml&file-filters%5B%5D=No+extension&file-filters%5B%5D=dotfile#diff-053d18c1fc73a7f732c55cecea5d9c2631319f0fb8978b6d0f5fb2d39f830ef1) that the README for scripts wasn't being properly generated and the unified wasn't getting deleted

## Description
The `generate_script_doc` function would fail, resulting in the readme for a script extracted to a package not getting generated and the unified YAML for the script not being removed as it should be.

## Must have
- [x] Tests
- [x] Documentation
