### PR TITLE
fix identify unified integration when running create-id-set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 * Fixed an issue where in some cases the `get_remote_file` function failed due to an invalid path.
+* Fixed an issue where running **create-id-set** and there are an integration yml with an empty value in the script field, it's identify it as a unified integration.
 
 # 1.3.5
 * Added a validation that layoutscontainer's id and name are matching. Updated the format of layoutcontainer to include update_id too.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 * Fixed an issue where in some cases the `get_remote_file` function failed due to an invalid path.
-* Fixed an issue where running **create-id-set** and there are an integration yml with an empty value in the script field, it's identify it as a unified integration.
+* Fixed an issue where the **create-id-set** command did not identify unified integrations correctly.
 
 # 1.3.5
 * Added a validation that layoutscontainer's id and name are matching. Updated the format of layoutcontainer to include update_id too.

--- a/demisto_sdk/commands/common/tests/dependencies_test.py
+++ b/demisto_sdk/commands/common/tests/dependencies_test.py
@@ -1038,7 +1038,8 @@ def test_dependencies_case_1(mocker, repo):
     pack_common_types = repo.create_pack('CommonTypes')
 
     playbook_foo = pack_foo.create_playbook('playbook_foo')
-    integration_foo = pack_foo.create_integration('integration_foo', yml={'name': '=integration_foo'})
+    integration_foo = pack_foo.create_integration('integration_foo', yml={'name': '=integration_foo', 'category': '',
+                                                                          'script': {'type': 'python'}})
     script_bar = pack_bar.create_script('script_bar', yml={'script': '', 'type': 'python', 'name': 'script_bar'})
     incident_field_email = pack_common_types.create_incident_field(name='incident_Email',
                                                                    content={'id': 'incident_Email',
@@ -1096,14 +1097,16 @@ def test_dependencies_case_2(mocker, repo):
     pack_bar = repo.create_pack('bar')
     pack_common_types = repo.create_pack('CommonTypes')
 
-    integration_foo = pack_foo.create_integration('integration_foo', yml={'name': 'integration_foo', 'category': ''})
+    integration_foo = pack_foo.create_integration('integration_foo', yml={'name': 'integration_foo', 'category': '',
+                                                                          'script': {'type': 'python'}})
     mapper_in_bar = pack_bar.create_mapper(name='mapper_in_bar', content={'id': 'mapper_in_bar',
                                                                           'name': 'mapper_in_bar',
                                                                           'mapping': {},
                                                                           'type': 'mapping'})
     # Pack can not be empty
     pack_common_types.create_integration('integration_common_types',
-                                         yml={'name': 'integration_common_types', 'category': ''})
+                                         yml={'name': 'integration_common_types', 'category': '',
+                                              'script': {'type': 'python'}})
 
     # make integration_foo feed
     IntegrationDependencies.make_integration_feed(

--- a/demisto_sdk/commands/common/update_id_set.py
+++ b/demisto_sdk/commands/common/update_id_set.py
@@ -194,7 +194,7 @@ def get_integration_data(file_path):
     integration_data = OrderedDict()
     data_dictionary = get_yaml(file_path)
 
-    is_unified_integration = data_dictionary.get('script', {}).get('script', '') != '-'
+    is_unified_integration = data_dictionary.get('script', {}).get('script', '') not in ['-', '']
 
     id_ = data_dictionary.get('commonfields', {}).get('id', '-')
     name = data_dictionary.get('name', '-')

--- a/demisto_sdk/commands/create_id_set/tests/update_id_set_test.py
+++ b/demisto_sdk/commands/create_id_set/tests/update_id_set_test.py
@@ -107,12 +107,13 @@ class TestIDSetCreator:
         packs = repo.packs
 
         pack_to_create_id_set_on = repo.create_pack('pack_to_create_id_set_on')
-        pack_to_create_id_set_on.create_integration(yml={'commonfields': {'id': 'id1'}, 'name':
-                                                         'integration to create id set'}, name='integration1')
+        pack_to_create_id_set_on.create_integration(yml={'commonfields': {'id': 'id1'}, 'category': '', 'name':
+                                                         'integration to create id set', 'script': {'type': 'python'}},
+                                                    name='integration1')
         packs.append(pack_to_create_id_set_on)
 
         pack_to_not_create_id_set_on = repo.create_pack('pack_to_not_create_id_set_on')
-        pack_to_not_create_id_set_on.create_integration(yml={'commonfields': {'id2': 'id'}, 'name':
+        pack_to_not_create_id_set_on.create_integration(yml={'commonfields': {'id2': 'id'}, 'category': '', 'name':
                                                              'integration to not create id set'}, name='integration2')
         packs.append(pack_to_not_create_id_set_on)
 

--- a/demisto_sdk/commands/create_id_set/tests/update_id_set_test.py
+++ b/demisto_sdk/commands/create_id_set/tests/update_id_set_test.py
@@ -108,7 +108,8 @@ class TestIDSetCreator:
 
         pack_to_create_id_set_on = repo.create_pack('pack_to_create_id_set_on')
         pack_to_create_id_set_on.create_integration(yml={'commonfields': {'id': 'id1'}, 'name':
-                                                         'integration to create id set'}, name='integration1')
+                                                         'integration to create id set',
+                                                         'script': {'script': 'not empty'}}, name='integration1')
         packs.append(pack_to_create_id_set_on)
 
         pack_to_not_create_id_set_on = repo.create_pack('pack_to_not_create_id_set_on')

--- a/demisto_sdk/commands/create_id_set/tests/update_id_set_test.py
+++ b/demisto_sdk/commands/create_id_set/tests/update_id_set_test.py
@@ -108,8 +108,7 @@ class TestIDSetCreator:
 
         pack_to_create_id_set_on = repo.create_pack('pack_to_create_id_set_on')
         pack_to_create_id_set_on.create_integration(yml={'commonfields': {'id': 'id1'}, 'name':
-                                                         'integration to create id set',
-                                                         'script': {'script': 'not empty'}}, name='integration1')
+                                                         'integration to create id set'}, name='integration1')
         packs.append(pack_to_create_id_set_on)
 
         pack_to_not_create_id_set_on = repo.create_pack('pack_to_not_create_id_set_on')


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/36166

## Description
fixed identify unified integration when running create-id-set

## Must have
- [ ] Tests
- [ ] Documentation
