### PR TITLE
detailed description_missing_in_beta_integration error message

### DIFF
--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -1025,7 +1025,7 @@ class Errors:
     @staticmethod
     @error_code_decorator
     def description_missing_in_beta_integration():
-        return f"No detailed description file (<integration_name>_description.yml) was found in the package." \
+        return f"No detailed description file (<integration_name>_description.md) was found in the package." \
                f" Please add one, and make sure it includes the beta disclaimer note." \
                f"Add the following to the detailed description:\n{BETA_INTEGRATION_DISCLAIMER}"
 

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -1025,8 +1025,8 @@ class Errors:
     @staticmethod
     @error_code_decorator
     def description_missing_in_beta_integration():
-        return f"No detailed description file was found in the package. Please add one, " \
-               f"and make sure it includes the beta disclaimer note." \
+        return f"No detailed description file (<integration_name>_description.yml) was found in the package." \
+               f" Please add one, and make sure it includes the beta disclaimer note." \
                f"Add the following to the detailed description:\n{BETA_INTEGRATION_DISCLAIMER}"
 
     @staticmethod

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -1027,7 +1027,7 @@ class Errors:
     def description_missing_in_beta_integration():
         return f"No detailed description file (<integration_name>_description.md) was found in the package." \
                f" Please add one, and make sure it includes the beta disclaimer note." \
-               f"Add the following to the detailed description:\n{BETA_INTEGRATION_DISCLAIMER}"
+               f" Add the following to the detailed description:\n{BETA_INTEGRATION_DISCLAIMER}"
 
     @staticmethod
     @error_code_decorator


### PR DESCRIPTION
## Status
- [x] Ready

## Description
A clearer error message regarding `description_missing_in_beta_integration` when the description file is missing.
