### PR TITLE
Gitlab support fix

### DIFF
--- a/demisto_sdk/commands/common/GitContentConfig.py
+++ b/demisto_sdk/commands/common/GitContentConfig.py
@@ -103,7 +103,7 @@ class GitContentConfig:
     def _search_gitlab_id(self, github_hostname: str, repo: str) -> Optional[int]:
         res = requests.get(f"https://{github_hostname}/api/v4/projects",
                            params={'search': repo},
-                           headers={'PRIVATE-TOKEN': self.Credentials.GITHUB_TOKEN},
+                           headers={'PRIVATE-TOKEN': self.Credentials.GITLAB_TOKEN},
                            timeout=10,
                            verify=False)
         res.raise_for_status()

--- a/demisto_sdk/commands/common/GitContentConfig.py
+++ b/demisto_sdk/commands/common/GitContentConfig.py
@@ -100,8 +100,8 @@ class GitContentConfig:
             self.CURRENT_REPOSITORY = GitContentConfig.OFFICIAL_CONTENT_REPO_NAME
 
     @lru_cache(maxsize=10)
-    def _search_gitlab_id(self, github_hostname: str, repo: str) -> Optional[int]:
-        res = requests.get(f"https://{github_hostname}/api/v4/projects",
+    def _search_gitlab_id(self, gitlab_hostname: str, repo: str) -> Optional[int]:
+        res = requests.get(f"https://{gitlab_hostname}/api/v4/projects",
                            params={'search': repo},
                            headers={'PRIVATE-TOKEN': self.Credentials.GITLAB_TOKEN},
                            timeout=10,


### PR DESCRIPTION

## Status
- [x] Ready


## Description
Fixed to use gitlab token to get the repo ID instead of github token


## Must have
- [x] Tests
- [x] Documentation
