### PR TITLE
update RN docker image bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Fixed an issue where author image validations were not checked properly.
 * Fixed an issue where new old-formatted scripts and integrations were not validated.
 * Fixed an issue where the wording in the from version validation error for subplaybooks was incorrect.
-* Fixed an issue where **update-release-notes** command used the old docker image version instead of the new when the docker was changed.
+* Fixed an issue where the **update-release-notes** command used the old docker image version instead of the new when detecting a docker change.
 
 # 1.4.6
 * Fixed an issue where **validate** suggests, with no reason, running **format** on missing mandatory keys in yml file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Fixed an issue where author image validations were not checked properly.
 * Fixed an issue where new old-formatted scripts and integrations were not validated.
 * Fixed an issue where the wording in the from version validation error for subplaybooks was incorrect.
+* Fixed an issue where **update-release-notes** command used the old docker image version instead of the new when the docker was changed.
 
 # 1.4.6
 * Fixed an issue where **validate** suggests, with no reason, running **format** on missing mandatory keys in yml file.

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -1055,10 +1055,23 @@ class TestRNUpdateUnit:
 
         from demisto_sdk.commands.update_release_notes.update_rn import \
             UpdateRN
+        expected_res = "diff --git a/Packs/test1/Integrations/test1/test1.yml b/Packs/test1/Integrations/test1/test1.yml\n" \
+                       "--- a/Packs/test1/Integrations/test1/test1.yml\n" \
+                       "+++ b/Packs/test1/Integrations/test1/test1.yml\n" \
+                       "@@ -1270,7 +1270,7 @@ script:\n" \
+                       "description: update docker image.\n" \
+                       "execution: false\n" \
+                       "name: test1\n" \
+                       "-  dockerimage: demisto/python3:3.9.6.22912\n" \
+                       "+  dockerimage: demisto/python3:3.9.6.22914\n" \
+                       "feed: false\n" \
+                       "isfetch: false\n" \
+                       "longRunning: false\n"
+
         with open('demisto_sdk/commands/update_release_notes/tests_data/Packs/Test/pack_metadata.json', 'r') as file:
             pack_data = json.load(file)
         mocker.patch('demisto_sdk.commands.update_release_notes.update_rn.run_command',
-                     return_value='+  dockerimage:python/test:1243')
+                     return_value=expected_res)
         mocker.patch.object(UpdateRN, 'is_bump_required', return_value=False)
         mocker.patch.object(UpdateRN, 'get_pack_metadata', return_value=pack_data)
         mocker.patch.object(UpdateRN, 'get_changed_file_name_and_type', return_value=('Test', FileType.INTEGRATION))
@@ -1074,7 +1087,7 @@ class TestRNUpdateUnit:
         with open('demisto_sdk/commands/update_release_notes/tests_data/Packs/release_notes/1_1_0.md', 'r') as file:
             RN = file.read()
         os.remove('demisto_sdk/commands/update_release_notes/tests_data/Packs/release_notes/1_1_0.md')
-        assert 'Updated the Docker image to: *dockerimage:python/test:1243*.' in RN
+        assert 'Updated the Docker image to: *demisto/python3:3.9.6.22914*.' in RN
 
     def test_update_docker_image_in_yml_when_RN_aleady_exists(self, mocker):
         """

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -761,7 +761,9 @@ def check_docker_image_changed(added_or_modified_yml: str) -> Optional[str]:
         for diff_line in diff_lines:
             if 'dockerimage:' in diff_line:  # search whether exists a line that notes that the Docker image was
                 # changed.
-                return diff_line.split()[-1]
+                split_line = diff_line.split()
+                if split_line[0] == '+':
+                    return split_line[-1]
         return None
 
 


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/40148

## Description
The update release notes command used the old docker image version instead of the new when the docker image was changed. Fixed the issue and fixed the unitest.

## Must have
- [x] Tests
- [x] Documentation
