### PR TITLE
generate docs: disable md auto links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Enhanced the "vX" display name validation for scripts and integrations in the **validate** command to check for every versioned script or integration, and not only v2.
 * Added the *--fail-duplicates* flag for the **create-id-set** command which will fail the command if duplicates are found.
 * Added to the **generate-docs** command automatic addition to git when a new readme file is created.
+* Added url escaping to markdown human readable section in generate docs to avoid autolinking.
 
 # 1.4.1
 * When in private repo without `DEMSITO_SDK_GITHUB_TOKEN` configured, get_remote_file will take files from the local origin/master.

--- a/demisto_sdk/commands/generate_docs/generate_integration_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_integration_doc.py
@@ -419,6 +419,23 @@ def get_previous_version_differences(new_integration_path, previous_integration_
     return differences_section
 
 
+def disable_md_autolinks(markdown: str) -> str:
+    """Disable auto links that markdown clients (such as xosar.pan.dev) auto create. This behaviour is more
+    consistent with how the Server works were links are only created for explicitly defined links.
+    We take: https//lgtm.com/rules/9980089 and change to: https:<span>//</span>lgtm.com/rules/9980089
+    Note that we don't want to change legitimate md links of the form: (link)[http://test.com]. We avoid
+    legitimate md links by using a negative lookbehind in the regex to make sure before the http match
+    we don't have ")[".
+
+    Args:
+        markdown (str): markdown to process
+
+    Returns:
+        str: processed markdown
+    """
+    return re.sub(r'\b(?<!\)\[)(https?)://([\w\d]+?\.[\w\d]+?)\b', r'\1:<span>//</span>\2', markdown, flags=re.IGNORECASE)
+
+
 def generate_command_example(cmd, cmd_example=None):
     errors = []
     context_example = None
@@ -445,7 +462,7 @@ def generate_command_example(cmd, cmd_example=None):
         ])
     example.extend([
         '#### Human Readable Output',
-        '{}'.format('>'.join(f'\n{md_example}'.splitlines(True))),  # prefix human readable with quote
+        '{}'.format('>'.join(f'\n{disable_md_autolinks(md_example)}'.splitlines(True))),  # prefix human readable with quote
         '',
     ])
 

--- a/demisto_sdk/commands/generate_docs/generate_integration_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_integration_doc.py
@@ -433,6 +433,8 @@ def disable_md_autolinks(markdown: str) -> str:
     Returns:
         str: processed markdown
     """
+    if not markdown:
+        return markdown
     return re.sub(r'\b(?<!\)\[)(https?)://([\w\d]+?\.[\w\d]+?)\b', r'\1:<span>//</span>\2', markdown, flags=re.IGNORECASE)
 
 

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -943,6 +943,14 @@ def test_generate_versions_differences_section(monkeypatch):
 
 
 def test_disable_md_autolinks():
+    """
+        Given
+            - Markdown with http link.
+        When
+            - Run disable_md_autolinks.
+        Then
+            - Make sure non-md links are escaped. MD links should remain in place.
+    """
     assert disable_md_autolinks('http://test.com') == 'http:<span>//</span>test.com'
     no_replace_str = '(link)[http://test.com]'
     assert disable_md_autolinks(no_replace_str) == no_replace_str

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -7,9 +7,10 @@ from demisto_sdk.commands.common.legacy_git_tools import git_path
 from demisto_sdk.commands.common.tools import get_json, get_yaml
 from demisto_sdk.commands.create_id_set.create_id_set import IDSetCreator
 from demisto_sdk.commands.generate_docs.generate_integration_doc import (
-    append_or_replace_command_in_docs, generate_commands_section,
-    generate_integration_doc, generate_setup_section,
-    generate_single_command_section, get_command_examples)
+    append_or_replace_command_in_docs, disable_md_autolinks,
+    generate_commands_section, generate_integration_doc,
+    generate_setup_section, generate_single_command_section,
+    get_command_examples)
 from demisto_sdk.commands.generate_docs.generate_script_doc import \
     generate_script_doc
 
@@ -939,3 +940,16 @@ def test_generate_versions_differences_section(monkeypatch):
     ]
 
     assert section == expected_section
+
+
+def test_disable_md_autolinks():
+    assert disable_md_autolinks('http://test.com') == 'http:<span>//</span>test.com'
+    no_replace_str = '(link)[http://test.com]'
+    assert disable_md_autolinks(no_replace_str) == no_replace_str
+    no_replace_str = 'nohttp://test.com'
+    assert disable_md_autolinks(no_replace_str) == no_replace_str
+    # taken from here: https://github.com/demisto/content/pull/13423/files
+    big_str = """{'language': 'python', 'status': 'success', 'status-message': '11 fixed alerts', 'new': 0, 'fixed': 11, 'alerts': [{'query': {'id': 9980089, 'pack': 'com.lgtm/python-queries', 'name': 'Statement has no effect', 'language': 'python', 'properties': {'id': 'py/ineffectual-statement', 'name': 'Statement has no effect', 'severity': 'recommendation', 'tags': ['maintainability', 'useless-code', 'external/cwe/cwe-561']}, 'url': 'https://lgtm.com/rules/9980089'}, 'new': 0, 'fixed': 0}, {'query': {'id': 1510006386081, 'pack': 'com.lgtm/python-queries', 'name': 'Clear-text storage of sensitive information', 'language': 'python', 'properties': {'id': 'py/clear-text-storage-sensitive-data', 'name': 'Clear-text storage of sensitive information', 'severity': 'error', 'tags': ['security', 'external/cwe/cwe-312', 'external/cwe/cwe-315', 'external/cwe/cwe-359']}, 'url': 'https://lgtm.com/rules/1510006386081'}, 'new': 0, 'fixed': 1}, {'query': {'id': 6780086, 'pack': 'com.lgtm/python-queries', 'name': 'Unused local variable', 'language': 'python', 'properties': {'id': 'py/unused-local-variable', 'name': 'Unused local variable', 'severity': 'recommendation', 'tags': ['maintainability', 'useless-code', 'external/cwe/cwe-563']}, 'url': 'https://lgtm.com/rules/6780086'}, 'new': 0, 'fixed': 4}, {'query': {'id': 1800095, 'pack': 'com.lgtm/python-queries', 'name': 'Variable defined multiple times', 'language': 'python', 'properties': {'id': 'py/multiple-definition', 'name': 'Variable defined multiple times', 'severity': 'warning', 'tags': ['maintainability', 'useless-code', 'external/cwe/cwe-563']}, 'url': 'https://lgtm.com/rules/1800095'}, 'new': 0, 'fixed': 4}, {'query': {'id': 3960089, 'pack': 'com.lgtm/python-queries', 'name': 'Explicit returns mixed with implicit (fall through) returns', 'language': 'python', 'properties': {'id': 'py/mixed-returns', 'name': 'Explicit returns mixed with implicit (fall through) returns', 'severity': 'recommendation', 'tags': ['reliability', 'maintainability']}, 'url': 'https://lgtm.com/rules/3960089'}, 'new': 0, 'fixed': 0}, {'query': {'id': 1780094, 'pack': 'com.lgtm/python-queries', 'name': 'Wrong number of arguments in a call', 'language': 'python', 'properties': {'id': 'py/call/wrong-arguments', 'name': 'Wrong number of arguments in a call', 'severity': 'error', 'tags': ['reliability', 'correctness', 'external/cwe/cwe-685']}, 'url': 'https://lgtm.com/rules/1780094'}, 'new': 0, 'fixed': 2}, {'query': {'id': 10030095, 'pack': 'com.lgtm/python-queries', 'name': 'File is not always closed', 'language': 'python', 'properties': {'id': 'py/file-not-closed', 'name': 'File is not always closed', 'severity': 'warning', 'tags': ['efficiency', 'correctness', 'resources', 'external/cwe/cwe-772']}, 'url': 'https://lgtm.com/rules/10030095'}, 'new': 0, 'fixed': 0}]} | https://lgtm.com/projects/g/my-devsecops/moon/rev/pr- """  # noqa
+    res = disable_md_autolinks(big_str)
+    assert 'http://' not in res
+    assert res.count('https:<span>//</span>') == 8

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 addopts = --ignore=demisto_sdk/commands/init/templates
+testpaths = demisto_sdk


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
When generating docs disable auto linking to human readable output http links. This output has a lot of times garbage links and is disabled by default in the Server. This change makes human readable output act similar regarding linking as is in the Server.

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
