### PR TITLE
Contribution Management - Formatting on modified files only

### DIFF
--- a/demisto_sdk/commands/init/contribution_converter.py
+++ b/demisto_sdk/commands/init/contribution_converter.py
@@ -240,10 +240,10 @@ class ContributionConverter:
 
     def format_converted_pack(self) -> None:
         """Runs the demisto-sdk's format command on the pack converted from the contribution zipfile"""
-        click.echo(f'Executing \'format\' on the restructured contribution zip files at "{self.pack_dir_path}"')
+        click.echo('Executing \'format\' on the restructured-contribution-zip new/modified files')
         from_version = '6.0.0' if self.create_new else ''
         format_manager(
-            input=self.pack_dir_path, from_version=from_version, no_validate=True, update_docker=True, assume_yes=True
+            from_version=from_version, no_validate=True, update_docker=True, verbose=True, assume_yes=True
         )
 
     def generate_readme_for_pack_content_item(self, yml_path: str) -> None:

--- a/demisto_sdk/commands/init/contribution_converter.py
+++ b/demisto_sdk/commands/init/contribution_converter.py
@@ -240,7 +240,9 @@ class ContributionConverter:
 
     def format_converted_pack(self) -> None:
         """Runs the demisto-sdk's format command on the pack converted from the contribution zipfile"""
-        click.echo('Executing \'format\' on the restructured-contribution-zip new/modified files')
+        click.echo(
+            f'Executing \'format\' on the restructured contribution zip new/modified files at {self.pack_dir_path}'
+        )
         from_version = '6.0.0' if self.create_new else ''
         format_manager(
             from_version=from_version, no_validate=True, update_docker=True, verbose=True, assume_yes=True


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/35912

## Description
Formatting without specifying an input pack, will run on modified files via git.

## Attached build on updated pack:
https://github.com/demisto/contribution-management/runs/2813735595?check_suite_focus=true

## Attached build on new pack:
https://github.com/demisto/contribution-management/runs/2784670854?check_suite_focus=true
