### PR TITLE
added filter for '.gitlab', '.circleci', and '.github' dirs in validate manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fixed an issue where the **update-release-notes** command used the old docker image version instead of the new when detecting a docker change.
 * Fixed an issue where the **generate-test-playbook** command used an incorrect argument name as default
 * Fixed an issue where the **json-to-outputs** command used an incorrect argument name as default when using `-d`.
+* Fixed an issue where validations failed while trying to validate non content files.
 
 # 1.4.6
 * Fixed an issue where **validate** suggests, with no reason, running **format** on missing mandatory keys in yml file.

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -1153,3 +1153,20 @@ def test_quite_bc_flag(repo):
     existing_pack1 = repo.create_pack('PackWithModifiedIntegration')
     moodified_integration = existing_pack1.create_integration('MyIn')
     moodified_integration.create_default_integration()
+
+
+data_test_filted_dirs_in_format_file_path = [
+    ('Packs/PackName/Integrations/IntegrationName/IntegrationName.yml', 'Packs/PackName/Integrations/IntegrationName/IntegrationName.yml'),
+    ('.circleci/config.yml', None),
+    ('.github/workflows/check-contribution-form-filled.yml', None),
+    ('.gitlab/ci/.gitlab-ci.yml', None),
+]
+
+
+@pytest.mark.parametrize('input_file_path, output_file_path', data_test_filted_dirs_in_format_file_path)
+def test_filted_dirs_in_format_file_path(mocker, input_file_path, output_file_path):
+    validator_obj = ValidateManager(is_external_repo=True, check_is_unskipped=False)
+    mocker.patch.object(validator_obj, 'is_old_file_format', return_value=False)
+    mocker.patch.object(tools, 'get_dict_from_file', return_value=({'category': 'test'}, 'yml'))
+    filterd_files = validator_obj.format_file_path(input_file_path, None, set())
+    assert filterd_files == output_file_path

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -1295,6 +1295,10 @@ class ValidateManager:
 
     def format_file_path(self, file_path, old_path, old_format_files):
         """Determines if a file is relevant for validation and create any modification to the file_path if needed"""
+
+        if file_path.split(os.path.sep)[0] in ('.gitlab', '.circleci', '.github'):
+            return None
+
         file_type = find_type(file_path)
 
         # ignore unrecognized file types, unified.yml, doc data and test_data

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -1300,7 +1300,6 @@ class ValidateManager:
             return None
 
         file_type = find_type(file_path)
-
         # ignore unrecognized file types, unified.yml, doc data and test_data
         if not file_type or file_path.endswith('_unified.yml') or \
                 any(test_dir in str(file_path) for test_dir in TESTS_AND_DOC_DIRECTORIES):


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/40196

## Description
added filter for '.gitlab', '.circleci', and '.github' dirs.
so they will be removed from the validation section.