### PR TITLE
fixed get_pack_name function to work properly with full paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Added identification for parameter differences in **integration-diff** command.
 * Fixed **format** to use git as a default value.
 * Updated the **upload** command to support reports.
+* Fixed the **get_pack_name** function to work as expected with full path.
 
 # 1.3.9
 * Added a validation verifying that the pack's README.md file is not equal to pack description.

--- a/demisto_sdk/commands/common/constants.py
+++ b/demisto_sdk/commands/common/constants.py
@@ -9,7 +9,7 @@ from demisto_sdk.commands.common.git_util import GitUtil
 # dirs
 from git import InvalidGitRepositoryError
 
-CAN_START_WITH_DOT_SLASH = '(?:./)?'
+CAN_START_WITH_DOT_SLASH = '(?:/.*)?'
 NOT_TEST = '(?!Test)'
 INTEGRATIONS_DIR = 'Integrations'
 SCRIPTS_DIR = 'Scripts'

--- a/demisto_sdk/commands/common/tests/tools_test.py
+++ b/demisto_sdk/commands/common/tests/tools_test.py
@@ -29,6 +29,7 @@ from demisto_sdk.commands.common.tools import (LOG_COLORS, arg_to_list,
                                                get_last_remote_release_version,
                                                get_latest_release_notes_text,
                                                get_pack_metadata,
+                                               get_pack_name,
                                                get_release_notes_file_path,
                                                get_ryaml, get_to_version,
                                                has_remote_configured,
@@ -207,6 +208,17 @@ class TestGenericFunctions:
         snake = tools.camel_to_snake('CamelCase')
 
         assert snake == 'camel_case'
+
+    FILE_PATH = [
+        ('Packs/Pack1/Integrations/test1/integration.yml', 'Pack1'),
+        ('/test/test/test/test/test/Packs/Pack2/Integrations/test2', 'Pack2'),
+        ('/Packs/Pack3/Integrations/', 'Pack3')
+    ]
+
+    @pytest.mark.parametrize('path, pack', FILE_PATH)
+    def test_get_pack_name(self, path, pack):
+        output = get_pack_name(path)
+        assert output == pack
 
 
 class TestGetRemoteFile:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/37796

## Description
Fixed the **get_pack_name** function to work as expected with full path.
