### PR TITLE
remove the suggestion to run format when a key is missing from yml 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Fixed an issue where **openapi-codegen** entered into an infinite loop on circular references in the swagger file.
 * The **format** command will now set `fromVersion: 6.2.0` for widgets with 'metrics' data type.
 * Updated the **find-dependencies** command to support generic modules, definitions, fields and types.
-* Fixed an issue where **validate** suggests, with no reason, running **format** on missing mandatory keys in yml file. 
+* Fixed an issue where **validate** suggests, with no reason, running **format** on missing mandatory keys in yml file.
 
 # 1.4.4
 * When formatting incident types with Auto-Extract rules and without mode field, the **format** command will now add the user selected mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fixed an issue where **openapi-codegen** entered into an infinite loop on circular references in the swagger file.
 * The **format** command will now set `fromVersion: 6.2.0` for widgets with 'metrics' data type.
 * Updated the **find-dependencies** command to support generic modules, definitions, fields and types.
+* Fixed an issue where **validate** suggests, with no reason, running **format** on missing mandatory keys in yml file. 
 
 # 1.4.4
 * When formatting incident types with Auto-Extract rules and without mode field, the **format** command will now add the user selected mode.

--- a/demisto_sdk/commands/common/hook_validations/structure.py
+++ b/demisto_sdk/commands/common/hook_validations/structure.py
@@ -406,7 +406,9 @@ class StructureValidator(BaseValidator):
         if error_path:
             error_path_str = self.translate_error_path(error_path)
             error_message, error_code = Errors.pykwalify_missing_parameter(str(error_key), error_path_str)
-            return error_message, error_code, True
+            # for now, format does not support adding mandatory fields, for example 'description'.
+            # Showing a suggestion to run format is useless in such cases
+            return error_message, error_code, False
 
         # if no path found this is an error in root
         else:


### PR DESCRIPTION

## Status
- [] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/39271

## Description
When running validate on a `yml` file that is missing mandatory fields as `description, `name` etc an error is returned along with a suggestion to run demisto-sdk format to fix the issue. The issue is that the format does not add those fields for now (with default / required values).
My fix was to remove the suggestion to run format as it does nothing to the yml file.
