### PR TITLE
Validate Params Performs Contains on AdditionalInfo Instead Of Equals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Added the *--include-untracked* flag to the **validate** command to include files which are untracked by git in the validation process.
 * Improved the `pykwalify` error outputs in the **validate** command.
 * Added the *--print-pykwalify* flag to the **validate** command to print the unchanged output from `pykwalify`.
-* Updated the **demisto-sdk validate** command to check that 'additionalinfo' field contains the expected 'additionalinfo' value for feed required parameters.
+* Updated the **demisto-sdk validate** command to check that the 'additionalinfo' field only contains the expected value for feed required parameters and not equal to it.
 
 # 1.3.2
 * Updated the format of the outputs when using the *--json-file* flag to create a JSON file output for the **validate** and **lint** commands.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fixed issue where **update-release-notes** deleted release note file if command was called more than once.
 * Fixed issue where **update-release-notes** added docker image release notes every time the command was called.
 * Fixed an issue where running **update-release-notes** on a pack with newly created integration, had also added a docker image entry in the release notes.
+* Updated the **demisto-sdk validate** command to check that 'additionalinfo' field contains the expected 'additionalinfo' value for feed required parameters.
 
 # 1.3.2
 * Updated the format of the outputs when using the *--json-file* flag to create a JSON file output for the **validate** and **lint** commands.

--- a/demisto_sdk/commands/common/constants.py
+++ b/demisto_sdk/commands/common/constants.py
@@ -887,6 +887,110 @@ NON_SUPPORTED_PACK = "NonSupported"
 DEPRECATED_CONTENT_PACK = "DeprecatedContent"
 IGNORED_DEPENDENCY_CALCULATION = {BASE_PACK, NON_SUPPORTED_PACK, DEPRECATED_CONTENT_PACK}
 
+# FEED_REQUIRED_PARAMS = [
+#     {
+#         'name': 'feed',
+#         'must_equal': {
+#             'defaultvalue': 'true',
+#             'display': 'Fetch indicators',
+#             'type': 8,
+#             'required': False
+#         },
+#         'must_contain': {}
+#     },
+#     {
+#         'name': 'feedReputation',
+#         'must_equal': {
+#             'display': 'Indicator Reputation',
+#             'type': 18,
+#             'required': False,
+#             'options': ['None', 'Good', 'Suspicious', 'Bad']
+#         },
+#         'must_contain': {
+#             'additionalinfo': 'Indicators from this integration instance will be marked with this reputation'
+#         }
+#     },
+#     {
+#         'name': 'feedReliability',
+#         'must_equal': {
+#             'display': 'Source Reliability',
+#             'type': 15,
+#             'required': True,
+#             'options': [
+#                 'A - Completely reliable', 'B - Usually reliable', 'C - Fairly reliable', 'D - Not usually reliable',
+#                 'E - Unreliable', 'F - Reliability cannot be judged']
+#         },
+#         'must_contain': {
+#             'additionalinfo': 'Reliability of the source providing the intelligence data'
+#         }
+#     },
+#     {
+#         'name': 'feedExpirationPolicy',
+#         'must_equal': {
+#             'display': "",
+#             'type': 17,
+#             'required': False,
+#             'options': ['never', 'interval', 'indicatorType', 'suddenDeath']
+#         },
+#         'must_contain': {}
+#     },
+#     {
+#         'name': 'feedExpirationInterval',
+#         'must_equal': {
+#             'display': "",
+#             'type': 1,
+#             'required': False
+#         },
+#         'must_contain': {}
+#     },
+#     {
+#         'name': 'feedFetchInterval',
+#         'must_equal': {
+#             'display': 'Feed Fetch Interval',
+#             'type': 19,
+#             'required': False
+#         },
+#         'must_contain': {}
+#     },
+#     {
+#         'name': 'feedBypassExclusionList',
+#         'must_equal': {
+#             'display': 'Bypass exclusion list',
+#             'type': 8,
+#             'required': False
+#         },
+#         'must_contain': {
+#             'additionalinfo': 'When selected, the exclusion list is ignored for indicators from this feed.'
+#                               ' This means that if an indicator from this feed is on the exclusion list,'
+#                               ' the indicator might still be added to the system.'
+#         }
+#     },
+#     {
+#         'name': 'feedTags',
+#         'must_equal': {
+#             'display': 'Tags',
+#             'required': False,
+#             'type': 0
+#         },
+#         'must_contain': {
+#             'additionalinfo': 'Supports CSV values.'
+#         }
+#     },
+#     {
+#         'name': 'tlp_color',
+#         'must_equal': {
+#             'display': 'Traffic Light Protocol Color',
+#             'options': ['RED', 'AMBER', 'GREEN', 'WHITE'],
+#             'required': False,
+#             'type': 15
+#         },
+#         'must_contain': {
+#             'additionalinfo': 'The Traffic Light Protocol (TLP) designation to apply to indicators fetched from the '
+#                               'feed'
+#         }
+#     }
+# ]
+
 FEED_REQUIRED_PARAMS = [
     {
         'defaultvalue': 'true',

--- a/demisto_sdk/commands/common/constants.py
+++ b/demisto_sdk/commands/common/constants.py
@@ -887,178 +887,107 @@ NON_SUPPORTED_PACK = "NonSupported"
 DEPRECATED_CONTENT_PACK = "DeprecatedContent"
 IGNORED_DEPENDENCY_CALCULATION = {BASE_PACK, NON_SUPPORTED_PACK, DEPRECATED_CONTENT_PACK}
 
-# FEED_REQUIRED_PARAMS = [
-#     {
-#         'name': 'feed',
-#         'must_equal': {
-#             'defaultvalue': 'true',
-#             'display': 'Fetch indicators',
-#             'type': 8,
-#             'required': False
-#         },
-#         'must_contain': {}
-#     },
-#     {
-#         'name': 'feedReputation',
-#         'must_equal': {
-#             'display': 'Indicator Reputation',
-#             'type': 18,
-#             'required': False,
-#             'options': ['None', 'Good', 'Suspicious', 'Bad']
-#         },
-#         'must_contain': {
-#             'additionalinfo': 'Indicators from this integration instance will be marked with this reputation'
-#         }
-#     },
-#     {
-#         'name': 'feedReliability',
-#         'must_equal': {
-#             'display': 'Source Reliability',
-#             'type': 15,
-#             'required': True,
-#             'options': [
-#                 'A - Completely reliable', 'B - Usually reliable', 'C - Fairly reliable', 'D - Not usually reliable',
-#                 'E - Unreliable', 'F - Reliability cannot be judged']
-#         },
-#         'must_contain': {
-#             'additionalinfo': 'Reliability of the source providing the intelligence data'
-#         }
-#     },
-#     {
-#         'name': 'feedExpirationPolicy',
-#         'must_equal': {
-#             'display': "",
-#             'type': 17,
-#             'required': False,
-#             'options': ['never', 'interval', 'indicatorType', 'suddenDeath']
-#         },
-#         'must_contain': {}
-#     },
-#     {
-#         'name': 'feedExpirationInterval',
-#         'must_equal': {
-#             'display': "",
-#             'type': 1,
-#             'required': False
-#         },
-#         'must_contain': {}
-#     },
-#     {
-#         'name': 'feedFetchInterval',
-#         'must_equal': {
-#             'display': 'Feed Fetch Interval',
-#             'type': 19,
-#             'required': False
-#         },
-#         'must_contain': {}
-#     },
-#     {
-#         'name': 'feedBypassExclusionList',
-#         'must_equal': {
-#             'display': 'Bypass exclusion list',
-#             'type': 8,
-#             'required': False
-#         },
-#         'must_contain': {
-#             'additionalinfo': 'When selected, the exclusion list is ignored for indicators from this feed.'
-#                               ' This means that if an indicator from this feed is on the exclusion list,'
-#                               ' the indicator might still be added to the system.'
-#         }
-#     },
-#     {
-#         'name': 'feedTags',
-#         'must_equal': {
-#             'display': 'Tags',
-#             'required': False,
-#             'type': 0
-#         },
-#         'must_contain': {
-#             'additionalinfo': 'Supports CSV values.'
-#         }
-#     },
-#     {
-#         'name': 'tlp_color',
-#         'must_equal': {
-#             'display': 'Traffic Light Protocol Color',
-#             'options': ['RED', 'AMBER', 'GREEN', 'WHITE'],
-#             'required': False,
-#             'type': 15
-#         },
-#         'must_contain': {
-#             'additionalinfo': 'The Traffic Light Protocol (TLP) designation to apply to indicators fetched from the '
-#                               'feed'
-#         }
-#     }
-# ]
-
 FEED_REQUIRED_PARAMS = [
     {
-        'defaultvalue': 'true',
-        'display': 'Fetch indicators',
         'name': 'feed',
-        'type': 8,
-        'required': False
+        'must_equal': {
+            'defaultvalue': 'true',
+            'display': 'Fetch indicators',
+            'type': 8,
+            'required': False
+        },
+        'must_contain': {}
     },
     {
-        'display': 'Indicator Reputation',
         'name': 'feedReputation',
-        'type': 18,
-        'required': False,
-        'options': ['None', 'Good', 'Suspicious', 'Bad'],
-        'additionalinfo': 'Indicators from this integration instance will be marked with this reputation'
+        'must_equal': {
+            'display': 'Indicator Reputation',
+            'type': 18,
+            'required': False,
+            'options': ['None', 'Good', 'Suspicious', 'Bad']
+        },
+        'must_contain': {
+            'additionalinfo': 'Indicators from this integration instance will be marked with this reputation'
+        }
     },
     {
-        'display': 'Source Reliability',
         'name': 'feedReliability',
-        'type': 15,
-        'required': True,
-        'options': [
-            'A - Completely reliable', 'B - Usually reliable', 'C - Fairly reliable', 'D - Not usually reliable',
-            'E - Unreliable', 'F - Reliability cannot be judged'],
-        'additionalinfo': 'Reliability of the source providing the intelligence data'
+        'must_equal': {
+            'display': 'Source Reliability',
+            'type': 15,
+            'required': True,
+            'options': [
+                'A - Completely reliable', 'B - Usually reliable', 'C - Fairly reliable', 'D - Not usually reliable',
+                'E - Unreliable', 'F - Reliability cannot be judged']
+        },
+        'must_contain': {
+            'additionalinfo': 'Reliability of the source providing the intelligence data'
+        }
     },
     {
-        'display': "",
         'name': 'feedExpirationPolicy',
-        'type': 17,
-        'required': False,
-        'options': ['never', 'interval', 'indicatorType', 'suddenDeath']
+        'must_equal': {
+            'display': "",
+            'type': 17,
+            'required': False,
+            'options': ['never', 'interval', 'indicatorType', 'suddenDeath']
+        },
+        'must_contain': {}
     },
     {
-        'display': "",
         'name': 'feedExpirationInterval',
-        'type': 1,
-        'required': False
+        'must_equal': {
+            'display': "",
+            'type': 1,
+            'required': False
+        },
+        'must_contain': {}
     },
     {
-        'display': 'Feed Fetch Interval',
         'name': 'feedFetchInterval',
-        'type': 19,
-        'required': False
+        'must_equal': {
+            'display': 'Feed Fetch Interval',
+            'type': 19,
+            'required': False
+        },
+        'must_contain': {}
     },
     {
-        'display': 'Bypass exclusion list',
         'name': 'feedBypassExclusionList',
-        'type': 8,
-        'required': False,
-        'additionalinfo': 'When selected, the exclusion list is ignored for indicators from this feed.'
-                          ' This means that if an indicator from this feed is on the exclusion list,'
-                          ' the indicator might still be added to the system.'
+        'must_equal': {
+            'display': 'Bypass exclusion list',
+            'type': 8,
+            'required': False
+        },
+        'must_contain': {
+            'additionalinfo': 'When selected, the exclusion list is ignored for indicators from this feed.'
+                              ' This means that if an indicator from this feed is on the exclusion list,'
+                              ' the indicator might still be added to the system.'
+        }
     },
     {
-        'additionalinfo': 'Supports CSV values.',
-        'display': 'Tags',
         'name': 'feedTags',
-        'required': False,
-        'type': 0
+        'must_equal': {
+            'display': 'Tags',
+            'required': False,
+            'type': 0
+        },
+        'must_contain': {
+            'additionalinfo': 'Supports CSV values.'
+        }
     },
     {
-        'additionalinfo': 'The Traffic Light Protocol (TLP) designation to apply to indicators fetched from the feed',
-        'display': 'Traffic Light Protocol Color',
         'name': 'tlp_color',
-        'options': ['RED', 'AMBER', 'GREEN', 'WHITE'],
-        'required': False,
-        'type': 15
+        'must_equal': {
+            'display': 'Traffic Light Protocol Color',
+            'options': ['RED', 'AMBER', 'GREEN', 'WHITE'],
+            'required': False,
+            'type': 15
+        },
+        'must_contain': {
+            'additionalinfo': 'The Traffic Light Protocol (TLP) designation to apply to indicators fetched from the '
+                              'feed'
+        }
     }
 ]
 

--- a/demisto_sdk/commands/common/hook_validations/integration.py
+++ b/demisto_sdk/commands/common/hook_validations/integration.py
@@ -652,7 +652,8 @@ class IntegrationValidator(ContentEntityValidator):
 
     def is_changed_removed_yml_fields(self):
         """checks if some specific Fields in the yml file were changed from true to false or removed"""
-        fields = ['feed', 'isfetch', 'longRunning', 'longRunningPort', 'ismappable', 'isremotesyncin', 'isremotesyncout']
+        fields = ['feed', 'isfetch', 'longRunning', 'longRunningPort', 'ismappable', 'isremotesyncin',
+                  'isremotesyncout']
         currentscript = self.current_file.get('script', {})
         oldscript = self.old_file.get('script', {})
 
@@ -842,12 +843,28 @@ class IntegrationValidator(ContentEntityValidator):
             bool. True if the integration is defined as well False otherwise.
         """
         params_exist = True
+        # params = {
+        #   param.get('name'): {k: v for k, v in param.items()} for param in self.current_file.get('configuration', [])}
         params = [_key for _key in self.current_file.get('configuration', [])]
+
         for counter, param in enumerate(params):
             if 'defaultvalue' in param and param['name'] != 'feed':
                 params[counter].pop('defaultvalue')
             if 'hidden' in param:
                 params[counter].pop('hidden')
+        # for required_param in FEED_REQUIRED_PARAMS:
+            # is_valid = False
+            # param_configs = params.get(required_param.get('name'))
+            # if param_configs:
+            #     is_valid = all(k in param_configs and param_configs[k] == v
+            #                    for k, v in required_param.get('must_equal', dict()).items()) and \
+            #                all(k in param_configs and v in param_configs[k]
+            #                    for k, v in required_param.get('must_contain', dict()).items())
+            # if not is_valid:
+            #     error_message, error_code = Errors.parameter_missing_for_feed(required_param.get('name'),
+            #                                                                   yaml.dump(required_param))
+            #     if self.handle_error(error_message, error_code, file_path=self.file_path):
+            #         params_exist = False
         for param in FEED_REQUIRED_PARAMS:
             if param not in params:
                 error_message, error_code = Errors.parameter_missing_for_feed(param.get('name'), yaml.dump(param))
@@ -1014,7 +1031,8 @@ class IntegrationValidator(ContentEntityValidator):
         """
         valid = True
         # the pattern to get the context part out of command section:
-        context_section_pattern = CONTEXT_OUTPUT_README_TABLE_HEADER.replace('|', '\\|').replace('*', r'\*') + ".(.*?)#{3,5}"
+        context_section_pattern = CONTEXT_OUTPUT_README_TABLE_HEADER.replace('|', '\\|').replace('*',
+                                                                                                 r'\*') + ".(.*?)#{3,5}"
         # the pattern to get the value in the first column under the outputs table:
         context_path_pattern = r"\| ([^\|]*) \| [^\|]* \| [^\|]* \|"
 

--- a/demisto_sdk/commands/common/hook_validations/integration.py
+++ b/demisto_sdk/commands/common/hook_validations/integration.py
@@ -1,5 +1,6 @@
 import os
 import re
+from typing import Dict
 
 import yaml
 from demisto_sdk.commands.common.constants import (
@@ -652,8 +653,7 @@ class IntegrationValidator(ContentEntityValidator):
 
     def is_changed_removed_yml_fields(self):
         """checks if some specific Fields in the yml file were changed from true to false or removed"""
-        fields = ['feed', 'isfetch', 'longRunning', 'longRunningPort', 'ismappable', 'isremotesyncin',
-                  'isremotesyncout']
+        fields = ['feed', 'isfetch', 'longRunning', 'longRunningPort', 'ismappable', 'isremotesyncin', 'isremotesyncout']
         currentscript = self.current_file.get('script', {})
         oldscript = self.old_file.get('script', {})
 
@@ -843,31 +843,31 @@ class IntegrationValidator(ContentEntityValidator):
             bool. True if the integration is defined as well False otherwise.
         """
         params_exist = True
-        # params = {
-        #   param.get('name'): {k: v for k, v in param.items()} for param in self.current_file.get('configuration', [])}
-        params = [_key for _key in self.current_file.get('configuration', [])]
+        params = {
+            param.get('name'): {k: v for k, v in param.items()} for param in self.current_file.get('configuration', [])}
 
-        for counter, param in enumerate(params):
-            if 'defaultvalue' in param and param['name'] != 'feed':
-                params[counter].pop('defaultvalue')
-            if 'hidden' in param:
-                params[counter].pop('hidden')
-        # for required_param in FEED_REQUIRED_PARAMS:
-            # is_valid = False
-            # param_configs = params.get(required_param.get('name'))
-            # if param_configs:
-            #     is_valid = all(k in param_configs and param_configs[k] == v
-            #                    for k, v in required_param.get('must_equal', dict()).items()) and \
-            #                all(k in param_configs and v in param_configs[k]
-            #                    for k, v in required_param.get('must_contain', dict()).items())
-            # if not is_valid:
-            #     error_message, error_code = Errors.parameter_missing_for_feed(required_param.get('name'),
-            #                                                                   yaml.dump(required_param))
-            #     if self.handle_error(error_message, error_code, file_path=self.file_path):
-            #         params_exist = False
-        for param in FEED_REQUIRED_PARAMS:
-            if param not in params:
-                error_message, error_code = Errors.parameter_missing_for_feed(param.get('name'), yaml.dump(param))
+        for param_name, param_details in params.items():
+            if 'defaultvalue' in param_details and param_name != 'feed':
+                param_details.pop('defaultvalue')
+            if 'hidden' in param_details:
+                param_details.pop('hidden')
+
+        for required_param in FEED_REQUIRED_PARAMS:
+            is_valid = False
+            param_details = params.get(required_param.get('name'))  # type: ignore
+            equal_key_values: Dict = required_param.get('must_equal', dict())   # type: ignore
+            contained_key_values: Dict = required_param.get('must_contain', dict())  # type: ignore
+            if param_details:
+                # Check length to see no unexpected key exists in the config. Add +1 for the 'name' key.
+                is_valid = len(equal_key_values) + len(contained_key_values) + 1 == len(param_details) and \
+                    all(k in param_details and param_details[k] == v
+                        for k, v in equal_key_values.items()) and \
+                    all(k in param_details and v in param_details[k]
+                        for k, v in contained_key_values.items())
+            if not is_valid:
+                param_structure = dict(equal_key_values, **contained_key_values, name=required_param.get('name'))
+                error_message, error_code = Errors.parameter_missing_for_feed(required_param.get('name'),
+                                                                              yaml.dump(param_structure))
                 if self.handle_error(error_message, error_code, file_path=self.file_path):
                     params_exist = False
 
@@ -1031,8 +1031,7 @@ class IntegrationValidator(ContentEntityValidator):
         """
         valid = True
         # the pattern to get the context part out of command section:
-        context_section_pattern = CONTEXT_OUTPUT_README_TABLE_HEADER.replace('|', '\\|').replace('*',
-                                                                                                 r'\*') + ".(.*?)#{3,5}"
+        context_section_pattern = CONTEXT_OUTPUT_README_TABLE_HEADER.replace('|', '\\|').replace('*', r'\*') + ".(.*?)#{3,5}"
         # the pattern to get the value in the first column under the outputs table:
         context_path_pattern = r"\| ([^\|]*) \| [^\|]* \| [^\|]* \|"
 

--- a/demisto_sdk/commands/common/tests/integration_test.py
+++ b/demisto_sdk/commands/common/tests/integration_test.py
@@ -526,7 +526,7 @@ class TestIntegrationValidator:
         current = {
             "script": {"feed": feed},
             "fromversion": fromversion,
-            'configuration': FEED_REQUIRED_PARAMS_STRUCTURE
+            'configuration': deepcopy(FEED_REQUIRED_PARAMS_STRUCTURE)
         }
         structure = mock_structure("", current)
         validator = IntegrationValidator(structure)
@@ -805,7 +805,7 @@ class TestIsFeedParamsExist:
 
     def setup(self):
         config = {
-            'configuration': FEED_REQUIRED_PARAMS_STRUCTURE,
+            'configuration': deepcopy(FEED_REQUIRED_PARAMS_STRUCTURE),
             'script': {'feed': True}
         }
         self.validator = IntegrationValidator(mock_structure("", config))

--- a/demisto_sdk/commands/common/tests/integration_test.py
+++ b/demisto_sdk/commands/common/tests/integration_test.py
@@ -17,6 +17,7 @@ from mock import mock_open, patch
 FEED_REQUIRED_PARAMS_STRUCTURE = [dict(required_param.get('must_equal'), **required_param.get('must_contain'),
                                        name=required_param.get('name')) for required_param in FEED_REQUIRED_PARAMS]
 
+
 def mock_structure(file_path=None, current_file=None, old_file=None):
     # type: (Optional[str], Optional[dict], Optional[dict]) -> StructureValidator
     with patch.object(StructureValidator, '__init__', lambda a, b: None):

--- a/demisto_sdk/commands/common/tests/integration_test.py
+++ b/demisto_sdk/commands/common/tests/integration_test.py
@@ -802,7 +802,8 @@ class TestIsFeedParamsExist:
 
     def setup(self):
         config = {
-            'configuration': deepcopy(FEED_REQUIRED_PARAMS),
+            'configuration': [dict(required_param.get('must_equal'), **required_param.get('must_contain'),
+                                   name=required_param.get('name')) for required_param in FEED_REQUIRED_PARAMS],
             'script': {'feed': True}
         }
         self.validator = IntegrationValidator(mock_structure("", config))

--- a/demisto_sdk/commands/common/tests/integration_test.py
+++ b/demisto_sdk/commands/common/tests/integration_test.py
@@ -14,6 +14,8 @@ from demisto_sdk.commands.common.hook_validations.structure import \
 from demisto_sdk.commands.common.legacy_git_tools import git_path
 from mock import mock_open, patch
 
+FEED_REQUIRED_PARAMS_STRUCTURE = [dict(required_param.get('must_equal'), **required_param.get('must_contain'),
+                                       name=required_param.get('name')) for required_param in FEED_REQUIRED_PARAMS]
 
 def mock_structure(file_path=None, current_file=None, old_file=None):
     # type: (Optional[str], Optional[dict], Optional[dict]) -> StructureValidator
@@ -496,7 +498,7 @@ class TestIntegrationValidator:
         (INVALID_DISPLAY_NON_HIDDEN, False),
         (VALID_NO_DISPLAY_TYPE_EXPIRATION, True),
         (INVALID_DISPLAY_TYPE_EXPIRATION, False),
-        (FEED_REQUIRED_PARAMS, True),
+        (FEED_REQUIRED_PARAMS_STRUCTURE, True),
     ]
 
     @pytest.mark.parametrize("configuration_setting, answer", IS_VALID_DISPLAY_INPUTS)
@@ -523,7 +525,7 @@ class TestIntegrationValidator:
         current = {
             "script": {"feed": feed},
             "fromversion": fromversion,
-            'configuration': deepcopy(FEED_REQUIRED_PARAMS)
+            'configuration': FEED_REQUIRED_PARAMS_STRUCTURE
         }
         structure = mock_structure("", current)
         validator = IntegrationValidator(structure)
@@ -802,8 +804,7 @@ class TestIsFeedParamsExist:
 
     def setup(self):
         config = {
-            'configuration': [dict(required_param.get('must_equal'), **required_param.get('must_contain'),
-                                   name=required_param.get('name')) for required_param in FEED_REQUIRED_PARAMS],
+            'configuration': FEED_REQUIRED_PARAMS_STRUCTURE,
             'script': {'feed': True}
         }
         self.validator = IntegrationValidator(mock_structure("", config))

--- a/demisto_sdk/commands/common/tests/integration_test.py
+++ b/demisto_sdk/commands/common/tests/integration_test.py
@@ -844,6 +844,24 @@ class TestIsFeedParamsExist:
         assert self.validator.all_feed_params_exist() is True, \
             'all_feed_params_exist() returns False instead True for feedReputation param'
 
+    def test_additional_info_contained(self):
+        """
+        Given:
+        - Parameters of feed integration.
+
+        When:
+        - Integration has all feed required params, and additionalinfo containing the expected additionalinfo parameter.
+
+        Then:
+        - Ensure that all_feed_params_exists() returns true.
+        """
+        configuration = self.validator.current_file['configuration']
+        for item in configuration:
+            if item.get('additionalinfo'):
+                item['additionalinfo'] = f'''{item['additionalinfo']}.'''
+        assert self.validator.all_feed_params_exist() is True, \
+            'all_feed_params_exist() returns False instead True'
+
     NO_HIDDEN = {"configuration": [{"id": "new", "name": "new", "display": "test"}, {"d": "123", "n": "s", "r": True}]}
     HIDDEN_FALSE = {"configuration": [{"id": "n", "hidden": False}, {"display": "123", "name": "serer"}]}
     HIDDEN_TRUE = {"configuration": [{"id": "n", "n": "n"}, {"display": "123", "required": "false", "hidden": True}]}


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://github.com/demisto/etc/issues/34765

## Description
Changing integration validation for additionalinfo in parameter, changing its condition from equals to contained.
This is needed because some integrations do require to add more additionalinfo in their parameter, and currently
are enforced to stick to the current additionalinfo structure exactly instead of containing it

## Must have
- [x] Tests
- [ ] Documentation
