### PR TITLE
Reformat validate and lint json output file results

### DIFF
--- a/demisto_sdk/commands/common/hook_validations/base_validator.py
+++ b/demisto_sdk/commands/common/hook_validations/base_validator.py
@@ -178,32 +178,28 @@ class BaseValidator:
         error_data = get_error_object(error_code)
 
         output = {
-            "severity": "warning" if warning else "error",
-            "code": error_code,
-            "message": error_message,
-            "ui": error_data.get('ui_applicable'),
-            'related-field': error_data.get('related_field')
+            'severity': 'warning' if warning else 'error',
+            'errorCode': error_code,
+            'message': error_message,
+            'ui': error_data.get('ui_applicable'),
+            'relatedField': error_data.get('related_field')
         }
 
         if os.path.exists(self.json_file_path):
             json_contents = get_json(self.json_file_path)
 
         else:
-            json_contents = {}
+            json_contents = []
 
         file_type = find_type(file_path)
-        if file_path in json_contents:
-            if output in json_contents[file_path].get('outputs'):
-                return
-            json_contents[file_path]['outputs'].append(output)
-        else:
-            json_contents[file_path] = {
-                "file-type": os.path.splitext(file_path)[1].replace('.', ''),
-                "entity-type": file_type.value if file_type else 'pack',
-                "display-name": get_file_displayed_name(file_path),
-                "outputs": [
-                    output
-                ]
-            }
+        formatted_error_output = {
+            'filePath': file_path,
+            'fileType': os.path.splitext(file_path)[1].replace('.', ''),
+            'entityType': file_type.value if file_type else 'pack',
+            'errorType': 'Settings',
+            'name': get_file_displayed_name(file_path),
+            **output
+        }
+        json_contents.append(formatted_error_output)
         with open(self.json_file_path, 'w') as f:
             json.dump(json_contents, f, indent=4)

--- a/demisto_sdk/commands/common/tests/base_validator_test.py
+++ b/demisto_sdk/commands/common/tests/base_validator_test.py
@@ -268,46 +268,47 @@ def test_json_output(repo):
     base = BaseValidator(json_file_path=json_path)
     ui_applicable_error_message, ui_applicable_error_code = Errors.wrong_display_name('param1', 'param2')
     non_ui_applicable_error_message, non_ui_applicable_error_code = Errors.wrong_subtype()
-    expected_json_1 = {
-        integration.yml.path: {
-            "file-type": "yml",
-            "entity-type": "integration",
-            "display-name": "Sample",
-            "outputs": [
-                {
-                    "severity": "error",
-                    "code": ui_applicable_error_code,
-                    "message": ui_applicable_error_message,
-                    "ui": True,
-                    'related-field': '<parameter-name>.display'
-                }
-            ]
+    expected_json_1 = [
+        {
+            'filePath': integration.yml.path,
+            'fileType': 'yml',
+            'entityType': 'integration',
+            'errorType': 'Settings',
+            'name': 'Sample',
+            'severity': 'error',
+            'errorCode': ui_applicable_error_code,
+            'message': ui_applicable_error_message,
+            'ui': True,
+            'relatedField': '<parameter-name>.display'
         }
-    }
+    ]
 
-    expected_json_2 = {
-        integration.yml.path: {
-            "file-type": "yml",
-            "entity-type": "integration",
-            "display-name": "Sample",
-            "outputs": [
-                {
-                    "severity": "error",
-                    "code": ui_applicable_error_code,
-                    "message": ui_applicable_error_message,
-                    "ui": True,
-                    'related-field': '<parameter-name>.display'
-                },
-                {
-                    "severity": "warning",
-                    "code": non_ui_applicable_error_code,
-                    "message": non_ui_applicable_error_message,
-                    "ui": False,
-                    'related-field': 'subtype'
-                }
-            ]
+    expected_json_2 = [
+        {
+            'filePath': integration.yml.path,
+            'fileType': 'yml',
+            'entityType': 'integration',
+            'errorType': 'Settings',
+            'name': 'Sample',
+            'severity': 'error',
+            'errorCode': ui_applicable_error_code,
+            'message': ui_applicable_error_message,
+            'ui': True,
+            'relatedField': '<parameter-name>.display'
+        },
+        {
+            'filePath': integration.yml.path,
+            'fileType': 'yml',
+            'entityType': 'integration',
+            'errorType': 'Settings',
+            'name': 'Sample',
+            'severity': 'warning',
+            'errorCode': non_ui_applicable_error_code,
+            'message': non_ui_applicable_error_message,
+            'ui': False,
+            'relatedField': 'subtype'
         }
-    }
+    ]
 
     with ChangeCWD(repo.path):
         # create new file

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -363,7 +363,7 @@ def get_file(method, file_path, type_of_file):
                 print_error(
                     "{} has a structure issue of file type{}. Error was: {}".format(file_path, type_of_file, str(e)))
                 return {}
-    if type(data_dictionary) is dict:
+    if type(data_dictionary) in (dict, list):
         return data_dictionary
     return {}
 

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -363,7 +363,7 @@ def get_file(method, file_path, type_of_file):
                 print_error(
                     "{} has a structure issue of file type{}. Error was: {}".format(file_path, type_of_file, str(e)))
                 return {}
-    if type(data_dictionary) in (dict, list):
+    if isinstance(data_dictionary, (dict, list)):
         return data_dictionary
     return {}
 

--- a/demisto_sdk/commands/lint/lint_manager.py
+++ b/demisto_sdk/commands/lint/lint_manager.py
@@ -710,7 +710,7 @@ class LintManager:
             json_contents = get_json(self.json_file_path)
 
         else:
-            json_contents = {}
+            json_contents = []
 
         # format all linters to JSON format -
         # if any additional linters are added, please add a formatting function here
@@ -729,12 +729,12 @@ class LintManager:
         with open(self.json_file_path, 'w') as f:
             json.dump(json_contents, f, indent=4)
 
-    def flake8_error_formatter(self, errors: Dict, json_contents: Dict) -> None:
+    def flake8_error_formatter(self, errors: Dict, json_contents: List) -> None:
         """Format flake8 error strings to JSON format and add them the json_contents
 
         Args:
             errors (Dict): A dictionary containing flake8 error strings
-            json_contents (Dict): The JSON file outputs
+            json_contents (List): The JSON file outputs
         """
         error_messages = errors.get('messages', '')
         error_messages = error_messages.split('\n') if error_messages else []
@@ -745,10 +745,10 @@ class LintManager:
                 output = {
                     'linter': 'flake8',
                     'severity': errors.get('type'),
-                    'code': code,
+                    'errorCode': code,
                     'message': message.split(code)[1].lstrip(),
-                    'line-number': line_number,
-                    'column-number': column_number
+                    'row': line_number,
+                    'col': column_number
                 }
                 self.add_to_json_outputs(output, file_path, json_contents)
 
@@ -778,12 +778,12 @@ class LintManager:
 
         return mypy_errors
 
-    def mypy_error_formatter(self, errors: Dict, json_contents: Dict) -> None:
+    def mypy_error_formatter(self, errors: Dict, json_contents: List) -> None:
         """Format mypy error strings to JSON format and add them the json_contents
 
         Args:
             errors (Dict): A dictionary containing mypy error strings
-            json_contents (Dict): The JSON file outputs
+            json_contents (List): The JSON file outputs
         """
         error_messages = errors.get('messages', '')
         error_messages = error_messages.split('\n') if error_messages else []
@@ -798,17 +798,17 @@ class LintManager:
                     'linter': 'mypy',
                     'severity': errors.get('type'),
                     'message': output_message,
-                    'line-number': line_number,
-                    'column-number': column_number
+                    'row': line_number,
+                    'col': column_number
                 }
                 self.add_to_json_outputs(output, file_path, json_contents)
 
-    def bandit_error_formatter(self, errors: Dict, json_contents: Dict) -> None:
+    def bandit_error_formatter(self, errors: Dict, json_contents: List) -> None:
         """Format bandit error strings to JSON format and add them the json_contents
 
         Args:
             errors (Dict): A dictionary containing bandit error strings
-            json_contents (Dict): The JSON file outputs
+            json_contents (List): The JSON file outputs
         """
         error_messages = errors.get('messages', '')
         error_messages = error_messages.split('\n') if error_messages else []
@@ -818,9 +818,9 @@ class LintManager:
                 output = {
                     'linter': 'bandit',
                     'severity': errors.get('type'),
-                    'code': message.split(' ')[1],
+                    'errorCode': message.split(' ')[1],
                     'message': message.split('[')[1].replace(']', ' -'),
-                    'line-number': line_number,
+                    'row': line_number,
                 }
                 self.add_to_json_outputs(output, file_path, json_contents)
 
@@ -842,12 +842,12 @@ class LintManager:
             file_name = file_name.replace(file_ending, 'py')
         return find_file(content_path, file_name)
 
-    def vulture_error_formatter(self, errors: Dict, json_contents: Dict) -> None:
+    def vulture_error_formatter(self, errors: Dict, json_contents: List) -> None:
         """Format vulture error strings to JSON format and add them the json_contents
 
         Args:
             errors (Dict): A dictionary containing vulture error strings
-            json_contents (Dict): The JSON file outputs
+            json_contents (List): The JSON file outputs
         """
         error_messages = errors.get('messages', '')
         error_messages = error_messages.split('\n') if error_messages else []
@@ -860,16 +860,16 @@ class LintManager:
                     'linter': 'vulture',
                     'severity': errors.get('type'),
                     'message': error_contents.lstrip(),
-                    'line-number': line_number,
+                    'row': line_number,
                 }
                 self.add_to_json_outputs(output, file_path, json_contents)
 
-    def xsoar_linter_error_formatter(self, errors: Dict, json_contents: Dict) -> None:
+    def xsoar_linter_error_formatter(self, errors: Dict, json_contents: List) -> None:
         """Format XSOAR linter error strings to JSON format and add them the json_contents
 
         Args:
             errors (Dict): A dictionary containing XSOAR linter error strings
-            json_contents (Dict): The JSON file outputs
+            json_contents (List): The JSON file outputs
         """
         error_messages = errors.get('messages', '')
         error_messages = error_messages.split('\n') if error_messages else []
@@ -881,35 +881,30 @@ class LintManager:
                 output = {
                     'linter': 'xsoar_linter',
                     'severity': errors.get('type'),
-                    'code': code,
+                    'errorCode': code,
                     'message': message.split(code)[-1].lstrip() if len(message.split(code)) >= 1 else '',
-                    'line-number': split_message[1] if len(split_message) >= 2 else '',
-                    'column-number': split_message[2] if len(split_message) >= 3 else ''
+                    'row': split_message[1] if len(split_message) >= 2 else '',
+                    'col': split_message[2] if len(split_message) >= 3 else ''
                 }
                 self.add_to_json_outputs(output, file_path, json_contents)
 
     @staticmethod
-    def add_to_json_outputs(output: Dict, file_path: str, json_contents: Dict) -> None:
+    def add_to_json_outputs(output: Dict, file_path: str, json_contents: List) -> None:
         """Adds an error entry to the JSON file contents
 
         Args:
             output (Dict): The information about an error entry
             file_path (str): The file path where the error occurred
-            json_contents (Dict): The JSON file outputs
+            json_contents (List): The JSON file outputs
         """
         yml_file_path = file_path.replace('.py', '.yml').replace('.ps1', '.yml')
         file_type = find_type(yml_file_path)
-        if file_path in json_contents:
-            if output in json_contents[file_path]['outputs']:
-                return
-            json_contents[file_path]['outputs'].append(output)
-
-        else:
-            json_contents[file_path] = {
-                'file-type': os.path.splitext(file_path)[1].replace('.', ''),
-                'entity-type': file_type.value if file_type else '',
-                "display-name": get_file_displayed_name(yml_file_path),
-                'outputs': [
-                    output
-                ]
-            }
+        full_error_output = {
+            'filePath': file_path,
+            'fileType': os.path.splitext(file_path)[1].replace('.', ''),
+            'entityType': file_type.value if file_type else '',
+            'errorType': 'Code',
+            'name': get_file_displayed_name(yml_file_path),
+            **output
+        }
+        json_contents.append(full_error_output)

--- a/demisto_sdk/commands/lint/tests/linter_manager_test.py
+++ b/demisto_sdk/commands/lint/tests/linter_manager_test.py
@@ -383,36 +383,36 @@ def test_create_json_output_flake8(repo, mocker):
                     'Packs/myPack/Integrations/INT2/INT2.py:160:9: E225 missing whitespace around operator'
 
     }
-    json_contents = {}
+    json_contents = []
     mocked_lint_manager.flake8_error_formatter(check, json_contents)
-    expected_format = {
-        "Packs/myPack/Integrations/INT1/INT1.py": {
-            'file-type': 'py',
-            'entity-type': 'integration',
-            'display-name': 'Display',
-            'outputs': [{
-                'linter': 'flake8',
-                'severity': 'error',
-                'code': 'E225',
-                'message': 'missing whitespace around operator',
-                'line-number': "160",
-                'column-number': "9"
-            }]
+    expected_format = [
+        {
+            'filePath': 'Packs/myPack/Integrations/INT1/INT1.py',
+            'fileType': 'py',
+            'entityType': 'integration',
+            'errorType': 'Code',
+            'name': 'Display',
+            'linter': 'flake8',
+            'severity': 'error',
+            'errorCode': 'E225',
+            'message': 'missing whitespace around operator',
+            'row': '160',
+            'col': '9'
         },
-        "Packs/myPack/Integrations/INT2/INT2.py": {
-            'file-type': 'py',
-            'entity-type': 'integration',
-            'display-name': 'Display',
-            'outputs': [{
-                'linter': 'flake8',
-                'severity': 'error',
-                'code': 'E225',
-                'message': 'missing whitespace around operator',
-                'line-number': "160",
-                'column-number': "9"
-            }]
+        {
+            'filePath': 'Packs/myPack/Integrations/INT2/INT2.py',
+            'fileType': 'py',
+            'entityType': 'integration',
+            'errorType': 'Code',
+            'name': 'Display',
+            'linter': 'flake8',
+            'severity': 'error',
+            'errorCode': 'E225',
+            'message': 'missing whitespace around operator',
+            'row': '160',
+            'col': '9'
         }
-    }
+    ]
     assert json_contents == expected_format
 
 
@@ -451,44 +451,52 @@ def test_create_json_output_mypy(repo, mocker):
                     f'Found 6 errors in 1 file (checked 1 source file)'
 
     }
-    json_contents = {}
+    json_contents = []
     with ChangeCWD(repo.path):
         mocked_lint_manager.mypy_error_formatter(check, json_contents)
 
-    expected_format = {
-        f"{integration.code.path}": {
-            'file-type': 'py',
-            'entity-type': 'integration',
-            'display-name': 'Display',
-            'outputs': [
-                {
-                    'linter': 'mypy',
-                    'severity': 'error',
-                    'message': 'Item "None" of "Optional[datetime]" has no attribute "timestamp"  [union-attr]\n'
-                               '            if incident_created_time.timestamp() > latest_created_time.tim...\n'
-                               '               ^',
-                    'line-number': "280",
-                    'column-number': "12"
-                },
-                {
-                    'linter': 'mypy',
-                    'severity': 'error',
-                    'message': 'See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports',
-                    'line-number': "11",
-                    'column-number': "2"
-                },
-                {
-                    'linter': 'mypy',
-                    'severity': 'error',
-                    'message': 'Item "None" of "Optional[datetime]" has no attribute "timestamp"  [union-attr]\n'
-                               '            if last_fetch.timestamp() < incident_created_time.timestamp():\n'
-                               '                                        ^',
-                    'line-number': "284",
-                    'column-number': "37"
-                },
-            ]
+    expected_format = [
+        {
+            'filePath': f'{integration.code.path}',
+            'fileType': 'py',
+            'entityType': 'integration',
+            'errorType': 'Code',
+            'name': 'Display',
+            'linter': 'mypy',
+            'severity': 'error',
+            'message': 'Item "None" of "Optional[datetime]" has no attribute "timestamp"  [union-attr]\n'
+                        '            if incident_created_time.timestamp() > latest_created_time.tim...\n'
+                        '               ^',
+            'row': '280',
+            'col': '12'
+        },
+        {
+            'filePath': f'{integration.code.path}',
+            'fileType': 'py',
+            'entityType': 'integration',
+            'errorType': 'Code',
+            'name': 'Display',
+            'linter': 'mypy',
+            'severity': 'error',
+            'message': 'See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports',
+            'row': '11',
+            'col': '2'
+        },
+        {
+            'filePath': f'{integration.code.path}',
+            'fileType': 'py',
+            'entityType': 'integration',
+            'errorType': 'Code',
+            'name': 'Display',
+            'linter': 'mypy',
+            'severity': 'error',
+            'message': 'Item "None" of "Optional[datetime]" has no attribute "timestamp"  [union-attr]\n'
+                        '            if last_fetch.timestamp() < incident_created_time.timestamp():\n'
+                        '                                        ^',
+            'row': '284',
+            'col': '37'
         }
-    }
+    ]
     assert json_contents == expected_format
 
 
@@ -515,22 +523,22 @@ def test_create_json_output_bandit(repo, mocker):
                     'B110 [Severity: LOW Confidence: HIGH] Try, Except, Pass detected.'
 
     }
-    json_contents = {}
+    json_contents = []
     mocked_lint_manager.bandit_error_formatter(check, json_contents)
-    expected_format = {
-        "Packs/myPack/Integrations/INT1/INT1.py": {
-            'file-type': 'py',
-            'display-name': 'Display',
-            'entity-type': 'integration',
-            'outputs': [{
-                'linter': 'bandit',
-                'severity': 'error',
-                'code': 'B110',
-                'message': 'Severity: LOW Confidence: HIGH - Try, Except, Pass detected.',
-                'line-number': "117",
-            }]
+    expected_format = [
+        {
+            'filePath': 'Packs/myPack/Integrations/INT1/INT1.py',
+            'fileType': 'py',
+            'errorType': 'Code',
+            'name': 'Display',
+            'entityType': 'integration',
+            'linter': 'bandit',
+            'severity': 'error',
+            'errorCode': 'B110',
+            'message': 'Severity: LOW Confidence: HIGH - Try, Except, Pass detected.',
+            'row': '117'
         }
-    }
+    ]
     assert json_contents == expected_format
 
 
@@ -556,21 +564,21 @@ def test_create_json_output_vulture(repo, mocker):
         'type': 'error',
         'messages': "INT1.py:289: unreachable code after 'return' (100% confidence)"
     }
-    json_contents = {}
+    json_contents = []
     mocked_lint_manager.vulture_error_formatter(check, json_contents)
-    expected_format = {
-        "Packs/myPack/Integrations/INT1/INT1.py": {
-            'file-type': 'py',
-            'display-name': 'Display',
-            'entity-type': 'integration',
-            'outputs': [{
-                'linter': 'vulture',
-                'severity': 'error',
-                'message': "unreachable code after 'return' (100% confidence)",
-                'line-number': "289",
-            }]
+    expected_format = [
+        {
+            'filePath': 'Packs/myPack/Integrations/INT1/INT1.py',
+            'fileType': 'py',
+            'errorType': 'Code',
+            'name': 'Display',
+            'entityType': 'integration',
+            'linter': 'vulture',
+            'severity': 'error',
+            'message': 'unreachable code after \'return\' (100% confidence)',
+            'row': '289',
         }
-    }
+    ]
     assert json_contents == expected_format
 
 
@@ -596,21 +604,21 @@ def test_create_json_output_xsoar_linter(repo, mocker):
         'messages': 'Packs/myPack/Integrations/INT1/INT1.py:105:8: '
                     'E9001 FileShareLink.prepare_request_object: Sys.exit use is found, Please use return instead.'
     }
-    json_contents = {}
+    json_contents = []
     mocked_lint_manager.xsoar_linter_error_formatter(check, json_contents)
-    expected_format = {
-        "Packs/myPack/Integrations/INT1/INT1.py": {
-            'file-type': 'py',
-            'entity-type': 'integration',
-            'display-name': 'Display',
-            'outputs': [{
-                'linter': 'xsoar_linter',
-                'severity': 'error',
-                'code': 'E9001',
-                'message': 'FileShareLink.prepare_request_object: Sys.exit use is found, Please use return instead.',
-                'line-number': "105",
-                "column-number": '8'
-            }]
+    expected_format = [
+        {
+            'filePath': 'Packs/myPack/Integrations/INT1/INT1.py',
+            'fileType': 'py',
+            'entityType': 'integration',
+            'errorType': 'Code',
+            'name': 'Display',
+            'linter': 'xsoar_linter',
+            'severity': 'error',
+            'errorCode': 'E9001',
+            'message': 'FileShareLink.prepare_request_object: Sys.exit use is found, Please use return instead.',
+            'row': '105',
+            'col': '8'
         }
-    }
+    ]
     assert json_contents == expected_format

--- a/demisto_sdk/commands/split_yml/extractor.py
+++ b/demisto_sdk/commands/split_yml/extractor.py
@@ -36,14 +36,16 @@ class Extractor:
         base_name (str): the base name of all extracted files
         no_readme (bool): whether to extract readme
         no_pipenv (boo): whether to create pipenv
+        basic_fmt (bool): whether to perform basic formatting on the code, i.e. autopep8 and isort
         file_type (str): yml file type (integration/script)
         configuration (Configuration): Configuration object
+        lines_inserted_at_code_start (int): the amount of lines inserted at the beginning of the code file
     """
 
     def __init__(self, input: str, output: str, file_type: str, no_demisto_mock: bool = False,
                  no_common_server: bool = False, no_auto_create_dir: bool = False, configuration: Configuration = None,
                  base_name: str = '', no_readme: bool = False, no_pipenv: bool = False,
-                 no_logging: bool = False):
+                 no_logging: bool = False, no_basic_fmt: bool = False):
         self.input = input
         self.output = output
         self.demisto_mock = not no_demisto_mock
@@ -53,6 +55,8 @@ class Extractor:
         self.readme = not no_readme
         self.pipenv = not no_pipenv
         self.logging = not no_logging
+        self.basic_fmt = not no_basic_fmt
+        self.lines_inserted_at_code_start = 0
         if configuration is None:
             self.config = Configuration()
         else:
@@ -131,21 +135,23 @@ class Extractor:
 
         # Python code formatting and dev env setup
         if code_type == TYPE_PYTHON:
-            self.print_logs("Running autopep8 on file: {} ...".format(code_file), log_color=LOG_COLORS.NATIVE)
-            try:
-                subprocess.call(["autopep8", "-i", "--max-line-length", "130", code_file])
-            except FileNotFoundError:
-                self.print_logs("autopep8 skipped! It doesn't seem you have autopep8 installed.\n"
-                                "Make sure to install it with: pip install autopep8.\n"
-                                "Then run: autopep8 -i {}".format(code_file), LOG_COLORS.YELLOW)
-            if self.pipenv:
-                self.print_logs("Running isort on file: {} ...".format(code_file), LOG_COLORS.NATIVE)
+            if self.basic_fmt:
+                self.print_logs("Running autopep8 on file: {} ...".format(code_file), log_color=LOG_COLORS.NATIVE)
                 try:
-                    subprocess.call(["isort", code_file])
+                    subprocess.call(["autopep8", "-i", "--max-line-length", "130", code_file])
                 except FileNotFoundError:
-                    self.print_logs("isort skipped! It doesn't seem you have isort installed.\n"
-                                    "Make sure to install it with: pip install isort.\n"
-                                    "Then run: isort {}".format(code_file), LOG_COLORS.YELLOW)
+                    self.print_logs("autopep8 skipped! It doesn't seem you have autopep8 installed.\n"
+                                    "Make sure to install it with: pip install autopep8.\n"
+                                    "Then run: autopep8 -i {}".format(code_file), LOG_COLORS.YELLOW)
+            if self.pipenv:
+                if self.basic_fmt:
+                    self.print_logs("Running isort on file: {} ...".format(code_file), LOG_COLORS.NATIVE)
+                    try:
+                        subprocess.call(["isort", code_file])
+                    except FileNotFoundError:
+                        self.print_logs("isort skipped! It doesn't seem you have isort installed.\n"
+                                        "Make sure to install it with: pip install isort.\n"
+                                        "Then run: isort {}".format(code_file), LOG_COLORS.YELLOW)
 
                 self.print_logs("Detecting python version and setting up pipenv files ...", log_color=LOG_COLORS.NATIVE)
                 docker = get_all_docker_images(script_obj)[0]
@@ -225,11 +231,14 @@ class Extractor:
         with open(code_file_path, 'wt') as code_file:
             if lang_type == TYPE_PYTHON and self.demisto_mock:
                 code_file.write("import demistomock as demisto  # noqa: F401\n")
+                self.lines_inserted_at_code_start += 1
             if common_server:
                 if lang_type == TYPE_PYTHON:
                     code_file.write("from CommonServerPython import *  # noqa: F401\n")
+                    self.lines_inserted_at_code_start += 1
                 if lang_type == TYPE_PWSH:
                     code_file.write(". $PSScriptRoot\\CommonServerPowerShell.ps1\n")
+                    self.lines_inserted_at_code_start += 1
             code_file.write(script)
             if script and script[-1] != '\n':
                 # make sure files end with a new line (pyml seems to strip the last newline)


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Updates the output results of the `validate`/`lint` command to be formatted appropriately for use in the client. This is only applicable when outputting the results of `validate`/`lint` to an output json file.

## Must have
- [x] Tests
- [ ] Documentation
