### PR TITLE
Fix cpu_count in unittests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,11 +1,11 @@
 """Configuring tests for the content suite
 """
-import pytest
+from typing import Generator
 from unittest import mock
+
+import pytest
 from _pytest.fixtures import FixtureRequest
 from _pytest.tmpdir import TempPathFactory, _mk_tmp
-from typing import Generator
-
 from TestSuite.integration import Integration
 from TestSuite.pack import Pack
 from TestSuite.playbook import Playbook
@@ -73,10 +73,10 @@ def playbook(request: FixtureRequest, tmp_path_factory: TempPathFactory) -> Play
 
 
 @pytest.fixture(scope='session', autouse=True)
-def mock_cpu_count() -> Generator:
+def mock_update_id_set_cpu_count() -> Generator:
     """
     Since Circle build has an issue in it's virtualization where it has only 2 vcpu's but the 'cpu_count' method returns
     all physical cpu's (36) it uses too many processes in the process pools.
     """
-    with mock.patch('demisto_sdk.commands.common.update_id_set.cpu_count', return_value=4) as _fixture:
+    with mock.patch('demisto_sdk.commands.common.update_id_set.cpu_count', return_value=2) as _fixture:
         yield _fixture

--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,11 @@
 """Configuring tests for the content suite
 """
 import pytest
+from unittest import mock
 from _pytest.fixtures import FixtureRequest
 from _pytest.tmpdir import TempPathFactory, _mk_tmp
+from typing import Generator
+
 from TestSuite.integration import Integration
 from TestSuite.pack import Pack
 from TestSuite.playbook import Playbook
@@ -67,3 +70,13 @@ def playbook(request: FixtureRequest, tmp_path_factory: TempPathFactory) -> Play
     """Mocking tmp_path
     """
     return get_playbook(request, tmp_path_factory)
+
+
+@pytest.fixture(scope='session', autouse=True)
+def mock_cpu_count() -> Generator:
+    """
+    Since Circle build has an issue in it's virtualization where it has only 2 vcpu's but the 'cpu_count' method returns
+    all physical cpu's (36) it uses too many processes in the process pools.
+    """
+    with mock.patch('demisto_sdk.commands.common.update_id_set.cpu_count', return_value=4) as _fixture:
+        yield _fixture

--- a/demisto_sdk/commands/init/tests/contribution_converter_test.py
+++ b/demisto_sdk/commands/init/tests/contribution_converter_test.py
@@ -146,8 +146,6 @@ def test_convert_contribution_zip_updated_pack(get_content_path_mock, get_python
 
 @patch('demisto_sdk.commands.split_yml.extractor.get_python_version')
 @patch('demisto_sdk.commands.init.contribution_converter.get_content_path')
-@pytest.mark.skip(reason="Test is flaky and seems to fail occasionally on "
-                         "SIGTERM - https://github.com/demisto/etc/issues/33244")
 def test_convert_contribution_zip_outputs_structure(get_content_path_mock, get_python_version_mock, tmp_path):
     """Create a fake contribution zip file and test that it is converted to a Pack correctly
 


### PR DESCRIPTION
Fixing the cpu_count method to return 2.

Since Circle build has an issue in it's virtualization where it has only 2 VCPU's but the 'cpu_count' method returns all physical CPU's (36) which causes it to use too many processes in the process pools.

fixes: https://github.com/demisto/etc/issues/33244
