### PR TITLE
Update id according to old file in format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Fixed an issue in the **merge-id-set** command, where merging fails because of duplicates but the packs are in the XSOAR repo but in different version control.
 * Fixed missing `Lists` Content Item as valid `IDSetType`
 * Added enhancement for **generate-docs**. It is possible to provide both file or a comma seperated list as `examples`. Also, it's possible to provide more than one example for a script or a command.
-
+* Fixed an issue in **format** when running on a modified YML, that the `id` value is not changed to its old `id` value. 
 
 # 1.5.4
 * Fixed an issue with the **format** command when contributing via the UI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Added feature in **format** to sync YML and JSON files to the `master` file structure.
 * Added option to specify `Incident Type`, `Incoming Mapper` and `Classifier` when configuring instance in **test-content**
 * added a new command **run-test-playbook** to run a test playbook in a given XSOAR instance.
-* Fixed an issue in **format** when running on a modified YML, that the `id` value is not changed to its old `id` value. 
+* Fixed an issue in **format** when running on a modified YML, that the `id` value is not changed to its old `id` value.
 
 # 1.5.4
 * Fixed an issue with the **format** command when contributing via the UI

--- a/demisto_sdk/commands/format/tests/test_formatting_yml_test.py
+++ b/demisto_sdk/commands/format/tests/test_formatting_yml_test.py
@@ -1209,4 +1209,3 @@ class TestFormatting:
         base_yml = IntegrationYMLFormat(input=playbook.yml.path)
         base_yml.update_id_to_equal_name()
         assert base_yml.data.get('id') == uid
-

--- a/demisto_sdk/commands/format/update_generic_yml.py
+++ b/demisto_sdk/commands/format/update_generic_yml.py
@@ -86,11 +86,14 @@ class BaseUpdateYML(BaseUpdate):
                 updated_integration_id[self.id_and_version_location['id']] = self.data['name']
             self.id_and_version_location['id'] = self.data['name']
         else:
-            modified_yml_id = self.get_id_and_version_for_data(self.old_file).get('id')
-            modified_yml_id_from_master = self.get_id_and_version_for_data(self.old_file)['id']
-            if modified_yml_id_from_master != modified_yml_id:
-                click.secho(f'The modified YML file corresponding to the path: {self.path} ID does not match the ID in remote YML file. Changing the YML ID from {modified_yml_file} back to {modified_yml_id_from_master}.'
-                self.id_and_version_location['id'] = modified_yml_id_from_master
+            if self.verbose:
+                click.echo('It is a modified file, keeping the old ID')
+            current_id = self.id_and_version_location.get('id')
+            old_id = self.get_id_and_version_for_data(self.old_file).get('id')
+            if current_id != old_id:
+                click.secho(f'The modified YML file corresponding to the path: {self.relative_content_path} ID does not match the ID in remote YML file.'
+                            f' Changing the YML ID from {current_id} back to {old_id}.')
+                self.id_and_version_location['id'] = old_id
         if updated_integration_id:
             self.updated_ids.update(updated_integration_id)
 

--- a/demisto_sdk/commands/format/update_generic_yml.py
+++ b/demisto_sdk/commands/format/update_generic_yml.py
@@ -85,8 +85,6 @@ class BaseUpdateYML(BaseUpdate):
                 updated_integration_id[self.id_and_version_location['id']] = self.data['name']
             self.id_and_version_location['id'] = self.data['name']
         else:
-            if self.verbose:
-                click.echo('It is a modified file, keeping the old ID')
             current_id = self.id_and_version_location.get('id')
             old_id = self.get_id_and_version_for_data(self.old_file).get('id')
             if current_id != old_id:

--- a/demisto_sdk/commands/format/update_generic_yml.py
+++ b/demisto_sdk/commands/format/update_generic_yml.py
@@ -86,9 +86,11 @@ class BaseUpdateYML(BaseUpdate):
                 updated_integration_id[self.id_and_version_location['id']] = self.data['name']
             self.id_and_version_location['id'] = self.data['name']
         else:
-            if self.verbose:
-                click.echo('It is a modified file, keeping the old ID')
-            self.id_and_version_location['id'] = self.get_id_and_version_for_data(self.old_file)['id']
+            modified_yml_id = self.get_id_and_version_for_data(self.old_file).get('id')
+            modified_yml_id_from_master = self.get_id_and_version_for_data(self.old_file)['id']
+            if modified_yml_id_from_master != modified_yml_id:
+                click.secho(f'The modified YML file corresponding to the path: {self.path} ID does not match the ID in remote YML file. Changing the YML ID from {modified_yml_file} back to {modified_yml_id_from_master}.'
+                self.id_and_version_location['id'] = modified_yml_id_from_master
         if updated_integration_id:
             self.updated_ids.update(updated_integration_id)
 

--- a/demisto_sdk/commands/format/update_generic_yml.py
+++ b/demisto_sdk/commands/format/update_generic_yml.py
@@ -72,7 +72,7 @@ class BaseUpdateYML(BaseUpdate):
     def get_id_and_version_for_data(self, data):
         yml_type = self.__class__.__name__
         path = self.ID_AND_VERSION_PATH_BY_YML_TYPE[yml_type]
-        return data.get(path, self.data)
+        return data.get(path, data)
 
     def update_id_to_equal_name(self) -> None:
         """Updates the id of the YML to be the same as it's name

--- a/demisto_sdk/commands/format/update_generic_yml.py
+++ b/demisto_sdk/commands/format/update_generic_yml.py
@@ -67,9 +67,12 @@ class BaseUpdateYML(BaseUpdate):
         Returns:
             Dict. Holds the id and version fields.
         """
+        return self.get_id_and_version_for_data(self.data)
+
+    def get_id_and_version_for_data(self, data):
         yml_type = self.__class__.__name__
         path = self.ID_AND_VERSION_PATH_BY_YML_TYPE[yml_type]
-        return self.data.get(path, self.data)
+        return data.get(path, self.data)
 
     def update_id_to_equal_name(self) -> None:
         """Updates the id of the YML to be the same as it's name
@@ -82,6 +85,10 @@ class BaseUpdateYML(BaseUpdate):
             if is_uuid(self.id_and_version_location['id']):
                 updated_integration_id[self.id_and_version_location['id']] = self.data['name']
             self.id_and_version_location['id'] = self.data['name']
+        else:
+            if self.verbose:
+                click.echo('It is a modified file, keeping the old ID')
+            self.id_and_version_location['id'] = self.get_id_and_version_for_data(self.old_file)['id']
         if updated_integration_id:
             self.updated_ids.update(updated_integration_id)
 


### PR DESCRIPTION

## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/43893

## Description
When running a format on a YML file, the `id` value should be changed to the `name` value. However, we don't change existing YMLs, because we have legacy YMLs which the `id` value is not equal to the `name`, but we don't set the `id` as the old `id`. 
This change will keep the existing `id` when running `format`

## Must have
- [x] Tests
- [x] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
