### PR TITLE
Add an if statement to check if secrets have been detected

### DIFF
--- a/demisto_sdk/commands/init/initiator.py
+++ b/demisto_sdk/commands/init/initiator.py
@@ -457,13 +457,14 @@ class Initiator:
 
         if self.template != self.DEFAULT_INTEGRATION_TEMPLATE:  # DEFAULT_INTEGRATION_TEMPLATE there are no secrets
             secrets = self.find_secrets()
-            new_line = '\n'
-            click.echo(f"\nThe following secrets were detected:\n"
-                       f"{new_line.join(secret for secret in secrets)}", color=LOG_COLORS.GREEN)
+            if secrets:
+                new_line = '\n'
+                click.echo(f"\nThe following secrets were detected:\n"
+                           f"{new_line.join(secret for secret in secrets)}", color=LOG_COLORS.GREEN)
 
-            ignore_secrets = input("\nWould you like ignore them automatically? Y/N ").lower()
-            if ignore_secrets in ['y', 'yes']:
-                self.ignore_secrets(secrets)
+                ignore_secrets = input("\nWould you like ignore them automatically? Y/N ").lower()
+                if ignore_secrets in ['y', 'yes']:
+                    self.ignore_secrets(secrets)
 
         click.echo(f"Finished creating integration: {self.full_output_path}.", color=LOG_COLORS.GREEN)
 
@@ -507,13 +508,14 @@ class Initiator:
         self.copy_demistotmock()
 
         secrets = self.find_secrets()
-        new_line = '\n'
-        click.echo(f"\nThe following secrets were detected in the pack:\n"
-                   f"{new_line.join(secret for secret in secrets)}", color=LOG_COLORS.GREEN)
+        if secrets:
+            new_line = '\n'
+            click.echo(f"\nThe following secrets were detected in the pack:\n"
+                       f"{new_line.join(secret for secret in secrets)}", color=LOG_COLORS.GREEN)
 
-        ignore_secrets = input("\nWould you like ignore them automatically? Y/N ").lower()
-        if ignore_secrets in ['y', 'yes']:
-            self.ignore_secrets(secrets)
+            ignore_secrets = input("\nWould you like ignore them automatically? Y/N ").lower()
+            if ignore_secrets in ['y', 'yes']:
+                self.ignore_secrets(secrets)
 
         click.echo(f"Finished creating script: {self.full_output_path}", color=LOG_COLORS.GREEN)
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
In the init command it is possible to ignore secrets automatically. Before you choose to ignore then there is a message to those secrets you are going to ignore. The message also appears in case there are no secrets. To fix this I have added an if statement to check if there are any secrets and only if so then print this message.

## Screenshots
![Screen Shot 2021-08-29 at 9 08 27](https://user-images.githubusercontent.com/78307768/131240548-5919c513-2f36-417a-9a1a-11f98db7a0e1.png)

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
