### PR TITLE
fixing rn validation pack path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added a playbook validation to check if a task sub playbook exists in the id set in the **validate** command.
 * Added the option to add new tags/usecases to the approved list and to the pack metadata on the same pull request.
 * Fixed an issue in **test_content** where when different servers ran tests for the same integration, the server URL parameters were not set correctly.
+* Fixed an issue where the release notes validation attempted to open a pack metadata file using an incorrect path.
 
 # 1.4.2
 * Added to `pylint` summary an indication if a test was skipped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Added the option to add new tags/usecases to the approved list and to the pack metadata on the same pull request.
 * Fixed an issue in **test_content** where when different servers ran tests for the same integration, the server URL parameters were not set correctly.
 * Added a validation in the **validate** command to ensure that the ***endpoint*** command is configured correctly in yml file.
-* Fixed an issue where the release notes validation attempted to open a pack metadata file using an incorrect path.
+* Fixed an issue where a redundant print occurred on release notes validation.
 
 # 1.4.2
 * Added to `pylint` summary an indication if a test was skipped.

--- a/demisto_sdk/commands/common/hook_validations/release_notes.py
+++ b/demisto_sdk/commands/common/hook_validations/release_notes.py
@@ -1,9 +1,11 @@
 from __future__ import print_function
 
 import itertools
+import os
 import re
 
-from demisto_sdk.commands.common.constants import (RN_HEADER_BY_FILE_TYPE,
+from demisto_sdk.commands.common.constants import (PACKS_DIR,
+                                                   RN_HEADER_BY_FILE_TYPE,
                                                    FileType)
 from demisto_sdk.commands.common.errors import Errors
 from demisto_sdk.commands.common.hook_validations.base_validator import \
@@ -31,6 +33,7 @@ class ReleaseNotesValidator(BaseValidator):
         self.modified_files = modified_files
         self.added_files = added_files
         self.pack_name = pack_name
+        self.pack_path = os.path.join(PACKS_DIR, self.pack_name)
         self.release_notes_path = get_release_notes_file_path(self.release_notes_file_path)
         self.latest_release_notes = get_latest_release_notes_text(self.release_notes_path)
         self.file_types_that_should_not_appear_in_rn = {FileType.TEST_SCRIPT, FileType.TEST_PLAYBOOK, FileType.README,
@@ -50,7 +53,7 @@ class ReleaseNotesValidator(BaseValidator):
                 elif self.pack_name + '/' in file:
                     # Refer image and description file paths to the corresponding yml files
                     file = UpdateRN.check_for_release_notes_valid_file_path(file)
-                    update_rn_util = UpdateRN(pack_path=self.release_notes_file_path, modified_files_in_pack=set(),
+                    update_rn_util = UpdateRN(pack_path=self.pack_path, modified_files_in_pack=set(),
                                               update_type=None, added_files=set(), pack=self.pack_name)
                     file_name, file_type = update_rn_util.identify_changed_file_type(file)
                     if file_name and file_type:

--- a/demisto_sdk/commands/common/tests/release_notes_test.py
+++ b/demisto_sdk/commands/common/tests/release_notes_test.py
@@ -23,6 +23,7 @@ def get_validator(file_path='', modified_files=None, added_files=None):
     release_notes_validator.ignored_errors = {}
     release_notes_validator.checked_files = set()
     release_notes_validator.json_file_path = ''
+    release_notes_validator.pack_path = 'Path/CortexXDR'
     return release_notes_validator
 
 

--- a/demisto_sdk/commands/common/tests/release_notes_test.py
+++ b/demisto_sdk/commands/common/tests/release_notes_test.py
@@ -74,7 +74,7 @@ def test_init():
     - Ensure init returns valid file path and release notes contents.
     """
     filepath = os.path.join(FILES_PATH, 'ReleaseNotes', '1_1_1.md')
-    release_notes_validator = ReleaseNotesValidator(filepath)
+    release_notes_validator = ReleaseNotesValidator(filepath, pack_name='test')
     release_notes_validator.release_notes_file_path = 'demisto_sdk/tests/test_files/ReleaseNotes/1_1_1.md'
     assert release_notes_validator.release_notes_path == filepath
     assert release_notes_validator.latest_release_notes == '### Test'


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/38946

## Description
Fixed an issue where the release notes validation attempted to open a pack metadata file using an incorrect path.

