### PR TITLE
Validate on partner playbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+* Fixed an issue where **validate** with the `--input` flag failed on ignored error.
 * Enable passing a comma-separated list of paths for the `--input` option of the **lint** command.
 * Added new validation of unimplemented test-module command in the code to the `XSOAR-linter` in the **lint** command.
 * Fixed the **generate-docs** to handle integration authentication parameter.

--- a/demisto_sdk/commands/common/tests/tools_test.py
+++ b/demisto_sdk/commands/common/tests/tools_test.py
@@ -29,6 +29,7 @@ from demisto_sdk.commands.common.tools import (LOG_COLORS, arg_to_list,
                                                get_last_remote_release_version,
                                                get_latest_release_notes_text,
                                                get_pack_metadata,
+                                               get_pack_name,
                                                get_release_notes_file_path,
                                                get_ryaml, get_to_version,
                                                has_remote_configured,
@@ -980,3 +981,17 @@ def test_is_pack_path(input_path: str, expected: bool):
 
     """
     assert is_pack_path(input_path) == expected
+
+
+def test_get_pack_name():
+    """
+    When:
+        - Run the get_pack_name function on different file paths
+
+    Then:
+        - Ensure that the expected pack name is returned.
+
+    """
+    assert get_pack_name('/Users/test/dev/demisto/content/Packs/BitcoinAbuse') == 'BitcoinAbuse'
+    assert get_pack_name('Packs/BitcoinAbuse') == 'BitcoinAbuse'
+    assert get_pack_name('Packs/BitcoinAbuse/Integrations') == 'BitcoinAbuse'

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -737,7 +737,7 @@ def get_pack_name(file_path):
     if isinstance(file_path, Path):
         file_path = str(file_path)
     # the regex extracts pack name from relative paths, for example: Packs/EWSv2 -> EWSv2
-    match = re.search(rf'^{PACKS_DIR_REGEX}[/\\]([^/\\]+)[/\\]?', file_path)
+    match = re.search(rf'{PACKS_DIR_REGEX}[/\\]([^/\\]+)[/\\]?', file_path)
     return match.group(1) if match else None
 
 

--- a/demisto_sdk/commands/upload/README.md
+++ b/demisto_sdk/commands/upload/README.md
@@ -22,7 +22,7 @@ Supported content entities:
 - Incident Fields
 - Layouts
 - Classifiers
-- Packs 
+- Packs
 
 #### Limitation
 Uploading classifiers to Cortex XSOAR is available from version 6.0.0 and up.


### PR DESCRIPTION
Due to the change of the -i flag of validate to `click.Path` with `resolve_path=true` argument, the inserted path was converted to the absolute path on which the `get_pack_name` function returned None with the current regex.

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes:  https://github.com/demisto/etc/issues/38042

## Description
Due to the change of the -i flag of validate to `click.Path` with `resolve_path=true` argument, the inserted path was converted to the absolute path on which the `get_pack_name` function returned None with the current regex.

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
