### PR TITLE
Fixed docker image recognition in update-release-notes

### DIFF
--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -1026,20 +1026,49 @@ class TestRNUpdateUnit:
         from demisto_sdk.commands.update_release_notes.update_rn import \
             check_docker_image_changed
 
-        return_value = '+category: Utilities\
-                        +commonfields:\
-                        +  id: Test\
-                        +  version: -1\
-                        +configuration:\
-                        +- defaultvalue: https://soar.test.com\
-                        +  display: Server URL (e.g. https://soar.test.com)\
-                        +- display: Fetch incidents\
-                        +  name: isFetch\
-                        +- display: Incident type'
+        return_value = '+category: Utilities' \
+            '+commonfields:\n' \
+            '+  id: Test\n' \
+            '+  version: -1\n' \
+            '+configuration:\n' \
+            '+- defaultvalue: https://soar.test.com\n' \
+            '+  display: Server URL (e.g. https://soar.test.com)\n' \
+            '+- display: Fetch incidents\n' \
+            '+  name: isFetch\n' \
+            '+- display: Incident type'
 
         mocker.patch('demisto_sdk.commands.update_release_notes.update_rn.run_command', return_value=return_value)
 
         assert check_docker_image_changed('test.yml') is None
+
+    def test_update_docker_image_when_docker_image_changed(self, mocker):
+        """
+        Given
+            - Modified .yml file
+        When
+            - Working on an integration's yml, and updated docker image
+
+        Then
+            - find the correct docker image
+        """
+        from demisto_sdk.commands.update_release_notes.update_rn import \
+            check_docker_image_changed
+
+        return_value = '+category: Utilities' \
+            '+commonfields:\n' \
+            '+  id: Test\n' \
+            '+  version: -1\n' \
+            '+configuration:\n' \
+            '+- defaultvalue: https://soar.test.com\n' \
+            '+  display: Server URL (e.g. https://soar.test.com)\n' \
+            '+- display: Fetch incidents\n' \
+            '+  name: isFetch\n' \
+            '-dockerimage: demisto/python3:1.2.3.0\n' \
+            '+dockerimage: demisto/python3:1.2.3.4'
+
+        mocker.patch('demisto_sdk.commands.update_release_notes.update_rn.run_command', return_value=return_value)
+
+        assert check_docker_image_changed('test.yml') == 'demisto/python3:1.2.3.4'
 
     def test_update_docker_image_in_yml(self, mocker):
         """

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -1087,7 +1087,7 @@ class TestRNUpdateUnit:
         with open('demisto_sdk/commands/update_release_notes/tests_data/Packs/Test/pack_metadata.json', 'r') as file:
             pack_data = json.load(file)
         mocker.patch('demisto_sdk.commands.update_release_notes.update_rn.run_command',
-                     return_value='+  dockerimage:python/test:1243')
+                     return_value='+  dockerimage: python/test:1243')
         mocker.patch.object(UpdateRN, 'is_bump_required', return_value=False)
         mocker.patch.object(UpdateRN, 'get_pack_metadata', return_value=pack_data)
         mocker.patch.object(UpdateRN, 'get_changed_file_name_and_type', return_value=('Test', FileType.INTEGRATION))
@@ -1103,7 +1103,7 @@ class TestRNUpdateUnit:
         with open('demisto_sdk/commands/update_release_notes/tests_data/Packs/release_notes/1_1_0.md', 'r') as file:
             RN = file.read()
         os.remove('demisto_sdk/commands/update_release_notes/tests_data/Packs/release_notes/1_1_0.md')
-        assert 'Updated the Docker image to: *dockerimage:python/test:1243*.' in RN
+        assert 'Updated the Docker image to: *python/test:1243*.' in RN
 
     def test_update_docker_image_in_yml_when_RN_aleady_exists(self, mocker):
         """
@@ -1122,7 +1122,7 @@ class TestRNUpdateUnit:
         with open('demisto_sdk/commands/update_release_notes/tests_data/Packs/release_notes/1_0_0.md', 'w') as file:
             file.write('### Integrations\n')
         mocker.patch('demisto_sdk.commands.update_release_notes.update_rn.run_command',
-                     return_value='+  dockerimage:python/test:1243')
+                     return_value='+  dockerimage: python/test:1243')
         mocker.patch.object(UpdateRN, 'is_bump_required', return_value=False)
         mocker.patch.object(UpdateRN, 'get_pack_metadata', return_value=pack_data)
         mocker.patch.object(UpdateRN, 'get_display_name', return_value='Test')
@@ -1139,7 +1139,7 @@ class TestRNUpdateUnit:
         client.execute_update()
         with open('demisto_sdk/commands/update_release_notes/tests_data/Packs/release_notes/1_0_0.md', 'r') as file:
             RN = file.read()
-        assert RN.count('Updated the Docker image to: *dockerimage:python/test:1243*.') == 1
+        assert RN.count('Updated the Docker image to: *python/test:1243*.') == 1
 
         with open('demisto_sdk/commands/update_release_notes/tests_data/Packs/release_notes/1_0_0.md', 'w') as file:
             file.write('')
@@ -1178,7 +1178,7 @@ class TestRNUpdateUnit:
         with open('demisto_sdk/commands/update_release_notes/tests_data/Packs/release_notes/1_1_0.md', 'r') as file:
             RN = file.read()
         os.remove('demisto_sdk/commands/update_release_notes/tests_data/Packs/release_notes/1_1_0.md')
-        assert 'Updated the Docker image to: *dockerimage:python/test:1243*' not in RN
+        assert 'Updated the Docker image to: *python/test:1243*' not in RN
 
     def test_new_integration_docker_not_updated(self, mocker):
         """

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -748,6 +748,7 @@ def check_docker_image_changed(added_or_modified_yml: str) -> Optional[str]:
         :return
         The latest docker image
     """
+    regex = re.compile(r'\+\s*dockerimage: (.*)')
     try:
         diff = run_command(f'git diff origin/master -- {added_or_modified_yml}', exit_on_error=False)
     except RuntimeError as e:
@@ -759,9 +760,10 @@ def check_docker_image_changed(added_or_modified_yml: str) -> Optional[str]:
     else:
         diff_lines = diff.splitlines()
         for diff_line in diff_lines:
-            if 'dockerimage:' in diff_line:  # search whether exists a line that notes that the Docker image was
-                # changed.
-                return diff_line.split()[-1]
+            # search whether exists a line that notes that the Docker image was changed.
+            docker_image = regex.match(diff_line)
+            if docker_image:
+                return docker_image.group(1)
         return None
 
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
the selected docker image was the first image present in the yml diff.
however, in most cases, the first line will be the original code (prefixed with `-`).
