### PR TITLE
fixing git util to only recognize 100% rename and handle non 100% recognition

### DIFF
--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -313,7 +313,7 @@ def validate(config, **kwargs):
             create_id_set=kwargs.get('create_id_set'),
             json_file_path=kwargs.get('json_file'),
             skip_schema_check=kwargs.get('skip_schema_check'),
-            debug_git=kwargs.get('debug_git')
+            debug_git=kwargs.get('debug_git'),
         )
         return validator.run_validation()
     except (git.InvalidGitRepositoryError, git.NoSuchPathError, FileNotFoundError) as e:

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -276,6 +276,9 @@ def unify(**kwargs):
 @click.option(
     '--skip-schema-check', is_flag=True,
     help='Whether to skip the file schema check.')
+@click.option(
+    '--debug-git', is_flag=True,
+    help='Whether to print debug logs for git statuses.')
 @pass_config
 def validate(config, **kwargs):
     sys.path.append(config.configuration.env_dir)
@@ -309,7 +312,8 @@ def validate(config, **kwargs):
             staged=kwargs['staged'],
             create_id_set=kwargs.get('create_id_set'),
             json_file_path=kwargs.get('json_file'),
-            skip_schema_check=kwargs.get('skip_schema_check')
+            skip_schema_check=kwargs.get('skip_schema_check'),
+            debug_git=kwargs.get('debug_git')
         )
         return validator.run_validation()
     except (git.InvalidGitRepositoryError, git.NoSuchPathError, FileNotFoundError) as e:

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -915,7 +915,7 @@ def update_pack_releasenotes(**kwargs):
     if _pack and '/' in _pack:
         _pack = get_pack_name(_pack)
     try:
-        validate_manager = ValidateManager(skip_pack_rn_validation=True, prev_ver=prev_ver)
+        validate_manager = ValidateManager(skip_pack_rn_validation=True, prev_ver=prev_ver, silence_init_prints=True)
         validate_manager.setup_git_params()
         modified, added, changed_meta_files, old = validate_manager.get_changed_files_from_git()
         _packs = get_packs(modified).union(get_packs(old)).union(

--- a/demisto_sdk/commands/common/git_util.py
+++ b/demisto_sdk/commands/common/git_util.py
@@ -366,14 +366,11 @@ class GitUtil:
 
     def debug_print(self, debug: bool, status: str, staged: Set, committed: Set) -> None:
         if debug:
-            if staged or committed:
-                click.echo(f'######## - {status} staged:')
-                click.echo(staged)
-                click.echo('\n')
-                click.echo(f'######## - {status} committed:')
-                click.echo(committed)
-            else:
-                click.echo(f"######## - Found no {status} files")
+            click.echo(f'######## - {status} staged:')
+            click.echo(staged)
+            click.echo('\n')
+            click.echo(f'######## - {status} committed:')
+            click.echo(committed)
             click.echo('\n')
 
     def handle_wrong_renamed_status(self, status: str, remote: str, branch: str, staged_only: bool) -> Set[Path]:

--- a/demisto_sdk/commands/common/git_util.py
+++ b/demisto_sdk/commands/common/git_util.py
@@ -372,9 +372,9 @@ class GitUtil:
                 click.echo('\n')
                 click.echo(f'######## - {status} committed:')
                 click.echo(committed)
-                click.echo('\n')
             else:
                 click.echo(f"######## - Found no {status} files")
+            click.echo('\n')
 
     def handle_wrong_renamed_status(self, status: str, remote: str, branch: str, staged_only: bool) -> Set[Path]:
         """Get all the files that are recognized as non-100% rename in a given file status.

--- a/demisto_sdk/commands/common/git_util.py
+++ b/demisto_sdk/commands/common/git_util.py
@@ -288,8 +288,9 @@ class GitUtil:
             line = line.strip()
             file_status = line.split()[0].upper() if not line.startswith('?') else 'A'
             if file_status.startswith(requested_status):
-                if requested_status == 'R' and file_status == 'R100':
-                    extracted_paths.add((Path(line.split()[-2]), Path(line.split()[-1])))
+                if requested_status == 'R':
+                    if file_status == 'R100':
+                        extracted_paths.add((Path(line.split()[-2]), Path(line.split()[-1])))
                 else:
                     extracted_paths.add(Path(line.split()[-1]))  # type: ignore
 

--- a/demisto_sdk/commands/common/git_util.py
+++ b/demisto_sdk/commands/common/git_util.py
@@ -70,6 +70,10 @@ class GitUtil:
         committed_added = {Path(os.path.join(item.a_path)) for item in
                            self.repo.remote(name=remote).refs[branch].commit.
                            diff(self.repo.active_branch).iter_change_type('A')}
+        print('######## - committed added:')
+        print(committed_added)
+        print('######## - staged modified:')
+        print(staged)
 
         staged = staged - committed_added
 

--- a/demisto_sdk/commands/common/git_util.py
+++ b/demisto_sdk/commands/common/git_util.py
@@ -70,15 +70,20 @@ class GitUtil:
         committed_added = {Path(os.path.join(item.a_path)) for item in
                            self.repo.remote(name=remote).refs[branch].commit.
                            diff(self.repo.active_branch).iter_change_type('A')}
-        print('######## - committed added:')
-        print(committed_added)
-        print('######## - staged modified:')
-        print(staged)
 
         staged = staged - committed_added
 
         if staged_only:
             return staged - renamed - deleted
+
+        print('######## - staged:')
+        print(staged)
+        print('######## - commited:')
+        print(committed)
+        print('######## - renamed:')
+        print(renamed)
+        print('######## - deleted:')
+        print(deleted)
 
         return staged.union(committed) - renamed - deleted
 

--- a/demisto_sdk/commands/common/git_util.py
+++ b/demisto_sdk/commands/common/git_util.py
@@ -76,6 +76,11 @@ class GitUtil:
         if staged_only:
             return staged - renamed - deleted
 
+        print('######## -  modified staged:')
+        print(staged)
+        print('######## - modified committed:')
+        print(committed)
+
         return staged.union(committed) - renamed - deleted
 
     def added_files(self, prev_ver: str = 'master', committed_only: bool = False,
@@ -134,6 +139,11 @@ class GitUtil:
 
         if staged_only:
             return staged - deleted
+
+        print('######## -  added staged:')
+        print(staged)
+        print('######## - added committed:')
+        print(committed)
 
         return staged.union(committed) - deleted
 
@@ -230,9 +240,9 @@ class GitUtil:
         if staged_only:
             return staged
 
-        print('######## - staged:')
+        print('######## -  renamed staged:')
         print(staged)
-        print('######## - commited:')
+        print('######## - renamed committed:')
         print(committed)
 
         return staged.union(committed)

--- a/demisto_sdk/commands/common/git_util.py
+++ b/demisto_sdk/commands/common/git_util.py
@@ -76,15 +76,6 @@ class GitUtil:
         if staged_only:
             return staged - renamed - deleted
 
-        print('######## - staged:')
-        print(staged)
-        print('######## - commited:')
-        print(committed)
-        print('######## - renamed:')
-        print(renamed)
-        print('######## - deleted:')
-        print(deleted)
-
         return staged.union(committed) - renamed - deleted
 
     def added_files(self, prev_ver: str = 'master', committed_only: bool = False,
@@ -238,6 +229,11 @@ class GitUtil:
 
         if staged_only:
             return staged
+
+        print('######## - staged:')
+        print(staged)
+        print('######## - commited:')
+        print(committed)
 
         return staged.union(committed)
 

--- a/demisto_sdk/commands/common/git_util.py
+++ b/demisto_sdk/commands/common/git_util.py
@@ -267,7 +267,7 @@ class GitUtil:
                   in self.repo.head.commit.diff().iter_change_type('R') if item.score == 100}.union(untracked)
 
         if staged_only:
-            self.debug_print(debug=debug, status='Renamed', staged=staged, committed=committed)
+            self.debug_print(debug=debug, status='Renamed', staged=staged, committed=set())
             return staged
 
         self.debug_print(debug=debug, status='Renamed', staged=staged, committed=committed)
@@ -366,11 +366,16 @@ class GitUtil:
 
     def debug_print(self, debug: bool, status: str, staged: Set, committed: Set) -> None:
         if debug:
-            click.echo(f'######## - {status} staged:')
-            click.echo(staged)
-            click.echo(f'######## - {status} committed:')
-            click.echo(committed)
-            click.echo('\n')
+            if staged:
+                click.echo(f'######## - {status} staged:')
+                click.echo(staged)
+                click.echo('\n')
+            if committed:
+                click.echo(f'######## - {status} committed:')
+                click.echo(committed)
+                click.echo('\n')
+            if not staged and not committed:
+                click.echo(f"######## - Found no {status} files")
 
     def handle_wrong_renamed_status(self, status: str, remote: str, branch: str, staged_only: bool) -> Set[Path]:
         """Get all the files that are recognized as non-100% rename in a given file status.

--- a/demisto_sdk/commands/common/git_util.py
+++ b/demisto_sdk/commands/common/git_util.py
@@ -402,4 +402,7 @@ class GitUtil:
         """
         diff_line = self.repo.git.diff('--name-status',
                                        f'{remote}/{branch}...{self.repo.active_branch}', '--', file_path)
-        return diff_line.split()[0].upper()
+        if not diff_line:
+            return ''
+
+        return diff_line.split()[0].upper() if not diff_line.startswith('?') else 'A'

--- a/demisto_sdk/commands/common/git_util.py
+++ b/demisto_sdk/commands/common/git_util.py
@@ -366,15 +366,14 @@ class GitUtil:
 
     def debug_print(self, debug: bool, status: str, staged: Set, committed: Set) -> None:
         if debug:
-            if staged:
+            if staged or committed:
                 click.echo(f'######## - {status} staged:')
                 click.echo(staged)
                 click.echo('\n')
-            if committed:
                 click.echo(f'######## - {status} committed:')
                 click.echo(committed)
                 click.echo('\n')
-            if not staged and not committed:
+            else:
                 click.echo(f"######## - Found no {status} files")
 
     def handle_wrong_renamed_status(self, status: str, remote: str, branch: str, staged_only: bool) -> Set[Path]:

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -1191,7 +1191,7 @@ class ValidateManager:
         else:
             id_set = open_id_set_file(id_set_path)
 
-        if not id_set:
+        if not id_set and not self.no_configuration_prints:
             error_message, error_code = Errors.no_id_set_file()
             self.handle_error(error_message, error_code, file_path=id_set_path, warning=True)
 

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -76,7 +76,7 @@ class ValidateManager:
             print_ignored_files=False, skip_conf_json=True, validate_id_set=False, file_path=None,
             validate_all=False, is_external_repo=False, skip_pack_rn_validation=False, print_ignored_errors=False,
             silence_init_prints=False, no_docker_checks=False, skip_dependencies=False, id_set_path=None, staged=False,
-            create_id_set=False, json_file_path=None, skip_schema_check=False
+            create_id_set=False, json_file_path=None, skip_schema_check=False, debug_git=False
     ):
         # General configuration
         self.skip_docker_checks = False
@@ -95,6 +95,7 @@ class ValidateManager:
         self.compare_type = '...'
         self.staged = staged
         self.skip_schema_check = skip_schema_check
+        self.debug_git = debug_git
 
         if json_file_path:
             self.json_file_path = os.path.join(json_file_path, 'validate_outputs.json') if \
@@ -948,11 +949,12 @@ class ValidateManager:
         """
         # get files from git by status identification against prev-ver
         modified_files = self.git_util.modified_files(prev_ver=self.prev_ver,
-                                                      committed_only=self.is_circle, staged_only=self.staged)
+                                                      committed_only=self.is_circle, staged_only=self.staged,
+                                                      debug=self.debug_git)
         added_files = self.git_util.added_files(prev_ver=self.prev_ver, committed_only=self.is_circle,
-                                                staged_only=self.staged)
+                                                staged_only=self.staged, debug=self.debug_git)
         renamed_files = self.git_util.renamed_files(prev_ver=self.prev_ver, committed_only=self.is_circle,
-                                                    staged_only=self.staged)
+                                                    staged_only=self.staged, debug=self.debug_git)
 
         # filter files only to relevant files
         filtered_modified, old_format_files = self.filter_to_relevant_files(modified_files)

--- a/demisto_sdk/tests/workflow_test.py
+++ b/demisto_sdk/tests/workflow_test.py
@@ -117,7 +117,7 @@ class ContentGitRepo:
                 assert res.exit_code == 0
                 res = runner.invoke(main, "lint -g --no-test")
                 assert res.exit_code == 0
-                res = runner.invoke(main, "validate -g --skip-pack-dependencies --no-docker-checks")
+                res = runner.invoke(main, "validate -g --skip-pack-dependencies --no-docker-checks --debug-git")
                 assert res.exit_code == 0
             except AssertionError:
                 raise AssertionError(f"stdout = {res.stdout}\nstderr = {res.stderr}")

--- a/demisto_sdk/tests/workflow_test.py
+++ b/demisto_sdk/tests/workflow_test.py
@@ -107,18 +107,26 @@ class ContentGitRepo:
         Run all of the following validations:
         * secrets
         * lint -g --no-test
+        * validate -g --staged
         * validate -g
         """
         with ChangeCWD(self.content):
             runner = CliRunner(mix_stderr=False)
             self.run_command("git add .")
-            res = runner.invoke(main, "secrets")
             try:
+                # commit flow - secrets, lint and validate only on staged files
+                res = runner.invoke(main, "secrets")
                 assert res.exit_code == 0
                 res = runner.invoke(main, "lint -g --no-test")
                 assert res.exit_code == 0
+                res = runner.invoke(main, "validate -g --staged --skip-pack-dependencies "
+                                          "--no-docker-checks --debug-git")
+                assert res.exit_code == 0
+
+                # build flow - validate on all changed files
                 res = runner.invoke(main, "validate -g --skip-pack-dependencies --no-docker-checks --debug-git")
                 assert res.exit_code == 0
+
             except AssertionError:
                 raise AssertionError(f"stdout = {res.stdout}\nstderr = {res.stderr}")
 

--- a/demisto_sdk/tests/workflow_test.py
+++ b/demisto_sdk/tests/workflow_test.py
@@ -114,12 +114,12 @@ class ContentGitRepo:
             runner = CliRunner(mix_stderr=False)
             self.run_command("git add .")
             try:
-                # commit flow - secrets, lint and validate only on staged files
+                # commit flow - secrets, lint and validate only on staged files without rn
                 res = runner.invoke(main, "secrets")
                 assert res.exit_code == 0
                 res = runner.invoke(main, "lint -g --no-test")
                 assert res.exit_code == 0
-                res = runner.invoke(main, "validate -g --staged --skip-pack-dependencies "
+                res = runner.invoke(main, "validate -g --staged --skip-pack-dependencies --skip-pack-release-notes "
                                           "--no-docker-checks --debug-git")
                 assert res.exit_code == 0
 


### PR DESCRIPTION
fixing git util to only recognize 100% rename and handle non 100% recognition 

This handles cases like this:
![image](https://user-images.githubusercontent.com/50295826/108736937-c0e94c80-753a-11eb-9b8e-4b196633b347.png)
