### PR TITLE
Update rn force flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-
+* Added a  *--force* flag to the **update release notes** command, so the update can takes place even without a change.
 
 # 1.4.0
 * Enable passing a comma-separated list of paths for the `--input` option of the **lint** command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 * Refactor **update-release-notes** command - new classs manager, split some logic to smaller functions, added docsrings and type annotations.
-* Added a  *--force* flag to the **update release notes** command, so the update can takes place even without a change.
+* Added a  *--force* flag to the **update-release-notes** command, so the update can take place even without a change in the pack.
 
 # 1.4.0
 * Enable passing a comma-separated list of paths for the `--input` option of the **lint** command.

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -1045,6 +1045,9 @@ def merge_id_sets(**kwargs):
     '--all', help="Update all changed packs", is_flag=True
 )
 @click.option(
+    '-f', '--force', help="Force update rn (even if not required).", is_flag=True
+)
+@click.option(
     '--text', help="Text to add to all of the release notes files",
 )
 @click.option(
@@ -1059,6 +1062,9 @@ def merge_id_sets(**kwargs):
 def update_release_notes(**kwargs):
     """Auto-increment pack version and generate release notes template."""
     check_configuration_file('update-release-notes', kwargs)
+    if not kwargs.get('input') and kwargs.get('force'):
+        print_error('Please add a specific pack in order to force a release notes update.')
+        sys.exit(0)
 
     if not kwargs.get('all') and not kwargs.get('input'):
         click.confirm('No specific pack was given, do you want to update all changed packs?', abort=True)
@@ -1066,7 +1072,8 @@ def update_release_notes(**kwargs):
     rn_mng = UpdateReleaseNotesManager(user_input=kwargs.get('input'), update_type=kwargs.get('update_type'),
                                        pre_release=kwargs.get('pre_release'), is_all=kwargs.get('all'),
                                        text=kwargs.get('text'), specific_version=kwargs.get('version'),
-                                       id_set_path=kwargs.get('id_set_path'), prev_ver=kwargs.get('prev_ver'))
+                                       id_set_path=kwargs.get('id_set_path'), prev_ver=kwargs.get('prev_ver'),
+                                       is_force=kwargs.get('force'))
     rn_mng.manage_rn_update()
 
 

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -1045,7 +1045,7 @@ def merge_id_sets(**kwargs):
     '--all', help="Update all changed packs", is_flag=True
 )
 @click.option(
-    '-f', '--force', help="Force update rn (even if not required).", is_flag=True
+    '-f', '--force', help="Force update release notes for a pack (even if not required).", is_flag=True
 )
 @click.option(
     '--text', help="Text to add to all of the release notes files",

--- a/demisto_sdk/commands/update_release_notes/README.md
+++ b/demisto_sdk/commands/update_release_notes/README.md
@@ -38,6 +38,10 @@ Supported content entities:
 
     Update all release notes in every pack which has been changed. Please note that the `-u` argument will be applied to **all** changed packs.
 
+* **-f, --force**
+
+    Update the release notes of a pack even if no changes that require update were made.
+
 * **--pre_release**
 
     Indicates that this update is for a pre-release version. The `currentVersion` will change to reflect the pre-release version number.

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -469,6 +469,8 @@ class UpdateRN:
             rn_string += f'\n#### Integrations\n##### {self.pack}\n- Documentation and metadata improvements.\n'
             return rn_string
         rn_template_as_dict: dict = {}
+        if self.is_force:
+            rn_string = self.build_rn_desc(content_name=self.pack)
         for content_name, data in sorted(changed_items.items(),
                                          key=lambda x: RN_HEADER_BY_FILE_TYPE[x[1].get('type', '')] if x[1].get('type')
                                          else ''):  # Sort RN by header
@@ -486,12 +488,12 @@ class UpdateRN:
             rn_template_as_dict[header] = rn_template_as_dict.get(header, '') + rn_desc
 
         for key, val in rn_template_as_dict.items():
-            rn_string = f"{rn_string}{key}{val}"
+            rn_string += f"{rn_string}{key}{val}"
 
         return rn_string
 
-    def build_rn_desc(self, _type: FileType, content_name: str, desc: str, is_new_file: bool, text: str,
-                      from_version: str = '') -> str:
+    def build_rn_desc(self, _type: FileType = None, content_name: str = '', desc: str = '', is_new_file: bool = False,
+                      text: str = '', from_version: str = '') -> str:
         """ Builds the release notes description.
 
             :param

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -488,7 +488,7 @@ class UpdateRN:
             rn_template_as_dict[header] = rn_template_as_dict.get(header, '') + rn_desc
 
         for key, val in rn_template_as_dict.items():
-            rn_string += f"{rn_string}{key}{val}"
+            rn_string = f"{rn_string}{key}{val}"
 
         return rn_string
 

--- a/demisto_sdk/commands/update_release_notes/update_rn_manager.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn_manager.py
@@ -20,7 +20,7 @@ class UpdateReleaseNotesManager:
     def __init__(self, user_input: Optional[str] = None, update_type: Optional[str] = None,
                  pre_release: Optional[bool] = False, is_all: Optional[bool] = False, text: Optional[str] = None,
                  specific_version: Optional[str] = None, id_set_path: Optional[str] = None,
-                 prev_ver: Optional[str] = None):
+                 prev_ver: Optional[str] = None, is_force: Optional[bool] = False):
         self.given_pack = user_input
         self.changed_packs_from_git: set = set()
         self.update_type = update_type
@@ -28,6 +28,7 @@ class UpdateReleaseNotesManager:
         # update release notes to every required pack if not specified.
         self.is_all = True if not self.given_pack else is_all
         self.text: str = '' if text is None else text
+        self.is_force = False if not is_force else is_force
         self.specific_version = specific_version
         self.id_set_path = id_set_path
         self.prev_ver = prev_ver
@@ -153,12 +154,12 @@ class UpdateReleaseNotesManager:
         pack_old = filter_files_on_pack(pack, old_format_files)
 
         # Checks if update is required
-        if pack_modified or pack_added or pack_old:
+        if pack_modified or pack_added or pack_old or self.is_force:
             update_pack_rn = UpdateRN(pack_path=f'Packs/{pack}', update_type=self.update_type,
                                       modified_files_in_pack=pack_modified.union(pack_old),
                                       pre_release=self.pre_release,
                                       added_files=pack_added, specific_version=self.specific_version,
-                                      text=self.text,
+                                      text=self.text, is_force=self.is_force,
                                       existing_rn_version_path=existing_rn_version)
             updated = update_pack_rn.execute_update()
             # If new release notes were created and if previous release notes existed, remove previous

--- a/demisto_sdk/tests/integration_tests/update_release_notes_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/update_release_notes_integration_test.py
@@ -485,4 +485,4 @@ def test_force_update_release(demisto_client, mocker, repo):
 
     with open(rn_path, 'r') as f:
         rn = f.read()
-    assert "" == rn
+    assert '##### ThinkCanary\n- %%UPDATE_RN%%\n' == rn


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/37772

## depends on
https://github.com/demisto/demisto-sdk/pull/1368

## Description
Added the ability to force update release notes with the --force flag or -f flag. After speaking to @ShahafBenYakir, we agreed that we only need the ability to automatically bump a version with the update release notes command and then manually filling in the changes.

## Must have
- [x] Tests
- [x] Documentation
