### PR TITLE
Supporting lab lockdown

### DIFF
--- a/demisto_sdk/commands/test_content/constants.py
+++ b/demisto_sdk/commands/test_content/constants.py
@@ -1,0 +1,2 @@
+LOAD_BALANCER_DNS = 'content-build-lb.demisto.works'
+SSH_USER = 'ec2-user'

--- a/demisto_sdk/commands/test_content/execute_test_content.py
+++ b/demisto_sdk/commands/test_content/execute_test_content.py
@@ -44,8 +44,8 @@ def execute_test_content(**kwargs):
     logging_manager = ParallelLoggingManager('Run_Tests.log', real_time_logs_only=not kwargs['nightly'])
     build_context = BuildContext(kwargs, logging_manager)
     threads_list = []
-    for server_ip in build_context.instances_ips:
-        tests_execution_instance = ServerContext(build_context, server_ip)
+    for server_ip, port in build_context.instances_ips.items():
+        tests_execution_instance = ServerContext(build_context, server_private_ip=server_ip, tunnel_port=port)
         threads_list.append(Thread(target=tests_execution_instance.execute_tests))
 
     for thread in threads_list:
@@ -56,7 +56,9 @@ def execute_test_content(**kwargs):
 
     if not build_context.unmockable_tests_to_run.empty() or not build_context.mockable_tests_to_run.empty():
         raise Exception('Not all tests have been executed')
-    if build_context.tests_data_keeper.playbook_skipped_integration and build_context.build_name != 'master':
+    if build_context.tests_data_keeper.playbook_skipped_integration \
+            and build_context.build_name != 'master' \
+            and not build_context.is_nightly:
         comment = 'The following integrations are skipped and critical for the test:\n {}'. \
             format('\n- '.join(build_context.tests_data_keeper.playbook_skipped_integration))
         _add_pr_comment(comment, logging_manager)

--- a/demisto_sdk/commands/test_content/tests/build_context_test.py
+++ b/demisto_sdk/commands/test_content/tests/build_context_test.py
@@ -131,7 +131,8 @@ def generate_env_results_content(
     }
     env_results = [{'AmiName': role_to_ami_name_mapping[role],
                     'Role': role,
-                    'InstanceDNS': '1.1.1.1'} for _ in range(number_of_instances)]
+                    'InstanceDNS': '1.1.1.1',
+                    'TunnelPort': 4445} for _ in range(number_of_instances)]
     return env_results
 
 
@@ -367,3 +368,17 @@ def test_mockable_playbook_configuration(mocker, tmp_path):
                                              content_conf_json=content_conf_json,
                                              filtered_tests_content=filtered_tests)
     assert 'mockable_playbook' not in build_context.unmockable_test_ids
+
+
+def test_get_instances_ips(mocker, tmp_path):
+    """
+    Given:
+        - A build context
+    When:
+        - Initializing the BuildContext instance
+    Then:
+        - Ensure that the instance ips are parsed as a dict that maps the IPs to the tunnel port.
+    """
+    build_context = get_mocked_build_context(mocker,
+                                             tmp_path)
+    assert build_context.instances_ips == {'1.1.1.1': 4445}

--- a/demisto_sdk/commands/test_content/tests/mock_unit_test.py
+++ b/demisto_sdk/commands/test_content/tests/mock_unit_test.py
@@ -2,10 +2,8 @@ from __future__ import print_function
 
 import time
 from threading import Thread
-from unittest.mock import patch
 
-from demisto_sdk.commands.test_content.mock_server import (AMIConnection,
-                                                           MITMProxy,
+from demisto_sdk.commands.test_content.mock_server import (MITMProxy,
                                                            clean_filename,
                                                            get_folder_path,
                                                            get_log_file_path,
@@ -23,23 +21,6 @@ def test_get_paths():
     assert get_log_file_path(test_playbook_id) == 'test_playbook/test_playbook_playback.log'
     assert get_log_file_path(test_playbook_id, record=True) == 'test_playbook/test_playbook_record.log'
     assert get_folder_path(test_playbook_id) == 'test_playbook/'
-
-
-def test_ami():
-    with patch('demisto_sdk.commands.test_content.mock_server.AMIConnection.check_output') as mock:
-        mock.return_value = b"""
-        eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9001
-            inet 2.2.2.2  netmask 255.255.240.0  broadcast 172.31.63.255
-            inet6 fe80::c9d:ccff:fe7f:1e91  prefixlen 64  scopeid 0x20<link>
-            ether 0e:9d:cc:7f:1e:91  txqueuelen 1000  (Ethernet)
-            RX packets 37051  bytes 47117967 (44.9 MiB)
-            RX errors 0  dropped 0  overruns 0  frame 0
-            TX packets 26025  bytes 28722186 (27.3 MiB)
-            TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0"""
-
-        ami = AMIConnection('1.1.1.1')
-        assert ami.public_ip == '1.1.1.1'
-        assert ami.internal_ip == '2.2.2.2'
 
 
 def test_push_mock_files_thread_safety(mocker):

--- a/demisto_sdk/commands/test_content/tests/test_context_test.py
+++ b/demisto_sdk/commands/test_content/tests/test_context_test.py
@@ -25,7 +25,7 @@ def test_is_runnable_on_this_instance(mocker):
                                                          test_playbook_configuration),
                                    client=mocker.MagicMock())
 
-    test_context = test_context_builder(is_instance_using_docker=False)
+    test_context = test_context_builder(server_context=mocker.MagicMock(is_instance_using_docker=False))
     assert not test_context._is_runnable_on_current_server_instance()
-    test_context = test_context_builder(is_instance_using_docker=True)
+    test_context = test_context_builder(server_context=mocker.MagicMock(is_instance_using_docker=True))
     assert test_context._is_runnable_on_current_server_instance()

--- a/demisto_sdk/commands/test_content/tools.py
+++ b/demisto_sdk/commands/test_content/tools.py
@@ -4,6 +4,7 @@ from pprint import pformat
 from subprocess import STDOUT, CalledProcessError, check_output
 
 import demisto_client
+from demisto_sdk.commands.test_content.constants import SSH_USER
 
 
 def update_server_configuration(client, server_configuration, error_msg, logging_manager=None):
@@ -76,7 +77,7 @@ def is_redhat_instance(instance_ip: str) -> bool:
         True if the file '/home/ec2-user/rhel_ami' exists on the instance, else False
     """
     try:
-        check_output(f'ssh -o StrictHostKeyChecking=no ec2-user@{instance_ip} ls -l /home/ec2-user/rhel_ami'.split(),
+        check_output(f'ssh {SSH_USER}@{instance_ip} ls -l /home/ec2-user/rhel_ami'.split(),
                      stderr=STDOUT)
         return True
     except CalledProcessError:


### PR DESCRIPTION
## Description:
As part of the [content-test-conf PR](https://github.com/demisto/content-test-conf/pull/1105) and the [content PR](https://github.com/demisto/content/pull/11149), this PR implements the lab lockdown.

Mostly this PR is about replacing the usage of the public IP with the private IP in the `ssh`, and `scp` calls, and about replacing the public IP in the localhost and port used in the tunneling for the https calls:

## Related issue:
https://github.com/demisto/etc/issues/32500