### PR TITLE
fixed broken generate-test-playbook argument name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fixed an issue where new old-formatted scripts and integrations were not validated.
 * Fixed an issue where the wording in the from version validation error for subplaybooks was incorrect.
 * Fixed an issue where the **update-release-notes** command used the old docker image version instead of the new when detecting a docker change.
+* Fixed an issue where the **generate-test-playbook** command used an incorrect argument name as default
 
 # 1.4.6
 * Fixed an issue where **validate** suggests, with no reason, running **format** on missing mandatory keys in yml file.

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -945,7 +945,7 @@ def json_to_outputs_command(**kwargs):
 @click.option(
     "-v", "--verbose", help="Verbose output for debug purposes - shows full exception stack trace", is_flag=True)
 @click.option(
-    "-ab", "--all-brands","use_all_brands",
+    "-ab", "--all-brands", "use_all_brands",
     help="Generate a test-playbook which calls commands using integrations of all available brands. "
          "When not used, the generated playbook calls commands using instances of the provided integration brand.",
     is_flag=True

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -945,7 +945,7 @@ def json_to_outputs_command(**kwargs):
 @click.option(
     "-v", "--verbose", help="Verbose output for debug purposes - shows full exception stack trace", is_flag=True)
 @click.option(
-    "-ab", "--all-brands",
+    "-ab", "--all-brands","use_all_brands",
     help="Generate a test-playbook which calls commands using integrations of all available brands. "
          "When not used, the generated playbook calls commands using instances of the provided integration brand.",
     is_flag=True


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] Ready

## Description
Made `all-brands` an alias of the actual argument name `use_all_brands`
