### PR TITLE
update-release-notes --git flag bug fix

### DIFF
--- a/demisto_sdk/commands/update_release_notes/update_rn_manager.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn_manager.py
@@ -82,7 +82,7 @@ class UpdateReleaseNotesManager:
 
                 filtered_set.add(file)
 
-        return validate_manager.filter_to_relevant_files(filtered_set)
+        return validate_manager.filter_to_relevant_files(file_set)
 
     def filter_files_from_git(self, modified_files: set, added_files: set, renamed_files: set,
                               validate_manager: ValidateManager):


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
The --use-git/-g flag is used to update relevant changed files compared to git. The -g flag did not work. I found out that the filtering was wrong.

## related issue
fixes: https://github.com/demisto/etc/issues/45328