### PR TITLE
Fix format command issue when not having an input

### DIFF
--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -577,7 +577,7 @@ def format(
     incidenttype/indicatortype/layout/dashboard/classifier/mapper/widget/report file.
     """
     return format_manager(
-        str(input),
+        str(input) if input else None,
         str(output) if output else None,
         from_version=from_version,
         no_validate=no_validate,

--- a/demisto_sdk/tests/integration_tests/format_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/format_integration_test.py
@@ -14,6 +14,7 @@ from demisto_sdk.commands.common.hook_validations.playbook import \
 from demisto_sdk.commands.common.tools import (get_dict_from_file,
                                                is_test_config_match)
 from demisto_sdk.commands.format import update_generic
+from demisto_sdk.commands.format import format_module
 from demisto_sdk.commands.format.update_generic_yml import BaseUpdateYML
 from demisto_sdk.commands.format.update_integration import IntegrationYMLFormat
 from demisto_sdk.commands.format.update_playbook import PlaybookYMLFormat
@@ -717,6 +718,38 @@ def test_format_playbook_copy_removed_from_name_and_id(repo):
     playbook.yml.write_dict(playbook_content)
     runner = CliRunner(mix_stderr=False)
     format_result = runner.invoke(main, [FORMAT_CMD, '-i', str(playbook.yml.path), '-v'], input='y\n5.5.0')
+    assert 'Success' in format_result.stdout
+    assert playbook.yml.read_dict().get('id') == playbook_id
+    assert playbook.yml.read_dict().get('name') == playbook_name
+
+
+def test_format_playbook_no_input_specified(mocker, repo):
+    """
+    Given:
+        - A playbook with name and id ending in `_copy`
+
+    When:
+        - Running format on the pack
+        - The path of the playbook was not provided
+
+    Then:
+        - The command will find the changed playbook
+        - Ensure format runs successfully
+        - Ensure format removes `_copy` from both name and id.
+    """
+    pack = repo.create_pack('Temp')
+    playbook = pack.create_playbook('my_temp_playbook')
+    playbook.create_default_playbook()
+    playbook_content = playbook.yml.read_dict()
+    playbook_id = playbook_content['id']
+    playbook_name = playbook_content['name']
+    playbook_content['id'] = playbook_id + '_copy'
+    playbook_content['name'] = playbook_name + '_copy'
+    playbook.yml.write_dict(playbook_content)
+    playbook_file = {'name': str(playbook.yml.path)}
+    mocker.patch.object(format_module, 'get_changed_files', return_value=[playbook_file])
+    runner = CliRunner(mix_stderr=False)
+    format_result = runner.invoke(main, [FORMAT_CMD, '-v'], input='y\n5.5.0')
     assert 'Success' in format_result.stdout
     assert playbook.yml.read_dict().get('id') == playbook_id
     assert playbook.yml.read_dict().get('name') == playbook_name

--- a/demisto_sdk/tests/integration_tests/format_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/format_integration_test.py
@@ -7,7 +7,6 @@ from typing import List
 import pytest
 import yaml
 from click.testing import CliRunner
-
 from demisto_sdk.__main__ import main
 from demisto_sdk.commands.common import tools
 from demisto_sdk.commands.common.hook_validations.playbook import \

--- a/demisto_sdk/tests/integration_tests/format_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/format_integration_test.py
@@ -7,14 +7,14 @@ from typing import List
 import pytest
 import yaml
 from click.testing import CliRunner
+
 from demisto_sdk.__main__ import main
 from demisto_sdk.commands.common import tools
 from demisto_sdk.commands.common.hook_validations.playbook import \
     PlaybookValidator
 from demisto_sdk.commands.common.tools import (get_dict_from_file,
                                                is_test_config_match)
-from demisto_sdk.commands.format import update_generic
-from demisto_sdk.commands.format import format_module
+from demisto_sdk.commands.format import format_module, update_generic
 from demisto_sdk.commands.format.update_generic_yml import BaseUpdateYML
 from demisto_sdk.commands.format.update_integration import IntegrationYMLFormat
 from demisto_sdk.commands.format.update_playbook import PlaybookYMLFormat


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/23560, https://github.com/demisto/etc/issues/37649

## Description
Solves issue when format command doesn't have an input which caused format command to not properly.
Solved by checking if it's None before casting to string.

## Must have
- [x] Tests
- [ ] Documentation
