### PR TITLE
Added support in docker threshold test for powershell integrations

### DIFF
--- a/demisto_sdk/commands/test_content/Docker.py
+++ b/demisto_sdk/commands/test_content/Docker.py
@@ -9,6 +9,7 @@ class Docker:
 
     """
     PYTHON_INTEGRATION_TYPE = 'python'
+    POWERSHELL_INTEGRATION_TYPE = 'powershell'
     JAVASCRIPT_INTEGRATION_TYPE = 'javascript'
     DEFAULT_PYTHON2_IMAGE = 'demisto/python'
     DEFAULT_PYTHON3_IMAGE = 'demisto/python3'
@@ -185,7 +186,7 @@ class Docker:
 
         if integration_type == cls.JAVASCRIPT_INTEGRATION_TYPE:
             return None
-        elif integration_type == cls.PYTHON_INTEGRATION_TYPE and docker_image:
+        elif integration_type in {cls.PYTHON_INTEGRATION_TYPE, cls.POWERSHELL_INTEGRATION_TYPE} and docker_image:
             return [docker_image]
         else:
             return [cls.DEFAULT_PYTHON2_IMAGE, cls.DEFAULT_PYTHON3_IMAGE]


### PR DESCRIPTION
Added support in powershell docker threshold test.

Up until now - the docker images that were collected weren't the right ones.

Here's an example of how it looks (and fails) with that new fix.
![image](https://user-images.githubusercontent.com/41257953/109615613-cba87080-7b3c-11eb-9007-ef312f3504e7.png)
