### PR TITLE
Fix SDK Nightly Unittests Missing Required Param

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ export DEMISTO_SDK_SKIP_VERSION_CHECK=yes
 ## Commands
 
 Supported commands:
-get_ignore_pack_skipped_tests
+
 1. [init](https://github.com/demisto/demisto-sdk/blob/master/demisto_sdk/commands/init/README.md)
 1. [Validate](https://github.com/demisto/demisto-sdk/blob/master/demisto_sdk/commands/validate/README.md)
 1. [Lint](https://github.com/demisto/demisto-sdk/blob/master/demisto_sdk/commands/lint/README.md)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ export DEMISTO_SDK_SKIP_VERSION_CHECK=yes
 ## Commands
 
 Supported commands:
-
+get_ignore_pack_skipped_tests
 1. [init](https://github.com/demisto/demisto-sdk/blob/master/demisto_sdk/commands/init/README.md)
 1. [Validate](https://github.com/demisto/demisto-sdk/blob/master/demisto_sdk/commands/validate/README.md)
 1. [Lint](https://github.com/demisto/demisto-sdk/blob/master/demisto_sdk/commands/lint/README.md)

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -863,7 +863,7 @@ def get_test_playbook_id(test_playbooks_list: list, tpb_path: str) -> Tuple:  # 
             return None, None
 
 
-def get_ignore_pack_skipped_tests(pack_name: str, modified_packs: set) -> set:
+def get_ignore_pack_skipped_tests(pack_name: str, modified_packs: Optional[set] = None) -> set:
     """
     Retrieve the skipped tests of a given pack, as detailed in the .pack-ignore file
 
@@ -879,6 +879,8 @@ def get_ignore_pack_skipped_tests(pack_name: str, modified_packs: set) -> set:
         ignored_tests_set (set[str]): set of ignored test ids
 
     """
+    if not modified_packs:
+        modified_packs = set()
     ignored_tests_set = set()
     ignore_list = []
     id_set = get_content_id_set()


### PR DESCRIPTION
8 tests failed last night, all of them had this error
ignored_tests_set.update(tools.get_ignore_pack_skipped_tests(pack))
TypeError: get_ignore_pack_skipped_tests() missing 1 required positional argument: 'modified_packs'

https://code.pan.run/xsoar/content/-/jobs/7467479

due to a change that was pushed yesterday
https://github.com/demisto/demisto-sdk/pull/1599
added default value for this argument 