### PR TITLE
Update Release Notes Breaking Changes Entry Addition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   - Generic Module validator - verify that the 'fromVersion' field is above 6.5.0
   - Generic Definition validator - verify that the 'fromVersion' field is above 6.5.0
  * Expanded Format command to support Generic Objects - Fixes generic objects according to their validations.
+* Added the **bc** flag to indicate pack version is breaking changes.
 
 # 1.4.5
 * Enhanced the **postman-codegen** command to name all generated arguments with lower case.

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -1208,7 +1208,8 @@ def update_release_notes(**kwargs):
                                            pre_release=kwargs.get('pre_release', False), is_all=kwargs.get('use_git'),
                                            text=kwargs.get('text'), specific_version=kwargs.get('version'),
                                            id_set_path=kwargs.get('id_set_path'), prev_ver=kwargs.get('prev_ver'),
-                                           is_force=kwargs.get('force', False), is_bc=kwargs.get('breaking_changes'))
+                                           is_force=kwargs.get('force', False),
+                                           is_bc=kwargs.get('breaking_changes', False))
         rn_mng.manage_rn_update()
         sys.exit(0)
     except Exception as e:

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -1191,6 +1191,8 @@ def merge_id_sets(**kwargs):
 @click.option(
     "-idp", "--id-set-path", help="The path of the id-set.json used for APIModule updates.",
     type=click.Path(resolve_path=True))
+@click.option(
+    '-b', '--breaking-changes', help='Indicates that this version is breaking changes.', is_flag=True)
 def update_release_notes(**kwargs):
     """Auto-increment pack version and generate release notes template."""
     check_configuration_file('update-release-notes', kwargs)
@@ -1206,7 +1208,7 @@ def update_release_notes(**kwargs):
                                            pre_release=kwargs.get('pre_release', False), is_all=kwargs.get('use_git'),
                                            text=kwargs.get('text'), specific_version=kwargs.get('version'),
                                            id_set_path=kwargs.get('id_set_path'), prev_ver=kwargs.get('prev_ver'),
-                                           is_force=kwargs.get('force', False))
+                                           is_force=kwargs.get('force', False), is_bc=kwargs.get('breaking_changes'))
         rn_mng.manage_rn_update()
         sys.exit(0)
     except Exception as e:

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -1192,7 +1192,7 @@ def merge_id_sets(**kwargs):
     "-idp", "--id-set-path", help="The path of the id-set.json used for APIModule updates.",
     type=click.Path(resolve_path=True))
 @click.option(
-    '-b', '--breaking-changes', help='Indicates that this version is breaking changes.', is_flag=True)
+    '-bc', '--breaking-changes', help='Indicates that this version is breaking changes.', is_flag=True)
 def update_release_notes(**kwargs):
     """Auto-increment pack version and generate release notes template."""
     check_configuration_file('update-release-notes', kwargs)

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -995,15 +995,15 @@ class TestRNUpdateUnit:
         modified = {'/Packs/ApiModules/Scripts/ApiModules_script/ApiModules_script.yml'}
         added = {}
         id_set_content = {'integrations':
-            [
-                {'FeedTAXII_integration':
-                     {'name': 'FeedTAXII_integration',
-                      'file_path': '/FeedTAXII_integration.yml',
-                      'pack': 'FeedTAXII',
-                      'api_modules': 'ApiModules_script'
-                      }
-                 }
-            ]}
+                          [
+                              {'FeedTAXII_integration':
+                               {'name': 'FeedTAXII_integration',
+                                'file_path': '/FeedTAXII_integration.yml',
+                                'pack': 'FeedTAXII',
+                                'api_modules': 'ApiModules_script'
+                                }
+                               }
+                          ]}
         id_set_f = tmpdir / "id_set.json"
         id_set_f.write(json.dumps(id_set_content))
 
@@ -1144,7 +1144,7 @@ class TestRNUpdateUnit:
         mocker.patch.object(UpdateRN, 'get_master_version', return_value='0.0.0')
         client = UpdateRN(pack_path="demisto_sdk/commands/update_release_notes/tests_data/Packs/Test",
                           update_type='minor', modified_files_in_pack={
-                'Packs/Test/Integrations/Test.yml'}, added_files=set('Packs/Test/some_added_file.py'))
+                              'Packs/Test/Integrations/Test.yml'}, added_files=set('Packs/Test/some_added_file.py'))
         client.execute_update()
         with open('demisto_sdk/commands/update_release_notes/tests_data/Packs/release_notes/1_1_0.md', 'r') as file:
             RN = file.read()

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -995,15 +995,15 @@ class TestRNUpdateUnit:
         modified = {'/Packs/ApiModules/Scripts/ApiModules_script/ApiModules_script.yml'}
         added = {}
         id_set_content = {'integrations':
-                          [
-                              {'FeedTAXII_integration':
-                               {'name': 'FeedTAXII_integration',
-                                'file_path': '/FeedTAXII_integration.yml',
-                                'pack': 'FeedTAXII',
-                                'api_modules': 'ApiModules_script'
-                                }
-                               }
-                          ]}
+            [
+                {'FeedTAXII_integration':
+                     {'name': 'FeedTAXII_integration',
+                      'file_path': '/FeedTAXII_integration.yml',
+                      'pack': 'FeedTAXII',
+                      'api_modules': 'ApiModules_script'
+                      }
+                 }
+            ]}
         id_set_f = tmpdir / "id_set.json"
         id_set_f.write(json.dumps(id_set_content))
 
@@ -1144,7 +1144,7 @@ class TestRNUpdateUnit:
         mocker.patch.object(UpdateRN, 'get_master_version', return_value='0.0.0')
         client = UpdateRN(pack_path="demisto_sdk/commands/update_release_notes/tests_data/Packs/Test",
                           update_type='minor', modified_files_in_pack={
-                              'Packs/Test/Integrations/Test.yml'}, added_files=set('Packs/Test/some_added_file.py'))
+                'Packs/Test/Integrations/Test.yml'}, added_files=set('Packs/Test/some_added_file.py'))
         client.execute_update()
         with open('demisto_sdk/commands/update_release_notes/tests_data/Packs/release_notes/1_1_0.md', 'r') as file:
             RN = file.read()
@@ -1199,6 +1199,38 @@ class TestRNUpdateUnit:
          '#### Integrations\n##### BitcoinAbuse Feed\n- %%UPDATE_RN%%\n- Updated the Docker image '
          'to: *demisto/python3:3.9.1.149616*.\n', True)
     ]
+
+    ADD_BC_ENTRY_IF_NEEDED_INPUTS = [(False, '#### Integrations\n##### BitcoinAbuse Feed\n- %%UPDATE_RN%%\n',
+                                      '#### Integrations\n##### BitcoinAbuse Feed\n- %%UPDATE_RN%%\n'),
+                                     (True, '#### Integrations\n##### BitcoinAbuse Feed\n- %%UPDATE_RN%%\n',
+                                      '#### Integrations\n##### BitcoinAbuse Feed\n- %%UPDATE_RN%%\n'
+                                      f'{UpdateRN.BREAKING_CHANGES_ENTRY_TEMPLATE}'),
+                                     (True, '#### Integrations\n##### BitcoinAbuse Feed\n- %%UPDATE_RN%%\n'
+                                      '\n#### Breaking Changes\n- **Breaking changes:** Stopped support for command x',
+                                      '#### Integrations\n##### BitcoinAbuse Feed\n- %%UPDATE_RN%%\n'
+                                      '\n#### Breaking Changes\n- **Breaking changes:** Stopped support for command x')
+                                     ]
+
+    @pytest.mark.parametrize('is_bc, rn_string, expected_rn_string', ADD_BC_ENTRY_IF_NEEDED_INPUTS)
+    def test_add_bc_entry_if_needed(self, is_bc: bool, rn_string: str, expected_rn_string: str):
+        """
+        Given
+            - RN string.
+        When
+            - Adding BC entry to given RN string if needed
+            Case a: Version is not BC, and does not contain BC entry.
+            Case a: Version is BC, and does not contain BC entry.
+            Case a: Version is BC, and contains BC entry.
+
+        Then
+            - Ensure BC entry is added when needed
+            Case a: Ensure same RN is returned.
+            Case b: Ensure RN with BC entry is returned.
+            Case c: Ensure same RN is returned.
+        """
+        update_rn: UpdateRN = UpdateRN(pack_path='', update_type=None, modified_files_in_pack=set(), added_files=set(),
+                                       is_bc=is_bc)
+        assert update_rn.add_bc_entry_if_needed(rn_string) == expected_rn_string
 
 
 def test_get_from_version_at_update_rn(integration):

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -1206,9 +1206,9 @@ class TestRNUpdateUnit:
                                       '#### Integrations\n##### BitcoinAbuse Feed\n- %%UPDATE_RN%%\n'
                                       f'{UpdateRN.BREAKING_CHANGES_ENTRY_TEMPLATE}'),
                                      (True, '#### Integrations\n##### BitcoinAbuse Feed\n- %%UPDATE_RN%%\n'
-                                      '\n#### Breaking Changes\n- **Breaking changes:** Stopped support for command x',
+                                      '\n#### Breaking Changes\n- **Breaking Change:** Stopped support for command x',
                                       '#### Integrations\n##### BitcoinAbuse Feed\n- %%UPDATE_RN%%\n'
-                                      '\n#### Breaking Changes\n- **Breaking changes:** Stopped support for command x')
+                                      '\n#### Breaking Changes\n- **Breaking Change:** Stopped support for command x')
                                      ]
 
     @pytest.mark.parametrize('is_bc, rn_string, expected_rn_string', ADD_BC_ENTRY_IF_NEEDED_INPUTS)

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -26,7 +26,8 @@ from demisto_sdk.commands.common.tools import (LOG_COLORS, find_type,
 
 
 class UpdateRN:
-    BREAKING_CHANGES_ENTRY_TEMPLATE = '\n#### Breaking Changes\n- **Breaking changes:** %%UPDATE_BC_CHANGES%%'
+    BREAKING_CHANGES_ENTRY = '\n#### Breaking Changes\n- **Breaking changes:**'
+    BREAKING_CHANGES_ENTRY_TEMPLATE = f'{BREAKING_CHANGES_ENTRY} %%UPDATE_BC_CHANGES%%'
 
     def __init__(self, pack_path: str, update_type: Union[str, None], modified_files_in_pack: set, added_files: set,
                  specific_version: str = None, pre_release: bool = False, pack: str = None,
@@ -483,6 +484,8 @@ class UpdateRN:
         for key, val in rn_template_as_dict.items():
             rn_string = f"{rn_string}{key}{val}"
 
+        self.add_bc_entry_if_needed(rn_string)
+
         return rn_string
 
     def build_rn_desc(self, _type: FileType = None, content_name: str = '', desc: str = '', is_new_file: bool = False,
@@ -589,14 +592,15 @@ class UpdateRN:
 
     def add_bc_entry_if_needed(self, rn_string: str) -> str:
         """
-        Adds BC entry to 'rn_string' if such entry does not exist
+        Adds BC entry to 'rn_string' if such entry does not exist. Handles both cases of newly created RN and
+        existing RN being updated.
         Args:
             rn_string (str): RN string.
 
         Returns:
             (str): RN string, with BC entry if it is needed and no such entry exists.
         """
-        if self.is_bc and self.BREAKING_CHANGES_ENTRY_TEMPLATE not in rn_string:
+        if self.is_bc and self.BREAKING_CHANGES_ENTRY not in rn_string:
             rn_string += self.BREAKING_CHANGES_ENTRY_TEMPLATE
         return rn_string
 

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -26,7 +26,7 @@ from demisto_sdk.commands.common.tools import (LOG_COLORS, find_type,
 
 
 class UpdateRN:
-    BREAKING_CHANGES_ENTRY = '\n#### Breaking Changes\n- **Breaking changes:**'
+    BREAKING_CHANGES_ENTRY = '\n#### Breaking Changes\n- **Breaking Change:**'
     BREAKING_CHANGES_ENTRY_TEMPLATE = f'{BREAKING_CHANGES_ENTRY} %%UPDATE_BC_CHANGES%%'
 
     def __init__(self, pack_path: str, update_type: Union[str, None], modified_files_in_pack: set, added_files: set,

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -484,7 +484,7 @@ class UpdateRN:
         for key, val in rn_template_as_dict.items():
             rn_string = f"{rn_string}{key}{val}"
 
-        self.add_bc_entry_if_needed(rn_string)
+        rn_string = self.add_bc_entry_if_needed(rn_string)
 
         return rn_string
 

--- a/demisto_sdk/commands/update_release_notes/update_rn_manager.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn_manager.py
@@ -21,7 +21,7 @@ class UpdateReleaseNotesManager:
     def __init__(self, user_input: Optional[str] = None, update_type: Optional[str] = None,
                  pre_release: bool = False, is_all: Optional[bool] = False, text: Optional[str] = None,
                  specific_version: Optional[str] = None, id_set_path: Optional[str] = None,
-                 prev_ver: Optional[str] = None, is_force: bool = False):
+                 prev_ver: Optional[str] = None, is_force: bool = False, is_bc: bool = False):
         self.given_pack = user_input
         self.changed_packs_from_git: set = set()
         self.update_type = update_type
@@ -39,6 +39,7 @@ class UpdateReleaseNotesManager:
         if self.given_pack and self.is_all:
             raise ValueError('Please remove the -g flag when specifying only one pack.')
         self.rn_path: list = list()
+        self.is_bc = is_bc
 
     def manage_rn_update(self):
         """
@@ -169,7 +170,7 @@ class UpdateReleaseNotesManager:
                                       pre_release=self.pre_release,
                                       added_files=pack_added, specific_version=self.specific_version,
                                       text=self.text, is_force=self.is_force,
-                                      existing_rn_version_path=existing_rn_version)
+                                      existing_rn_version_path=existing_rn_version, is_bc=self.is_bc)
             updated = update_pack_rn.execute_update()
             self.rn_path.append(update_pack_rn.rn_path)
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/39725

## Description
Adding support for BC flag for new content support for breaking changes

## Screenshots
Adding update scenarios:
1) Create new RN with bc flag
demisto-sdk update-release-notes -i Packs/BitcoinAbuse -bc
![Screen Shot 2021-08-02 at 14 13 06](https://user-images.githubusercontent.com/70005542/127853005-75c50fe2-9a6b-42bd-951a-e9bcb0e40301.png)


2) Release notes for new version existed without -bc entry.
after running demisto-sdk update-release-notes -i Packs/BitcoinAbuse -bc
![Screen Shot 2021-08-02 at 14 02 22](https://user-images.githubusercontent.com/70005542/127851771-bc25ab13-407b-46f5-a47b-76d1136dbb9e.png)

3) Release notes for new version existed with BC
![Screen Shot 2021-08-02 at 14 04 03](https://user-images.githubusercontent.com/70005542/127851955-2a9f7237-b9d4-4da5-bc02-ed87ed5d6111.png)
after running demisto-sdk update-release-notes -i Packs/BitcoinAbuse -bc (See no duplicate entry appears)
![Screen Shot 2021-08-02 at 14 04 03](https://user-images.githubusercontent.com/70005542/127851973-c27a599d-8dd7-41d0-ba5a-1029cadd2bf3.png)


Paste here any images that will help the reviewer

## Must have
- [x] Tests
- [x] Documentation
