### PR TITLE
Skip generation of used_in section in script README creation

### DIFF
--- a/demisto_sdk/commands/generate_docs/generate_script_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_script_doc.py
@@ -11,7 +11,8 @@ from demisto_sdk.commands.generate_docs.common import (
 
 
 def generate_script_doc(input, examples, output: str = None, permissions: str = None,
-                        limitations: str = None, insecure: bool = False, verbose: bool = False):
+                        limitations: str = None, insecure: bool = False, verbose: bool = False,
+                        include_used_in: bool = True):
     try:
         doc: list = []
         errors: list = []
@@ -42,10 +43,13 @@ def generate_script_doc(input, examples, output: str = None, permissions: str = 
         # get script dependencies
         dependencies, _ = get_depends_on(script)
 
-        # get the script usages by the id set
-        id_set_creator = IDSetCreator(output='', print_logs=False)
-        id_set = id_set_creator.create_id_set()
-        used_in = get_used_in(id_set, script_id)
+        if include_used_in:
+            # get the script usages by the id set
+            id_set_creator = IDSetCreator(output='', print_logs=False)
+            id_set = id_set_creator.create_id_set()
+            used_in = get_used_in(id_set, script_id)
+        else:
+            used_in = ''
 
         description = script.get('comment', '')
         # get inputs/outputs

--- a/demisto_sdk/commands/init/contribution_converter.py
+++ b/demisto_sdk/commands/init/contribution_converter.py
@@ -252,7 +252,7 @@ class ContributionConverter:
         if file_type == 'integration':
             generate_integration_doc(yml_path)
         if file_type == 'script':
-            generate_script_doc(input=yml_path, examples=[])
+            generate_script_doc(input=yml_path, examples=[], include_used_in=False)
         if file_type == 'playbook':
             generate_playbook_doc(yml_path)
 


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: see example of failed unit tests [here](https://app.circleci.com/pipelines/github/demisto/demisto-sdk/7882/workflows/385a6b60-1daf-4208-85b0-8534d68bd120/jobs/29367)

## Description
The README generation for scripts, involves the creation of the `id_set.json` to create the "used in" section. The creation of the `id_set.json` is a very time-consuming process so we are skipping that part of the README generation to keep the execution time down with the intention to address it in the future.
