### PR TITLE
moved the ssh tunnel log before configuring the integrations

### DIFF
--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -1308,7 +1308,8 @@ class TestContext:
             Empty string or
         """
         try:
-            server_url = self.client.api_client.configuration.host
+            self.build_context.logging_module.info(f'ssh tunnel command: {self.tunnel_command}')
+
             if not self.playbook.configure_integrations(self.client):
                 return PB_Status.FAILED
 
@@ -1327,10 +1328,10 @@ class TestContext:
                 self.build_context.logging_module.error(f'Failed to get investigation id of incident: {incident}')
                 return ''
 
+            server_url = self.client.api_client.configuration.host
             self.build_context.logging_module.info(f'Investigation URL: {server_url}/#/WorkPlan/{investigation_id}')
-            self.build_context.logging_module.info(
-                f'ssh tunnel command: {self.tunnel_command}')
             playbook_state = self._poll_for_playbook_state()
+
             self.playbook.disable_integrations(self.client)
             self._clean_incident_if_successful(playbook_state)
             return playbook_state


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
moved the ssh tunnel log to the beginning of the function so it will be printed even if the test failed on configuring the integrations.

## Screenshots
before:
![image](https://user-images.githubusercontent.com/30797606/110110036-ed149100-7db6-11eb-8c74-ba48efa76d15.png)

after:
![image](https://user-images.githubusercontent.com/30797606/110112758-d1ab8500-7dba-11eb-8ce3-3d52400cfc79.png)

