### PR TITLE
End to end test - instance's classifier/ mapper

### DIFF
--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -107,6 +107,7 @@ class TestConfiguration:
         self.context_print_dt = test_configuration.get('context_print_dt')
         self.test_integrations: List[str] = self._parse_integrations_conf(test_configuration)
         self.test_instance_names: List[str] = self._parse_instance_names_conf(test_configuration)
+        self.instance_configuration: dict = test_configuration.get('instance_configuration', {})
 
     @staticmethod
     def _parse_integrations_conf(test_configuration):
@@ -250,7 +251,8 @@ class TestPlaybook:
                 return False
         return True
 
-    def configure_integrations(self, client: DefaultApi, server_context: 'ServerContext') -> bool:
+    def configure_integrations(self, client: DefaultApi, server_context: 'ServerContext',
+                               instance_configuration: dict) -> bool:
         """
         Configures all integrations that the playbook uses and return a boolean indicating the result
         Args:
@@ -266,6 +268,7 @@ class TestPlaybook:
                                                                        self.configuration.playbook_id,
                                                                        self.is_mockable,
                                                                        server_context,
+                                                                       instance_configuration,
                                                                        )
             if not instance_created:
                 self.build_context.logging_module.error(
@@ -1078,6 +1081,7 @@ class Integration:
                                     playbook_id: str,
                                     is_mockable: bool,
                                     server_context: 'ServerContext',
+                                    instance_configuration: dict
                                     ) -> bool:
         """
         Create an instance of the integration in the server specified in the demisto client instance.
@@ -1113,7 +1117,7 @@ class Integration:
         )
 
         # define module instance:
-        print(f'### conf: {self.build_context.conf.__dict__}')
+        print(f'### conf: {instance_configuration}')
         params = self.configuration.params  # type: ignore
         incident_configuration = params.get('incident_configuration', {})
 
@@ -1417,8 +1421,9 @@ class TestContext:
         """
         try:
             self.build_context.logging_module.info(f'ssh tunnel command:\n{self.tunnel_command}')
+            instance_configuration = self.playbook.configuration.instance_configuration
 
-            if not self.playbook.configure_integrations(self.client, self.server_context):
+            if not self.playbook.configure_integrations(self.client, self.server_context, instance_configuration):
                 return PB_Status.FAILED
 
             test_module_result = self.playbook.run_test_module_on_integrations(self.client)

--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -1113,6 +1113,7 @@ class Integration:
         )
 
         # define module instance:
+        print(f'### conf: {self.build_context.conf}')
         params = self.configuration.params  # type: ignore
         incident_configuration = params.get('incident_configuration', {})
 

--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -1119,9 +1119,8 @@ class Integration:
         # define module instance:
         print(f'### conf: {instance_configuration}')
         params = self.configuration.params  # type: ignore
-        incident_configuration = params.get('incident_configuration', {})
 
-        module_instance = self.create_module(instance_name, configuration, incident_configuration)
+        module_instance = self.create_module(instance_name, configuration, instance_configuration)
 
         # set server keys
         self._set_server_keys(client, server_context)

--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -1427,7 +1427,7 @@ class TestContext:
 
             test_module_result = self.playbook.run_test_module_on_integrations(self.client)
             if not test_module_result:
-                # self.playbook.disable_integrations(self.client, self.server_context)
+                self.playbook.disable_integrations(self.client, self.server_context)
                 return PB_Status.FAILED
 
             incident = self.playbook.create_incident(self.client)

--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -1113,7 +1113,7 @@ class Integration:
         )
 
         # define module instance:
-        print(f'### conf: {self.build_context.conf}')
+        print(f'### conf: {self.build_context.conf.__dict__}')
         params = self.configuration.params  # type: ignore
         incident_configuration = params.get('incident_configuration', {})
 

--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -1117,7 +1117,6 @@ class Integration:
         )
 
         # define module instance:
-        print(f'### conf: {instance_configuration}')
         params = self.configuration.params  # type: ignore
 
         module_instance = self.create_module(instance_name, configuration, instance_configuration)

--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -1427,7 +1427,7 @@ class TestContext:
 
             test_module_result = self.playbook.run_test_module_on_integrations(self.client)
             if not test_module_result:
-                self.playbook.disable_integrations(self.client, self.server_context)
+                # self.playbook.disable_integrations(self.client, self.server_context)
                 return PB_Status.FAILED
 
             incident = self.playbook.create_incident(self.client)


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://github.com/demisto/etc/issues/38628)

## Description
Changed Classifier/ Mapper to be given in the conf.json in content instead of test-conf.
*Can be only tested live while build is running, as the classifier and mapper configured are erased from the instance once it is deactivated. *

## Must have
- [x] Tests

