### PR TITLE
allowing indicator field upload

### DIFF
--- a/demisto_sdk/commands/upload/uploader.py
+++ b/demisto_sdk/commands/upload/uploader.py
@@ -35,7 +35,8 @@ from tabulate import tabulate
 UPLOAD_SUPPORTED_ENTITIES = [FileType.INTEGRATION, FileType.SCRIPT, FileType.PLAYBOOK, FileType.WIDGET,
                              FileType.TEST_PLAYBOOK, FileType.INCIDENT_TYPE, FileType.CLASSIFIER,
                              FileType.LAYOUT, FileType.LAYOUTS_CONTAINER, FileType.DASHBOARD, FileType.INCIDENT_FIELD,
-                             FileType.OLD_CLASSIFIER, FileType.TEST_SCRIPT, FileType.MAPPER, FileType.BETA_INTEGRATION]
+                             FileType.OLD_CLASSIFIER, FileType.TEST_SCRIPT, FileType.MAPPER, FileType.BETA_INTEGRATION,
+                             FileType.INDICATOR_FIELD]
 
 
 UNIFIED_ENTITIES_DIR = [INTEGRATIONS_DIR, SCRIPTS_DIR]


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
N/A

## Description
Up until now the SDK does not allow to upload indicator fields from the indicator fields folder of a pack. One has to wrap the individual JSON files into a temporary JSON array file and then upload it via the UI (Settings -> Advanced -> Fields -> Upload Icon). The API endpoint used in this operation is `/incidentfields/import` (which is wrapped in the Python client as `client.import_incident_fields()`).

The fix does something similar here: it re-uses the upload logic from the incident field pack object class. I decided against subclassing the incident field pack object class because I feel indicator fields deserve either a dedicated endpoint for uploads or the incident upload endpoint is generalized. So subclassing would create an unnecessary dependency between the two.

## Screenshots
N/A

## Must have
- [ ] Tests
- [ ] Documentation
