### PR TITLE
splitting dependencies for layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 * Updated the **demisto-sdk validate** command to check that the 'additionalinfo' field only contains the expected value for feed required parameters and not equal to it.
+* Updated the dependencies detection for layout and layoutcontainer in the **find-dependencies** command.
 
 # 1.3.3
 * Fixed an issue where **lint** failed where *.Dockerfile* exists prior running the lint command.

--- a/demisto_sdk/commands/find_dependencies/find_dependencies.py
+++ b/demisto_sdk/commands/find_dependencies/find_dependencies.py
@@ -4,7 +4,7 @@ import os
 import sys
 from copy import deepcopy
 from distutils.version import LooseVersion
-from typing import Union
+from typing import Optional, Union
 
 import click
 import networkx as nx
@@ -192,7 +192,7 @@ class PackDependencies:
     def _search_packs_by_items_names_or_ids(items_names: Union[str, list],
                                             items_list: list,
                                             exclude_ignored_dependencies: bool = True,
-                                            incident_or_indicator=None) -> set:
+                                            incident_or_indicator: Optional[str] = None) -> set:
         """
         Searches for implemented packs of the given items.
 
@@ -200,7 +200,8 @@ class PackDependencies:
             items_names (str or list): items names to search.
             items_list (list): specific section of id set.
             exclude_ignored_dependencies (bool): Determines whether to include unsupported dependencies or not.
-
+            incident_or_indicator (str): 'indicator' if should focus on indicator fields,
+                 'incident' if should focus on incident fields and None to focus on both.
         Returns:
             set: found pack ids.
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/35366

## Description
Splitting the dependencies detection for incident and indicator layouts.


