### PR TITLE
Readme image validation regex fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fixed an issue where the **validate** command failed on pack input if git detected changed files outside of `Packs` directory.
 * Fixed an issue where **validate** command failed to recognize files inside validated pack when validation release notes, resulting in a false error message for missing entity in release note.
 * Fixed an issue where the **download** command failed when downloading an invalid YML, instead of skipping it.
+* Fixed an issue were the **validate** command was falsely recognizing image paths in readme files.
 
 # 1.4.9
 * Added validation that the support URL in partner contribution pack metadata does not lead to a GitHub repo.

--- a/demisto_sdk/commands/common/hook_validations/readme.py
+++ b/demisto_sdk/commands/common/hook_validations/readme.py
@@ -250,7 +250,7 @@ class ReadMeValidator(BaseValidator):
         should_print_error = not is_pack_readme
         relative_images = re.findall(r'(\!\[.*?\])\(((?!http).*?)\)$', self.readme_content, re.IGNORECASE | re.MULTILINE)
         relative_images += re.findall(  # HTML image tag
-            r'(<img.*?src\s*=\s*\"((?!http).*?)\")', self.readme_content,
+            r'(<img.*?src\s*=\s*"((?!http).*?)")', self.readme_content,
             re.IGNORECASE | re.MULTILINE)
 
         for img in relative_images:

--- a/demisto_sdk/commands/common/hook_validations/readme.py
+++ b/demisto_sdk/commands/common/hook_validations/readme.py
@@ -250,7 +250,7 @@ class ReadMeValidator(BaseValidator):
         should_print_error = not is_pack_readme
         relative_images = re.findall(r'(\!\[.*?\])\(((?!http).*?)\)$', self.readme_content, re.IGNORECASE | re.MULTILINE)
         relative_images += re.findall(  # HTML image tag
-            r'(src\s*=\s*"((?!http).*?)")', self.readme_content,
+            r'(<img.*?src\s*=\s*\"((?!http).*?)\")', self.readme_content,
             re.IGNORECASE | re.MULTILINE)
 
         for img in relative_images:

--- a/demisto_sdk/commands/common/hook_validations/readme.py
+++ b/demisto_sdk/commands/common/hook_validations/readme.py
@@ -292,8 +292,8 @@ class ReadMeValidator(BaseValidator):
         # files validation.
         absolute_links = re.findall(
             r'(!\[.*\])\((https://.*)\)$', self.readme_content, re.IGNORECASE | re.MULTILINE)
-        absolute_links += re.findall(  # image tag
-            r'(src\s*=\s*"(https://.*?)")', self.readme_content, re.IGNORECASE | re.MULTILINE)
+        absolute_links += re.findall(
+            r'(<img.*?src\s*=\s*"(https://.*?)")', self.readme_content, re.IGNORECASE | re.MULTILINE)
         for link in absolute_links:
             prefix = '' if 'src' in link[0] else link[0].strip()
             img_url = link[1].strip()  # striping in case there are whitespaces at the beginning/ending of url.

--- a/demisto_sdk/commands/common/tests/pack_unique_files_test.py
+++ b/demisto_sdk/commands/common/tests/pack_unique_files_test.py
@@ -630,7 +630,8 @@ class TestPackUniqueFilesValidator:
         assert 'please repair it:\n![Identity with High Risk Score](https://github.com/demisto/content/raw/test1.png)' in errors
         assert 'please repair it:\n![Identity with High Risk Score](https://raw.githubusercontent.com/demisto/content/raw/test1.png)' in errors
         assert 'please repair it:\n(https://raw.githubusercontent.com/demisto/content/raw/test1.jpg)' in errors
-        assert 'https://test.com' not in errors  # this path is not an image path and should not be shown.
+        # this path is not an image path and should not be shown.
+        assert 'https://github.com/demisto/content/raw/test3.png' not in errors
 
     @pytest.mark.parametrize('readme_content, is_valid', [
         ('Hey there, just testing', True),

--- a/demisto_sdk/commands/common/tests/pack_unique_files_test.py
+++ b/demisto_sdk/commands/common/tests/pack_unique_files_test.py
@@ -630,6 +630,7 @@ class TestPackUniqueFilesValidator:
         assert 'please repair it:\n![Identity with High Risk Score](https://github.com/demisto/content/raw/test1.png)' in errors
         assert 'please repair it:\n![Identity with High Risk Score](https://raw.githubusercontent.com/demisto/content/raw/test1.png)' in errors
         assert 'please repair it:\n(https://raw.githubusercontent.com/demisto/content/raw/test1.jpg)' in errors
+        assert 'https://test.com' not in errors  # this path is not an image path and should not be shown.
 
     @pytest.mark.parametrize('readme_content, is_valid', [
         ('Hey there, just testing', True),

--- a/demisto_sdk/tests/test_files/Packs/DummyPack2/README.md
+++ b/demisto_sdk/tests/test_files/Packs/DummyPack2/README.md
@@ -15,9 +15,3 @@ This integration was integrated and tested with version 1.0.1 of PhishTank.
 
 #### paths that should not be caught
 !command host="ip" action="test" src="https://github.com/demisto/content/raw/test3.png" state="present"
-
-
-
-
-
-

--- a/demisto_sdk/tests/test_files/Packs/DummyPack2/README.md
+++ b/demisto_sdk/tests/test_files/Packs/DummyPack2/README.md
@@ -14,7 +14,7 @@ This integration was integrated and tested with version 1.0.1 of PhishTank.
 <img src="https://raw.githubusercontent.com/demisto/content/raw/test1.jpg" width="757" height="54">
 
 #### paths that should not be caught
-!command host="ip" action="test" src="https://test.com" state="present"
+!command host="ip" action="test" src="https://github.com/demisto/content/raw/test3.png" state="present"
 
 
 

--- a/demisto_sdk/tests/test_files/Packs/DummyPack2/README.md
+++ b/demisto_sdk/tests/test_files/Packs/DummyPack2/README.md
@@ -13,6 +13,10 @@ This integration was integrated and tested with version 1.0.1 of PhishTank.
 ![Identity with High Risk Score](https://raw.githubusercontent.com/demisto/content/raw/test1.png)
 <img src="https://raw.githubusercontent.com/demisto/content/raw/test1.jpg" width="757" height="54">
 
+#### paths that should not be caught
+!command host="ip" action="test" src="https://test.com" state="present"
+
+
 
 
 


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/40414

## Description
fixed the regex to find only src paths that are inside an html img tag.

## Must have
- [x] Tests
- [x] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
