### PR TITLE
parsing datetime.min as date on json-to-outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fixed an issue where the skipped tests validation ran on the `ApiModules` pack in the **validate** command.
 * The **init** command will now create the `Generic Object` entities directories.
 * Fixed an issue where the **format** command failed to recognize changed files from git.
+* Fixed an issue where the **json-to-outputs** command failed checking whether `0001-01-01T00:00:00` is of type `Date`
 
 # 1.4.9
 * Added validation that the support URL in partner contribution pack metadata does not lead to a GitHub repo.

--- a/demisto_sdk/commands/json_to_outputs/json_to_outputs.py
+++ b/demisto_sdk/commands/json_to_outputs/json_to_outputs.py
@@ -119,23 +119,25 @@ def jsonise(context_key, value, description=''):
     }
 
 
+def _is_min_date(val: str):
+    # catches `0001-01-01Z00:00:00`, `0001-01-01T00:00:00`, `0001-01-01 00:00`, etc
+    return '0001-01-01' in val and '00:00' in val
+
+
 def is_date(val):
     """
     Determines if val is Date, if yes returns True otherwise False
     """
     if isinstance(val, (int, float)) and val > 15737548065 and val < 2573754806500:
-        # 15737548065 is the lowest timestamp that exist year - 1970
-        # 2573754806500 is the year 2050 - I believe no json will contain date time over this time
+        # 15737548065 is Jul 02 1970 (milliseconds)
+        # 2573754806500 is the year 2050 (milliseconds)
         # if number is between these two numbers it probably is timestamp=date
         return True
 
-    if isinstance(val, str) and len(val) >= 10 and len(val) <= 30 and dateparser.parse(val):
+    if isinstance(val, str) and len(val) >= 10 and len(val) <= 30 and (_is_min_date(val) or dateparser.parse(val)):
         # the shortest date string is => len(2019-10-10) = 10
         # The longest date string I could think of wasn't of length over len=30 '2019-10-10T00:00:00.000 +0900'
-        # To reduce in performance of using dateparser.parse,I
         return True
-
-    return False
 
 
 def determine_type(val):

--- a/demisto_sdk/commands/json_to_outputs/tests/json_to_outputs_test.py
+++ b/demisto_sdk/commands/json_to_outputs/tests/json_to_outputs_test.py
@@ -79,7 +79,11 @@ def test_json_to_outputs__invalid_json():
         assert str(ex) == 'Invalid input JSON'
 
 
-def test_json_to_outputs__detect_date():
+DATETIME_MIN_VALUES = ['0001-01-01T00:00:00', '0001-01-01T00:00', '0001-01-01Z00:00:00', '0001-01-01Z00:00']
+
+
+@pytest.mark.parametrize('time_created', ['2019-10-10T00:00:00'] + DATETIME_MIN_VALUES)
+def test_json_to_outputs__detect_date(time_created):
     """
     Given
         - valid json {"create_at": "2019-10-10T00:00:00"}
@@ -90,7 +94,7 @@ def test_json_to_outputs__detect_date():
 
     """
     yaml_output = parse_json(
-        data='{"created_at": "2019-10-10T00:00:00"}',
+        data=json.dumps({'created_at': time_created}),
         command_name='jira-ticket',
         prefix='Jira.Ticket',
         descriptions={'created_at': 'time when the ticket was created.'}


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/40195

## Description
Patch solving the issue, as the elegant solution caused too much hassle compared to the size of the bug. 

## Must have
- [x] Tests
- [x] Documentation
