### PR TITLE
Skipped-test comments

### DIFF
--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -1693,8 +1693,11 @@ class Errors:
 
     @staticmethod
     @error_code_decorator
-    def integration_is_skipped(integration_id):
-        return f"The integration {integration_id} is currently in skipped. Please add working tests and unskip."
+    def integration_is_skipped(integration_id, skip_comment: Optional[str] = None):
+        message = f"The integration {integration_id} is currently in skipped. Please add working tests and unskip."
+        if skip_comment:
+            message += f" Skip comment: {skip_comment}"
+        return message
 
     @staticmethod
     @error_code_decorator

--- a/demisto_sdk/commands/common/hook_validations/integration.py
+++ b/demisto_sdk/commands/common/hook_validations/integration.py
@@ -168,7 +168,8 @@ class IntegrationValidator(ContentEntityValidator):
         skipped_integrations = conf_json_data.get('skipped_integrations', {})
         integration_id = _get_file_id('integration', self.current_file)
         if skipped_integrations and integration_id in skipped_integrations:
-            error_message, error_code = Errors.integration_is_skipped(integration_id)
+            skip_comment = skipped_integrations[integration_id]
+            error_message, error_code = Errors.integration_is_skipped(integration_id, skip_comment)
             if self.handle_error(error_message, error_code, file_path=self.file_path):
                 self.is_valid = False
         return self.is_valid

--- a/demisto_sdk/commands/common/tests/errors_test.py
+++ b/demisto_sdk/commands/common/tests/errors_test.py
@@ -143,3 +143,26 @@ class TestErrors(unittest.TestCase):
         expected_result = (error_statement, "RM101")
         result = Errors.image_path_error(path, alternative_path)
         assert result == expected_result
+
+    def test_integration_is_skipped(self):
+        """
+        Given: Name of a skipped integration, with no `skip comment`
+        When: Returning an error message
+        Then: Compile an error message, without the comment part.
+        """
+        integration_id = "dummy_integration"
+        expected = f"The integration {integration_id} is currently in skipped. Please add working tests and unskip."
+
+        assert Errors.integration_is_skipped(integration_id, skip_comment=None)[0] == expected
+        assert Errors.integration_is_skipped(integration_id, skip_comment='')[0] == expected
+        assert Errors.integration_is_skipped(integration_id)[0] == expected  # skip_comment argument is None by default
+
+    def test_integration_is_skipped__comment(self):
+        integration_id = "dummy_integration"
+        skip_comment = "Issue 00000"
+
+        expected = f"The integration {integration_id} is currently in skipped. Please add working tests and " + \
+                   f"unskip. Skip comment: {skip_comment}"
+
+        result = Errors.integration_is_skipped(integration_id, skip_comment)
+        assert result[0] == expected


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/40242

## Description
When a test is skipped, and a skip-comment is available (for example, `No instance` or `Issue 12345`), show it as part of the validation error message.

## Must have
- [x] Tests
- [ ] Documentation
