### PR TITLE
test playbook location fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 * Added validation that the support URL in partner contribution pack metadata does not lead to a GitHub repo.
+* Fixed an issue where the **generate-test-playbook** command would not place the playbook in the proper folder.
 
 # 1.4.8
 * Fixed an issue where yml files with `!reference` failed to load properly.

--- a/demisto_sdk/commands/generate_test_playbook/test_playbook_generator.py
+++ b/demisto_sdk/commands/generate_test_playbook/test_playbook_generator.py
@@ -331,12 +331,15 @@ class PlaybookTestsGenerator:
             if input yml is under standard Packs/<Pack>/<...>/<Integration> path,
             save the test-playbook under   Packs/<Pack>/TestPlaybooks
             """
+            pack_path = None
             for p in input_folder.parents:
                 if p.parent.name == "Packs":
                     pack_path = p
-                    folder = (pack_path / 'TestPlaybooks')
-                    folder.mkdir(exist_ok=True, parents=True)
                     break
+
+            if pack_path:
+                folder = (pack_path / 'TestPlaybooks')
+                folder.mkdir(exist_ok=True, parents=True)
             else:
                 """ otherwise, save the generated test-playbook in the folder from which SDK is called."""
                 folder = Path()

--- a/demisto_sdk/commands/generate_test_playbook/test_playbook_generator.py
+++ b/demisto_sdk/commands/generate_test_playbook/test_playbook_generator.py
@@ -327,13 +327,16 @@ class PlaybookTestsGenerator:
         else:
             input_folder = Path(input)
 
-            if 'Packs' in (p.name for p in input_folder.parents):
-                """
-                if input yml is under standard Packs/<Pack>/Integrations/<Integration> path,
-                save the test-playbook under   Packs/<Pack>/TestPlaybooks
-                """
-                folder = (input_folder.parent.parent / 'TestPlaybooks')
-                folder.mkdir(exist_ok=True, parents=True)
+            """
+            if input yml is under standard Packs/<Pack>/<...>/<Integration> path,
+            save the test-playbook under   Packs/<Pack>/TestPlaybooks
+            """
+            for p in input_folder.parents:
+                if p.parent.name == "Packs":
+                    pack_path = p
+                    folder = (pack_path / 'TestPlaybooks')
+                    folder.mkdir(exist_ok=True, parents=True)
+                    break
             else:
                 """ otherwise, save the generated test-playbook in the folder from which SDK is called."""
                 folder = Path()


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/40605

## Description
Test playbooks were placed one level too deep (as the `test-integration` path does not perfectly reflect the one at `content`)
Now, the location is set relative to the pack folder, to prevent such confusions.

## Must have
- [x] Tests
- [x] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [x] N/A - Functionality cannot be implemented in the extension because it's a behind-the-scenes behaviour.