### PR TITLE
fixing getting local "remote" file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 * Enhanced the **postman-codegen** command to name all generated arguments with lower case.
+* Fixed an issue where the **validate** command failed in external repositories in case the DEMISTO_SDK_GITHUB_TOKEN was not set.
 
 # 1.4.4
 * When formatting incident types with Auto-Extract rules and without mode field, the **format** command will now add the user selected mode.

--- a/demisto_sdk/commands/common/git_util.py
+++ b/demisto_sdk/commands/common/git_util.py
@@ -509,7 +509,7 @@ class GitUtil:
         """
         relative_file_path = os.path.relpath(full_file_path, self.git_path())
         try:
-            remote_name = self.repo.remote().name
+            remote_name = self.repo.remote()
         except ValueError as exc:
             if "Remote named 'origin' didn't exist" in str(exc):
                 remote_name = 'origin'

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -235,28 +235,29 @@ def get_remote_file(
                 # And maybe it's just not defined. 😢
                 if not res.ok:
                     if not suppress_print:
-                        print_warning(
+                        click.secho(
                             f'You are working in a private repository: "{githhub_config.CURRENT_REPOSITORY}".\n'
                             f'The github token in your environment is undefined.\n'
                             f'Getting file from local repository instead. \n'
                             f'If you wish to get the file from the remote repository, \n'
                             f'Please define your github token in your environment.\n'
-                            f'`export {githhub_config.Credentials.ENV_TOKEN_NAME}=<TOKEN>`'
+                            f'`export {githhub_config.Credentials.ENV_TOKEN_NAME}=<TOKEN>`\n', fg='yellow'
                         )
+                        click.echo("Getting file from local environment")
                     # Get from local git origin/master instead
                     repo = git.Repo(os.path.dirname(full_file_path), search_parent_directories=True)
                     repo_git_util = GitUtil(repo)
-                    github_path = repo_git_util.get_local_remote_file_path(full_file_path, tag)
+                    github_path = repo_git_util.get_local_remote_file_path(full_file_path, github_tag)
                     local_content = repo_git_util.get_local_remote_file_content(github_path)
         else:
             res = requests.get(github_path, verify=False, timeout=10)
             res.raise_for_status()
     except Exception as exc:
         if not suppress_print:
-            print_warning(
+            click.secho(
                 f'Could not find the old entity file under "{github_path}".\n'
                 'please make sure that you did not break backward compatibility.\n'
-                f'Reason: {exc}'
+                f'Reason: {exc}', fg='yellow'
             )
         return {}
     file_content = res.content if res.ok else local_content


### PR DESCRIPTION
The tag that was sent to the `get_local_remote_file_path` included the git remote resulting in an incorrect path.
like here: https://github.com/demisto/content-internal-dist/pull/49/checks?check_run_id=3104104481