### PR TITLE
Enable multi-path input for lint command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+* Enable passing a comma-separated list of paths for the `--input` option of the **lint** command.
 * Added new validation of unimplemented test-module command in the code to the `XSOAR-linter` in the **lint** command.
 * Fixed the **generate-docs** to handle integration authentication parameter.
 * Added a validation to ensure that description and README do not contain the word 'Demisto'.

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -68,6 +68,16 @@ from demisto_sdk.commands.validate.validate_manager import ValidateManager
 
 
 class PathsParamType(click.Path):
+    """
+    Defines a click options type for use with the @click.option decorator
+
+    The type accepts a string of comma-separated values where each individual value adheres
+    to the definition for the click.Path type. The class accepts the same parameters as the
+    click.Path type, applying those arguments for each comma-separated value in the list.
+    See https://click.palletsprojects.com/en/8.0.x/parameters/#implementing-custom-types for
+    more details.
+    """
+
     def convert(self, value, param, ctx):
         if ',' not in value:
             return super(PathsParamType, self).convert(value, param, ctx)

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -67,16 +67,14 @@ from demisto_sdk.commands.upload.uploader import Uploader
 from demisto_sdk.commands.validate.validate_manager import ValidateManager
 
 
-class MultiPathParamType(click.Path):
-    name = "path[,path]"
-
+class PathsParamType(click.Path):
     def convert(self, value, param, ctx):
         if ',' not in value:
-            return super(MultiPathParamType, self).convert(value, param, ctx)
+            return super(PathsParamType, self).convert(value, param, ctx)
 
         split_paths = value.split(',')
         # check the validity of each of the paths
-        _ = [super(MultiPathParamType, self).convert(path, param, ctx) for path in split_paths]
+        _ = [super(PathsParamType, self).convert(path, param, ctx) for path in split_paths]
         return value
 
 
@@ -495,7 +493,7 @@ def secrets(config, **kwargs):
 )
 @click.option(
     "-i", "--input", help="Specify directory(s) of integration/script",
-    type=MultiPathParamType(exists=True, resolve_path=True)
+    type=PathsParamType(exists=True, resolve_path=True)
 )
 @click.option("-g", "--git", is_flag=True, help="Will run only on changed packages")
 @click.option("-a", "--all-packs", is_flag=True, help="Run lint on all directories in content repo")

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -67,6 +67,19 @@ from demisto_sdk.commands.upload.uploader import Uploader
 from demisto_sdk.commands.validate.validate_manager import ValidateManager
 
 
+class MultiPathParamType(click.Path):
+    name = "path[,path]"
+
+    def convert(self, value, param, ctx):
+        if ',' not in value:
+            return super(MultiPathParamType, self).convert(value, param, ctx)
+
+        split_paths = value.split(',')
+        # check the validity of each of the paths
+        _ = [super(MultiPathParamType, self).convert(path, param, ctx) for path in split_paths]
+        return value
+
+
 class DemistoSDK:
     """
     The core class for the SDK.
@@ -480,8 +493,10 @@ def secrets(config, **kwargs):
 @click.help_option(
     '-h', '--help'
 )
-@click.option("-i", "--input", help="Specify directory of integration/script", type=click.Path(exists=True,
-                                                                                               resolve_path=True))
+@click.option(
+    "-i", "--input", help="Specify directory(s) of integration/script",
+    type=MultiPathParamType(exists=True, resolve_path=True)
+)
 @click.option("-g", "--git", is_flag=True, help="Will run only on changed packages")
 @click.option("-a", "--all-packs", is_flag=True, help="Run lint on all directories in content repo")
 @click.option('-v', "--verbose", count=True, help="Verbosity level -v / -vv / .. / -vvv",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: link to the issue

## Description
The `lint_manager` already included logic to handle comma-separated paths passed as the value for the `-i` command option argument but the `click.option` type of `click.Path` prevented passing such a value. Updates the type of the `-i` option to accept multiple paths separated by commas.

## Must have
- [ ] Tests
- [ ] Documentation
