### PR TITLE
Filter generic and reputation command from scripts and PBs deps calc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+* Filter generic and reputation command from scripts dependencies calculation.
 * Added support for the incident fields in outgoing mappers in the ID set.
 * Added a validation that the taskid field and the id field under the task field are both from uuid format and contain the same value.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-* Filter generic and reputation command from scripts dependencies calculation.
+* Filter out generic and reputation command from scripts and playbooks dependencies calculation.
 * Added support for the incident fields in outgoing mappers in the ID set.
 * Added a validation that the taskid field and the id field under the task field are both from uuid format and contain the same value.
 

--- a/demisto_sdk/commands/common/constants.py
+++ b/demisto_sdk/commands/common/constants.py
@@ -841,6 +841,8 @@ ACCEPTED_FILE_EXTENSIONS = [
 
 BANG_COMMAND_NAMES = {'file', 'email', 'domain', 'url', 'ip'}
 
+GENERIC_COMMANDS_NAMES = BANG_COMMAND_NAMES.union({'send-mail', 'send-notification'})
+
 DBOT_SCORES_DICT = {
     'DBotScore.Indicator': 'The indicator that was tested.',
     'DBotScore.Type': 'The indicator type.',

--- a/demisto_sdk/commands/find_dependencies/find_dependencies.py
+++ b/demisto_sdk/commands/find_dependencies/find_dependencies.py
@@ -9,6 +9,7 @@ from typing import Union
 import click
 import networkx as nx
 from demisto_sdk.commands.common import constants
+from demisto_sdk.commands.common.constants import GENERIC_COMMANDS_NAMES
 from demisto_sdk.commands.common.tools import print_error
 from demisto_sdk.commands.create_id_set.create_id_set import IDSetCreator
 
@@ -320,11 +321,21 @@ class PackDependencies:
             script_dependencies = set()
 
             # depends on list can have both scripts and integration commands
-            depends_on = script.get('depends_on', [])
-            command_to_integration = list(script.get('command_to_integration', {}).keys())
-            script_executions = script.get('script_executions', [])
+            all_depends_on = script.get('depends_on', [])
+            depends_on = list(filter(lambda cmd: cmd not in GENERIC_COMMANDS_NAMES, all_depends_on))
+            all_command_to_integration = list(script.get('command_to_integration', {}).keys())
+            command_to_integration = list(filter(lambda cmd: cmd not in GENERIC_COMMANDS_NAMES,
+                                                 all_command_to_integration))
+
+            all_script_executions = script.get('script_executions', [])
+            script_executions = list(filter(lambda cmd: cmd not in GENERIC_COMMANDS_NAMES,
+                                            all_script_executions))
 
             dependencies_commands = list(set(depends_on + command_to_integration + script_executions))
+            print("depends_on:" + str(depends_on))
+            print("command_to_integration:" + str(command_to_integration))
+            print("script_executions:" + str(script_executions))
+            print("dependencies_commands:" + str(dependencies_commands))
 
             for command in dependencies_commands:
                 # try to search dependency by scripts first

--- a/demisto_sdk/commands/find_dependencies/find_dependencies.py
+++ b/demisto_sdk/commands/find_dependencies/find_dependencies.py
@@ -321,21 +321,13 @@ class PackDependencies:
             script_dependencies = set()
 
             # depends on list can have both scripts and integration commands
-            all_depends_on = script.get('depends_on', [])
-            depends_on = list(filter(lambda cmd: cmd not in GENERIC_COMMANDS_NAMES, all_depends_on))
-            all_command_to_integration = list(script.get('command_to_integration', {}).keys())
-            command_to_integration = list(filter(lambda cmd: cmd not in GENERIC_COMMANDS_NAMES,
-                                                 all_command_to_integration))
+            depends_on = script.get('depends_on', [])
+            command_to_integration = list(script.get('command_to_integration', {}).keys())
+            script_executions = script.get('script_executions', [])
 
-            all_script_executions = script.get('script_executions', [])
-            script_executions = list(filter(lambda cmd: cmd not in GENERIC_COMMANDS_NAMES,
-                                            all_script_executions))
-
-            dependencies_commands = list(set(depends_on + command_to_integration + script_executions))
-            print("depends_on:" + str(depends_on))
-            print("command_to_integration:" + str(command_to_integration))
-            print("script_executions:" + str(script_executions))
-            print("dependencies_commands:" + str(dependencies_commands))
+            all_dependencies_commands = list(set(depends_on + command_to_integration + script_executions))
+            dependencies_commands = list(filter(lambda cmd: cmd not in GENERIC_COMMANDS_NAMES,
+                                                all_dependencies_commands))  # filter out generic commands
 
             for command in dependencies_commands:
                 # try to search dependency by scripts first
@@ -428,10 +420,11 @@ class PackDependencies:
             implementing_commands_and_integrations = playbook_data.get('command_to_integration', {})
 
             for command, integration_name in implementing_commands_and_integrations.items():
+                packs_found_from_integration = set()
                 if integration_name:
                     packs_found_from_integration = PackDependencies._search_packs_by_items_names(
                         integration_name, id_set['integrations'], exclude_ignored_dependencies)
-                else:
+                elif command not in GENERIC_COMMANDS_NAMES:  # do not collect deps on generic command in Pbs
                     packs_found_from_integration = PackDependencies._search_packs_by_integration_command(
                         command, id_set, exclude_ignored_dependencies)
 

--- a/demisto_sdk/commands/find_dependencies/tests/find_dependencies_test.py
+++ b/demisto_sdk/commands/find_dependencies/tests/find_dependencies_test.py
@@ -366,18 +366,10 @@ class TestDependsOnScriptAndIntegration:
 
         Then
             - Extracting the packs that the script depends on.
-            - Should recognize the mandatory pack and the non mandatory packs.
+            - Should recognize the mandatory pack and ignore the packs that implement the file command.
         """
         expected_result = {
-            ('Active_Directory_Query', True), ('Recorded_Future', False), ('illuminate', False), ('ThreatQ', False),
-            ('Anomali_ThreatStream', False), ('URLHaus', False), ('Symantec_Deepsight', False),
-            ('XForceExchange', False), ('Active_Directory_Query', True), ('XFE', False), ('MISP', False),
-            ('AlienVault_OTX', False), ('ThreatMiner', False), ('isight', False), ('CrowdStrikeIntel', False),
-            ('ReversingLabs_A1000', False), ('PolySwarm', False), ('TruSTAR', False),
-            ('ReversingLabs_Titanium_Cloud', False), ('ThreatExchange', False), ('EclecticIQ', False),
-            ('AutoFocus', False), ('McAfee-TIE', False), ('Maltiverse', False), ('Palo_Alto_Networks_WildFire', False),
-            ('Polygon', False), ('Cofense-Intelligence', False), ('Lastline', False), ('ThreatConnect', False),
-            ('VirusTotal', False), ('Flashpoint', False)
+            ('Active_Directory_Query', True)
         }
 
         test_input = [
@@ -450,8 +442,19 @@ class TestDependsOnScriptAndIntegration:
 
         assert IsEqualFunctions.is_sets_equal(found_result, expected_result)
 
-    @pytest.mark.parametrize("generic_command", ["ip", "domain", "url"])
+    @pytest.mark.parametrize("generic_command", ["ip", "domain", "url", 'send-mail', 'send-notification'])
     def test_collect_detection_of_optional_dependencies(self, generic_command, id_set):
+        """
+        Given
+            - Scripts that depends on generic commands
+
+        When
+            - Building dependency graph for the packs.
+
+        Then
+            - Extracting the packs that the scripts depends on.
+            - Should NOT recognize packs.
+        """
         test_input = [
             {
                 "DummyScript": {
@@ -470,10 +473,7 @@ class TestDependsOnScriptAndIntegration:
                                                                           verbose=False,
                                                                           )
 
-        assert len(dependencies_set) > 0
-
-        for dependency_data in dependencies_set:
-            assert not dependency_data[1]  # validate that mandatory is set to False
+        assert len(dependencies_set) == 0
 
 
 class TestDependsOnPlaybook:
@@ -614,6 +614,17 @@ class TestDependsOnPlaybook:
 
     @pytest.mark.parametrize("integration_command", ["ip", "domain", "url"])
     def test_collect_detection_of_optional_dependencies_in_playbooks(self, integration_command, id_set):
+        """
+        Given
+            - Playbooks that are using generic commands
+
+        When
+            - Building dependency graph for the packs.
+
+        Then
+            - Extracting the packs that the scripts depends on.
+            - Should NOT recognize packs.
+        """
         test_input = [
             {
                 "Dummy Playbook": {
@@ -640,10 +651,7 @@ class TestDependsOnPlaybook:
                                                                             verbose=False,
                                                                             )
 
-        assert len(found_result_set) > 0
-
-        for found_result in found_result_set:
-            assert not found_result[1]  # validate that mandatory is set to False
+        assert len(found_result_set) == 0
 
     def test_collect_playbooks_dependencies_on_incident_fields(self, id_set):
         """


### PR DESCRIPTION
…lation

## Status
- [x] In Progress

## Related Issues
fixes: https://github.com/demisto/etc/issues/29940
fixes: https://github.com/demisto/etc/issues/33105

## Description
ignore file/email/ip/send-mail/send-notification dependencies
when collecting script dependencies.

~~TODO - Consider ignoring them for PB dependencies as well.~~  decided to do so. please see the referenced issue 33105.

## Screenshots
commonscripts pack deps after change:
```
Found dependencies result for CommonScripts pack:
{
    "DemistoRESTAPI": {
        "mandatory": true,
        "display_name": "Demisto REST API"
    }
}

```

## Must have
- [x] Tests
