### PR TITLE
Add-Error-Message-To-Unify-Not-Dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-
+* Enhanced the **unify** command when giving input of a file and not a directory return a clear error message.
 
 # 1.4.0
 * Enable passing a comma-separated list of paths for the `--input` option of the **lint** command.

--- a/demisto_sdk/commands/unify/tests/unifier_test.py
+++ b/demisto_sdk/commands/unify/tests/unifier_test.py
@@ -180,7 +180,7 @@ def test_insert_description_to_yml_with_no_detailed_desc(tmp_path):
     detailed_desc.write_text('')
     unifier = Unifier(str(tmp_path))
     yml_unified, _ = unifier.insert_description_to_yml({'commonfields': {'id': 'some integration id'}}, {})
-    assert '[View Integration Documentation](https://xsoar.pan.dev/docs/reference/integrations/some-integration-id)' \
+    assert '[View Integration Documentation](https://xsoar.pan.dev/docs/reference/integrations/some-integration-id)'\
            == yml_unified['detaileddescription']
 
 
@@ -201,7 +201,7 @@ def test_get_integration_doc_link_positive(tmp_path):
     unifier = Unifier(str(tmp_path))
     integration_doc_link = unifier.get_integration_doc_link({'commonfields': {'id': 'Cortex XDR - IOC'}})
     assert integration_doc_link == \
-           '[View Integration Documentation](https://xsoar.pan.dev/docs/reference/integrations/cortex-xdr---ioc)'
+        '[View Integration Documentation](https://xsoar.pan.dev/docs/reference/integrations/cortex-xdr---ioc)'
     link = re.findall(r'\(([^)]+)\)', integration_doc_link)[0]
     try:
         r = requests.get(link, verify=False, timeout=10)

--- a/demisto_sdk/commands/unify/tests/unifier_test.py
+++ b/demisto_sdk/commands/unify/tests/unifier_test.py
@@ -951,4 +951,4 @@ def test_invalid_path_to_unifier(repo):
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(main, [UNIFY_CMD, '-i', f'{integration.path}/integration.yml'])
     assert 'You have failed to provide a legal file path, a legal file path should be to a directory of an ' \
-           'integration or script.' in result.stdout
+           'integration or a script.' in result.stdout

--- a/demisto_sdk/commands/unify/tests/unifier_test.py
+++ b/demisto_sdk/commands/unify/tests/unifier_test.py
@@ -81,8 +81,10 @@ class MicrosoftClient(BaseClient):
 TESTS_DIR = f'{git_path()}/demisto_sdk/tests'
 
 
-def test_clean_python_code():
-    unifier = Unifier("test_files/VulnDB")
+def test_clean_python_code(repo):
+    pack = repo.create_pack('PackName')
+    integration = pack.create_integration('integration', 'bla', INTEGRATION_YAML)
+    unifier = Unifier(str(integration.path))
     script_code = "import demistomock as demisto\nfrom CommonServerPython import *  # test comment being removed\n" \
                   "from CommonServerUserPython import *\nfrom __future__ import print_function"
     # Test remove_print_future is False

--- a/demisto_sdk/commands/unify/tests/unifier_test.py
+++ b/demisto_sdk/commands/unify/tests/unifier_test.py
@@ -950,5 +950,5 @@ def test_invalid_path_to_unifier(repo):
     with ChangeCWD(pack.repo_path):
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(main, [UNIFY_CMD, '-i', f'{integration.path}/integration.yml'])
-    assert 'You have failed to provide a legal file path, a legal file path should be to a directory if an ' \
+    assert 'You have failed to provide a legal file path, a legal file path should be to a directory of an ' \
            'integration or script.' in result.stdout

--- a/demisto_sdk/commands/unify/tests/unifier_test.py
+++ b/demisto_sdk/commands/unify/tests/unifier_test.py
@@ -180,7 +180,7 @@ def test_insert_description_to_yml_with_no_detailed_desc(tmp_path):
     detailed_desc.write_text('')
     unifier = Unifier(str(tmp_path))
     yml_unified, _ = unifier.insert_description_to_yml({'commonfields': {'id': 'some integration id'}}, {})
-    assert '[View Integration Documentation](https://xsoar.pan.dev/docs/reference/integrations/some-integration-id)'\
+    assert '[View Integration Documentation](https://xsoar.pan.dev/docs/reference/integrations/some-integration-id)' \
            == yml_unified['detaileddescription']
 
 
@@ -201,7 +201,7 @@ def test_get_integration_doc_link_positive(tmp_path):
     unifier = Unifier(str(tmp_path))
     integration_doc_link = unifier.get_integration_doc_link({'commonfields': {'id': 'Cortex XDR - IOC'}})
     assert integration_doc_link == \
-        '[View Integration Documentation](https://xsoar.pan.dev/docs/reference/integrations/cortex-xdr---ioc)'
+           '[View Integration Documentation](https://xsoar.pan.dev/docs/reference/integrations/cortex-xdr---ioc)'
     link = re.findall(r'\(([^)]+)\)', integration_doc_link)[0]
     try:
         r = requests.get(link, verify=False, timeout=10)
@@ -927,3 +927,26 @@ def test_unify_community_contributed(mocker, repo):
     assert COMMUNITY_UNIFY["display"] == COMMUNITY_DISPLAY_NAME
     assert '#### Integration Author:' in COMMUNITY_UNIFY["detaileddescription"]
     assert 'No support or maintenance is provided by the author.' in COMMUNITY_UNIFY["detaileddescription"]
+
+
+def test_invalid_path_to_unifier(repo):
+    """
+    Given:
+    - Input path to integration YML for unify command.
+
+    When:
+    - Performing unify command.
+
+    Then:
+    - Ensure error message indicating path should be to a directory returned.
+
+    """
+    pack = repo.create_pack('PackName')
+    integration = pack.create_integration('integration', 'bla', INTEGRATION_YAML)
+    integration.create_default_integration()
+
+    with ChangeCWD(pack.repo_path):
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(main, [UNIFY_CMD, '-i', f'{integration.path}/integration.yml'])
+    assert 'You have failed to provide a legal file path, a legal file path should be to a directory if an ' \
+           'integration or script.' in result.stdout

--- a/demisto_sdk/commands/unify/unifier.py
+++ b/demisto_sdk/commands/unify/unifier.py
@@ -55,7 +55,7 @@ class Unifier:
             input = os.path.abspath(input)
         if not os.path.isdir(input):
             print_error('You have failed to provide a legal file path, a legal file path '
-                        'should be to a directory of an integration or script.')
+                        'should be to a directory of an integration or a script.')
             sys.exit(1)
         for optional_dir_name in DIR_TO_PREFIX:
             if optional_dir_name in input:

--- a/demisto_sdk/commands/unify/unifier.py
+++ b/demisto_sdk/commands/unify/unifier.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 from typing import Dict, List, Tuple, Union
+import sys
 
 import click
 from demisto_sdk.commands.common.constants import (DEFAULT_IMAGE_PREFIX,
@@ -52,6 +53,10 @@ class Unifier:
         # Changing relative path to current abspath fixed problem with default output file name.
         if input == '.':
             input = os.path.abspath(input)
+        # if not os.path.isdir(input):
+        #     print_error('You have failed to provide a legal file path, a legal file path '
+        #                 'should be to a directory if an integration or script.')
+        #     sys.exit(1)
         for optional_dir_name in DIR_TO_PREFIX:
             if optional_dir_name in input:
                 directory_name = optional_dir_name

--- a/demisto_sdk/commands/unify/unifier.py
+++ b/demisto_sdk/commands/unify/unifier.py
@@ -5,8 +5,8 @@ import io
 import json
 import os
 import re
-from typing import Dict, List, Tuple, Union
 import sys
+from typing import Dict, List, Tuple, Union
 
 import click
 from demisto_sdk.commands.common.constants import (DEFAULT_IMAGE_PREFIX,
@@ -53,10 +53,10 @@ class Unifier:
         # Changing relative path to current abspath fixed problem with default output file name.
         if input == '.':
             input = os.path.abspath(input)
-        # if not os.path.isdir(input):
-        #     print_error('You have failed to provide a legal file path, a legal file path '
-        #                 'should be to a directory if an integration or script.')
-        #     sys.exit(1)
+        if not os.path.isdir(input):
+            print_error('You have failed to provide a legal file path, a legal file path '
+                        'should be to a directory if an integration or script.')
+            sys.exit(1)
         for optional_dir_name in DIR_TO_PREFIX:
             if optional_dir_name in input:
                 directory_name = optional_dir_name

--- a/demisto_sdk/commands/unify/unifier.py
+++ b/demisto_sdk/commands/unify/unifier.py
@@ -55,7 +55,7 @@ class Unifier:
             input = os.path.abspath(input)
         if not os.path.isdir(input):
             print_error('You have failed to provide a legal file path, a legal file path '
-                        'should be to a directory if an integration or script.')
+                        'should be to a directory of an integration or script.')
             sys.exit(1)
         for optional_dir_name in DIR_TO_PREFIX:
             if optional_dir_name in input:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/38351

## Description
When giving input to unify that is a path to a file (e.g, YML of integration) it does not indicate that the input is not expected but sends an unclear error message.
Enhanced the command to return a more precise error message.

## Must have
- [x] Tests
- [x] Documentation
