### PR TITLE
Fixed issue when validate failed on invalid display and valid display password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 * Added a validation to ensure correct image and description file names.
+* Fixed an issue where **validate** failed when 'display' field in credentials param in yml is empty but 'displaypassword' was provided.
 
 # 1.3.6
 * Added a validation that core packs are not dependent on non-core packs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 * Added a validation to ensure correct image and description file names.
-* Fixed an issue where **validate** failed when 'display' field in credentials param in yml is empty but 'displaypassword' was provided.
+* Fixed an issue where the **validate** command failed when 'display' field in credentials param in yml is empty but 'displaypassword' was provided.
 
 # 1.3.6
 * Added a validation that core packs are not dependent on non-core packs.

--- a/demisto_sdk/commands/common/hook_validations/integration.py
+++ b/demisto_sdk/commands/common/hook_validations/integration.py
@@ -770,10 +770,8 @@ class IntegrationValidator(ContentEntityValidator):
                         self.is_valid = False
                         return True
 
-            elif not is_field_hidden and not configuration_display \
+            elif not is_field_hidden and not configuration_display and not configuration_param.get('displaypassword') \
                     and configuration_param['name'] not in ('feedExpirationPolicy', 'feedExpirationInterval'):
-                if configuration_param.get('displaypassword'):
-                    continue
                 error_message, error_code = Errors.empty_display_configuration(configuration_param['name'])
                 if self.handle_error(error_message, error_code, file_path=self.file_path):
                     self.is_valid = False

--- a/demisto_sdk/commands/common/hook_validations/integration.py
+++ b/demisto_sdk/commands/common/hook_validations/integration.py
@@ -772,6 +772,8 @@ class IntegrationValidator(ContentEntityValidator):
 
             elif not is_field_hidden and not configuration_display \
                     and configuration_param['name'] not in ('feedExpirationPolicy', 'feedExpirationInterval'):
+                if configuration_param.get('displaypassword'):
+                    continue
                 error_message, error_code = Errors.empty_display_configuration(configuration_param['name'])
                 if self.handle_error(error_message, error_code, file_path=self.file_path):
                     self.is_valid = False

--- a/demisto_sdk/commands/common/tests/integration_test.py
+++ b/demisto_sdk/commands/common/tests/integration_test.py
@@ -513,14 +513,18 @@ class TestIntegrationValidator:
         {"name": "unsecure", "type": 17, "required": False, "hidden": False}]
     INVALID_DISPLAY_TYPE_EXPIRATION = [
         {"name": "unsecure", "type": 17, "display": "some display", "required": False, "hidden": False}]
+    INVALID_DISPLAY_BUT_VALID_DISPLAYPASSWORD = [
+        {"name": "credentials", "type": 9, "display": "", "displaypassword": "some display password", "required": True,
+         "hiddenusername": True}]
     IS_VALID_DISPLAY_INPUTS = [
         (VALID_DISPLAY_NON_HIDDEN, True),
         (VALID_DISPLAY_HIDDEN, True),
         (INVALID_DISPLAY_NON_HIDDEN, False),
-        (INVALID_DISPLAY_NON_HIDDEN, False),
+        (INVALID_NO_DISPLAY_NON_HIDDEN, False),
         (VALID_NO_DISPLAY_TYPE_EXPIRATION, True),
         (INVALID_DISPLAY_TYPE_EXPIRATION, False),
         (FEED_REQUIRED_PARAMS_STRUCTURE, True),
+        (INVALID_DISPLAY_BUT_VALID_DISPLAYPASSWORD, True)
     ]
 
     @pytest.mark.parametrize("configuration_setting, answer", IS_VALID_DISPLAY_INPUTS)


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/36846

## Description
Fixed an issue where **validate** failed when the 'display' field is empty but 'displaypassword' was provided.

## Must have
- [ ] Tests
- [ ] Documentation
