### PR TITLE
Fix regex flag in download command

### DIFF
--- a/demisto_sdk/commands/download/downloader.py
+++ b/demisto_sdk/commands/download/downloader.py
@@ -233,7 +233,10 @@ class Downloader:
         """
         input_files_regex_match = []
         if self.regex:
-            for input_file in self.input_files:
+            custom_content_objects: list = self.get_custom_content_objects()
+            names_list: list = [cco['name'] for cco in custom_content_objects]
+
+            for input_file in names_list:
                 if re.search(self.regex, input_file):
                     input_files_regex_match.append(input_file)
             self.input_files = input_files_regex_match


### PR DESCRIPTION
## Status
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/45585 
fixes: https://github.com/demisto/demisto-sdk/issues/1803

## Description
Fix regex flag in download command.
The bug:
The `handle_regex_flag` func handle just the list of the files from the previous func -> `handle_all_custom_content_flag`

The fix:
The regex func will open the file with all the downloaded files and extract files according to the regex pattern.