### PR TITLE
adding prev_ver setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 * Fixed an issue where the **validate** command failed to validate the release notes of beta integrations.
 * Updated the **upload** command to support indicator fields.
+* The **validate** and **update-release-notes** commands will now check changed files against `demisto/master` if it is configured locally.
+* Fixed an issue where **validate** would incorrectly identify files as renamed.
 
 # 1.3.0
 * Do not collect optional dependencies on indicator types reputation commands.

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -905,7 +905,7 @@ def update_pack_releasenotes(**kwargs):
     text: str = kwargs.get('text', '')
     specific_version = kwargs.get('version')
     id_set_path = kwargs.get('id_set_path')
-    prev_ver = kwargs.get('prev_ver') if kwargs.get('prev_ver') else 'origin/master'
+    prev_ver = kwargs.get('prev_ver')
     prev_rn_text = ''
     # _pack can be both path or pack name thus, we extract the pack name from the path if beeded.
     if _pack and is_all:

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -87,7 +87,6 @@ class ValidateManager:
         self.validate_all = validate_all
         self.use_git = use_git
         self.skip_pack_rn_validation = skip_pack_rn_validation
-        self.prev_ver = prev_ver if prev_ver else 'origin/master'
         self.print_ignored_files = print_ignored_files
         self.print_ignored_errors = print_ignored_errors
         self.skip_dependencies = skip_dependencies or not use_git
@@ -132,7 +131,7 @@ class ValidateManager:
                 self.git_util = None  # type: ignore[assignment]
                 self.branch_name = ''
 
-        self.branch_name = ''
+        self.prev_ver = self.setup_prev_ver(prev_ver)
         self.check_only_schema = False
         self.always_valid = False
         self.ignored_files = set()
@@ -877,6 +876,19 @@ class ValidateManager:
             return True
 
     """ ######################################## Git Tools and filtering ####################################### """
+
+    def setup_prev_ver(self, prev_ver: Optional[str]):
+        """Setting up the prev_ver parameter"""
+        # if prev_ver parameter is set, use it
+        if prev_ver:
+            return prev_ver
+
+        # check if git is connected and if demisto exists in remotes if so set prev_ver as 'demisto/master'
+        if self.git_util and self.git_util.check_if_remote_exists('demisto'):
+            return 'demisto/master'
+
+        # default to 'origin/master' if none of the above apply
+        return 'origin/master'
 
     def setup_git_params(self):
         """Setting up the git relevant params"""

--- a/demisto_sdk/tests/integration_tests/validate_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/validate_integration_test.py
@@ -234,6 +234,7 @@ class TestDeprecatedIntegration:
         mocker.patch.object(BaseValidator, 'check_file_flags', return_value='')
         mocker.patch.object(PackUniqueFilesValidator, 'are_valid_files', return_value='')
         mocker.patch.object(ValidateManager, 'setup_git_params', return_value=True)
+        mocker.patch.object(ValidateManager, 'setup_prev_ver', return_value='origin/master')
 
         pack = repo.create_pack('PackName')
         pack_integration_path = join(AZURE_FEED_PACK_PATH, "Integrations/FeedAzure/FeedAzure.yml")
@@ -301,6 +302,7 @@ class TestDeprecatedIntegration:
         mocker.patch.object(tools, 'is_external_repository', return_value=True)
         mocker.patch.object(BaseValidator, 'check_file_flags', return_value='')
         mocker.patch.object(ValidateManager, 'setup_git_params', return_value=True)
+        mocker.patch.object(ValidateManager, 'setup_prev_ver', return_value='origin/master')
         mocker.patch.object(PackUniqueFilesValidator, 'are_valid_files', return_value='')
 
         pack = repo.create_pack('PackName')
@@ -1605,6 +1607,7 @@ class TestPlaybookValidateDeprecated:
         mocker.patch.object(BaseValidator, 'check_file_flags', return_value='')
         mocker.patch.object(PackUniqueFilesValidator, 'are_valid_files', return_value='')
         mocker.patch.object(ValidateManager, 'setup_git_params', return_value=True)
+        mocker.patch.object(ValidateManager, 'setup_prev_ver', return_value='origin/master')
         pack = repo.create_pack('PackName')
         valid_playbook_yml = get_yaml(VALID_DEPRECATED_PLAYBOOK_FILE_PATH)
         valid_playbook_yml['hidden'] = True
@@ -1671,6 +1674,7 @@ class TestPlaybookValidateDeprecated:
         mocker.patch.object(BaseValidator, 'check_file_flags', return_value='')
         mocker.patch.object(PackUniqueFilesValidator, 'are_valid_files', return_value='')
         mocker.patch.object(ValidateManager, 'setup_git_params', return_value=True)
+        mocker.patch.object(ValidateManager, 'setup_prev_ver', return_value='origin/master')
         pack = repo.create_pack('PackName')
         valid_playbook_yml = get_yaml(VALID_DEPRECATED_PLAYBOOK_FILE_PATH)
         valid_playbook_yml['toversion'] = '4.4.4'
@@ -1932,6 +1936,7 @@ class TestScriptDeprecatedValidation:
         mocker.patch.object(BaseValidator, 'check_file_flags', return_value='')
         mocker.patch.object(PackUniqueFilesValidator, 'are_valid_files', return_value='')
         mocker.patch.object(ValidateManager, 'setup_git_params', return_value=True)
+        mocker.patch.object(ValidateManager, 'setup_prev_ver', return_value='origin/master')
 
         pack = repo.create_pack('PackName')
         valid_script_yml = get_yaml(VALID_SCRIPT_PATH)
@@ -1997,6 +2002,7 @@ class TestScriptDeprecatedValidation:
         mocker.patch.object(BaseValidator, 'check_file_flags', return_value='')
         mocker.patch.object(PackUniqueFilesValidator, 'are_valid_files', return_value='')
         mocker.patch.object(ValidateManager, 'setup_git_params', return_value=True)
+        mocker.patch.object(ValidateManager, 'setup_prev_ver', return_value='origin/master')
 
         pack = repo.create_pack('PackName')
         valid_script_yml = get_yaml(VALID_SCRIPT_PATH)
@@ -2255,6 +2261,7 @@ class TestValidationUsingGit:
         added_files = {dashboard.get_path_from_pack(), script.yml.rel_path}
         old_files = {old_integration.yml.rel_path}
         mocker.patch.object(ValidateManager, 'setup_git_params', return_value=True)
+        mocker.patch.object(ValidateManager, 'setup_prev_ver', return_value='origin/master')
         mocker.patch.object(ValidateManager, 'get_changed_files_from_git', return_value=(modified_files, added_files,
                                                                                          set(), old_files))
         mocker.patch.object(GitUtil, '__init__', return_value=None)
@@ -2310,6 +2317,7 @@ class TestValidationUsingGit:
         modified_files = {integration.yml.rel_path, incident_field.get_path_from_pack()}
         added_files = {dashboard.get_path_from_pack(), script.yml.rel_path}
         mocker.patch.object(ValidateManager, 'setup_git_params', return_value=True)
+        mocker.patch.object(ValidateManager, 'setup_prev_ver', return_value='origin/master')
         mocker.patch.object(ValidateManager, 'get_changed_files_from_git', return_value=(modified_files, added_files,
                                                                                          set(), set()))
         mocker.patch.object(GitUtil, '__init__', return_value=None)
@@ -2357,6 +2365,7 @@ class TestValidationUsingGit:
         mocker.patch.object(BaseValidator, 'update_checked_flags_by_support_level', return_value=None)
         mocker.patch.object(PackUniqueFilesValidator, 'validate_pack_meta_file', return_value=True)
         mocker.patch.object(ValidateManager, 'setup_git_params', return_value=True)
+        mocker.patch.object(ValidateManager, 'setup_prev_ver', return_value='origin/master')
         mocker.patch.object(ValidateManager, 'get_changed_files_from_git', return_value=(modified_files, set(),
                                                                                          set(), set()))
         mocker.patch.object(GitUtil, '__init__', return_value=None)
@@ -2393,6 +2402,8 @@ class TestValidationUsingGit:
         modified_files = {integration.yml.rel_path}
         mocker.patch.object(tools, 'is_external_repository', return_value=False)
         mocker.patch.object(ValidateManager, 'setup_git_params', return_value=True)
+        mocker.patch.object(ValidateManager, 'setup_prev_ver', return_value='origin/master')
+
         mocker.patch.object(PackDependencies, 'find_dependencies', return_value={})
         mocker.patch.object(PackUniqueFilesValidator, 'validate_pack_meta_file', return_value=True)
         mocker.patch.object(BaseValidator, 'update_checked_flags_by_support_level', return_value=None)


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/34153

## Description
Now validate will try and use `demisto/master` as a default if demisto exists in local remotes.
Will revert to 'origin/master' otherwise.
Will use the given `--prev-ver` if set.