### PR TITLE
Supporting gitlab-ci build

### DIFF
--- a/demisto_sdk/commands/common/constants.py
+++ b/demisto_sdk/commands/common/constants.py
@@ -774,7 +774,7 @@ CONTENT_GITHUB_ORIGIN = r'origin.*demisto/content'
 
 # Run all test signal
 RUN_ALL_TESTS_FORMAT = 'Run all tests'
-FILTER_CONF = './Tests/filter_file.txt'
+FILTER_CONF = './artifacts/filter_file.txt'
 
 
 class PB_Status:

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/pack_metadata/pack_metadata_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/pack_metadata/pack_metadata_test.py
@@ -302,7 +302,7 @@ def test_load_user_metadata_no_metadata_file(repo, capsys):
     pack_1_metadata.load_user_metadata('Pack1', 'Pack Number 1', pack_1.path, logging_setup(3))
 
     captured = capsys.readouterr()
-    assert 'Pack Number 1 pack is missing pack_metadata.json file.' in captured.err
+    assert 'Pack Number 1 pack is missing pack_metadata.json file.' in captured.out
 
 
 def test_load_user_metadata_invalid_price(repo, capsys):
@@ -338,7 +338,7 @@ def test_load_user_metadata_invalid_price(repo, capsys):
     pack_1_metadata.load_user_metadata('Pack1', 'Pack Number 1', pack_1.path, logging_setup(3))
     captured = capsys.readouterr()
 
-    assert 'Pack Number 1 pack price is not valid. The price was set to 0.' in captured.err
+    assert 'Pack Number 1 pack price is not valid. The price was set to 0.' in captured.out
 
 
 def test_load_user_metadata_bad_pack_metadata_file(repo, capsys):
@@ -365,4 +365,4 @@ def test_load_user_metadata_bad_pack_metadata_file(repo, capsys):
     pack_1_metadata.load_user_metadata('Pack1', 'Pack Number 1', pack_1.path, logging_setup(3))
 
     captured = capsys.readouterr()
-    assert 'Failed loading Pack Number 1 user metadata.' in captured.err
+    assert 'Failed loading Pack Number 1 user metadata.' in captured.out

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/pack_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/pack_test.py
@@ -106,9 +106,8 @@ def test_sign_pack_exception_thrown(repo, capsys, mocker):
     signer_path = Path('./signer')
 
     content_object_pack.sign_pack(pack_class.logger, content_object_pack.path, signer_path)
-
     captured = capsys.readouterr()
-    assert 'Error while trying to sign pack Pack1' in captured.err
+    assert 'Error while trying to sign pack Pack1' in captured.out
 
 
 def test_sign_pack_error_from_subprocess(repo, capsys, fake_process):
@@ -140,7 +139,7 @@ def test_sign_pack_error_from_subprocess(repo, capsys, fake_process):
     content_object_pack.sign_pack(pack_class.logger, content_object_pack.path, signer_path)
 
     captured = capsys.readouterr()
-    assert 'Failed to sign pack for Pack1 -' in captured.err
+    assert 'Failed to sign pack for Pack1 -' in captured.out
 
 
 def test_sign_pack_success(repo, capsys, fake_process):
@@ -171,4 +170,4 @@ def test_sign_pack_success(repo, capsys, fake_process):
     content_object_pack.sign_pack(pack_class.logger, content_object_pack.path, signer_path)
 
     captured = capsys.readouterr()
-    assert f'Signed {content_object_pack.path.name} pack successfully' in captured.err
+    assert f'Signed {content_object_pack.path.name} pack successfully' in captured.out

--- a/demisto_sdk/commands/common/logger.py
+++ b/demisto_sdk/commands/common/logger.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 from typing import Optional
 
 
@@ -35,7 +36,7 @@ def logging_setup(verbose: int, quiet: Optional[bool] = False,
                 file_handler_index = i
 
     if verbose:
-        console_handler = logging.StreamHandler()
+        console_handler = logging.StreamHandler(sys.stdout)
         console_handler.name = 'console-handler'
         console_handler.setFormatter(fmt)
         console_handler.setLevel(log_level)

--- a/demisto_sdk/commands/create_artifacts/tests/content_artifacts_creator_test.py
+++ b/demisto_sdk/commands/create_artifacts/tests/content_artifacts_creator_test.py
@@ -278,4 +278,4 @@ def test_sign_packs_failure(repo, capsys, key, tool):
 
     captured = capsys.readouterr()
     assert 'Failed to sign packs. In order to do so, you need to provide both signature_key and ' \
-           'sign_directory arguments.' in captured.err
+           'sign_directory arguments.' in captured.out

--- a/demisto_sdk/commands/test_content/IntegrationsLock.py
+++ b/demisto_sdk/commands/test_content/IntegrationsLock.py
@@ -10,9 +10,10 @@ from google.cloud import storage
 
 LOCKS_PATH = 'content-locks'
 BUCKET_NAME = os.environ.get('GCS_ARTIFACTS_BUCKET')
-CIRCLE_BUILD_NUM = os.environ.get('CIRCLE_BUILD_NUM')
-WORKFLOW_ID = os.environ.get('CIRCLE_WORKFLOW_ID')
+BUILD_NUM = os.environ.get('CI_BUILD_ID')
+WORKFLOW_ID = os.environ.get('CI_PIPELINE_ID')
 CIRCLE_STATUS_TOKEN = os.environ.get('CIRCLECI_STATUS_TOKEN')
+GITLAB_STATUS_TOKEN = os.environ.get('GITLAB_STATUS_TOKEN')
 
 
 @contextmanager
@@ -98,14 +99,28 @@ def workflow_still_running(workflow_id: str, test_playbook) -> bool:
         return True
     else:
         try:
+            test_playbook.build_context.logging_module.debug(
+                f'Getting status for circle workflow with id: {workflow_id}')
             workflow_details_response = requests.get(f'https://circleci.com/api/v2/workflow/{workflow_id}',
                                                      headers={'Accept': 'application/json'},
                                                      auth=(CIRCLE_STATUS_TOKEN, ''))
             workflow_details_response.raise_for_status()
         except Exception:
             test_playbook.build_context.logging_module.exception(
-                f'Failed to get circleci response about workflow with id {workflow_id}.')
-            return True
+                f'Failed to get circleci response about workflow with id {workflow_id}. will try again with gitlab CI')
+            try:
+                test_playbook.build_context.logging_module.debug(
+                    f'Getting status for gitlab pipeline with id: {workflow_id}')
+                api_v4_url = os.environ.get('CI_API_V4_URL')
+                ci_project_id = os.environ.get('CI_PROJECT_ID')
+                workflow_details_response = requests.get(
+                    f'{api_v4_url}/projects/{ci_project_id}/pipelines/{workflow_id}',
+                    headers={'PRIVATE-TOKEN': GITLAB_STATUS_TOKEN})
+                workflow_details_response.raise_for_status()
+            except Exception:
+                test_playbook.build_context.logging_module.exception(
+                    f'Failed to get gitlab-ci response about pipeline with id {workflow_id}.')
+                return True
         return workflow_details_response.json().get('status') not in ('canceled', 'success', 'failed')
 
 
@@ -170,7 +185,7 @@ def create_lock_files(integrations_generation_number: dict,
     for integration, generation_number in integrations_generation_number.items():
         blob = bucket.blob(f'{LOCKS_PATH}/{integration}')
         try:
-            blob.upload_from_string(f'{WORKFLOW_ID}:{CIRCLE_BUILD_NUM}:{test_playbook.configuration.timeout + 30}',
+            blob.upload_from_string(f'{WORKFLOW_ID}:{BUILD_NUM}:{test_playbook.configuration.timeout + 30}',
                                     if_generation_match=generation_number)
             test_playbook.build_context.logging_module.debug(f'integration {integration} locked')
             locked_integrations.append(integration)
@@ -202,7 +217,7 @@ def unlock_integrations(integrations_to_unlock: list,
         try:
             # Verifying build number is the same as current build number to avoid deleting other tests lock files
             _, build_number, _ = lock_file.download_as_string().decode().split(':')
-            if build_number == CIRCLE_BUILD_NUM:
+            if build_number == BUILD_NUM:
                 lock_file.delete(if_generation_match=lock_file.generation)
                 test_playbook.build_context.logging_module.debug(
                     f'Integration {integration} unlocked')

--- a/demisto_sdk/commands/test_content/ParallelLoggingManager.py
+++ b/demisto_sdk/commands/test_content/ParallelLoggingManager.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Set
 
 import coloredlogs
 
-ARTIFACTS_PATH = os.environ.get('CIRCLE_ARTIFACTS', '.')
+ARTIFACTS_PATH = os.environ.get('ARTIFACTS_FOLDER', '.')
 LOGGING_FORMAT = '[%(asctime)s] - [%(threadName)s] - [%(levelname)s] - %(message)s'
 LEVEL_STYLES = {
     'critical': {'bold': True, 'color': 'red'},

--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -34,7 +34,7 @@ from demisto_sdk.commands.test_content.tools import (
     is_redhat_instance, update_server_configuration)
 from slack import WebClient as SlackClient
 
-ENV_RESULTS_PATH = './env_results.json'
+ENV_RESULTS_PATH = './artifacts/env_results.json'
 FAILED_MATCH_INSTANCE_MSG = "{} Failed to run.\n There are {} instances of {}, please select one of them by using " \
                             "the instance_name argument in conf.json. The options are:\n{}"
 ENTRY_TYPE_ERROR = 4
@@ -496,7 +496,7 @@ class BuildContext:
     @staticmethod
     def _extract_filtered_tests() -> list:
         """
-        Reads the content from ./Tests/filter_file.txt and parses it into a list of test playbook IDs that should be run
+        Reads the content from ./artifacts/filter_file.txt and parses it into a list of test playbook IDs that should be run
         in the current build
         Returns:
             A list of playbook IDs that should be run in the current build
@@ -673,7 +673,10 @@ class BuildContext:
         """
         Gets the user id of the circle user who triggered the current build
         """
-        circle_user_name = self._get_user_name_from_circle()
+        if os.environ.get('GITLAB_USER_LOGIN'):
+            user_name = os.environ['GITLAB_USER_LOGIN']
+        else:
+            user_name = self._get_user_name_from_circle()
         user_id = ''
         res = self.slack_client.api_call('users.list')
 
@@ -681,7 +684,7 @@ class BuildContext:
         for user in user_list:
             profile = user.get('profile', {})
             name = profile.get('real_name_normalized', '')
-            if name == circle_user_name:
+            if name == user_name:
                 user_id = user.get('id', '')
 
         return user_id

--- a/demisto_sdk/commands/test_content/execute_test_content.py
+++ b/demisto_sdk/commands/test_content/execute_test_content.py
@@ -21,8 +21,8 @@ def _handle_github_response(response, logging_module) -> dict:
 
 def _add_pr_comment(comment, logging_module):
     token = os.environ['CONTENT_GITHUB_TOKEN']
-    branch_name = os.environ['CIRCLE_BRANCH']
-    sha1 = os.environ['CIRCLE_SHA1']
+    branch_name = os.environ['CI_COMMIT_BRANCH']
+    sha1 = os.environ['CI_COMMIT_SHA']
 
     query = '?q={}+repo:demisto/content+org:demisto+is:pr+is:open+head:{}+is:open'.format(sha1, branch_name)
     url = 'https://api.github.com/search/issues'


### PR DESCRIPTION
## Description:
Supporting gitlab and circle build infra:
- Replacing circle env variables with gitlab env variable.
- Moving files that should be used by multiple jobs in the same pipeline to artifacts.
- Adding mechanism for querying gitlab pipelines as well as circle workflows in the locking mechanism. 
- Using gitlab env variable for slack messages in case the build is in gitlab ci.

## Related issue:
-  https://github.com/demisto/etc/issues/35417
-  https://github.com/demisto/etc/issues/35418

## Related PRs:
- https://github.com/demisto/content/pull/12203
- https://github.com/demisto/content-private/pull/344