### PR TITLE
Fix content Python 3.9 support for Enum extension

### DIFF
--- a/demisto_sdk/commands/common/constants.py
+++ b/demisto_sdk/commands/common/constants.py
@@ -81,6 +81,10 @@ class FileType(Enum):
     PYTHON_FILE = 'pythonfile'
     JAVASCRIPT_FILE = 'javascriptfile'
     POWERSHELL_FILE = 'powershellfile'
+    CONF_JSON = 'confjson'
+    METADATA = 'metadata'
+    WHITE_LIST = 'whitelist'
+    LANDING_PAGE_SECTIONS_JSON = 'landingPage_sections.json'
 
 
 RN_HEADER_BY_FILE_TYPE = {


### PR DESCRIPTION
Fix content Python 3.9 support for Enum extension in order to support python 3.9

## Related PRs:
https://github.com/demisto/content/pull/12271