### PR TITLE
failing skipunavaiable only if fromversion about 6.0.0

### DIFF
--- a/demisto_sdk/commands/common/hook_validations/id.py
+++ b/demisto_sdk/commands/common/hook_validations/id.py
@@ -346,9 +346,10 @@ class IDSetValidations(BaseValidator):
                 is_version_valid = not entity_version or LooseVersion(entity_version) <= LooseVersion(
                     main_playbook_version)
                 skip_unavailable = all(task_data.get('skipunavailable', False) for task_data in tasks_data) \
-                    if tasks_data and LooseVersion(entity_version) >= LooseVersion('6.0.0') else False
+                    if tasks_data and LooseVersion(main_playbook_version) >= LooseVersion('6.0.0') else False
 
-                # if entities with miss-matched versions were found and skipunavailable is not set, fail the validation
+                # if entities with miss-matched versions were found and skipunavailable is
+                # not set or main playbook fromversion is below 6.0.0, fail the validation
                 if not is_version_valid and not skip_unavailable:
                     invalid_version_entities.append(entity_name)
                 implemented_entities.remove(entity_name)

--- a/demisto_sdk/commands/common/hook_validations/id.py
+++ b/demisto_sdk/commands/common/hook_validations/id.py
@@ -346,7 +346,7 @@ class IDSetValidations(BaseValidator):
                 is_version_valid = not entity_version or LooseVersion(entity_version) <= LooseVersion(
                     main_playbook_version)
                 skip_unavailable = all(task_data.get('skipunavailable', False) for task_data in tasks_data) \
-                    if tasks_data else False
+                    if tasks_data and LooseVersion(entity_version) >= LooseVersion('6.0.0') else False
 
                 # if entities with miss-matched versions were found and skipunavailable is not set, fail the validation
                 if not is_version_valid and not skip_unavailable:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/39936

## Description
make sure validate fails in case a playbook uses un supported versioned sub-playbook and the main playbook is fromversion below 6.0.0


