### PR TITLE
Added a configuration decorator

### DIFF
--- a/demisto_sdk/commands/common/constants.py
+++ b/demisto_sdk/commands/common/constants.py
@@ -2,6 +2,7 @@ import os
 import re
 from enum import Enum
 from functools import reduce
+from pathlib import Path
 from typing import Iterable, List, Optional
 
 import click
@@ -813,11 +814,15 @@ class GithubContentConfig:
     CURRENT_REPOSITORY: str
     CONTENT_GITHUB_LINK: str
     CONTENT_GITHUB_MASTER_LINK: str
+    REPOSITORY_LOCAL_ROOT_PATH: Optional[Path]
 
     def __init__(self, repo_name: Optional[str] = None):
+        self.REPOSITORY_LOCAL_ROOT_PATH = None
         if not repo_name:
             try:
-                urls = list(GitUtil().repo.remote().urls)
+                git_util = GitUtil()
+                urls = list(git_util.repo.remote().urls)
+                self.REPOSITORY_LOCAL_ROOT_PATH = git_util.repo.git.rev_parse('--show-toplevel')
                 self.CURRENT_REPOSITORY = self._get_repository_name(urls)
             except (InvalidGitRepositoryError, AttributeError):  # No repository
                 self.CURRENT_REPOSITORY = self.OFFICIAL_CONTENT_REPO_NAME

--- a/demisto_sdk/tests/conf_file_test.py
+++ b/demisto_sdk/tests/conf_file_test.py
@@ -1,3 +1,5 @@
+import os
+
 from click.testing import CliRunner
 from demisto_sdk.__main__ import main
 from demisto_sdk.commands.common import tools
@@ -29,10 +31,11 @@ def test_conf_file_custom(mocker, repo):
         assert '================= Validating file =================' in res.stdout
         assert 'DO106' in res.stdout
 
-    repo.make_file('.demisto-sdk-conf', '[validate]\nno_docker_checks=True')
+    repo.make_file('.demisto-sdk-conf', '[validate]\nno-docker-checks=True')
     with ChangeCWD(pack.repo_path):
         runner = CliRunner(mix_stderr=False)
         # post-conf file - see validate not fail on docker related issue as we are skipping
-        res = runner.invoke(main, f"validate -i {integration.yml.path}")
+        res = runner.invoke(main,
+                            f"validate -i {integration.yml.path} --config {os.path.join(repo.path, '.demisto-sdk-conf')}")
         assert '================= Validating file =================' in res.stdout
         assert 'DO106' not in res.stdout

--- a/tox.ini
+++ b/tox.ini
@@ -5,4 +5,6 @@ envlist = py37,py38
 passenv = *
 deps = -r {toxinidir}/requirements.txt
        -r {toxinidir}/requirements-dev.txt
+       git+https://github.com/jochman/click_config_file.git@f794aabc68dc1e01752837a8eab0fd053a23c234
+
 commands = pytest -p no:warnings -v {posargs}


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Description
A decorator to use the configuration with demisto-sdk

new:
You can use now type hints with the decorator itself as demonstrated in the `split-yml` command.
Use the `demisto-sdk configuration_file_path` to check where you should put your configuration in any given situation.
If running in a git repo - it'll use its root.
else it'll use the default path of `click.get_app_dir()`

Use just like the current usage:
put the `.demisto-sdk-conf` in the root of your git repository.
whenever you'll use any command with a configuration file - it'll automatically take it.

Example:
Use the configuration file:
```ini
[ split-yml ]
no_demisto_mock=True
no_common_server=True
no_auto_create_dir=True
no_pipenv=True
```
And run with `demisto-sdk split-yml -i Packs/ThreatExchange/Integrations/integration-ThreatExchange.yml -o .` 
and you'll see it works and non of Pipfile, CommonServerPython, demistomock were created.