### PR TITLE
fixed an issue with the coverage report when the test files were empty.

### DIFF
--- a/demisto_sdk/commands/lint/helpers.py
+++ b/demisto_sdk/commands/lint/helpers.py
@@ -482,6 +482,8 @@ def coverage_report_editor(coverage_file, code_file_absolute_path):
             cursor.execute('UPDATE file SET path = ? WHERE id = ?', (code_file_absolute_path, 1))
             sql_connection.commit()
         cursor.close()
+    if not index == 1:
+        os.remove(coverage_file)
 
 
 def coverage_files():


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
fixed an issue with the coverage report when the test files were empty.

an example : 
[PR](https://github.com/demisto/content/pull/12793/files/001b23be64004e6d0f4dfc604eff00fe0f6d2071..122c5ac840ff7c8170ed8045d2df8c164b68f0f4)
[build](https://app.circleci.com/pipelines/github/demisto/content/97120/workflows/7b934cb7-4cd7-467f-8329-64135270651b/jobs/390467)