### PR TITLE
Fix `validate` crashes  - skip files, validate `pack_metadata` exists 

### DIFF
--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -234,6 +234,7 @@ ERROR_CODE = {
     "pack_name_is_not_in_xsoar_standards": {'code': "PA125", 'ui_applicable': False, 'related_field': ''},
     "pack_metadata_long_description": {'code': "PA126", 'ui_applicable': False, 'related_field': ''},
     "metadata_url_invalid": {'code': "PA127", 'ui_applicable': False, 'related_field': ''},
+    "required_pack_file_does_not_exist": {'code': "PA128", 'ui_applicable': False, 'related_field': ''},
     "readme_error": {'code': "RM100", 'ui_applicable': False, 'related_field': ''},
     "image_path_error": {'code': "RM101", 'ui_applicable': False, 'related_field': ''},
     "readme_missing_output_context": {'code': "RM102", 'ui_applicable': False, 'related_field': ''},
@@ -1292,6 +1293,12 @@ class Errors:
     @error_code_decorator
     def pack_file_does_not_exist(file_name):
         return f'"{file_name}" file does not exist, create one in the root of the pack'
+
+    @staticmethod
+    @error_code_decorator
+    def required_pack_file_does_not_exist(file_name):
+        return f'The required "{file_name}" file does not exist in the pack root.\n ' \
+               f'Its absence may prevent other tests from being run! Create it and run validate again.'
 
     @staticmethod
     @error_code_decorator

--- a/demisto_sdk/commands/common/hook_validations/pack_unique_files.py
+++ b/demisto_sdk/commands/common/hook_validations/pack_unique_files.py
@@ -53,8 +53,10 @@ INCORRECT_PACK_NAME_PATTERN = '[^a-zA-Z]pack[^a-z]|^pack$|^pack[^a-z]|[^a-zA-Z]p
 
 
 class BlockingValidationFailureException(BaseException):
-    # This should block other validations from being run.
-    # For example, raise it when a required file is missing, and there's no reason to keep validating other files.
+    """
+    Used for blocking other validations from being run, force-stopping the validation process.
+    For example, when a required file is missing. Raise it after adding a suitable error to self._errors.
+    """
     pass
 
 

--- a/demisto_sdk/commands/common/hook_validations/pack_unique_files.py
+++ b/demisto_sdk/commands/common/hook_validations/pack_unique_files.py
@@ -114,8 +114,8 @@ class PackUniqueFilesValidator(BaseValidator):
         """Returns the full file path to pack's file"""
         return os.path.join(self.pack_path, file_name)
 
-    def _is_pack_file_exists(self, file_name):
-        """Check if .secrets-ignore exists"""
+    def _is_pack_file_exists(self, file_name: str):
+        """Check if a file with given name exists in pack root"""
         if not os.path.isfile(self._get_pack_file_path(file_name)):
             if self._add_error(Errors.pack_file_does_not_exist(file_name), file_name):
                 return False
@@ -582,6 +582,7 @@ class PackUniqueFilesValidator(BaseValidator):
 
     def are_valid_files(self, id_set_validations) -> str:
         """Main Execution Method"""
+        self._is_pack_file_exists(self.pack_meta_file)
         self.validate_secrets_file()
         self.validate_pack_ignore_file()
         # We don't want to check the metadata file for this pack

--- a/demisto_sdk/commands/common/hook_validations/pack_unique_files.py
+++ b/demisto_sdk/commands/common/hook_validations/pack_unique_files.py
@@ -344,25 +344,25 @@ class PackUniqueFilesValidator(BaseValidator):
             metadata = self._read_metadata_content()
             if not metadata:
                 if self._add_error(Errors.pack_metadata_empty(), self.pack_meta_file):
-                    return False
+                    raise BlockingValidationFailureException()
 
             if not isinstance(metadata, dict):
                 if self._add_error(Errors.pack_metadata_should_be_dict(self.pack_meta_file), self.pack_meta_file):
-                    return False
+                    raise BlockingValidationFailureException()
 
             missing_fields = [field for field in PACK_METADATA_FIELDS if field not in metadata.keys()]
             if missing_fields:
                 if self._add_error(Errors.missing_field_iin_pack_metadata(self.pack_meta_file, missing_fields),
                                    self.pack_meta_file):
-                    return False
+                    raise BlockingValidationFailureException()
 
             elif not self.validate_pack_name(metadata):
-                return False
+                raise BlockingValidationFailureException()
 
             description_name = metadata.get(PACK_METADATA_DESC, '').lower()
             if not description_name or 'fill mandatory field' in description_name:
                 if self._add_error(Errors.pack_metadata_field_invalid(), self.pack_meta_file):
-                    return False
+                    raise BlockingValidationFailureException()
 
             if not self.is_pack_metadata_desc_too_long(description_name):
                 return False
@@ -404,7 +404,7 @@ class PackUniqueFilesValidator(BaseValidator):
 
         except (ValueError, TypeError):
             if self._add_error(Errors.pack_metadata_isnt_json(self.pack_meta_file), self.pack_meta_file):
-                return False
+                raise BlockingValidationFailureException()
 
         return True
 

--- a/demisto_sdk/commands/common/tests/pack_metadata_validator_test.py
+++ b/demisto_sdk/commands/common/tests/pack_metadata_validator_test.py
@@ -129,9 +129,10 @@ class TestPackMetadataValidator:
         - Validating metadata structure.
 
         Then:
-        - Ensure false is returned.
+        - Ensure false is returned, and a BlockingValidationFailureException is raised.
         """
         mocker.patch.object(PackUniqueFilesValidator, '_read_metadata_content', return_value={'a', 'b'})
         validator = PackUniqueFilesValidator('fake')
         mocker.patch.object(validator, '_add_error')
-        assert not validator._is_pack_meta_file_structure_valid()
+        with pytest.raises(BlockingValidationFailureException):
+            assert not validator._is_pack_meta_file_structure_valid()

--- a/demisto_sdk/commands/common/tests/pack_metadata_validator_test.py
+++ b/demisto_sdk/commands/common/tests/pack_metadata_validator_test.py
@@ -9,7 +9,8 @@ from demisto_sdk.commands.common.constants import EXCLUDED_DISPLAY_NAME_WORDS
 from demisto_sdk.commands.common.hook_validations.base_validator import \
     BaseValidator
 from demisto_sdk.commands.common.hook_validations.pack_unique_files import (
-    PACK_METADATA_NAME, PACK_METADATA_SUPPORT, PackUniqueFilesValidator)
+    PACK_METADATA_NAME, PACK_METADATA_SUPPORT,
+    BlockingValidationFailureException, PackUniqueFilesValidator)
 from demisto_sdk.commands.common.legacy_git_tools import git_path
 
 
@@ -28,20 +29,15 @@ class TestPackMetadataValidator:
         validator = PackUniqueFilesValidator('fake')
         assert validator.validate_pack_meta_file()
 
-    @pytest.mark.parametrize('metadata', [os.path.join(FILES_PATH, 'pack_metadata_missing_fields.json'),
-                                          os.path.join(FILES_PATH, 'pack_metadata_invalid_price.json'),
-                                          os.path.join(FILES_PATH, 'pack_metadata_invalid_dependencies.json'),
-                                          os.path.join(FILES_PATH, 'pack_metadata_list_dependencies.json'),
-                                          os.path.join(FILES_PATH, 'pack_metadata_empty_category.json'),
-                                          os.path.join(FILES_PATH, 'pack_metadata_invalid_keywords.json'),
-                                          os.path.join(FILES_PATH, 'pack_metadata_invalid_tags.json'),
-                                          os.path.join(FILES_PATH, 'pack_metadata_list.json'),
-                                          os.path.join(FILES_PATH, 'pack_metadata_short_name.json'),
-                                          os.path.join(FILES_PATH, 'pack_metadata_name_start_lower.json'),
-                                          os.path.join(FILES_PATH, 'pack_metadata_name_start_incorrect.json'),
-                                          os.path.join(FILES_PATH, 'pack_metadata_pack_in_name.json'),
-                                          ])
-    def test_metadata_validator_invalid(self, mocker, metadata):
+    @pytest.mark.parametrize('metadata', [
+        os.path.join(FILES_PATH, 'pack_metadata_invalid_price.json'),
+        os.path.join(FILES_PATH, 'pack_metadata_invalid_dependencies.json'),
+        os.path.join(FILES_PATH, 'pack_metadata_list_dependencies.json'),
+        os.path.join(FILES_PATH, 'pack_metadata_empty_category.json'),
+        os.path.join(FILES_PATH, 'pack_metadata_invalid_keywords.json'),
+        os.path.join(FILES_PATH, 'pack_metadata_invalid_tags.json'),
+    ])
+    def test_metadata_validator_invalid__non_breaking(self, mocker, metadata):
         mocker.patch.object(tools, 'get_dict_from_file', return_value=({'approved_list': []}, 'json'))
         mocker.patch.object(PackUniqueFilesValidator, '_read_file_content',
                             return_value=TestPackMetadataValidator.read_file(metadata))
@@ -50,6 +46,33 @@ class TestPackMetadataValidator:
 
         validator = PackUniqueFilesValidator('fake')
         assert not validator.validate_pack_meta_file()
+
+    @pytest.mark.parametrize('metadata', [
+        os.path.join(FILES_PATH, 'pack_metadata_missing_fields.json'),
+        os.path.join(FILES_PATH, 'pack_metadata_list.json'),
+        os.path.join(FILES_PATH, 'pack_metadata_short_name.json'),
+        os.path.join(FILES_PATH, 'pack_metadata_name_start_lower.json'),
+        os.path.join(FILES_PATH, 'pack_metadata_name_start_incorrect.json'),
+        os.path.join(FILES_PATH, 'pack_metadata_pack_in_name.json'),
+    ])
+    def test_metadata_validator_invalid__breaking(self, mocker, metadata):
+        """
+        Given
+                A pack metadata file with invalid contents that should halt validations
+        When
+                Calling validate_pack_meta_file
+        Then
+                Ensure BlockingValidationFailureException is raised
+        """
+        mocker.patch.object(tools, 'get_dict_from_file', return_value=({'approved_list': []}, 'json'))
+        mocker.patch.object(PackUniqueFilesValidator, '_read_file_content',
+                            return_value=TestPackMetadataValidator.read_file(metadata))
+        mocker.patch.object(PackUniqueFilesValidator, '_is_pack_file_exists', return_value=True)
+        mocker.patch.object(BaseValidator, 'check_file_flags', return_value='')
+
+        validator = PackUniqueFilesValidator('fake')
+        with pytest.raises(BlockingValidationFailureException):
+            assert not validator.validate_pack_meta_file()
 
     VALIDATE_PACK_NAME_INPUTS = [({PACK_METADATA_NAME: 'fill mandatory field'}, False),
                                  ({PACK_METADATA_NAME: 'A'}, False),

--- a/demisto_sdk/commands/common/tests/pack_unique_files_test.py
+++ b/demisto_sdk/commands/common/tests/pack_unique_files_test.py
@@ -120,6 +120,7 @@ class TestPackUniqueFilesValidator:
         pack_metadata_no_email_and_url['url'] = ''
         mocker.patch.object(tools, 'is_external_repository', return_value=True)
         mocker.patch.object(PackUniqueFilesValidator, '_is_pack_file_exists', return_value=True)
+        mocker.patch.object(PackUniqueFilesValidator, 'validate_pack_name', return_value=True)
         mocker.patch.object(PackUniqueFilesValidator, 'get_master_private_repo_meta_file', return_value=None)
         mocker.patch.object(PackUniqueFilesValidator, '_read_file_content',
                             return_value=json.dumps(pack_metadata_no_email_and_url))
@@ -153,6 +154,7 @@ class TestPackUniqueFilesValidator:
 
         mocker.patch.object(tools, 'is_external_repository', return_value=True)
         mocker.patch.object(PackUniqueFilesValidator, '_is_pack_file_exists', return_value=True)
+        mocker.patch.object(PackUniqueFilesValidator, 'validate_pack_name', return_value=True)
         mocker.patch.object(PackUniqueFilesValidator, 'get_master_private_repo_meta_file', return_value=None)
         mocker.patch.object(PackUniqueFilesValidator, '_read_file_content',
                             return_value=json.dumps(pack_metadata_changed_url))
@@ -185,6 +187,7 @@ class TestPackUniqueFilesValidator:
         pack_metadata_price_changed['price'] = 3
         mocker.patch.object(tools, 'is_external_repository', return_value=True)
         mocker.patch.object(PackUniqueFilesValidator, '_is_pack_file_exists', return_value=True)
+        mocker.patch.object(PackUniqueFilesValidator, 'validate_pack_name', return_value=True)
         mocker.patch.object(PackUniqueFilesValidator, 'get_master_private_repo_meta_file',
                             return_value=PACK_METADATA_PARTNER)
         mocker.patch.object(PackUniqueFilesValidator, '_read_file_content',

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -10,8 +10,9 @@ from mock import patch
 
 import demisto_sdk.commands.validate.validate_manager
 from demisto_sdk.commands.common import tools
-from demisto_sdk.commands.common.constants import (CONF_PATH, TEST_PLAYBOOK,
-                                                   FileType, PACKS_PACK_META_FILE_NAME)
+from demisto_sdk.commands.common.constants import (CONF_PATH,
+                                                   PACKS_PACK_META_FILE_NAME,
+                                                   TEST_PLAYBOOK, FileType)
 from demisto_sdk.commands.common.git_util import GitUtil
 from demisto_sdk.commands.common.hook_validations.base_validator import \
     BaseValidator

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -296,13 +296,13 @@ class ValidateManager:
             all_packs_valid.add(self.conf_json_validator.is_valid_conf_json())
 
         count = 1
-        all_packs = os.listdir(PACKS_DIR) if os.listdir(PACKS_DIR) else []
+        # Ignores local files (non-packs), such as .DS_STORE on MacOS
+        all_packs = list(filter(os.path.isdir, [os.path.join(PACKS_DIR, p) for p in os.listdir(PACKS_DIR)]))
         num_of_packs = len(all_packs)
         all_packs.sort(key=str.lower)
 
-        for pack_name in all_packs:
+        for pack_path in all_packs:
             self.completion_percentage = format((count / num_of_packs) * 100, ".2f")  # type: ignore
-            pack_path = os.path.join(PACKS_DIR, pack_name)
             all_packs_valid.add(self.run_validations_on_pack(pack_path))
             count += 1
 

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -296,7 +296,7 @@ class ValidateManager:
             all_packs_valid.add(self.conf_json_validator.is_valid_conf_json())
 
         count = 1
-        # Ignores local files (non-packs), such as .DS_STORE on MacOS
+        # Filter non-pack files that might exist locally (e.g, .DS_STORE on MacOS)
         all_packs = list(filter(os.path.isdir, [os.path.join(PACKS_DIR, p) for p in os.listdir(PACKS_DIR)]))
         num_of_packs = len(all_packs)
         all_packs.sort(key=str.lower)


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/41424
fixes: https://github.com/demisto/etc/issues/41425

## Description
- skip non-folders when calling `validate -a`
- validate packs have `pack_metadata.json` 

both prevent crashes when running `validate`.

## Must have
- [x] Tests
- [x] Documentation