### PR TITLE
disable the upload of indicator type (not supported at the moment)

### DIFF
--- a/demisto_sdk/commands/upload/uploader.py
+++ b/demisto_sdk/commands/upload/uploader.py
@@ -50,7 +50,7 @@ UPLOAD_SUPPORTED_ENTITIES = [
 
     FileType.INCIDENT_TYPE,
     FileType.INCIDENT_FIELD,
-    FileType.REPUTATION,
+    # FileType.REPUTATION,  currently not supported by demisto-py
     FileType.INDICATOR_FIELD,
 
     FileType.WIDGET,


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
related: https://github.com/demisto/etc/issues/44184

## Description
removing the reputation from the supported list until we implement it in the demisto-py.
