### PR TITLE
Add Decorator to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ coloredlogs>=15.0
 configparser>=5.0.0
 coverage>=5.5
 dateparser>=0.7.2
+decorator>=4.4.2
 demisto-py>=2.0.19
 dictor>=0.1.5
 docker==4.3.0  # Issue #27819


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes:
```
[2021-07-13T15:19:52.047Z]   File "/usr/local/lib/python3.7/dist-packages/demisto_sdk/commands/common/errors.py", line 3, in <module>

[2021-07-13T15:19:52.047Z]     import decorator
```

## Description
Decorator used as an import, but missing in requirements

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [x] Tests (not necessary for import)
- [x] Documentation
