### PR TITLE
generated description logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fixed an issue where the skipped tests validation ran on the `ApiModules` pack in the **validate** command.
 * The **init** command will now create the `Generic Object` entities directories.
 * Fixed an issue where the **format** command failed to recognize changed files from git.
+* Fixed an issue where the **generate-docs** command would not use the `description` of content items, but `%%UPDATE_RN``.
 
 # 1.4.9
 * Added validation that the support URL in partner contribution pack metadata does not lead to a GitHub repo.

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -128,20 +128,23 @@ class TestRNUpdate(unittest.TestCase):
             Given:
                 - a dict of changed items
             When:
-                - we want to produce a release notes template for modified file
+                - we want to produce a release notes template for modified files
             Then:
-                - return a markdown string
+                - validate the returned release notes
         """
-        expected_result = "\n#### Playbooks\n##### Hello World Playbook\n- %%UPDATE_RN%%\n"
+        changed_file_description = "Hello World Playbook description"
+        expected_result = "\n".join(("",
+                                     "#### Playbooks",
+                                     "##### Hello World Playbook",
+                                     f"- {changed_file_description}",
+                                     ""))
         from demisto_sdk.commands.update_release_notes.update_rn import \
             UpdateRN
         mock_master.return_value = '1.0.0'
         update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='minor', modified_files_in_pack={'HelloWorld'},
                              added_files=set())
-        changed_items = {
-            ("Hello World Playbook", FileType.PLAYBOOK): {"description": "Hello World Playbook description",
-                                                          "is_new_file": False},
-        }
+        changed_items = {("Hello World Playbook", FileType.PLAYBOOK): {"description": changed_file_description,
+                                                                       "is_new_file": False}}
         release_notes = update_rn.build_rn_template(changed_items)
         assert expected_result == release_notes
 

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -548,7 +548,7 @@ class UpdateRN:
                 elif self.update_type == 'documentation':
                     rn_desc += '- Documentation and metadata improvements.\n'
                 else:
-                    rn_desc += f'- {text or "%%UPDATE_RN%%"}\n'
+                    rn_desc += f'- {desc or "%%UPDATE_RN%%"}\n'
         if docker_image:
             rn_desc += f'- Updated the Docker image to: *{docker_image}*.\n'
         return rn_desc


### PR DESCRIPTION

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/41114

## Description
Improving the way descriptions of content items are used on generated release notes.

## Must have
- [x] Tests
- [x] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
