### PR TITLE
validate context paths difference when only README changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Updated the **demisto-sdk validate** command to check that the 'additionalinfo' field only contains the expected value for feed required parameters and not equal to it.
 * Added a validation that community/partner details are not in the detailed description file.
 * Added a validation that the Use Case tag in pack_metadata file is only used when the pack contains at least one PB, Incident Type or Layout.
+* Added a validation that makes sure outputs in integrations are matching the README file when only README has changed.
 
 # 1.3.3
 * Fixed an issue where **lint** failed where *.Dockerfile* exists prior running the lint command.

--- a/demisto_sdk/commands/common/hook_validations/integration.py
+++ b/demisto_sdk/commands/common/hook_validations/integration.py
@@ -2,12 +2,19 @@ import os
 import re
 
 import yaml
-from demisto_sdk.commands.common.constants import (
-    BANG_COMMAND_NAMES, CONTEXT_OUTPUT_README_TABLE_HEADER, DBOT_SCORES_DICT,
-    FEED_REQUIRED_PARAMS, FETCH_REQUIRED_PARAMS, FIRST_FETCH,
-    FIRST_FETCH_PARAM, INTEGRATION_CATEGORIES, IOC_OUTPUTS_DICT, MAX_FETCH,
-    MAX_FETCH_PARAM, PYTHON_SUBTYPES, TYPE_PWSH)
-from demisto_sdk.commands.common.errors import Errors
+from demisto_sdk.commands.common.constants import (BANG_COMMAND_NAMES,
+                                                   DBOT_SCORES_DICT,
+                                                   FEED_REQUIRED_PARAMS,
+                                                   FETCH_REQUIRED_PARAMS,
+                                                   FIRST_FETCH,
+                                                   FIRST_FETCH_PARAM,
+                                                   INTEGRATION_CATEGORIES,
+                                                   IOC_OUTPUTS_DICT, MAX_FETCH,
+                                                   MAX_FETCH_PARAM,
+                                                   PYTHON_SUBTYPES, TYPE_PWSH)
+from demisto_sdk.commands.common.errors import (FOUND_FILES_AND_ERRORS,
+                                                FOUND_FILES_AND_IGNORED_ERRORS,
+                                                Errors)
 from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
     ContentEntityValidator
 from demisto_sdk.commands.common.hook_validations.description import \
@@ -15,10 +22,10 @@ from demisto_sdk.commands.common.hook_validations.description import \
 from demisto_sdk.commands.common.hook_validations.docker import \
     DockerImageValidator
 from demisto_sdk.commands.common.hook_validations.image import ImageValidator
-from demisto_sdk.commands.common.tools import (extract_multiple_keys_from_dict,
-                                               is_v2_file, print_error,
-                                               server_version_compare, compare_context_path_in_yml_and_readme)
-from demisto_sdk.commands.common.errors import FOUND_FILES_AND_IGNORED_ERRORS, FOUND_FILES_AND_ERRORS
+from demisto_sdk.commands.common.tools import (
+    compare_context_path_in_yml_and_readme, is_v2_file, print_error,
+    server_version_compare)
+
 
 class IntegrationValidator(ContentEntityValidator):
     """IntegrationValidator is designed to validate the correctness of the file structure we enter to content repo. And
@@ -652,7 +659,8 @@ class IntegrationValidator(ContentEntityValidator):
 
     def is_changed_removed_yml_fields(self):
         """checks if some specific Fields in the yml file were changed from true to false or removed"""
-        fields = ['feed', 'isfetch', 'longRunning', 'longRunningPort', 'ismappable', 'isremotesyncin', 'isremotesyncout']
+        fields = ['feed', 'isfetch', 'longRunning', 'longRunningPort', 'ismappable', 'isremotesyncin',
+                  'isremotesyncout']
         currentscript = self.current_file.get('script', {})
         oldscript = self.old_file.get('script', {})
 

--- a/demisto_sdk/commands/common/hook_validations/integration.py
+++ b/demisto_sdk/commands/common/hook_validations/integration.py
@@ -1017,6 +1017,8 @@ class IntegrationValidator(ContentEntityValidator):
         """
         Checks if there has been a corresponding change to the integration's README
         when changing the context paths of an integration.
+        This validation might run together with is_context_different_in_yml in Readme's validation.
+
         Returns:
             True if there has been a corresponding change to README file when context is changed in integration
         """
@@ -1026,11 +1028,16 @@ class IntegrationValidator(ContentEntityValidator):
         if not os.path.exists(os.path.join(dir_path, 'README.md')):
             return True
 
+        # Only run validation if the validation has not run with is_context_different_in_yml on readme
+        # so no duplicates errors will be created:
+        error, missing_from_readme_error_code = Errors.readme_missing_output_context('', '')
+        error, missing_from_yml_error_code = Errors.missing_output_context('', '')
         readme_path = os.path.join(dir_path, 'README.md')
-        if f'{readme_path} - [RM102]' in FOUND_FILES_AND_IGNORED_ERRORS \
-                or f'{readme_path} - [RM102]' in FOUND_FILES_AND_ERRORS \
-                or f'{self.file_path} - [IN136]' in FOUND_FILES_AND_IGNORED_ERRORS \
-                or f'{self.file_path} - [IN136]' in FOUND_FILES_AND_ERRORS:
+
+        if f'{readme_path} - [{missing_from_readme_error_code}]' in FOUND_FILES_AND_IGNORED_ERRORS \
+                or f'{readme_path} - [{missing_from_readme_error_code}]' in FOUND_FILES_AND_ERRORS \
+                or f'{self.file_path} - [{missing_from_yml_error_code}]' in FOUND_FILES_AND_IGNORED_ERRORS \
+                or f'{self.file_path} - [{missing_from_yml_error_code}]' in FOUND_FILES_AND_ERRORS:
             return False
 
         # get README file's content

--- a/demisto_sdk/commands/common/hook_validations/integration.py
+++ b/demisto_sdk/commands/common/hook_validations/integration.py
@@ -17,8 +17,8 @@ from demisto_sdk.commands.common.hook_validations.docker import \
 from demisto_sdk.commands.common.hook_validations.image import ImageValidator
 from demisto_sdk.commands.common.tools import (extract_multiple_keys_from_dict,
                                                is_v2_file, print_error,
-                                               server_version_compare)
-
+                                               server_version_compare, compare_context_path_in_yml_and_readme)
+from demisto_sdk.commands.common.errors import FOUND_FILES_AND_IGNORED_ERRORS, FOUND_FILES_AND_ERRORS
 
 class IntegrationValidator(ContentEntityValidator):
     """IntegrationValidator is designed to validate the correctness of the file structure we enter to content repo. And
@@ -1013,51 +1013,36 @@ class IntegrationValidator(ContentEntityValidator):
             True if there has been a corresponding change to README file when context is changed in integration
         """
         valid = True
-        # the pattern to get the context part out of command section:
-        context_section_pattern = CONTEXT_OUTPUT_README_TABLE_HEADER.replace('|', '\\|').replace('*', r'\*') + ".(.*?)#{3,5}"
-        # the pattern to get the value in the first column under the outputs table:
-        context_path_pattern = r"\| ([^\|]*) \| [^\|]* \| [^\|]* \|"
 
         dir_path = os.path.dirname(self.file_path)
         if not os.path.exists(os.path.join(dir_path, 'README.md')):
             return True
 
-        # get README file's content
         readme_path = os.path.join(dir_path, 'README.md')
+        if f'{readme_path} - [RM102]' in FOUND_FILES_AND_IGNORED_ERRORS \
+                or f'{readme_path} - [RM102]' in FOUND_FILES_AND_ERRORS \
+                or f'{self.file_path} - [IN136]' in FOUND_FILES_AND_IGNORED_ERRORS \
+                or f'{self.file_path} - [IN136]' in FOUND_FILES_AND_ERRORS:
+            return False
+
+        # get README file's content
         with open(readme_path, 'r') as readme:
             readme_content = readme.read()
-            readme_content += "### "  # mark end of file so last pattern of regex will be recognized.
 
-        commands = self.current_file.get("script", {}).get('commands', [])
-
-        for command in commands:
-            command_name = command.get('name')
-
-            # Gets all context path in the relevant command section from README file
-            command_section_pattern = fr" Base Command..`{command_name}`.(.*?)\n### "  # pattern to get command section
-            command_section = re.findall(command_section_pattern, readme_content, re.DOTALL)
-            if not command_section:
-                continue
-            if not command_section[0].endswith('###'):
-                command_section[0] += '###'  # mark end of file so last pattern of regex will be recognized.
-            context_section = re.findall(context_section_pattern, command_section[0], re.DOTALL)
-            if not context_section:
-                context_path_in_command = set()
-            else:
-                context_path_in_command = set(re.findall(context_path_pattern, context_section[0], re.DOTALL))
-                context_path_in_command.remove('---')
-
-            existing_context_in_yml = set(extract_multiple_keys_from_dict("contextPath", command))
-
-            # finds diff between YML and README
-            only_in_yml_paths = existing_context_in_yml - context_path_in_command
-            only_in_readme_paths = context_path_in_command - existing_context_in_yml
-            if only_in_yml_paths:
-                error, code = Errors.readme_missing_output_context(command_name, ", ".join(only_in_yml_paths))
+        # commands = self.current_file.get("script", {}).get('commands', [])
+        difference = compare_context_path_in_yml_and_readme(self.current_file, readme_content)
+        for command_name in difference:
+            if difference[command_name].get('only in yml'):
+                error, code = Errors.readme_missing_output_context(
+                    command_name,
+                    ", ".join(difference[command_name].get('only in yml')))
                 if self.handle_error(error, code, file_path=readme_path):
                     valid = False
-            if only_in_readme_paths:
-                error, code = Errors.missing_output_context(command_name, ", ".join(only_in_readme_paths))
+
+            if difference[command_name].get('only in readme'):
+                error, code = Errors.missing_output_context(command_name,
+                                                            ", ".join(difference[command_name].get('only in readme')))
                 if self.handle_error(error, code, file_path=self.file_path):
                     valid = False
+
         return valid

--- a/demisto_sdk/commands/common/hook_validations/readme.py
+++ b/demisto_sdk/commands/common/hook_validations/readme.py
@@ -273,6 +273,8 @@ class ReadMeValidator(BaseValidator):
         dir_path = os.path.dirname(self.file_path)
         if not os.path.exists(os.path.join(dir_path, 'README.md')):
             return True
+        if 'Scripts' in dir_path:
+            return True
 
         # Get YML file, assuming only one yml in integration
         files_in_integration = os.listdir(dir_path)
@@ -292,7 +294,6 @@ class ReadMeValidator(BaseValidator):
             readme_content = readme.read()
 
         yml_as_dict = get_yaml(yml_path)
-        # commands = self.current_file.get("script", {}).get('commands', [])
 
         difference = compare_context_path_in_yml_and_readme(yml_as_dict, readme_content)
         for command_name in difference:

--- a/demisto_sdk/commands/common/hook_validations/readme.py
+++ b/demisto_sdk/commands/common/hook_validations/readme.py
@@ -284,7 +284,7 @@ class ReadMeValidator(BaseValidator):
 
         # disregards scripts as the structure of the files is different:
         dir_path = os.path.dirname(self.file_path)
-        if 'Integrations' not in dir_path:
+        if 'Scripts' in dir_path:
             return True
 
         # Get YML file, assuming only one yml in integration

--- a/demisto_sdk/commands/common/hook_validations/readme.py
+++ b/demisto_sdk/commands/common/hook_validations/readme.py
@@ -293,7 +293,10 @@ class ReadMeValidator(BaseValidator):
         if not yml_file_paths:
             return True
         yml_file = yml_file_paths[1]  # yml_file_paths[1] should contain the first yml file found in dir
-        yml_path = os.path.join(dir_path, yml_file)
+
+        # If get_yml_paths_in_dir does not return full path, dir_path should be added to path.
+        if dir_path not in yml_file:
+            yml_path = os.path.join(dir_path, yml_file)
 
         # Getting the relevant error_code:
         error, missing_from_readme_error_code = Errors.readme_missing_output_context('', '')

--- a/demisto_sdk/commands/common/hook_validations/readme.py
+++ b/demisto_sdk/commands/common/hook_validations/readme.py
@@ -290,7 +290,7 @@ class ReadMeValidator(BaseValidator):
         # Get YML file, assuming only one yml in integration
 
         yml_file_paths = get_yml_paths_in_dir(dir_path)
-        if not yml_file_paths:
+        if not yml_file_paths[0]:
             return True
         yml_file_path = yml_file_paths[1]  # yml_file_paths[1] should contain the first yml file found in dir
 

--- a/demisto_sdk/commands/common/hook_validations/readme.py
+++ b/demisto_sdk/commands/common/hook_validations/readme.py
@@ -7,7 +7,7 @@ import tempfile
 from functools import lru_cache
 from pathlib import Path
 from threading import Lock
-from typing import Callable, Optional
+from typing import Callable, Optional, List
 
 import requests
 from demisto_sdk.commands.common.errors import (FOUND_FILES_AND_ERRORS,
@@ -281,7 +281,7 @@ class ReadMeValidator(BaseValidator):
         yml_file_paths = get_yml_paths_in_dir(dir_path)
         if not yml_file_paths:
             return True
-        yml_file = yml_file_paths[0]
+        yml_file = yml_file_paths[1]  # yml_file_paths[1] should contain the first yml file found in dir
         yml_path = os.path.join(dir_path, yml_file)
 
         # Only run validation if the validation has not run with is_context_change_in_readme on integration

--- a/demisto_sdk/commands/common/hook_validations/readme.py
+++ b/demisto_sdk/commands/common/hook_validations/readme.py
@@ -328,7 +328,7 @@ class ReadMeValidator(BaseValidator):
             if difference_context_paths[command_name].get('only in readme'):
                 error, code = Errors.missing_output_context(
                     command_name, ", ".join(difference_context_paths[command_name].get('only in readme')))
-                if self.handle_error(error, code, file_path=yml_path):
+                if self.handle_error(error, code, file_path=yml_file_path):
                     valid = False
 
         return valid

--- a/demisto_sdk/commands/common/hook_validations/readme.py
+++ b/demisto_sdk/commands/common/hook_validations/readme.py
@@ -289,7 +289,7 @@ class ReadMeValidator(BaseValidator):
                 or f'{yml_path} - [IN136]' in FOUND_FILES_AND_ERRORS:
             return False
 
-        # get README file's content
+        # get README file's content:
         with open(self.file_path, 'r') as readme:
             readme_content = readme.read()
 

--- a/demisto_sdk/commands/common/hook_validations/readme.py
+++ b/demisto_sdk/commands/common/hook_validations/readme.py
@@ -287,6 +287,8 @@ class ReadMeValidator(BaseValidator):
                 or f'{yml_path} - [IN136]' in FOUND_FILES_AND_ERRORS:
             return False
 
+
+
         # get README file's content
         with open(self.file_path, 'r') as readme:
             readme_content = readme.read()

--- a/demisto_sdk/commands/common/hook_validations/readme.py
+++ b/demisto_sdk/commands/common/hook_validations/readme.py
@@ -287,8 +287,6 @@ class ReadMeValidator(BaseValidator):
                 or f'{yml_path} - [IN136]' in FOUND_FILES_AND_ERRORS:
             return False
 
-
-
         # get README file's content
         with open(self.file_path, 'r') as readme:
             readme_content = readme.read()

--- a/demisto_sdk/commands/common/hook_validations/readme.py
+++ b/demisto_sdk/commands/common/hook_validations/readme.py
@@ -292,11 +292,11 @@ class ReadMeValidator(BaseValidator):
         yml_file_paths = get_yml_paths_in_dir(dir_path)
         if not yml_file_paths:
             return True
-        yml_file = yml_file_paths[1]  # yml_file_paths[1] should contain the first yml file found in dir
+        yml_file_path = yml_file_paths[1]  # yml_file_paths[1] should contain the first yml file found in dir
 
         # If get_yml_paths_in_dir does not return full path, dir_path should be added to path.
-        if dir_path not in yml_file:
-            yml_path = os.path.join(dir_path, yml_file)
+        if dir_path not in yml_file_path:
+            yml_file = os.path.join(dir_path, yml_file_path)
 
         # Getting the relevant error_code:
         error, missing_from_readme_error_code = Errors.readme_missing_output_context('', '')
@@ -307,12 +307,12 @@ class ReadMeValidator(BaseValidator):
         errors, ignored_errors = self._get_error_lists()
         if f'{self.file_path} - [{missing_from_readme_error_code}]' in ignored_errors \
                 or f'{self.file_path} - [{missing_from_readme_error_code}]' in errors \
-                or f'{yml_path} - [{missing_from_yml_error_code}]' in ignored_errors \
-                or f'{yml_path} - [{missing_from_yml_error_code}]' in errors:
+                or f'{yml_file_path} - [{missing_from_yml_error_code}]' in ignored_errors \
+                or f'{yml_file_path} - [{missing_from_yml_error_code}]' in errors:
             return False
 
         # get YML file's content:
-        yml_as_dict = get_yaml(yml_path)
+        yml_as_dict = get_yaml(yml_file_path)
 
         difference_context_paths = compare_context_path_in_yml_and_readme(yml_as_dict, self.readme_content)
 

--- a/demisto_sdk/commands/common/hook_validations/readme.py
+++ b/demisto_sdk/commands/common/hook_validations/readme.py
@@ -10,13 +10,14 @@ from threading import Lock
 from typing import Callable, Optional
 
 import requests
-from demisto_sdk.commands.common.errors import Errors
+from demisto_sdk.commands.common.errors import (FOUND_FILES_AND_ERRORS,
+                                                FOUND_FILES_AND_IGNORED_ERRORS,
+                                                Errors)
 from demisto_sdk.commands.common.hook_validations.base_validator import \
     BaseValidator
-from demisto_sdk.commands.common.tools import (get_content_path, print_warning, get_yaml,
-                                               run_command_os, compare_context_path_in_yml_and_readme)
-from demisto_sdk.commands.common.errors import FOUND_FILES_AND_IGNORED_ERRORS, FOUND_FILES_AND_ERRORS
-
+from demisto_sdk.commands.common.tools import (
+    compare_context_path_in_yml_and_readme, get_content_path, get_yaml,
+    print_warning, run_command_os)
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 

--- a/demisto_sdk/commands/common/hook_validations/readme.py
+++ b/demisto_sdk/commands/common/hook_validations/readme.py
@@ -268,10 +268,6 @@ class ReadMeValidator(BaseValidator):
             is_valid = False
         return is_valid
 
-    @staticmethod
-    def _get_error_lists():
-        return FOUND_FILES_AND_ERRORS, FOUND_FILES_AND_IGNORED_ERRORS
-
     def is_context_different_in_yml(self) -> bool:
         """
         Checks if there has been a corresponding change to the integration's README
@@ -290,8 +286,11 @@ class ReadMeValidator(BaseValidator):
         # Get YML file, assuming only one yml in integration
 
         yml_file_paths = get_yml_paths_in_dir(dir_path)
+
+        # Handles case of Pack's Readme, so no YML file is found in pack.
         if not yml_file_paths[0]:
             return True
+
         yml_file_path = yml_file_paths[1]  # yml_file_paths[1] should contain the first yml file found in dir
 
         # If get_yml_paths_in_dir does not return full path, dir_path should be added to path.
@@ -357,6 +356,10 @@ class ReadMeValidator(BaseValidator):
         if ReadMeValidator._MDX_SERVER_PROCESS:
             ReadMeValidator._MDX_SERVER_PROCESS.terminate()
             ReadMeValidator._MDX_SERVER_PROCESS = None
+
+    @staticmethod
+    def _get_error_lists():
+        return FOUND_FILES_AND_ERRORS, FOUND_FILES_AND_IGNORED_ERRORS
 
 
 atexit.register(ReadMeValidator.stop_mdx_server)

--- a/demisto_sdk/commands/common/hook_validations/readme.py
+++ b/demisto_sdk/commands/common/hook_validations/readme.py
@@ -284,7 +284,7 @@ class ReadMeValidator(BaseValidator):
 
         # disregards scripts as the structure of the files is different:
         dir_path = os.path.dirname(self.file_path)
-        if 'Scripts' in dir_path:
+        if 'Integrations' not in dir_path:
             return True
 
         # Get YML file, assuming only one yml in integration

--- a/demisto_sdk/commands/common/hook_validations/readme.py
+++ b/demisto_sdk/commands/common/hook_validations/readme.py
@@ -296,7 +296,7 @@ class ReadMeValidator(BaseValidator):
 
         # If get_yml_paths_in_dir does not return full path, dir_path should be added to path.
         if dir_path not in yml_file_path:
-            yml_file = os.path.join(dir_path, yml_file_path)
+            yml_file_path = os.path.join(dir_path, yml_file_path)
 
         # Getting the relevant error_code:
         error, missing_from_readme_error_code = Errors.readme_missing_output_context('', '')

--- a/demisto_sdk/commands/common/hook_validations/readme.py
+++ b/demisto_sdk/commands/common/hook_validations/readme.py
@@ -17,7 +17,7 @@ from demisto_sdk.commands.common.hook_validations.base_validator import \
     BaseValidator
 from demisto_sdk.commands.common.tools import (
     compare_context_path_in_yml_and_readme, get_content_path, get_yaml,
-    print_warning, run_command_os, get_yml_paths_in_dir)
+    get_yml_paths_in_dir, print_warning, run_command_os)
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 

--- a/demisto_sdk/commands/common/tests/readme_test.py
+++ b/demisto_sdk/commands/common/tests/readme_test.py
@@ -82,7 +82,7 @@ def test_is_image_path_valid():
         "https://github.com/demisto/content/raw/123/Packs/FeedOffice365/doc_files/test.png"]
     readme_validator = ReadMeValidator(INVALID_MD)
     result = readme_validator.is_image_path_valid()
-    sys.stdout = sys.__stdout__   # reset stdout.
+    sys.stdout = sys.__stdout__  # reset stdout.
     assert not result
     assert images_paths[0] and alternative_images_paths[0] in captured_output.getvalue()
     assert images_paths[1] and alternative_images_paths[1] in captured_output.getvalue()
@@ -208,12 +208,49 @@ ERROR_FOUND_CASES = [
 
 @pytest.mark.parametrize("errors_found, errors_ignore, expected", ERROR_FOUND_CASES)
 def test_context_only_runs_once_when_error_exist(mocker, integration, errors_found, errors_ignore, expected):
+    """
+        Given
+            - README that contains changes and YML file
+        When
+            - Run validate on README file and YML
+        Then
+            - Ensure validation only run once, either for YML or for README
+        """
     readme_validator = ReadMeValidator(FAKE_INTEGRATION_README)
     mocker.patch.object(ReadMeValidator, '_get_error_lists',
                         return_value=(errors_found, errors_ignore))
 
     result = readme_validator.is_context_different_in_yml()
     assert result == expected
+
+
+DIFFERENCE_CONTEXT_RESULTS_CASE = [
+    ({'zoom-create-user': {'only in yml': {'Zoom.User.id'}, 'only in readme': set()}}, False),  # case path exists only in yml
+    ({'zoom-list-users': {'only in yml': set(), 'only in readme': {'Zoom.User.last_name', 'Zoom.User.first_name'}}}, False),  # case path exists only in readme
+    ({}, True),  # case no changes were found
+]
+
+
+@pytest.mark.parametrize("difference_found, expected", DIFFERENCE_CONTEXT_RESULTS_CASE)
+def test_context_difference_created_is_valid(mocker, difference_found, expected):
+    """
+    Given
+        - README that contains changes and YML file
+    When
+        - Run validate on README file and YML
+    Then
+        - Ensure the difference context is correct
+    """
+    mocker.patch('demisto_sdk.commands.common.hook_validations.readme.compare_context_path_in_yml_and_readme',
+                 return_value=difference_found)
+    readme_validator = ReadMeValidator(FAKE_INTEGRATION_README)
+    handle_error_mock = mocker.patch.object(ReadMeValidator, 'handle_error')
+    valid = readme_validator.is_context_different_in_yml()
+    assert valid == expected
+    if not valid:
+        handle_error_mock.assert_called()
+    else:
+        handle_error_mock.assert_not_called()
 
 
 def test_invalid_short_file(capsys):

--- a/demisto_sdk/commands/common/tests/readme_test.py
+++ b/demisto_sdk/commands/common/tests/readme_test.py
@@ -11,6 +11,7 @@ INVALID_MD = f'{git_path()}/demisto_sdk/tests/test_files/README-invalid.md'
 INVALID2_MD = f'{git_path()}/demisto_sdk/tests/test_files/README-invalid2.md'
 INVALID3_MD = f'{git_path()}/demisto_sdk/tests/test_files/README-short-invalid.md'
 EMPTY_MD = f'{git_path()}/demisto_sdk/tests/test_files/README-empty.md'
+FAKE_INTEGRATION_README = f'{git_path()}/demisto_sdk/tests/test_files/fake_integration/fake_README.md'
 
 README_INPUTS = [
     (VALID_MD, True),
@@ -196,6 +197,23 @@ def test_verify_no_default_sections_left(integration, capsys, file_input, sectio
     section_error = f'Replace "{section}" with a suitable info.'
     assert not result
     assert section_error in stdout
+
+
+ERROR_FOUND_CASES = [
+    ([f'{FAKE_INTEGRATION_README} - [RM102]'], [], False),
+    ([], [f'{FAKE_INTEGRATION_README} - [RM102]'], False),
+    ([], [], True),
+]
+
+
+@pytest.mark.parametrize("errors_found, errors_ignore, expected", ERROR_FOUND_CASES)
+def test_context_only_runs_once_when_error_exist(mocker, integration, errors_found, errors_ignore, expected):
+    readme_validator = ReadMeValidator(FAKE_INTEGRATION_README)
+    mocker.patch.object(ReadMeValidator, '_get_error_lists',
+                        return_value=(errors_found, errors_ignore))
+
+    result = readme_validator.is_context_different_in_yml()
+    assert result == expected
 
 
 def test_invalid_short_file(capsys):

--- a/demisto_sdk/commands/common/tests/readme_test.py
+++ b/demisto_sdk/commands/common/tests/readme_test.py
@@ -5,6 +5,7 @@ import sys
 import pytest
 from demisto_sdk.commands.common.hook_validations.readme import ReadMeValidator
 from demisto_sdk.commands.common.legacy_git_tools import git_path
+from mock import patch
 
 VALID_MD = f'{git_path()}/demisto_sdk/tests/test_files/README-valid.md'
 INVALID_MD = f'{git_path()}/demisto_sdk/tests/test_files/README-invalid.md'

--- a/demisto_sdk/commands/common/tests/readme_test.py
+++ b/demisto_sdk/commands/common/tests/readme_test.py
@@ -5,7 +5,6 @@ import sys
 import pytest
 from demisto_sdk.commands.common.hook_validations.readme import ReadMeValidator
 from demisto_sdk.commands.common.legacy_git_tools import git_path
-from mock import patch
 
 VALID_MD = f'{git_path()}/demisto_sdk/tests/test_files/README-valid.md'
 INVALID_MD = f'{git_path()}/demisto_sdk/tests/test_files/README-invalid.md'

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -1562,7 +1562,7 @@ def compare_context_path_in_yml_and_readme(yml_dict, readme_content):
         readme_content: the content string of the readme file.
     Returns:
     """
-    different_contexts = {}
+    different_contexts: dict = {}
 
     # Gets the data from the README
     # the pattern to get the context part out of command section:

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -12,7 +12,7 @@ from functools import lru_cache, partial
 from pathlib import Path
 from subprocess import DEVNULL, PIPE, Popen, check_output
 from typing import Callable, Dict, List, Optional, Tuple, Type, Union
-from demisto_sdk.commands.common.constants import CONTEXT_OUTPUT_README_TABLE_HEADER
+
 import click
 import colorama
 import demisto_client
@@ -23,9 +23,10 @@ import yaml
 from demisto_sdk.commands.common.constants import (
     ALL_FILES_VALIDATION_IGNORE_WHITELIST, API_MODULES_PACK, CLASSIFIERS_DIR,
     CONTENT_GITHUB_LINK, CONTENT_GITHUB_ORIGIN, CONTENT_GITHUB_UPSTREAM,
-    DASHBOARDS_DIR, DEF_DOCKER, DEF_DOCKER_PWSH, DOC_FILES_DIR,
-    ID_IN_COMMONFIELDS, ID_IN_ROOT, INCIDENT_FIELDS_DIR, INCIDENT_TYPES_DIR,
-    INDICATOR_FIELDS_DIR, INTEGRATIONS_DIR, LAYOUTS_DIR, PACK_IGNORE_TEST_FLAG,
+    CONTEXT_OUTPUT_README_TABLE_HEADER, DASHBOARDS_DIR, DEF_DOCKER,
+    DEF_DOCKER_PWSH, DOC_FILES_DIR, ID_IN_COMMONFIELDS, ID_IN_ROOT,
+    INCIDENT_FIELDS_DIR, INCIDENT_TYPES_DIR, INDICATOR_FIELDS_DIR,
+    INTEGRATIONS_DIR, LAYOUTS_DIR, PACK_IGNORE_TEST_FLAG,
     PACKAGE_SUPPORTING_DIRECTORIES, PACKAGE_YML_FILE_REGEX, PACKS_DIR,
     PACKS_DIR_REGEX, PACKS_PACK_IGNORE_FILE_NAME, PACKS_PACK_META_FILE_NAME,
     PACKS_README_FILE_NAME, PLAYBOOKS_DIR, RELEASE_NOTES_DIR,
@@ -1590,6 +1591,7 @@ def compare_context_path_in_yml_and_readme(yml_dict, readme_content):
         # handles cases of old integrations with context in 'important' section
         if 'important' in command:
             command.pop('important')
+
         # Gets all context path in the relevant command section from YML file
         existing_context_in_yml = set(extract_multiple_keys_from_dict("contextPath", command))
 

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -1560,7 +1560,8 @@ def compare_context_path_in_yml_and_readme(yml_dict, readme_content):
     Args:
         yml_dict: a dictionary representing YML content.
         readme_content: the content string of the readme file.
-    Returns:
+    Returns: A dictionary as following: {<command_name>:{'only in yml': <set of context paths found only in yml>,
+                                                        'only in readme': <set of context paths found only in readme>}}
     """
     different_contexts: dict = {}
 

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -1576,7 +1576,7 @@ def compare_context_path_in_yml_and_readme(yml_dict, readme_content):
     # handles scripts
     if not commands:
         return different_contexts
-
+    commands = commands.get('commands', [])
     for command in commands:
         command_name = command.get('name')
 

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -1555,12 +1555,15 @@ def get_file_displayed_name(file_path):
 
 def compare_context_path_in_yml_and_readme(yml_dict, readme_content):
     """
-    Gets both README and YML file and compares the context path between them.
+    Gets both README and YML file of Integration and compares the context path between them.
+    Scripts are not being checked.
     Args:
         yml_dict: a dictionary representing YML content.
         readme_content: the content string of the readme file.
     Returns:
     """
+    different_contexts = {}
+
     # Gets the data from the README
     # the pattern to get the context part out of command section:
     context_section_pattern = CONTEXT_OUTPUT_README_TABLE_HEADER.replace('|', '\\|').replace('*',
@@ -1568,9 +1571,12 @@ def compare_context_path_in_yml_and_readme(yml_dict, readme_content):
     # the pattern to get the value in the first column under the outputs table:
     context_path_pattern = r"\| ([^\|]*) \| [^\|]* \| [^\|]* \|"
     readme_content += "### "  # mark end of file so last pattern of regex will be recognized.
-    commands = yml_dict.get("script", {}).get('commands', [])
+    commands = yml_dict.get("script", {})
 
-    different_contexts = {}
+    # handles scripts
+    if not commands:
+        return different_contexts
+
     for command in commands:
         command_name = command.get('name')
 


### PR DESCRIPTION
## Status
- [ ] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/34856

## Description
Added the validation of RM102 to run when either yml OR readme are changed (while making sure errors appear only once if both have been changed)

## Must have
- [ ] Tests

