### PR TITLE
Fix error with download command when invalid YAML file on Demisto server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fixed an issue where **validate** failed on release notes configuration files.
 * Fixed an issue where the **validate** command failed on pack input if git detected changed files outside of `Packs` directory.
 * Fixed an issue where **validate** command failed to recognize files inside validated pack when validation release notes, resulting in a false error message for missing entity in release note.
+* Fixed an issue where the **download** command failed when downloading an invalid YML, instead of skipping it.
 
 # 1.4.9
 * Added validation that the support URL in partner contribution pack metadata does not lead to a GitHub repo.

--- a/demisto_sdk/commands/download/downloader.py
+++ b/demisto_sdk/commands/download/downloader.py
@@ -184,10 +184,15 @@ class Downloader:
         custom_content_file_paths: list = get_child_files(self.custom_content_temp_dir)
         custom_content_objects: List = list()
         for file_path in custom_content_file_paths:
-            custom_content_object: Dict = self.build_custom_content_object(file_path)
-            if custom_content_object['type']:
-                # If custom content object's type is empty it means the file isn't of support content entity
-                custom_content_objects.append(custom_content_object)
+            try:
+                custom_content_object: Dict = self.build_custom_content_object(file_path)
+                if custom_content_object['type']:
+                    # If custom content object's type is empty it means the file isn't of support content entity
+                    custom_content_objects.append(custom_content_object)
+            # Do not add file to custom_content_objects if it has an invalid format
+            except ValueError as e:
+                print_color(f"Error when loading {file_path}, skipping", LOG_COLORS.RED)
+                print_color(f"{e}", LOG_COLORS.RED)
         return custom_content_objects
 
     def handle_list_files_flag(self) -> bool:


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description

When you have an invalid YAML file related to a custom object on your Demisto server, you cannot use the download command. 

The current implementation parses all YAML files and does not handle this case.

Here is the exception I got when using `demisto-sdk download -i xxx -o Packs/Custom`

```
Traceback (most recent call last):
  File "dem-sdk/.venv/bin/demisto-sdk", line 33, in <module>
    sys.exit(load_entry_point('demisto-sdk', 'console_scripts', 'demisto-sdk')())
  File "dem-sdk/.venv/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "dem-sdk/.venv/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "dem-sdk/.venv/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "dem-sdk/.venv/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "dem-sdk/.venv/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "dem-sdk/.venv/src/demisto-sdk/demisto_sdk/__main__.py", line 837, in download
    return downloader.download()
  File "dem-sdk/.venv/src/demisto-sdk/demisto_sdk/commands/download/downloader.py", line 85, in download
    exit_code: int = self.download_manager()
  File "dem-sdk/.venv/src/demisto-sdk/demisto_sdk/commands/download/downloader.py", line 105, in download_manager
    self.build_custom_content()
  File "dem-sdk/.venv/src/demisto-sdk/demisto_sdk/commands/download/downloader.py", line 332, in build_custom_content
    self.get_custom_content_objects()
  File "dem-sdk/.venv/src/demisto-sdk/demisto_sdk/commands/download/downloader.py", line 187, in get_custom_content_objects
    custom_content_object: Dict = self.build_custom_content_object(file_path)
  File "dem-sdk/.venv/src/demisto-sdk/demisto_sdk/commands/download/downloader.py", line 372, in build_custom_content_object
    file_data, file_ending = get_dict_from_file(file_path)  # For example: yml, for integration files
  File "dem-sdk/.venv/src/demisto-sdk/demisto_sdk/commands/common/tools.py", line 1028, in get_dict_from_file
    return get_yaml(path), 'yml'
  File "dem-sdk/.venv/src/demisto-sdk/demisto_sdk/commands/common/tools.py", line 471, in get_yaml
    return get_file(file_path, 'yml')
  File "dem-sdk/.venv/src/demisto-sdk/demisto_sdk/commands/common/tools.py", line 463, in get_file
    raise ValueError(
ValueError: /tmp/tmpihnvdhoo/xxx.yml has a structure issue of file type yml. Error was: while parsing a block mapping
  in "<file>", line 510, column 19
expected <block end>, but found '<scalar>'
  in "<file>", line 510, column 30
```

With the change proposed in this PR, here is the output the user will got:

```
$ demisto-sdk download --insecure -i xxx -o Packs/Custom 

Error when loading /tmp/tmpw7pt5apa/xxx.yml, skipping: /tmp/tmpw7pt5apa/xxx.yml has a structure issue of file type yml.
Error was: while parsing a block mapping
  in "<file>", line 510, column 19
expected <block end>, but found '<scalar>'
  in "<file>", line 510, column 30

Demisto instance: Enumerating objects: 1, done.
Demisto instance: Receiving objects: 100% (1/1), done.

- Added Script "xxx"

1 file added.
```

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
