### PR TITLE
Seperate validate files to sub-tasks in SDK build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,6 +161,8 @@ jobs:
               demisto-sdk -v
 
               export CIRCLE_ARTIFACTS="/home/circleci/project/artifacts"
+              CIRCLE_BRANCH="master" demisto-sdk create-id-set -o ./Tests/id_set.json
+
         - run:
             name: Merge Id Set
             when: always
@@ -169,7 +171,6 @@ jobs:
               cd content
               demisto-sdk -v
 
-              CIRCLE_BRANCH="master" demisto-sdk create-id-set -o ./Tests/id_set.json
               gsutil cp gs://marketplace-dist/content/private_id_set.json $CIRCLE_ARTIFACTS/unified_id_set.json
               CIRCLE_BRANCH="master" demisto-sdk merge-id-sets -i1 ./Tests/id_set.json -i2 $CIRCLE_ARTIFACTS/unified_id_set.json -o $CIRCLE_ARTIFACTS/unified_id_set.json
         - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,12 +165,6 @@ jobs:
 
               gsutil cp gs://marketplace-dist/content/private_id_set.json $CIRCLE_ARTIFACTS/unified_id_set.json
               CIRCLE_BRANCH="master" demisto-sdk merge-id-sets -i1 ./Tests/id_set.json -i2 $CIRCLE_ARTIFACTS/unified_id_set.json -o $CIRCLE_ARTIFACTS/unified_id_set.json
-
-
-        - run:
-            name: Merge Id Set
-            when: always
-            command: |
         - run:
             name: Test validate files and yaml
             when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,10 +169,6 @@ jobs:
             name: Test validate files and yaml
             when: always
             command: |
-              . .tox/py37/bin/activate
-              cd content
-              demisto-sdk -v
-
               CIRCLE_BRANCH="master" python3 ./Tests/scripts/update_conf_json.py
               CIRCLE_BRANCH="master" ./Tests/scripts/validate.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,6 +173,8 @@ jobs:
               npm ci
               export PYTHONPATH=".:${PYTHONPATH}"
               demisto-sdk -v
+              export CIRCLE_ARTIFACTS="/home/circleci/project/artifacts"
+
               gsutil cp gs://marketplace-dist/content/private_id_set.json $CIRCLE_ARTIFACTS/unified_id_set.json
               CIRCLE_BRANCH="master" demisto-sdk merge-id-sets -i1 ./Tests/id_set.json -i2 $CIRCLE_ARTIFACTS/unified_id_set.json -o $CIRCLE_ARTIFACTS/unified_id_set.json
         - run:
@@ -185,6 +187,8 @@ jobs:
               npm ci
               export PYTHONPATH=".:${PYTHONPATH}"
               demisto-sdk -v
+              export CIRCLE_ARTIFACTS="/home/circleci/project/artifacts"
+
 
               CIRCLE_BRANCH="master" python3 ./Tests/scripts/update_conf_json.py
               CIRCLE_BRANCH="master" ./Tests/scripts/validate.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,12 +163,14 @@ jobs:
               export CIRCLE_ARTIFACTS="/home/circleci/project/artifacts"
               CIRCLE_BRANCH="master" demisto-sdk create-id-set -o ./Tests/id_set.json
 
+              gsutil cp gs://marketplace-dist/content/private_id_set.json $CIRCLE_ARTIFACTS/unified_id_set.json
+              CIRCLE_BRANCH="master" demisto-sdk merge-id-sets -i1 ./Tests/id_set.json -i2 $CIRCLE_ARTIFACTS/unified_id_set.json -o $CIRCLE_ARTIFACTS/unified_id_set.json
+
+
         - run:
             name: Merge Id Set
             when: always
             command: |
-              gsutil cp gs://marketplace-dist/content/private_id_set.json $CIRCLE_ARTIFACTS/unified_id_set.json
-              CIRCLE_BRANCH="master" demisto-sdk merge-id-sets -i1 ./Tests/id_set.json -i2 $CIRCLE_ARTIFACTS/unified_id_set.json -o $CIRCLE_ARTIFACTS/unified_id_set.json
         - run:
             name: Test validate files and yaml
             when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,23 +188,6 @@ jobs:
 
               CIRCLE_BRANCH="master" python3 ./Tests/scripts/update_conf_json.py
               CIRCLE_BRANCH="master" ./Tests/scripts/validate.sh
-
-  create-id-set:
-      docker:
-        - image: circleci/python:3.8.3-buster-node
-      steps:
-        - checkout
-        - attach_workspace:
-            at: ~/project
-        - run:
-            name: Test create ID set
-            when: always
-            command: |
-              . .tox/py37/bin/activate
-
-              cd content
-              demisto-sdk -v
-              CIRCLE_BRANCH="master" demisto-sdk create-id-set -o ./Tests/id_set.json
   create-content-artifacts:
       docker:
         - image: circleci/python:3.8.3-buster-node
@@ -253,9 +236,6 @@ workflows:
       - validate-files:
           <<: *tag_filter
           <<: *reqs_content_checkout
-      - create-id-set:
-          <<: *tag_filter
-          <<: *reqs_content_checkout
       - create-content-artifacts:
           <<: *tag_filter
           <<: *reqs_content_checkout
@@ -266,5 +246,4 @@ workflows:
             - tox3-8-unit-tests
             - precommit-checks
             - validate-files
-            - create-id-set
             - create-content-artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,12 +163,29 @@ jobs:
               export CIRCLE_ARTIFACTS="/home/circleci/project/artifacts"
               CIRCLE_BRANCH="master" demisto-sdk create-id-set -o ./Tests/id_set.json
 
+        - run:
+            name: Merge Id Set
+            when: always
+            command: |
+              . .tox/py37/bin/activate
+              cd content
+              npm update
+              npm ci
+              export PYTHONPATH=".:${PYTHONPATH}"
+              demisto-sdk -v
               gsutil cp gs://marketplace-dist/content/private_id_set.json $CIRCLE_ARTIFACTS/unified_id_set.json
               CIRCLE_BRANCH="master" demisto-sdk merge-id-sets -i1 ./Tests/id_set.json -i2 $CIRCLE_ARTIFACTS/unified_id_set.json -o $CIRCLE_ARTIFACTS/unified_id_set.json
         - run:
             name: Test validate files and yaml
             when: always
             command: |
+              . .tox/py37/bin/activate
+              cd content
+              npm update
+              npm ci
+              export PYTHONPATH=".:${PYTHONPATH}"
+              demisto-sdk -v
+
               CIRCLE_BRANCH="master" python3 ./Tests/scripts/update_conf_json.py
               CIRCLE_BRANCH="master" ./Tests/scripts/validate.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ jobs:
             root: ~/project
             paths:
               - content
-  validate-filesssssss:
+  validate-files:
       docker:
         - image: circleci/python:3.8.3-buster-node
       steps:
@@ -150,7 +150,7 @@ jobs:
             command: |
               pip install gsutil
         - run:
-            name: Test validate files and yaml
+            name: Set Up & Create Id Set
             when: always
             command: |
               . .tox/py37/bin/activate
@@ -161,13 +161,25 @@ jobs:
               demisto-sdk -v
 
               export CIRCLE_ARTIFACTS="/home/circleci/project/artifacts"
-
+        - run:
+            name: Merge Id Set
+            when: always
+            command: |
+              . .tox/py37/bin/activate
+              cd content
               CIRCLE_BRANCH="master" demisto-sdk create-id-set -o ./Tests/id_set.json
               gsutil cp gs://marketplace-dist/content/private_id_set.json $CIRCLE_ARTIFACTS/unified_id_set.json
               CIRCLE_BRANCH="master" demisto-sdk merge-id-sets -i1 ./Tests/id_set.json -i2 $CIRCLE_ARTIFACTS/unified_id_set.json -o $CIRCLE_ARTIFACTS/unified_id_set.json
-
+        - run:
+            name: Test validate files and yaml
+            when: always
+            command: |
+              . .tox/py37/bin/activate
+              cd content
               CIRCLE_BRANCH="master" python3 ./Tests/scripts/update_conf_json.py
               CIRCLE_BRANCH="master" ./Tests/scripts/validate.sh
+
+
   create-id-set:
       docker:
         - image: circleci/python:3.8.3-buster-node
@@ -229,7 +241,7 @@ workflows:
       - precommit-checks:
           <<: *tag_filter
           <<: *reqs_tox
-      - validate-filesssssss:
+      - validate-files:
           <<: *tag_filter
           <<: *reqs_content_checkout
       - create-id-set:
@@ -244,6 +256,6 @@ workflows:
             - tox3-7-unit-tests
             - tox3-8-unit-tests
             - precommit-checks
-            - validate-filesssssss
+            - validate-files
             - create-id-set
             - create-content-artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,6 +165,7 @@ jobs:
             name: Merge Id Set
             when: always
             command: |
+              . .tox/py37/bin/activate
               CIRCLE_BRANCH="master" demisto-sdk create-id-set -o ./Tests/id_set.json
               gsutil cp gs://marketplace-dist/content/private_id_set.json $CIRCLE_ARTIFACTS/unified_id_set.json
               CIRCLE_BRANCH="master" demisto-sdk merge-id-sets -i1 ./Tests/id_set.json -i2 $CIRCLE_ARTIFACTS/unified_id_set.json -o $CIRCLE_ARTIFACTS/unified_id_set.json
@@ -172,6 +173,7 @@ jobs:
             name: Test validate files and yaml
             when: always
             command: |
+              . .tox/py37/bin/activate
               CIRCLE_BRANCH="master" python3 ./Tests/scripts/update_conf_json.py
               CIRCLE_BRANCH="master" ./Tests/scripts/validate.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,15 +162,13 @@ jobs:
 
               export CIRCLE_ARTIFACTS="/home/circleci/project/artifacts"
               CIRCLE_BRANCH="master" demisto-sdk create-id-set -o ./Tests/id_set.json
-
         - run:
             name: Merge Id Set
             when: always
             command: |
               . .tox/py37/bin/activate
               cd content
-              npm update
-              npm ci
+
               export PYTHONPATH=".:${PYTHONPATH}"
               demisto-sdk -v
               export CIRCLE_ARTIFACTS="/home/circleci/project/artifacts"
@@ -183,16 +181,13 @@ jobs:
             command: |
               . .tox/py37/bin/activate
               cd content
-              npm update
-              npm ci
+
               export PYTHONPATH=".:${PYTHONPATH}"
               demisto-sdk -v
               export CIRCLE_ARTIFACTS="/home/circleci/project/artifacts"
 
-
               CIRCLE_BRANCH="master" python3 ./Tests/scripts/update_conf_json.py
               CIRCLE_BRANCH="master" ./Tests/scripts/validate.sh
-
 
   create-id-set:
       docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ jobs:
             root: ~/project
             paths:
               - content
-  validate-files:
+  validate-filesssssss:
       docker:
         - image: circleci/python:3.8.3-buster-node
       steps:
@@ -229,7 +229,7 @@ workflows:
       - precommit-checks:
           <<: *tag_filter
           <<: *reqs_tox
-      - validate-files:
+      - validate-filesssssss:
           <<: *tag_filter
           <<: *reqs_content_checkout
       - create-id-set:
@@ -244,6 +244,6 @@ workflows:
             - tox3-7-unit-tests
             - tox3-8-unit-tests
             - precommit-checks
-            - validate-files
+            - validate-filesssssss
             - create-id-set
             - create-content-artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,6 +166,9 @@ jobs:
             when: always
             command: |
               . .tox/py37/bin/activate
+              cd content
+              demisto-sdk -v
+
               CIRCLE_BRANCH="master" demisto-sdk create-id-set -o ./Tests/id_set.json
               gsutil cp gs://marketplace-dist/content/private_id_set.json $CIRCLE_ARTIFACTS/unified_id_set.json
               CIRCLE_BRANCH="master" demisto-sdk merge-id-sets -i1 ./Tests/id_set.json -i2 $CIRCLE_ARTIFACTS/unified_id_set.json -o $CIRCLE_ARTIFACTS/unified_id_set.json
@@ -174,6 +177,9 @@ jobs:
             when: always
             command: |
               . .tox/py37/bin/activate
+              cd content
+              demisto-sdk -v
+
               CIRCLE_BRANCH="master" python3 ./Tests/scripts/update_conf_json.py
               CIRCLE_BRANCH="master" ./Tests/scripts/validate.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,10 +167,6 @@ jobs:
             name: Merge Id Set
             when: always
             command: |
-              . .tox/py37/bin/activate
-              cd content
-              demisto-sdk -v
-
               gsutil cp gs://marketplace-dist/content/private_id_set.json $CIRCLE_ARTIFACTS/unified_id_set.json
               CIRCLE_BRANCH="master" demisto-sdk merge-id-sets -i1 ./Tests/id_set.json -i2 $CIRCLE_ARTIFACTS/unified_id_set.json -o $CIRCLE_ARTIFACTS/unified_id_set.json
         - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,8 +165,6 @@ jobs:
             name: Merge Id Set
             when: always
             command: |
-              . .tox/py37/bin/activate
-              cd content
               CIRCLE_BRANCH="master" demisto-sdk create-id-set -o ./Tests/id_set.json
               gsutil cp gs://marketplace-dist/content/private_id_set.json $CIRCLE_ARTIFACTS/unified_id_set.json
               CIRCLE_BRANCH="master" demisto-sdk merge-id-sets -i1 ./Tests/id_set.json -i2 $CIRCLE_ARTIFACTS/unified_id_set.json -o $CIRCLE_ARTIFACTS/unified_id_set.json
@@ -174,8 +172,6 @@ jobs:
             name: Test validate files and yaml
             when: always
             command: |
-              . .tox/py37/bin/activate
-              cd content
               CIRCLE_BRANCH="master" python3 ./Tests/scripts/update_conf_json.py
               CIRCLE_BRANCH="master" ./Tests/scripts/validate.sh
 


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: demisto/etc#33434

## Description
Separate the create-id-set, merge-id-set and validate to sub-tasks in SDK build, plus removing the redundant create-id-set task.

## Must have
- [ ] Tests
- [ ] Documentation
