### PR TITLE
adding old format file version bump check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Updated the **format** command to generate uuid value for the taskid field and for the id under the task field in case they hold an invalid values.
 * Exclude changes from doc_files directory on validation.
 * Added a validation that an integration command has at most one default argument.
+* Fixing an issue where pack metadata version bump was not enforced when modifying an old format (unified) file.
 
 # 1.2.17
 * Added a validation that the classifier of an integration exists.

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -650,6 +650,8 @@ def get_pack_name(file_path):
     Returns:
         pack name (str)
     """
+    if isinstance(file_path, Path):
+        file_path = str(file_path)
     # the regex extracts pack name from relative paths, for example: Packs/EWSv2 -> EWSv2
     match = re.search(rf'^{PACKS_DIR_REGEX}[/\\]([^/\\]+)[/\\]?', file_path)
     return match.group(1) if match else None
@@ -670,7 +672,6 @@ def get_pack_names_from_files(file_paths, skip_file_types=None):
             pack = get_pack_name(path)
             if pack and is_file_path_in_pack(path):
                 packs.add(pack)
-
     return packs
 
 

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -1308,24 +1308,28 @@ def test_get_packs_that_should_have_version_raised(repo):
        Then
        -  The returning set includes the packs for 1, 4 & 5 and does not include the packs for 2 & 3.
    """
-    existing_pack1 = repo.create_pack('MyPack')
+    existing_pack1 = repo.create_pack('PackWithModifiedIntegration')
     moodified_integration = existing_pack1.create_integration('MyIn')
     moodified_integration.create_default_integration()
-    existing_pack2 = repo.create_pack('MySecondPack')
+
+    existing_pack2 = repo.create_pack('ExistingPackWithAddedScript')
     added_script_existing_pack = existing_pack2.create_script('MyScript')
     added_script_existing_pack.create_default_script()
-    new_pack = repo.create_pack('MyNewPack')
+
+    new_pack = repo.create_pack('NewPack')
     added_script_new_pack = new_pack.create_script('MyNewScript')
     added_script_new_pack.create_default_script()
-    existing_pack3 = repo.create_pack('MyThirdPack')
+
+    existing_pack3 = repo.create_pack('PackWithModifiedOldFile')
     modified_old_format_script = existing_pack3.create_script('OldScript')
     modified_old_format_script.create_default_script()
-    existing_pack4 = repo.create_pack('MyForthPack')
+
+    existing_pack4 = repo.create_pack('PackWithModifiedTestPlaybook')
     moodified_test_playbook = existing_pack4.create_test_playbook('TestBook')
     moodified_test_playbook.create_default_test_playbook()
 
     validate_manager = ValidateManager()
-    validate_manager.new_packs = {'MyNewPack'}
+    validate_manager.new_packs = {'NewPack'}
 
     modified_files = {moodified_integration.yml.rel_path, moodified_test_playbook.yml.rel_path}
     added_files = {added_script_existing_pack.yml.rel_path, added_script_new_pack.yml.rel_path}
@@ -1335,8 +1339,8 @@ def test_get_packs_that_should_have_version_raised(repo):
         packs_that_should_have_version_raised = validate_manager.get_packs_that_should_have_version_raised(
             modified_files=modified_files, added_files=added_files, old_format_files=old_files)
 
-        assert 'MyPack' in packs_that_should_have_version_raised
-        assert 'MySecondPack' in packs_that_should_have_version_raised
-        assert 'MyThirdPack' in packs_that_should_have_version_raised
-        assert 'MyForthPack' not in packs_that_should_have_version_raised
-        assert 'MyNewPack' not in packs_that_should_have_version_raised
+        assert 'PackWithModifiedIntegration' in packs_that_should_have_version_raised
+        assert 'ExistingPackWithAddedScript' in packs_that_should_have_version_raised
+        assert 'PackWithModifiedOldFile' in packs_that_should_have_version_raised
+        assert 'PackWithModifiedTestPlaybook' not in packs_that_should_have_version_raised
+        assert 'NewPack' not in packs_that_should_have_version_raised

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -426,7 +426,7 @@ class ValidateManager:
 
         validation_results.add(self.validate_modified_files(modified_files))
         validation_results.add(self.validate_added_files(added_files, modified_files))
-        validation_results.add(self.validate_changed_packs_unique_files(modified_files, added_files,
+        validation_results.add(self.validate_changed_packs_unique_files(modified_files, added_files, old_format_files,
                                                                         changed_meta_files))
 
         if old_format_files:
@@ -701,17 +701,18 @@ class ValidateManager:
         """
         return pack not in IGNORED_PACK_NAMES
 
-    def validate_changed_packs_unique_files(self, modified_files, added_files, changed_meta_files):
+    def validate_changed_packs_unique_files(self, modified_files, added_files, old_format_files, changed_meta_files):
         click.secho(f'\n================= Running validation on changed pack unique files =================',
                     fg="bright_cyan")
         valid_pack_files = set()
 
         added_packs = get_pack_names_from_files(added_files)
-        modified_packs = get_pack_names_from_files(modified_files)
+        modified_packs = get_pack_names_from_files(modified_files).union(get_pack_names_from_files(old_format_files))
         changed_meta_packs = get_pack_names_from_files(changed_meta_files)
 
         packs_that_should_have_version_raised = self.get_packs_that_should_have_version_raised(modified_files,
-                                                                                               added_files)
+                                                                                               added_files,
+                                                                                               old_format_files)
 
         changed_packs = modified_packs.union(added_packs).union(changed_meta_packs)
 
@@ -1193,9 +1194,10 @@ class ValidateManager:
             click.secho(f"\n=========== Ignored the following files ===========\n\n{all_ignored_files}",
                         fg="yellow")
 
-    def get_packs_that_should_have_version_raised(self, modified_files, added_files):
+    def get_packs_that_should_have_version_raised(self, modified_files, added_files, old_format_files):
         # modified packs (where the change is not test-playbook, test-script, readme, metadata file or release notes)
-        modified_packs_that_should_have_version_raised = get_pack_names_from_files(modified_files, skip_file_types={
+        all_modified_files = modified_files.union(old_format_files)
+        modified_packs_that_should_have_version_raised = get_pack_names_from_files(all_modified_files, skip_file_types={
             FileType.RELEASE_NOTES, FileType.README, FileType.TEST_PLAYBOOK, FileType.TEST_SCRIPT
         })
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)


## Description
Fixing an issue where pack metadata version bump was not enforced when modifying an old format (unified) file.