### PR TITLE
adding warning for empty pack readme - fixing issue where validation …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+* Fixed an issue where empty pack an README.md file could caused an error in the validation process.
+* Added a warning in case of an empty pack README.md file.
+
 
 # 1.4.2
 * Added to `pylint` summary an indication if a test was skipped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
-* Fixed an issue where empty pack an README.md file could caused an error in the validation process.
-* Added a warning in case of an empty pack README.md file.
-
+* Fixed an issue where if a pack README.md did not exist it could cause an error in the validation process.
 
 # 1.4.2
 * Added to `pylint` summary an indication if a test was skipped.

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -224,7 +224,6 @@ ERROR_CODE = {
     "readme_equal_description_error": {'code': "RM105", 'ui_applicable': False, 'related_field': ''},
     "readme_contains_demisto_word": {'code': "RM106", 'ui_applicable': False, 'related_field': ''},
     "template_sentence_in_readme": {'code': "RM107", 'ui_applicable': False, 'related_field': ''},
-    "pack_readme_is_empty": {'code': "RM108", 'ui_applicable': False, 'related_field': ''},
     "wrong_version_reputations": {'code': "RP100", 'ui_applicable': False, 'related_field': 'version'},
     "reputation_expiration_should_be_numeric": {'code': "RP101", 'ui_applicable': True, 'related_field': 'expiration'},
     "reputation_id_and_details_not_equal": {'code': "RP102", 'ui_applicable': False, 'related_field': 'id'},
@@ -1336,11 +1335,6 @@ class Errors:
     @error_code_decorator
     def template_sentence_in_readme(line_nums):
         return f"Please update the integration version differences section in lines: {line_nums}."
-
-    @staticmethod
-    @error_code_decorator
-    def pack_readme_is_empty():
-        return "Pack README.md file is empty - Consider filling it."
 
     @staticmethod
     @error_code_decorator

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -224,6 +224,7 @@ ERROR_CODE = {
     "readme_equal_description_error": {'code': "RM105", 'ui_applicable': False, 'related_field': ''},
     "readme_contains_demisto_word": {'code': "RM106", 'ui_applicable': False, 'related_field': ''},
     "template_sentence_in_readme": {'code': "RM107", 'ui_applicable': False, 'related_field': ''},
+    "pack_readme_is_empty": {'code': "RM108", 'ui_applicable': False, 'related_field': ''},
     "wrong_version_reputations": {'code': "RP100", 'ui_applicable': False, 'related_field': 'version'},
     "reputation_expiration_should_be_numeric": {'code': "RP101", 'ui_applicable': True, 'related_field': 'expiration'},
     "reputation_id_and_details_not_equal": {'code': "RP102", 'ui_applicable': False, 'related_field': 'id'},
@@ -1335,6 +1336,11 @@ class Errors:
     @error_code_decorator
     def template_sentence_in_readme(line_nums):
         return f"Please update the integration version differences section in lines: {line_nums}."
+
+    @staticmethod
+    @error_code_decorator
+    def pack_readme_is_empty():
+        return "Pack README.md file is empty - Consider filling it."
 
     @staticmethod
     @error_code_decorator

--- a/demisto_sdk/commands/common/hook_validations/pack_unique_files.py
+++ b/demisto_sdk/commands/common/hook_validations/pack_unique_files.py
@@ -77,7 +77,7 @@ class PackUniqueFilesValidator(BaseValidator):
         self.support = support
 
     # error handling
-    def _add_error(self, error, file_path):
+    def _add_error(self, error, file_path, warning=False):
         """Adds error entry to a list under pack's name
         Returns True if added and false otherwise"""
         error_message, error_code = error
@@ -85,7 +85,8 @@ class PackUniqueFilesValidator(BaseValidator):
         if self.pack_path not in file_path:
             file_path = os.path.join(self.pack_path, file_path)
 
-        formatted_error = self.handle_error(error_message, error_code, file_path=file_path, should_print=False)
+        formatted_error = self.handle_error(error_message, error_code, file_path=file_path, should_print=False,
+                                            warning=warning)
         if formatted_error:
             self._errors.append(formatted_error)
             return True
@@ -189,11 +190,15 @@ class PackUniqueFilesValidator(BaseValidator):
         metadata = json.loads(pack_meta_file_content)
         metadata_description = metadata.get(PACK_METADATA_DESC, '').lower().strip()
         if not self._check_if_file_is_empty(self.readme_file):
-            readme = self._read_file_content(self.readme_file)
-            readme_content = readme.lower().strip()
-            if metadata_description == readme_content:
-                self._add_error(Errors.readme_equal_description_error(), self.readme_file)
-                return False
+            pack_readme = self._read_file_content(self.readme_file)
+            if pack_readme:
+                readme_content = pack_readme.lower().strip()
+                if metadata_description == readme_content:
+                    self._add_error(Errors.readme_equal_description_error(), f"{self.pack_path}/{self.readme_file}")
+                    return False
+
+            else:
+                self._add_error(Errors.pack_readme_is_empty, f"{self.pack_path}/{self.readme_file}", warning=True)
 
         return True
 


### PR DESCRIPTION
…failed on empty pack

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/demisto-sdk/issues/1418

## Description
Fixing empty pack readme failure.
Adding empty pack readme warning

