### PR TITLE
Fix init pack without filling metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+* Fixed an issue where running **init** command without filling the metadata file.
 
 # 1.4.1
 * When in private repo without `DEMSITO_SDK_GITHUB_TOKEN` configured, get_remote_file will take files from the local origin/master.
@@ -9,7 +10,6 @@
 * Added a version differences section to readme in **generate-docs** command.
 * Added the *--docs-format* flag in the **integration-diff** command to get the output in README format.
 * Added the *--input-old-version* and *--skip-breaking-changes* flags in the **generate-docs** command to get the details for the breaking section and to skip the breaking changes section.
-* Fixed an issue where running **init** command without filling the metadata file.
 
 # 1.4.0
 * Enable passing a comma-separated list of paths for the `--input` option of the **lint** command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Added a validation to ensure integrations are not skipped and at least one test playbook is not skipped for each integration or script.
 * Added to the Content Tests support for `context_print_dt`, which queries the incident context and prints the result as a json.
 * Added new validation for the `xsoar_config.json` file in the **validate** command.
+* Fixed an issue where running **init** command without filling the metadata file.
 
 # 1.4.0
 * Enable passing a comma-separated list of paths for the `--input` option of the **lint** command.

--- a/demisto_sdk/commands/init/initiator.py
+++ b/demisto_sdk/commands/init/initiator.py
@@ -238,11 +238,11 @@ class Initiator:
 
         metadata_path = os.path.join(self.full_output_path, 'pack_metadata.json')
         with open(metadata_path, 'a') as fp:
-            user_response = str(input("\nWould you like fill pack's metadata file? Y/N ")).lower()
+            user_response = str(input("\nWould you like fill pack's metadata file? Y/N "))
             fill_manually = user_response in ['y', 'yes']
 
             pack_metadata = Initiator.create_metadata(fill_manually)
-            self.category = pack_metadata['categories'][0]
+            self.category = pack_metadata['categories'][0] if pack_metadata['categories'] else 'Utilities'
             json.dump(pack_metadata, fp, indent=4)
 
             click.echo(f"Created pack metadata at path : {metadata_path}", color=LOG_COLORS.GREEN)

--- a/demisto_sdk/commands/init/initiator.py
+++ b/demisto_sdk/commands/init/initiator.py
@@ -238,7 +238,7 @@ class Initiator:
 
         metadata_path = os.path.join(self.full_output_path, 'pack_metadata.json')
         with open(metadata_path, 'a') as fp:
-            user_response = str(input("\nWould you like fill pack's metadata file? Y/N "))
+            user_response = str(input("\nWould you like fill pack's metadata file? Y/N ")).lower()
             fill_manually = user_response in ['y', 'yes']
 
             pack_metadata = Initiator.create_metadata(fill_manually)

--- a/demisto_sdk/commands/init/initiator.py
+++ b/demisto_sdk/commands/init/initiator.py
@@ -238,7 +238,7 @@ class Initiator:
 
         metadata_path = os.path.join(self.full_output_path, 'pack_metadata.json')
         with open(metadata_path, 'a') as fp:
-            user_response = input("\nWould you like fill pack's metadata file? Y/N ").lower()
+            user_response = str(input("\nWould you like fill pack's metadata file? Y/N ")).lower()
             fill_manually = user_response in ['y', 'yes']
 
             pack_metadata = Initiator.create_metadata(fill_manually)

--- a/demisto_sdk/commands/init/tests/initiator_test.py
+++ b/demisto_sdk/commands/init/tests/initiator_test.py
@@ -263,6 +263,13 @@ class TestCreateMetadata:
         }
 
 
+def test_pack_init_without_filling_metadata(monkeypatch, mocker, initiator):
+    monkeypatch.setattr('builtins.input', 'n')
+    mocker.patch.object(Initiator, 'create_new_directory', return_value=True)
+    user_choice = initiator.pack_init()
+    assert user_choice
+
+
 def test_get_valid_user_input(monkeypatch, initiator):
     monkeypatch.setattr('builtins.input', generate_multiple_inputs(deque(['InvalidInput', '100', '1'])))
     user_choice = initiator.get_valid_user_input(INTEGRATION_CATEGORIES, 'Choose category')

--- a/demisto_sdk/commands/init/tests/initiator_test.py
+++ b/demisto_sdk/commands/init/tests/initiator_test.py
@@ -270,7 +270,7 @@ def test_pack_init_without_filling_metadata(monkeypatch, mocker, initiator):
     When
         - Creating new pack without filling the metadata file.
     Then
-        - Ensure it's not fail.
+        - Ensure it does not fail.
     """
     monkeypatch.setattr('builtins.input', lambda _: 'n')
     mocker.patch.object(Initiator, 'create_new_directory', return_value=True)

--- a/demisto_sdk/commands/init/tests/initiator_test.py
+++ b/demisto_sdk/commands/init/tests/initiator_test.py
@@ -264,6 +264,14 @@ class TestCreateMetadata:
 
 
 def test_pack_init_without_filling_metadata(monkeypatch, mocker, initiator):
+    """
+    Given
+        - Pack init inputs.
+    When
+        - Creating new pack without filling the metadata file.
+    Then
+        - Ensure it's not fail.
+    """
     monkeypatch.setattr('builtins.input', lambda _: 'n')
     mocker.patch.object(Initiator, 'create_new_directory', return_value=True)
     mocker.patch.object(os, 'mkdir', return_value=None)

--- a/demisto_sdk/commands/init/tests/initiator_test.py
+++ b/demisto_sdk/commands/init/tests/initiator_test.py
@@ -264,10 +264,10 @@ class TestCreateMetadata:
 
 
 def test_pack_init_without_filling_metadata(monkeypatch, mocker, initiator):
-    monkeypatch.setattr('builtins.input', 'n')
+    monkeypatch.setattr('builtins.input', lambda _: 'n')
     mocker.patch.object(Initiator, 'create_new_directory', return_value=True)
-    user_choice = initiator.pack_init()
-    assert user_choice
+    mocker.patch.object(os, 'mkdir', return_value=None)
+    assert initiator.pack_init()
 
 
 def test_get_valid_user_input(monkeypatch, initiator):


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/38435

## Description
Fixed init command when trying to init a pack without filling the metadata file.

## Must have
- [ ] Tests
- [ ] Documentation
