### PR TITLE
Fix overwrite existing files when updating existing pack

### DIFF
--- a/demisto_sdk/commands/init/contribution_converter.py
+++ b/demisto_sdk/commands/init/contribution_converter.py
@@ -231,7 +231,8 @@ class ContributionConverter:
                 for _, _, files in os.walk(src_path, topdown=False):
                     for name in files:
                         src_file_path = os.path.join(src_path, name)
-                        shutil.move(src_file_path, dst_path)
+                        dst_file_path = os.path.join(dst_path, name)
+                        shutil.move(src_file_path, dst_file_path)
             else:
                 # replace dst folder with src folder
                 shutil.move(src_path, dst_path)

--- a/demisto_sdk/commands/init/contribution_converter.py
+++ b/demisto_sdk/commands/init/contribution_converter.py
@@ -233,6 +233,7 @@ class ContributionConverter:
                         src_file_path = os.path.join(src_path, name)
                         dst_file_path = os.path.join(dst_path, name)
                         shutil.move(src_file_path, dst_file_path)
+                shutil.rmtree(src_path, ignore_errors=True)
             else:
                 # replace dst folder with src folder
                 shutil.move(src_path, dst_path)

--- a/demisto_sdk/commands/init/tests/contribution_converter_test.py
+++ b/demisto_sdk/commands/init/tests/contribution_converter_test.py
@@ -514,6 +514,7 @@ def test_convert_contribution_dir_to_pack_contents(tmp_path):
     cc.pack_dir_path = tmp_path
     cc.convert_contribution_dir_to_pack_contents(fake_pack_extracted_dir)
     assert json.loads(extant_file.read_text()) == new_json
+    assert not fake_pack_extracted_dir.exists()
 
 
 @pytest.mark.parametrize('contribution_converter', ['TestPack'], indirect=True)

--- a/demisto_sdk/commands/init/tests/contribution_converter_test.py
+++ b/demisto_sdk/commands/init/tests/contribution_converter_test.py
@@ -475,6 +475,47 @@ def test_format_pack_dir_name(contrib_converter, input_name, expected_output_nam
     assert not output_name.endswith(('-', '_')), 'The output\'s last character must be alphanumeric'
 
 
+def test_convert_contribution_dir_to_pack_contents(tmp_path):
+    """
+    Scenario: convert a directory which was unarchived from a contribution zip into the content
+        pack directory into which the contribution is intended to update, and the contribution
+        includes a file that already exists in the pack
+
+    Given
+    - The pack's original content contains incident field files and appears like so
+
+        ├── IncidentFields
+        │   └── incidentfield-SomeIncidentField.json
+
+    When
+    - After the contribution zip files have been unarchived to the destination pack the pack
+        directory tree appears like so
+
+        ├── IncidentFields
+        │   └── incidentfield-SomeIncidentField.json
+        ├── incidentfield
+        │   └── incidentfield-SomeIncidentField.json
+
+    Then
+    - Ensure the file '.../incidentfield/incidentfield-SomeIncidentField.json' is moved to
+        '.../IncidentFields/incidentfield-SomeIncidentField.json' and overwrites the existing file
+    """
+    fake_pack_subdir = tmp_path / 'IncidentFields'
+    fake_pack_subdir.mkdir()
+    extant_file = fake_pack_subdir / 'incidentfield-SomeIncidentField.json'
+    old_json = {"field": "old_value"}
+    extant_file.write_text(json.dumps(old_json))
+    fake_pack_extracted_dir = tmp_path / 'incidentfield'
+    fake_pack_extracted_dir.mkdir()
+    update_file = fake_pack_extracted_dir / 'incidentfield-SomeIncidentField.json'
+    new_json = {"field": "new_value"}
+    update_file.write_text(json.dumps(new_json))
+    cc = ContributionConverter()
+    cc.pack_dir_path = tmp_path
+    cc.convert_contribution_dir_to_pack_contents(fake_pack_extracted_dir)
+    assert json.loads(extant_file.read_text()) == new_json
+
+
 @pytest.mark.parametrize('contribution_converter', ['TestPack'], indirect=True)
 class TestEnsureUniquePackDirName:
     def test_ensure_unique_pack_dir_name_no_conflict(self, contribution_converter):


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
can see the failure in `process_pack` step of the github actions workflow [here](https://github.com/demisto/contribution-management/runs/2164144039?check_suite_focus=true)

## Description
In the flow of updating an existing content pack. After the contribution zip file would be unarchived into the destination pack directory, the contents of the unarchived directories would be moved to the corresponding directories in which they belong when in the content repo's Pack structure. e.g. `content/Packs/ExamplePack/integration/integration-exampleintegration.yml` would be moved to `content/Packs/ExamplePack/Integrations/integration-exampleintegration.yml`. This would work fine for content items like integrations and scripts because the package structure of the unified yml that was being copied to the pack was already present, no the unified. And then the `split-yml` part of contribution conversion would properly overwrite any existing files already in the package structure. But for files that are always in a unified yaml format both in the content repo as well as in a contribution zip file (as downloaded from the server), then the invocation of `shutil.move(src_file_path, dst_path)` in the `ContributionConverter`'s method `convert_contribution_dir_to_pack_contents` fails because the file already exists in the destination directory.

## Screenshots
![image](https://user-images.githubusercontent.com/46294017/112006641-90420600-8b2c-11eb-959a-3aa4a3b37051.png)


## Must have
- [x] Tests
- [x] ~~Documentation~~ N/A
