### PR TITLE
Removing redundant directories in test `test_two_files_with_same_name`

### DIFF
--- a/demisto_sdk/commands/secrets/tests/secrets_test.py
+++ b/demisto_sdk/commands/secrets/tests/secrets_test.py
@@ -155,6 +155,8 @@ my_email = "fooo@someorg.com"
         secrets_found = validator.search_potential_secrets([file1_path, file2_path], True)
         assert secrets_found[os.path.join(dir1_path, file_name)] == {4: ['fooo@someorg.com']}
         assert secrets_found[os.path.join(dir2_path, file_name)] == {4: ['fooo@someorg.com']}
+        shutil.rmtree(dir1_path)
+        shutil.rmtree(dir2_path)
 
     def test_remove_white_list_regex(self):
         white_list = '155.165.45.232'


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
This PR aims to improve test reliability of test `test_two_files_with_same_name` by removing redundant directories by calling method `shutil.rmtree`

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 $test_path`:

```
        create_empty_whitelist_secrets_file(os.path.join(TestSecrets.TEMP_DIR, TestSecrets.WHITE_LIST_FILE_NAME))
        dir1_path = os.path.join(TestSecrets.TEMP_DIR, "dir1")
        dir2_path = os.path.join(TestSecrets.TEMP_DIR, "dir2")
>       os.mkdir(dir1_path)
E       FileExistsError: [Errno 17] File exists: '/home/ailen/PycharmProjects/demisto-sdk/demisto_sdk/tests/test_files/temp/dir1'
```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.


## Must have
- [x] Tests
- [ ] Documentation
