### PR TITLE
Sdk nightly failure Fix

### DIFF
--- a/demisto_sdk/commands/common/tests/tools_test.py
+++ b/demisto_sdk/commands/common/tests/tools_test.py
@@ -583,7 +583,7 @@ def test_get_ignore_pack_tests__no_pack():
     - returns an empty set
     """
     nonexistent_pack = 'NonexistentFakeTestPack'
-    ignore_test_set = get_ignore_pack_skipped_tests(nonexistent_pack, {''})
+    ignore_test_set = get_ignore_pack_skipped_tests(nonexistent_pack, {})
     assert len(ignore_test_set) == 0
 
 
@@ -608,7 +608,7 @@ def test_get_ignore_pack_tests__no_ignore_pack(tmpdir):
     if os.path.exists(pack_ignore_path):
         os.remove(pack_ignore_path)
 
-    ignore_test_set = get_ignore_pack_skipped_tests(fake_pack_name, {fake_pack_name})
+    ignore_test_set = get_ignore_pack_skipped_tests(fake_pack_name, {})
     assert len(ignore_test_set) == 0
 
 
@@ -633,7 +633,7 @@ def test_get_ignore_pack_tests__test_not_ignored(tmpdir):
     # prepare .pack-ignore
     open(pack_ignore_path, 'a').close()
 
-    ignore_test_set = get_ignore_pack_skipped_tests(fake_pack_name, {fake_pack_name})
+    ignore_test_set = get_ignore_pack_skipped_tests(fake_pack_name, {})
     assert len(ignore_test_set) == 0
 
 
@@ -670,7 +670,7 @@ def test_get_ignore_pack_tests__ignore_test(tmpdir, mocker):
     mocker.patch.object(os.path, "join", return_value=str(test_playbook_path / (test_playbook.name + ".yml")))
     mocker.patch.object(tools, "get_test_playbook_id", return_value=('SamplePlaybookTest', 'FakeTestPack'))
 
-    ignore_test_set = get_ignore_pack_skipped_tests(fake_pack_name, {fake_pack_name})
+    ignore_test_set = get_ignore_pack_skipped_tests(fake_pack_name, {})
     assert len(ignore_test_set) == 1
     assert expected_id in ignore_test_set
 
@@ -706,7 +706,7 @@ def test_get_ignore_pack_tests__ignore_missing_test(tmpdir, mocker):
     mocker.patch.object(os.path, "join", return_value=str(test_playbook_path / fake_test_name))
     mocker.patch.object(tools, "get_test_playbook_id", return_value=(None, 'FakeTestPack'))
 
-    ignore_test_set = get_ignore_pack_skipped_tests(fake_pack_name, {fake_pack_name})
+    ignore_test_set = get_ignore_pack_skipped_tests(fake_pack_name, {})
     assert len(ignore_test_set) == 0
 
 

--- a/demisto_sdk/commands/common/tests/tools_test.py
+++ b/demisto_sdk/commands/common/tests/tools_test.py
@@ -583,7 +583,7 @@ def test_get_ignore_pack_tests__no_pack():
     - returns an empty set
     """
     nonexistent_pack = 'NonexistentFakeTestPack'
-    ignore_test_set = get_ignore_pack_skipped_tests(nonexistent_pack, {})
+    ignore_test_set = get_ignore_pack_skipped_tests(nonexistent_pack, {nonexistent_pack}, {})
     assert len(ignore_test_set) == 0
 
 
@@ -608,7 +608,7 @@ def test_get_ignore_pack_tests__no_ignore_pack(tmpdir):
     if os.path.exists(pack_ignore_path):
         os.remove(pack_ignore_path)
 
-    ignore_test_set = get_ignore_pack_skipped_tests(fake_pack_name, {})
+    ignore_test_set = get_ignore_pack_skipped_tests(fake_pack_name, {fake_pack_name}, {})
     assert len(ignore_test_set) == 0
 
 
@@ -633,7 +633,7 @@ def test_get_ignore_pack_tests__test_not_ignored(tmpdir):
     # prepare .pack-ignore
     open(pack_ignore_path, 'a').close()
 
-    ignore_test_set = get_ignore_pack_skipped_tests(fake_pack_name, {})
+    ignore_test_set = get_ignore_pack_skipped_tests(fake_pack_name, {fake_pack_name}, {})
     assert len(ignore_test_set) == 0
 
 
@@ -670,7 +670,7 @@ def test_get_ignore_pack_tests__ignore_test(tmpdir, mocker):
     mocker.patch.object(os.path, "join", return_value=str(test_playbook_path / (test_playbook.name + ".yml")))
     mocker.patch.object(tools, "get_test_playbook_id", return_value=('SamplePlaybookTest', 'FakeTestPack'))
 
-    ignore_test_set = get_ignore_pack_skipped_tests(fake_pack_name, {})
+    ignore_test_set = get_ignore_pack_skipped_tests(fake_pack_name, {fake_pack_name}, {})
     assert len(ignore_test_set) == 1
     assert expected_id in ignore_test_set
 
@@ -706,7 +706,7 @@ def test_get_ignore_pack_tests__ignore_missing_test(tmpdir, mocker):
     mocker.patch.object(os.path, "join", return_value=str(test_playbook_path / fake_test_name))
     mocker.patch.object(tools, "get_test_playbook_id", return_value=(None, 'FakeTestPack'))
 
-    ignore_test_set = get_ignore_pack_skipped_tests(fake_pack_name, {})
+    ignore_test_set = get_ignore_pack_skipped_tests(fake_pack_name, {fake_pack_name}, {})
     assert len(ignore_test_set) == 0
 
 

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -856,6 +856,8 @@ def get_test_playbook_id(test_playbooks_list: list, tpb_path: str) -> Tuple:  # 
         test_playbook_id = list(test_playbook_dict.keys())[0]
         test_playbook_path = test_playbook_dict[test_playbook_id].get('file_path')
         test_playbook_pack = test_playbook_dict[test_playbook_id].get('pack')
+        if not test_playbook_path or not test_playbook_pack:
+            continue
 
         if tpb_path in test_playbook_path:
             return test_playbook_id, test_playbook_pack

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -859,11 +859,10 @@ def get_test_playbook_id(test_playbooks_list: list, tpb_path: str) -> Tuple:  # 
 
         if tpb_path in test_playbook_path:
             return test_playbook_id, test_playbook_pack
-        else:
-            return None, None
+    return None, None
 
 
-def get_ignore_pack_skipped_tests(pack_name: str, modified_packs: Optional[set] = None) -> set:
+def get_ignore_pack_skipped_tests(pack_name: str, id_set: dict) -> set:
     """
     Retrieve the skipped tests of a given pack, as detailed in the .pack-ignore file
 
@@ -873,41 +872,37 @@ def get_ignore_pack_skipped_tests(pack_name: str, modified_packs: Optional[set] 
 
     Arguments:
         pack_name (str): name of the pack
-        modified_packs (set): Set of the modified packs.
+        id_set (dict): ID set
 
     Returns:
         ignored_tests_set (set[str]): set of ignored test ids
 
     """
-    if not modified_packs:
-        modified_packs = {pack_name}
     ignored_tests_set = set()
-    ignore_list = []
-    id_set = get_content_id_set()
-    test_playbooks = id_set['TestPlaybooks']
-    if pack_name in modified_packs:
-        pack_ignore_path = get_pack_ignore_file_path(pack_name)
-        if os.path.isfile(pack_ignore_path):
-            try:
-                # read pack_ignore using ConfigParser
-                config = ConfigParser(allow_no_value=True)
-                config.read(pack_ignore_path)
+    file_name_to_ignore_dict: Dict[str, List[str]] = {}
+    test_playbooks = id_set.get('TestPlaybooks', {})
 
-                # go over every file in the config
-                for section in config.sections():
-                    if section.startswith("file:"):
-                        # given section is of type file
-                        file_name = section[5:]
-                        for key in config[section]:
-                            if key == 'ignore':
-                                # group ignore codes to a list
-                                ignore_list.append({'file_name': file_name, 'ignore_code': str(config[section][key])})
-            except MissingSectionHeaderError:
-                pass
+    pack_ignore_path = get_pack_ignore_file_path(pack_name)
+    if os.path.isfile(pack_ignore_path):
+        try:
+            # read pack_ignore using ConfigParser
+            config = ConfigParser(allow_no_value=True)
+            config.read(pack_ignore_path)
 
-    for item in ignore_list:
-        file_name = item.get('file_name', '')
-        if item.get('ignore_code') == 'auto-test':
+            # go over every file in the config
+            for section in config.sections():
+                if section.startswith("file:"):
+                    # given section is of type file
+                    file_name: str = section[5:]
+                    for key in config[section]:
+                        if key == 'ignore':
+                            # group ignore codes to a list
+                            file_name_to_ignore_dict[file_name] = str(config[section][key]).split(',')
+        except MissingSectionHeaderError:
+            pass
+
+    for file_name, ignore_list in file_name_to_ignore_dict.items():
+        if any(ignore_code == 'auto-test' for ignore_code in ignore_list):
             test_id, test_pack = get_test_playbook_id(test_playbooks, file_name)
             if test_id:
                 ignored_tests_set.add(test_id)


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Few changes were made
1. changed ID set to be an argument (this works well for content tests), as well of not performing HTTP call every function call to get ID set
2. Added a sanity test to see id set returns the tpb path and pack if not skip

This requires a change from content side to send ID set to get_ignore_pack_skipped_tests in collect_tests_and_content_packs) which contains id_set as its argument so it shouldn't be a problem (and of course change sdk requirement to the hash of this merge)

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
