### PR TITLE
Validating pack readme vs description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 * Updated the **secrets** command to work on forked branches.
+* Added a validation verifying that the pack's README.md file is not equal to pack description.
 
 # 1.3.7
 * Added a validation to ensure correct image and description file names.

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -1292,7 +1292,7 @@ class Errors:
     @error_code_decorator
     def readme_equal_description_error():
         return 'README.md content is equal to pack description. ' \
-               'Please remove the duplicate description from README.md file'
+               'Please remove the duplicate description from README.md file.'
 
     @staticmethod
     @error_code_decorator

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -206,6 +206,7 @@ ERROR_CODE = {
     "readme_missing_output_context": {'code': "RM102", 'ui_applicable': False, 'related_field': ''},
     "error_starting_mdx_server": {'code': "RM103", 'ui_applicable': False, 'related_field': ''},
     "empty_readme_error": {'code': "RM104", 'ui_applicable': False, 'related_field': ''},
+    "readme_equal_description_error": {'code': "RM105", 'ui_applicable': False, 'related_field': ''},
 
     "wrong_version_reputations": {'code': "RP100", 'ui_applicable': False, 'related_field': 'version'},
     "reputation_expiration_should_be_numeric": {'code': "RP101", 'ui_applicable': True, 'related_field': 'expiration'},
@@ -1286,6 +1287,12 @@ class Errors:
     @error_code_decorator
     def empty_readme_error():
         return 'README.md is empty'
+
+    @staticmethod
+    @error_code_decorator
+    def readme_equal_description_error():
+        return 'README.md content is equal to pack description. ' \
+               'Please remove the duplicate description from README.md file'
 
     @staticmethod
     @error_code_decorator

--- a/demisto_sdk/commands/common/hook_validations/pack_unique_files.py
+++ b/demisto_sdk/commands/common/hook_validations/pack_unique_files.py
@@ -11,8 +11,6 @@ from pathlib import Path
 
 import click
 from dateutil import parser
-from git import GitCommandError, Repo
-
 from demisto_sdk.commands.common import tools
 from demisto_sdk.commands.common.constants import (  # PACK_METADATA_PRICE,
     API_MODULES_PACK, PACK_METADATA_CATEGORIES, PACK_METADATA_CERTIFICATION,
@@ -30,6 +28,7 @@ from demisto_sdk.commands.common.tools import (get_core_pack_list, get_json,
                                                pack_name_to_path)
 from demisto_sdk.commands.find_dependencies.find_dependencies import \
     PackDependencies
+from git import GitCommandError, Repo
 
 CONTRIBUTORS_LIST = ['partner', 'developer', 'community']
 SUPPORTED_CONTRIBUTORS_LIST = ['partner', 'developer']
@@ -188,9 +187,10 @@ class PackUniqueFilesValidator(BaseValidator):
         """
         pack_meta_file_content = self._read_file_content(self.pack_meta_file)
         metadata = json.loads(pack_meta_file_content)
-        metadata_description = metadata.get(PACK_METADATA_DESC, '').lower()
+        metadata_description = metadata.get(PACK_METADATA_DESC, '').lower().strip()
         if not self._check_if_file_is_empty(self.readme_file):
-            readme_content = self._read_file_content(self.readme_file).lower()
+            readme = self._read_file_content(self.readme_file)
+            readme_content = readme.lower().strip()
             if metadata_description == readme_content:
                 self._add_error(Errors.readme_equal_description_error(), self.readme_file)
                 return False

--- a/demisto_sdk/commands/common/hook_validations/pack_unique_files.py
+++ b/demisto_sdk/commands/common/hook_validations/pack_unique_files.py
@@ -180,6 +180,22 @@ class PackUniqueFilesValidator(BaseValidator):
 
         return True
 
+    def validate_pack_readme_and_pack_description(self):
+        """
+        Validates that README.md file is not the same as the pack description.
+        Returns False if the pack readme is different than the pack description.
+        """
+        pack_meta_file_content = self._read_file_content(self.pack_meta_file)
+        metadata = json.loads(pack_meta_file_content)
+        metadata_description = metadata.get(PACK_METADATA_DESC, '').lower()
+        if not self._check_if_file_is_empty(self.readme_file):
+            readme_content = self._read_file_content(self.readme_file).lower()
+            if metadata_description == readme_content:
+                self._add_error(Errors.readme_equal_description_error(), self.readme_file)
+                return False
+
+        return True
+
     def _is_secrets_file_structure_valid(self):
         """Check if .secrets-ignore structure is parse-able"""
         if self._parse_file_into_list(self.secrets_file):
@@ -491,6 +507,7 @@ class PackUniqueFilesValidator(BaseValidator):
             self.validate_pack_meta_file()
 
         self.validate_pack_readme_file_is_not_empty()
+        self.validate_pack_readme_and_pack_description()
 
         # We only check pack dependencies for -g flag
         if self.validate_dependencies:

--- a/demisto_sdk/commands/common/hook_validations/pack_unique_files.py
+++ b/demisto_sdk/commands/common/hook_validations/pack_unique_files.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 import click
 from dateutil import parser
+from git import GitCommandError, Repo
+
 from demisto_sdk.commands.common import tools
 from demisto_sdk.commands.common.constants import (  # PACK_METADATA_PRICE,
     API_MODULES_PACK, PACK_METADATA_CATEGORIES, PACK_METADATA_CERTIFICATION,
@@ -28,7 +30,6 @@ from demisto_sdk.commands.common.tools import (get_core_pack_list, get_json,
                                                pack_name_to_path)
 from demisto_sdk.commands.find_dependencies.find_dependencies import \
     PackDependencies
-from git import GitCommandError, Repo
 
 CONTRIBUTORS_LIST = ['partner', 'developer', 'community']
 SUPPORTED_CONTRIBUTORS_LIST = ['partner', 'developer']

--- a/demisto_sdk/commands/common/tests/pack_unique_files_test.py
+++ b/demisto_sdk/commands/common/tests/pack_unique_files_test.py
@@ -498,4 +498,3 @@ class TestPackUniqueFilesValidator:
         if not is_valid:
             assert 'README.md content is equal to pack description. ' \
                    'Please remove the duplicate description from README.md file' in self.validator.get_errors()
-

--- a/demisto_sdk/commands/common/tests/pack_unique_files_test.py
+++ b/demisto_sdk/commands/common/tests/pack_unique_files_test.py
@@ -3,20 +3,22 @@ import os
 
 import pytest
 from click.testing import CliRunner
+from git import GitCommandError
+
 from demisto_sdk.__main__ import main
 from demisto_sdk.commands.common import tools
-from demisto_sdk.commands.common.constants import (PACK_METADATA_SUPPORT,
+from demisto_sdk.commands.common.constants import (PACK_METADATA_DESC,
+                                                   PACK_METADATA_SUPPORT,
                                                    PACK_METADATA_TAGS,
                                                    PACK_METADATA_USE_CASES,
                                                    PACKS_README_FILE_NAME,
-                                                   XSOAR_SUPPORT, PACK_METADATA_DESC)
+                                                   XSOAR_SUPPORT)
 from demisto_sdk.commands.common.errors import Errors
 from demisto_sdk.commands.common.hook_validations.base_validator import \
     BaseValidator
 from demisto_sdk.commands.common.hook_validations.pack_unique_files import \
     PackUniqueFilesValidator
 from demisto_sdk.commands.common.legacy_git_tools import git_path
-from git import GitCommandError
 from TestSuite.test_tools import ChangeCWD
 
 VALIDATE_CMD = "validate"

--- a/demisto_sdk/commands/common/tests/pack_unique_files_test.py
+++ b/demisto_sdk/commands/common/tests/pack_unique_files_test.py
@@ -3,8 +3,6 @@ import os
 
 import pytest
 from click.testing import CliRunner
-from git import GitCommandError
-
 from demisto_sdk.__main__ import main
 from demisto_sdk.commands.common import tools
 from demisto_sdk.commands.common.constants import (PACK_METADATA_DESC,
@@ -19,6 +17,7 @@ from demisto_sdk.commands.common.hook_validations.base_validator import \
 from demisto_sdk.commands.common.hook_validations.pack_unique_files import \
     PackUniqueFilesValidator
 from demisto_sdk.commands.common.legacy_git_tools import git_path
+from git import GitCommandError
 from TestSuite.test_tools import ChangeCWD
 
 VALIDATE_CMD = "validate"
@@ -78,12 +77,14 @@ class TestPackUniqueFilesValidator:
 
     def test_validate_pack_unique_files(self, mocker):
         mocker.patch.object(BaseValidator, 'check_file_flags', return_value='')
+        mocker.patch.object(PackUniqueFilesValidator, 'validate_pack_readme_and_pack_description', return_value=True)
         assert not self.validator.are_valid_files(id_set_validations=False)
         fake_validator = PackUniqueFilesValidator('fake')
         assert fake_validator.are_valid_files(id_set_validations=False)
 
     def test_validate_pack_metadata(self, mocker):
         mocker.patch.object(BaseValidator, 'check_file_flags', return_value='')
+        mocker.patch.object(PackUniqueFilesValidator, 'validate_pack_readme_and_pack_description', return_value=True)
         assert not self.validator.are_valid_files(id_set_validations=False)
         fake_validator = PackUniqueFilesValidator('fake')
         assert fake_validator.are_valid_files(id_set_validations=False)

--- a/demisto_sdk/commands/common/tests/pack_unique_files_test.py
+++ b/demisto_sdk/commands/common/tests/pack_unique_files_test.py
@@ -473,6 +473,19 @@ class TestPackUniqueFilesValidator:
         ('This is a test. All good!', False),
     ])
     def test_pack_readme_is_different_then_pack_description(self, repo, readme_content, is_valid):
+        """
+        Given:
+            - Case A: A unique pack readme.
+            - Case B: Pack readme that is equal to pack description
+
+        When:
+            - Validating pack readme vs pack description
+
+        Then:
+            - Case A: Ensure validation passes as the pack readme and pack description are different.
+            - Case B: Ensure validation fails as the pack readme is the same as the pack description.
+                      Verify expected error is printed
+        """
         pack_name = 'PackName'
         pack = repo.create_pack(pack_name)
         pack.readme.write_text(readme_content)

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -25,6 +25,8 @@ from demisto_sdk.commands.common.hook_validations.layout import (
     LayoutsContainerValidator, LayoutValidator)
 from demisto_sdk.commands.common.hook_validations.old_release_notes import \
     OldReleaseNotesValidator
+from demisto_sdk.commands.common.hook_validations.pack_unique_files import \
+    PackUniqueFilesValidator
 from demisto_sdk.commands.common.hook_validations.playbook import \
     PlaybookValidator
 from demisto_sdk.commands.common.hook_validations.release_notes import \
@@ -463,7 +465,7 @@ class TestValidators:
         result = validate_manager.validate_pack_unique_files(VALID_PACK, pack_error_ignore_list={})
         assert result
 
-    def test_validate_pack_dependencies__invalid(self):
+    def test_validate_pack_dependencies__invalid(self, mocker):
         """
             Given:
                 - A file path with invalid pack dependencies
@@ -475,6 +477,7 @@ class TestValidators:
         id_set_path = os.path.normpath(
             os.path.join(__file__, git_path(), 'demisto_sdk', 'tests', 'test_files', 'id_set', 'id_set.json'))
         validate_manager = ValidateManager(skip_conf_json=True, id_set_path=id_set_path)
+        mocker.patch.object(PackUniqueFilesValidator, 'validate_pack_readme_and_pack_description', return_value=True)
         result = validate_manager.validate_pack_unique_files('QRadar', pack_error_ignore_list={})
         assert not result
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/37227

## Description
Added a validation that checks if pack's README is the equal to pack description, if so return error.

## Screenshots
![image](https://user-images.githubusercontent.com/45915502/119366769-f7f60800-bcb9-11eb-9454-f24b7e85ad77.png)


## Must have
- [x] Tests
