### PR TITLE
Fix error when entry.contents is not a str after running the run command

### DIFF
--- a/demisto_sdk/commands/run_cmd/runner.py
+++ b/demisto_sdk/commands/run_cmd/runner.py
@@ -131,7 +131,7 @@ class Runner:
             if entry.contents:
                 print_color('## Readable Output', LOG_COLORS.YELLOW)
                 if entry.type == self.ERROR_ENTRY_TYPE:
-                    print_error(entry.contents)
+                    print_error(f'{entry.contents}\n')
                 else:
                     print(entry.contents)
 

--- a/demisto_sdk/commands/run_cmd/runner.py
+++ b/demisto_sdk/commands/run_cmd/runner.py
@@ -131,9 +131,9 @@ class Runner:
             if entry.contents:
                 print_color('## Readable Output', LOG_COLORS.YELLOW)
                 if entry.type == self.ERROR_ENTRY_TYPE:
-                    print_error(entry.contents + '\n')
+                    print_error(entry.contents)
                 else:
-                    print(entry.contents + '\n')
+                    print(entry.contents)
 
             # and entries with `file_id`s defined, that is the fileID of the debug log file
             if entry.type == self.DEBUG_FILE_ENTRY_TYPE:

--- a/demisto_sdk/commands/run_cmd/runner.py
+++ b/demisto_sdk/commands/run_cmd/runner.py
@@ -133,7 +133,7 @@ class Runner:
                 if entry.type == self.ERROR_ENTRY_TYPE:
                     print_error(f'{entry.contents}\n')
                 else:
-                    print(entry.contents)
+                    print(f'{entry.contents}\n')
 
             # and entries with `file_id`s defined, that is the fileID of the debug log file
             if entry.type == self.DEBUG_FILE_ENTRY_TYPE:


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Description

When using the run command, and when the result returned is not a string, demisto-sdk crashes with
the following exception:

```
Traceback (most recent call last):
  File "dem-sdk/.venv/bin/demisto-sdk", line 33, in <module>
    sys.exit(load_entry_point('demisto-sdk', 'console_scripts', 'demisto-sdk')())
  File "dem-sdk/.venv/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "dem-sdk/.venv/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "dem-sdk/.venv/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "dem-sdk/.venv/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "dem-sdk/.venv/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "dem-sdk/.venv/src/demisto-sdk/demisto_sdk/__main__.py", line 874, in run
    return runner.run()
  File "dem-sdk/.venv/src/demisto-sdk/demisto_sdk/commands/run_cmd/runner.py", line 58, in run
    log_ids = self._run_query(playground_id)
  File "dem-sdk/.venv/src/demisto-sdk/demisto_sdk/commands/run_cmd/runner.py", line 136, in _run_query
    print(entry.contents + '\n')
TypeError: unsupported operand type(s) for +: 'dict' and 'str'

```

Command used to trigger the error:

```
demisto-sdk run --insecure -q '!demisto-api-get uri="/workers/status"'
```

This PR just remove the addition of \n to entry.contents.

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
