### PR TITLE
fix get_python_version_from_image method

### DIFF
--- a/demisto_sdk/commands/lint/commands_builder.py
+++ b/demisto_sdk/commands/lint/commands_builder.py
@@ -152,12 +152,12 @@ def build_xsoar_linter_command(files: List[Path], py_num: str, support_level: st
     return command
 
 
-def build_mypy_command(files: List[Path], version: float) -> str:
+def build_mypy_command(files: List[Path], version: str) -> str:
     """ Build command to execute with mypy module
         https://mypy.readthedocs.io/en/stable/command_line.html
     Args:
         files(List[Path]): files to execute lint
-        version(float): python varsion X.Y (3.7, 2.7 ..)
+        version(str): python varsion X.Y (3.7, 2.7 ..)
 
     Returns:
         str: mypy command

--- a/demisto_sdk/commands/lint/commands_builder.py
+++ b/demisto_sdk/commands/lint/commands_builder.py
@@ -20,17 +20,18 @@ from demisto_sdk.commands.lint.resources.pylint_plugins.xsoar_level_checker impo
 excluded_files = ["CommonServerPython.py", "demistomock.py", "CommonServerUserPython.py", "conftest.py", "venv"]
 
 
-def get_python_exec(py_num: float, is_py2: bool = False) -> str:
+def get_python_exec(py_num: str, is_py2: bool = False) -> str:
     """ Get python executable
 
     Args:
-        py_num(float): Python version X.Y
+        py_num(str): Python version X.Y
         is_py2(bool): for python 2 version, Set True if the returned result should have python2 or False for python.
 
     Returns:
         str: python executable
     """
-    if py_num < 3:
+    py_ver = float(py_num)
+    if py_ver < 3:
         if is_py2:
             py_str = "2"
         else:
@@ -41,12 +42,12 @@ def get_python_exec(py_num: float, is_py2: bool = False) -> str:
     return f"python{py_str}"
 
 
-def build_flake8_command(files: List[Path], py_num: float) -> str:
+def build_flake8_command(files: List[Path], py_num: str) -> str:
     """ Build command for executing flake8 lint check
         https://flake8.pycqa.org/en/latest/user/invocation.html
     Args:
         files(List[Path]): files to execute lint
-        py_num(float): The python version in use
+        py_num(str): The python version in use
 
     Returns:
         str: flake8 command
@@ -93,10 +94,10 @@ def build_bandit_command(files: List[Path]) -> str:
     return command
 
 
-def build_xsoar_linter_command(files: List[Path], py_num: float, support_level: str = "base") -> str:
+def build_xsoar_linter_command(files: List[Path], py_num: str, support_level: str = "base") -> str:
     """ Build command to execute with xsoar linter module
     Args:
-        py_num(float): The python version in use
+        py_num(str): The python version in use
         files(List[Path]): files to execute lint
         support_level: Support level for the file
 
@@ -189,11 +190,11 @@ def build_mypy_command(files: List[Path], version: float) -> str:
     return command
 
 
-def build_vulture_command(files: List[Path], pack_path: Path, py_num: float) -> str:
+def build_vulture_command(files: List[Path], pack_path: Path, py_num: str) -> str:
     """ Build command to execute with pylint module
         https://github.com/jendrikseipp/vulture
     Args:
-        py_num(float): The python version in use
+        py_num(str): The python version in use
         files(List[Path]): files to execute lint
         pack_path(Path): Package path
 

--- a/demisto_sdk/commands/lint/commands_builder.py
+++ b/demisto_sdk/commands/lint/commands_builder.py
@@ -215,7 +215,7 @@ def build_vulture_command(files: List[Path], pack_path: Path, py_num: str) -> st
     return command
 
 
-def build_pylint_command(files: List[Path], docker_version: Optional[float] = None) -> str:
+def build_pylint_command(files: List[Path], docker_version: Optional[str] = None) -> str:
     """ Build command to execute with pylint module
         https://docs.pylint.org/en/1.6.0/run.html#invoking-pylint
     Args:
@@ -232,7 +232,8 @@ def build_pylint_command(files: List[Path], docker_version: Optional[float] = No
     # disable xsoar linter messages
     disable = ['bad-option-value']
     # TODO: remove when pylint will update its version to support py3.9
-    if docker_version and docker_version >= 3.9:
+
+    if docker_version and float(docker_version) >= 3.9:
         disable.append('unsubscriptable-object')
     command += f" --disable={','.join(disable)}"
     # Disable specific errors

--- a/demisto_sdk/commands/lint/commands_builder.py
+++ b/demisto_sdk/commands/lint/commands_builder.py
@@ -2,6 +2,7 @@
 import os
 from pathlib import Path
 from typing import List, Optional
+
 from packaging.version import parse
 
 from demisto_sdk.commands.lint.resources.pylint_plugins.base_checker import \

--- a/demisto_sdk/commands/lint/commands_builder.py
+++ b/demisto_sdk/commands/lint/commands_builder.py
@@ -240,7 +240,7 @@ def build_pylint_command(files: List[Path], docker_version: Optional[str] = None
         major = py_ver.major
         minor = py_ver.minor
 
-        if major == 3 and minor == 9:
+        if major == 3 and minor >= 9:
             disable.append('unsubscriptable-object')
     command += f" --disable={','.join(disable)}"
     # Disable specific errors

--- a/demisto_sdk/commands/lint/commands_builder.py
+++ b/demisto_sdk/commands/lint/commands_builder.py
@@ -2,6 +2,7 @@
 import os
 from pathlib import Path
 from typing import List, Optional
+from packaging.version import parse
 
 from demisto_sdk.commands.lint.resources.pylint_plugins.base_checker import \
     base_msg
@@ -30,7 +31,7 @@ def get_python_exec(py_num: str, is_py2: bool = False) -> str:
     Returns:
         str: python executable
     """
-    py_ver = float(py_num)
+    py_ver = parse(py_num).major
     if py_ver < 3:
         if is_py2:
             py_str = "2"
@@ -233,8 +234,13 @@ def build_pylint_command(files: List[Path], docker_version: Optional[str] = None
     disable = ['bad-option-value']
     # TODO: remove when pylint will update its version to support py3.9
 
-    if docker_version and float(docker_version) >= 3.9:
-        disable.append('unsubscriptable-object')
+    if docker_version:
+        py_ver = parse(docker_version)
+        major = py_ver.major
+        minor = py_ver.minor
+
+        if major == 3 and minor == 9:
+            disable.append('unsubscriptable-object')
     command += f" --disable={','.join(disable)}"
     # Disable specific errors
     command += " -d duplicate-string-formatting-argument"

--- a/demisto_sdk/commands/lint/helpers.py
+++ b/demisto_sdk/commands/lint/helpers.py
@@ -174,14 +174,14 @@ def get_test_modules(content_repo: Optional[git.Repo], is_external_repo: bool) -
 
 
 @contextmanager
-def add_typing_module(lint_files: List[Path], python_version: float):
+def add_typing_module(lint_files: List[Path], python_version: str):
     """ Check for typing import for python2 packages
             1. Entrance - Add import typing in the begining of the file.
             2. Closing - change back to original.
 
         Args:
             lint_files(list): File to execute lint - for adding typing in python 2.7
-            python_version(float): The package python version.
+            python_version(str): The package python version.
 
         Raises:
             IOError: if can't write to files due permissions or other reasons
@@ -190,7 +190,7 @@ def add_typing_module(lint_files: List[Path], python_version: float):
     back_lint_files: List[Path] = []
     try:
         # Add typing import if needed to python version 2 packages
-        if python_version < 3:
+        if float(python_version) < 3:
             for lint_file in lint_files:
                 data = lint_file.read_text(encoding="utf-8")
                 typing_regex = "(from typing import|import typing)"

--- a/demisto_sdk/commands/lint/helpers.py
+++ b/demisto_sdk/commands/lint/helpers.py
@@ -190,7 +190,8 @@ def add_typing_module(lint_files: List[Path], python_version: str):
     back_lint_files: List[Path] = []
     try:
         # Add typing import if needed to python version 2 packages
-        if float(python_version) < 3:
+        py_ver = parse(python_version).major
+        if py_ver < 3:
             for lint_file in lint_files:
                 data = lint_file.read_text(encoding="utf-8")
                 typing_regex = "(from typing import|import typing)"

--- a/demisto_sdk/commands/lint/linter.py
+++ b/demisto_sdk/commands/lint/linter.py
@@ -565,7 +565,7 @@ class Linter:
         for image in self._facts["images"]:
             # Docker image status - visualize
             status = {
-                "image": float(image[0]),
+                "image": image[0],
                 "image_errors": "",
                 "pylint_errors": "",
                 "pytest_errors": "",
@@ -663,9 +663,11 @@ class Linter:
         test_image_id = ""
         # Get requirements file for image
         requirements = []
-        if 2 < docker_base_image[1] < 3:
+
+        py_num = float(docker_base_image[1])
+        if 2 < py_num < 3:
             requirements = self._req_2
-        elif docker_base_image[1] > 3:
+        elif py_num > 3:
             requirements = self._req_3
         # Using DockerFile template
         file_loader = FileSystemLoader(Path(__file__).parent / 'templates')

--- a/demisto_sdk/commands/lint/linter.py
+++ b/demisto_sdk/commands/lint/linter.py
@@ -224,7 +224,7 @@ class Linter:
             if self._facts["docker_engine"]:
                 # Getting python version from docker image - verifying if not valid docker image configured
                 for image in self._facts["images"]:
-                    py_num: float = get_python_version_from_image(image=image[0], timeout=self.docker_timeout, log_prompt=log_prompt)
+                    py_num: str = get_python_version_from_image(image=image[0], timeout=self.docker_timeout, log_prompt=log_prompt)
                     image[1] = py_num
                     logger.info(f"{self._pack_name} - Facts - {image[0]} - Python {py_num}")
                     if not self._facts["python_version"]:
@@ -247,7 +247,7 @@ class Linter:
                         self._pkg_lint_status["errors"].append('Unable to parse test-requirements.txt in package')
             elif not self._facts["python_version"]:
                 # get python version from yml
-                pynum = 3.7 if (script_obj.get('subtype', 'python3') == 'python3') else 2.7
+                pynum = '3.7' if (script_obj.get('subtype', 'python3') == 'python3') else '2.7'
                 self._facts["python_version"] = pynum
                 logger.info(f"{log_prompt} - Using python version from yml: {pynum}")
             # Get lint files

--- a/demisto_sdk/commands/lint/linter.py
+++ b/demisto_sdk/commands/lint/linter.py
@@ -369,11 +369,11 @@ class Linter:
                 else:
                     self._pkg_lint_status[f"{lint_check}_errors"] = "\n".join(other)
 
-    def _run_flake8(self, py_num: float, lint_files: List[Path]) -> Tuple[int, str]:
+    def _run_flake8(self, py_num: str, lint_files: List[Path]) -> Tuple[int, str]:
         """ Runs flake8 in pack dir
 
         Args:
-            py_num(float): The python version in use
+            py_num(str): The python version in use
             lint_files(List[Path]): file to perform lint
 
         Returns:
@@ -398,7 +398,7 @@ class Linter:
 
         return SUCCESS, ""
 
-    def _run_xsoar_linter(self, py_num: float, lint_files: List[Path]) -> Tuple[int, str]:
+    def _run_xsoar_linter(self, py_num: str, lint_files: List[Path]) -> Tuple[int, str]:
         """ Runs Xsaor linter in pack dir
 
         Args:
@@ -420,7 +420,7 @@ class Linter:
                 myenv['PYTHONPATH'] = str(self._pack_abs_dir)
             if self._facts['is_long_running']:
                 myenv['LONGRUNNING'] = 'True'
-            if py_num < 3:
+            if float(py_num) < 3:
                 myenv['PY2'] = 'True'
             myenv['is_script'] = str(self._facts['is_script'])
             # as Xsoar checker is a pylint plugin and runs as part of pylint code, we can not pass args to it.
@@ -517,11 +517,11 @@ class Linter:
 
         return SUCCESS, ""
 
-    def _run_vulture(self, py_num: float, lint_files: List[Path]) -> Tuple[int, str]:
+    def _run_vulture(self, py_num: str, lint_files: List[Path]) -> Tuple[int, str]:
         """ Run mypy in pack dir
 
         Args:
-            py_num(float): The python version in use
+            py_num(str): The python version in use
             lint_files(List[Path]): file to perform lint
 
         Returns:

--- a/demisto_sdk/commands/lint/linter.py
+++ b/demisto_sdk/commands/lint/linter.py
@@ -487,11 +487,11 @@ class Linter:
 
         return SUCCESS, ""
 
-    def _run_mypy(self, py_num: float, lint_files: List[Path]) -> Tuple[int, str]:
+    def _run_mypy(self, py_num: str, lint_files: List[Path]) -> Tuple[int, str]:
         """ Run mypy in pack dir
 
         Args:
-            py_num(float): The python version in use
+            py_num(str): The python version in use
             lint_files(List[Path]): file to perform lint
 
         Returns:

--- a/demisto_sdk/commands/lint/linter.py
+++ b/demisto_sdk/commands/lint/linter.py
@@ -18,9 +18,9 @@ import git
 import requests.exceptions
 import urllib3.exceptions
 from jinja2 import Environment, FileSystemLoader, exceptions
+from packaging.version import parse
 from ruamel.yaml import YAML
 from wcmatch.pathlib import NEGATE, Path
-from packaging.version import parse
 
 from demisto_sdk.commands.common.constants import (INTEGRATIONS_DIR,
                                                    PACKS_PACK_META_FILE_NAME,

--- a/demisto_sdk/commands/lint/linter.py
+++ b/demisto_sdk/commands/lint/linter.py
@@ -565,7 +565,7 @@ class Linter:
         for image in self._facts["images"]:
             # Docker image status - visualize
             status = {
-                "image": image[0],
+                "image": float(image[0]),
                 "image_errors": "",
                 "pylint_errors": "",
                 "pytest_errors": "",

--- a/demisto_sdk/commands/lint/linter.py
+++ b/demisto_sdk/commands/lint/linter.py
@@ -225,7 +225,8 @@ class Linter:
             if self._facts["docker_engine"]:
                 # Getting python version from docker image - verifying if not valid docker image configured
                 for image in self._facts["images"]:
-                    py_num: str = get_python_version_from_image(image=image[0], timeout=self.docker_timeout, log_prompt=log_prompt)
+                    py_num: str = get_python_version_from_image(image=image[0], timeout=self.docker_timeout,
+                                                                log_prompt=log_prompt)
                     image[1] = py_num
                     logger.info(f"{self._pack_name} - Facts - {image[0]} - Python {py_num}")
                     if not self._facts["python_version"]:

--- a/demisto_sdk/commands/lint/linter.py
+++ b/demisto_sdk/commands/lint/linter.py
@@ -668,12 +668,12 @@ class Linter:
         # Get requirements file for image
         requirements = []
 
-        py_ver = parse(docker_base_image[1]).major
-
-        if py_ver == 2:
-            requirements = self._req_2
-        elif py_ver == 3:
-            requirements = self._req_3
+        if docker_base_image[1] != -1:
+            py_ver = parse(docker_base_image[1]).major
+            if py_ver == 2:
+                requirements = self._req_2
+            elif py_ver == 3:
+                requirements = self._req_3
         # Using DockerFile template
         file_loader = FileSystemLoader(Path(__file__).parent / 'templates')
         env = Environment(loader=file_loader, lstrip_blocks=True, trim_blocks=True, autoescape=True)

--- a/demisto_sdk/commands/lint/linter.py
+++ b/demisto_sdk/commands/lint/linter.py
@@ -20,6 +20,7 @@ import urllib3.exceptions
 from jinja2 import Environment, FileSystemLoader, exceptions
 from ruamel.yaml import YAML
 from wcmatch.pathlib import NEGATE, Path
+from packaging.version import parse
 
 from demisto_sdk.commands.common.constants import (INTEGRATIONS_DIR,
                                                    PACKS_PACK_META_FILE_NAME,
@@ -420,7 +421,9 @@ class Linter:
                 myenv['PYTHONPATH'] = str(self._pack_abs_dir)
             if self._facts['is_long_running']:
                 myenv['LONGRUNNING'] = 'True'
-            if float(py_num) < 3:
+
+            py_ver = parse(py_num).major
+            if py_ver < 3:
                 myenv['PY2'] = 'True'
             myenv['is_script'] = str(self._facts['is_script'])
             # as Xsoar checker is a pylint plugin and runs as part of pylint code, we can not pass args to it.
@@ -664,10 +667,11 @@ class Linter:
         # Get requirements file for image
         requirements = []
 
-        py_num = float(docker_base_image[1])
-        if 2 < py_num < 3:
+        py_ver = parse(docker_base_image[1]).major
+
+        if py_ver == 2:
             requirements = self._req_2
-        elif py_num > 3:
+        elif py_ver == 3:
             requirements = self._req_3
         # Using DockerFile template
         file_loader = FileSystemLoader(Path(__file__).parent / 'templates')

--- a/demisto_sdk/commands/lint/tests/command_builder_test.py
+++ b/demisto_sdk/commands/lint/tests/command_builder_test.py
@@ -7,7 +7,7 @@ import pytest
 values = [[Path("file1.py")], [Path("file1.py"), Path("file2.py")]]
 
 
-@pytest.mark.parametrize(argnames="py_num , expected_exec", argvalues=[(3.7, 'python3'), (2.7, 'python')])
+@pytest.mark.parametrize(argnames="py_num , expected_exec", argvalues=[('3.7', 'python3'), ('2.7', 'python')])
 def test_get_python_exec(py_num, expected_exec):
     """Get python exec"""
     from demisto_sdk.commands.lint.commands_builder import get_python_exec
@@ -29,7 +29,7 @@ def test_build_xsoar_linter_py3_command(files):
     """Build xsoar linter command"""
     from demisto_sdk.commands.lint.commands_builder import \
         build_xsoar_linter_command
-    output = build_xsoar_linter_command(files, 3.8, "base")
+    output = build_xsoar_linter_command(files, '3.8', "base")
     files = [str(file) for file in files]
     expected = f"python3 -m pylint --ignore=CommonServerPython.py,demistomock.py,CommonServerUserPython.py," \
                "conftest.py,venv -E --disable=all --msg-template='{abspath}:{line}:{column}: {msg_id} {obj}: {msg}'" \
@@ -43,7 +43,7 @@ def test_build_xsoar_linter_py2_command(files):
     """Build xsoar linter command"""
     from demisto_sdk.commands.lint.commands_builder import \
         build_xsoar_linter_command
-    output = build_xsoar_linter_command(files, 2.7, "base")
+    output = build_xsoar_linter_command(files, '2.7', "base")
     files = [str(file) for file in files]
     expected = f"python2 -m pylint --ignore=CommonServerPython.py,demistomock.py,CommonServerUserPython.py," \
                "conftest.py,venv -E --disable=all --msg-template='{abspath}:{line}:{column}: {msg_id} {obj}: {msg}' " \
@@ -57,7 +57,7 @@ def test_build_xsoar_linter_no_base_command(files):
     """Build xsoar linter command"""
     from demisto_sdk.commands.lint.commands_builder import \
         build_xsoar_linter_command
-    output = build_xsoar_linter_command(files, 2.7, "unsupported")
+    output = build_xsoar_linter_command(files, '2.7', "unsupported")
     files = [str(file) for file in files]
     expected = "python2 -m pylint --ignore=CommonServerPython.py,demistomock.py,CommonServerUserPython.py," \
                "conftest.py,venv -E --disable=all --msg-template='{abspath}:{line}:{column}: {msg_id} {obj}: {msg}' " \

--- a/demisto_sdk/commands/lint/tests/command_builder_test.py
+++ b/demisto_sdk/commands/lint/tests/command_builder_test.py
@@ -19,7 +19,7 @@ def test_get_python_exec(py_num, expected_exec):
 def test_build_flak8_command(files):
     """Build flake8 command"""
     from demisto_sdk.commands.lint.commands_builder import build_flake8_command
-    output = build_flake8_command(files, 3.8)
+    output = build_flake8_command(files, '3.8')
     files = [str(file) for file in files]
     expected = f"python3 -m flake8 {' '.join(files)}"
     assert output == expected
@@ -100,7 +100,7 @@ def test_build_vulture_command(files, mocker):
         build_vulture_command
     mocker.patch.object(commands_builder, 'os')
     commands_builder.os.environ.get.return_value = 20
-    output = build_vulture_command(files, Path('~/dev/content/'), 2.7)
+    output = build_vulture_command(files, Path('~/dev/content/'), '2.7')
     files = [str(item) for item in files]
     expected = f"python -m vulture --min-confidence 20 --exclude=CommonServerPython.py,demistomock.py," \
                f"CommonServerUserPython.py,conftest.py,venv {' '.join(files)}"

--- a/demisto_sdk/commands/lint/tests/command_builder_test.py
+++ b/demisto_sdk/commands/lint/tests/command_builder_test.py
@@ -7,7 +7,8 @@ import pytest
 values = [[Path("file1.py")], [Path("file1.py"), Path("file2.py")]]
 
 
-@pytest.mark.parametrize(argnames="py_num , expected_exec", argvalues=[('3.7', 'python3'), ('2.7', 'python')])
+@pytest.mark.parametrize(argnames="py_num , expected_exec", argvalues=[('3.7', 'python3'), ('2.7', 'python'),
+                                                                       ('3.10', 'python3'), ('2.3.1', 'python')])
 def test_get_python_exec(py_num, expected_exec):
     """Get python exec"""
     from demisto_sdk.commands.lint.commands_builder import get_python_exec
@@ -125,6 +126,16 @@ def test_build_pylint_command_3_9_docker():
     NamedFile = namedtuple('File', 'name')
     files = [NamedFile('file1')]
     output = build_pylint_command(files, '3.9')
+    assert output.endswith(files[0].name)
+    assert 'disable=bad-option-value,unsubscriptable-object' in output
+
+
+def test_build_pylint_command_3_9_1_docker():
+    """Build Pylint command"""
+    from demisto_sdk.commands.lint.commands_builder import build_pylint_command
+    NamedFile = namedtuple('File', 'name')
+    files = [NamedFile('file1')]
+    output = build_pylint_command(files, '3.9.1')
     assert output.endswith(files[0].name)
     assert 'disable=bad-option-value,unsubscriptable-object' in output
 

--- a/demisto_sdk/commands/lint/tests/command_builder_test.py
+++ b/demisto_sdk/commands/lint/tests/command_builder_test.py
@@ -124,7 +124,7 @@ def test_build_pylint_command_3_9_docker():
     from demisto_sdk.commands.lint.commands_builder import build_pylint_command
     NamedFile = namedtuple('File', 'name')
     files = [NamedFile('file1')]
-    output = build_pylint_command(files, 3.9)
+    output = build_pylint_command(files, '3.9')
     assert output.endswith(files[0].name)
     assert 'disable=bad-option-value,unsubscriptable-object' in output
 

--- a/demisto_sdk/commands/lint/tests/helper_test.py
+++ b/demisto_sdk/commands/lint/tests/helper_test.py
@@ -54,8 +54,9 @@ def test_build_skipped_exit_code(no_flake8: bool, no_xsoar_linter: bool, no_band
                                             no_pwsh_analyze, no_pwsh_test, docker_engine)
 
 
-@pytest.mark.parametrize(argnames="image, output, expected", argvalues=[('alpine', b'3.7\n', 3.7),
-                                                                        ('alpine-3', b'2.7\n', 2.7)])
+@pytest.mark.parametrize(argnames="image, output, expected", argvalues=[('alpine', b'3.7\n', '3.7'),
+                                                                        ('alpine-3', b'2.7\n', '2.7'),
+                                                                        ('alpine-310', b'3.10\n', '3.10')])
 def test_get_python_version_from_image(image: str, output: bytes, expected: float, mocker):
     from demisto_sdk.commands.lint import helpers
     mocker.patch.object(helpers, 'docker')

--- a/demisto_sdk/commands/lint/tests/test_linter/conftest.py
+++ b/demisto_sdk/commands/lint/tests/test_linter/conftest.py
@@ -48,7 +48,7 @@ def create_integration(mocker) -> Callable:
                             flake8: bool = False, bandit: bool = False, mypy: bool = False, vulture: bool = False,
                             pylint: bool = False, test: bool = False, no_tests: bool = False, yml: bool = False,
                             js_type: bool = False, type_script_key: bool = False, image: bool = False,
-                            image_py_num: float = 3.7, test_reqs: bool = False) -> Path:
+                            image_py_num: str = '3.7', test_reqs: bool = False) -> Path:
         """ Creates tmp content repositry for integration test
 
         Args:
@@ -66,7 +66,7 @@ def create_integration(mocker) -> Callable:
             js_type(bool): True for definig pack as JavaScript in yml.
             type_script_key(bool): True for define type in script key.
             image(str): Image to define in yml.
-            image_py_num(float): Image python version.
+            image_py_num(str): Image python version.
             test_reqs(bool): True to include a test-requirements.txt file.
 
         Returns:

--- a/demisto_sdk/commands/lint/tests/test_linter/docker_runner_test.py
+++ b/demisto_sdk/commands/lint/tests/test_linter/docker_runner_test.py
@@ -37,7 +37,7 @@ class TestCreateImage:
 
         linter_obj._docker_client.images.build().__getitem__().short_id = exp_test_image_id
 
-        act_test_image_id, act_errors = linter_obj._docker_image_create(docker_base_image=[exp_test_image_id, 3.7])
+        act_test_image_id, act_errors = linter_obj._docker_image_create(docker_base_image=[exp_test_image_id, '3.7'])
 
         assert act_test_image_id == exp_test_image_id
         assert act_errors == exp_errors

--- a/demisto_sdk/commands/lint/tests/test_linter/gather_facts_test.py
+++ b/demisto_sdk/commands/lint/tests/test_linter/gather_facts_test.py
@@ -73,7 +73,7 @@ class TestPythonPack:
 class TestDockerImagesCollection:
     def test_docker_images_exists(self, mocker, demisto_content: Callable, create_integration: Callable):
         exp_image = "test-image:12.0"
-        exp_py_num = 2.7
+        exp_py_num = '2.7'
         mocker.patch.object(linter.Linter, '_docker_login')
         mocker.patch.object(linter.Linter, '_update_support_level')
         linter.Linter._docker_login.return_value = False
@@ -88,7 +88,7 @@ class TestDockerImagesCollection:
 
     def test_docker_images_not_exists(self, mocker, demisto_content: Callable, create_integration: Callable):
         exp_image = "demisto/python:1.3-alpine"
-        exp_py_num = 2.7
+        exp_py_num = '2.7'
         mocker.patch.object(linter.Linter, '_docker_login')
         mocker.patch.object(linter.Linter, '_update_support_level')
         linter.Linter._docker_login.return_value = False

--- a/demisto_sdk/commands/lint/tests/test_linter/os_runner_test.py
+++ b/demisto_sdk/commands/lint/tests/test_linter/os_runner_test.py
@@ -87,7 +87,7 @@ class TestMypy:
         mocker.patch.object(linter, 'run_command_os')
         linter.run_command_os.return_value = ('Success: no issues found', '', 0)
 
-        exit_code, output = linter_obj._run_mypy(lint_files=lint_files, py_num=3.7)
+        exit_code, output = linter_obj._run_mypy(lint_files=lint_files, py_num='3.7')
 
         assert exit_code == 0b0, "Exit code should be 0"
         assert output == '', "Output should be empty"
@@ -99,7 +99,7 @@ class TestMypy:
         expected_output = 'Error code found'
         linter.run_command_os.return_value = (expected_output, '', 1)
 
-        exit_code, output = linter_obj._run_mypy(lint_files=lint_files, py_num=3.7)
+        exit_code, output = linter_obj._run_mypy(lint_files=lint_files, py_num='3.7')
 
         assert exit_code == 0b1, "Exit code should be 1"
         assert output == expected_output, "Output should be empty"
@@ -111,7 +111,7 @@ class TestMypy:
         expected_output = 'Error code found'
         linter.run_command_os.return_value = ('not good', expected_output, 1)
 
-        exit_code, output = linter_obj._run_mypy(lint_files=lint_files, py_num=3.7)
+        exit_code, output = linter_obj._run_mypy(lint_files=lint_files, py_num='3.7')
 
         assert exit_code == 0b1, "Exit code should be 1"
         assert output == expected_output, "Output should be empty"

--- a/demisto_sdk/commands/lint/tests/test_linter/os_runner_test.py
+++ b/demisto_sdk/commands/lint/tests/test_linter/os_runner_test.py
@@ -340,13 +340,13 @@ class TestRunLintInHost:
         from demisto_sdk.commands.lint.linter import EXIT_CODES
         unittest_path = lint_files[0].parent / 'intergration_sample_test.py'
         mocker.patch.dict(linter_obj._facts, {
-            "images": [["image", 3.7]],
+            "images": [["image", '3.7']],
             "test": False,
             "version_two": False,
             "lint_files": [],
             "lint_unittest_files": [unittest_path],
             "additional_requirements": [],
-            "python_version": 3.7,
+            "python_version": '3.7',
         })
         mocker.patch.object(linter_obj, '_run_flake8')
         linter_obj._run_flake8.return_value = (0b1, 'Error')
@@ -389,13 +389,13 @@ class TestRunLintInHost:
         from demisto_sdk.commands.lint.linter import EXIT_CODES
         unittest_path = lint_files[0].parent / 'intergration_sample_test.py'
         mocker.patch.dict(linter_obj._facts, {
-            "images": [["image", 3.7]],
+            "images": [["image", '3.7']],
             "test": False,
             "version_two": False,
             "lint_files": lint_files,
             "lint_unittest_files": [unittest_path],
             "additional_requirements": [],
-            "python_version": 3.7,
+            "python_version": '3.7',
         })
         mocker.patch.object(linter_obj, '_run_flake8')
         linter_obj._run_flake8.return_value = (0b1, 'Error')

--- a/demisto_sdk/commands/lint/tests/test_linter/os_runner_test.py
+++ b/demisto_sdk/commands/lint/tests/test_linter/os_runner_test.py
@@ -13,7 +13,7 @@ class TestFlake8:
         mocker.patch.object(linter, 'run_command_os')
         linter.run_command_os.return_value = ('', '', 0)
 
-        exit_code, output = linter_obj._run_flake8(lint_files=lint_files, py_num=3.7)
+        exit_code, output = linter_obj._run_flake8(lint_files=lint_files, py_num='3.7')
 
         assert exit_code == 0b0, "Exit code should be 0"
         assert output == '', "Output should be empty"
@@ -25,7 +25,7 @@ class TestFlake8:
         expected_output = 'Error code found'
         linter.run_command_os.return_value = (expected_output, '', 1)
 
-        exit_code, output = linter_obj._run_flake8(lint_files=lint_files, py_num=3.7)
+        exit_code, output = linter_obj._run_flake8(lint_files=lint_files, py_num='3.7')
 
         assert exit_code == 0b1, "Exit code should be 1"
         assert output == expected_output, "Output should be empty"
@@ -37,7 +37,7 @@ class TestFlake8:
         expected_output = 'Error code found'
         linter.run_command_os.return_value = ('not good', expected_output, 1)
 
-        exit_code, output = linter_obj._run_flake8(lint_files=lint_files, py_num=3.7)
+        exit_code, output = linter_obj._run_flake8(lint_files=lint_files, py_num='3.7')
 
         assert exit_code == 0b1, "Exit code should be 1"
         assert output == expected_output, "Output should be empty"
@@ -124,7 +124,7 @@ class TestVulture:
         mocker.patch.object(linter, 'run_command_os')
         linter.run_command_os.return_value = ('', '', 0)
 
-        exit_code, output = linter_obj._run_vulture(lint_files=lint_files, py_num=3.7)
+        exit_code, output = linter_obj._run_vulture(lint_files=lint_files, py_num='3.7')
 
         assert exit_code == 0b0, "Exit code should be 0"
         assert output == '', "Output should be empty"
@@ -136,7 +136,7 @@ class TestVulture:
         expected_output = 'Error code found'
         linter.run_command_os.return_value = (expected_output, '', 1)
 
-        exit_code, output = linter_obj._run_vulture(lint_files=lint_files, py_num=3.7)
+        exit_code, output = linter_obj._run_vulture(lint_files=lint_files, py_num='3.7')
 
         assert exit_code == 0b1, "Exit code should be 1"
         assert output == expected_output, "Output should be empty"
@@ -148,7 +148,7 @@ class TestVulture:
         expected_output = 'Error code found'
         linter.run_command_os.return_value = ('not good', expected_output, 1)
 
-        exit_code, output = linter_obj._run_vulture(lint_files=lint_files, py_num=3.7)
+        exit_code, output = linter_obj._run_vulture(lint_files=lint_files, py_num='3.7')
 
         assert exit_code == 0b1, "Exit code should be 1"
         assert output == expected_output, "Output should be empty"

--- a/demisto_sdk/tests/integration_tests/xsoar_linter_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/xsoar_linter_integration_test.py
@@ -21,15 +21,15 @@ from demisto_sdk.tests.constants_test import (
 files = [
 
     # ---------------------------------------- For Valid file -------------------------------------------------
-    (Path(f"{XSOAR_LINTER_PY3_VALID}"), 3.8, 'base', False, 0, [], []),
-    (Path(f"{XSOAR_LINTER_PY3_VALID}"), 3.8, 'base', True, 0, [],
+    (Path(f"{XSOAR_LINTER_PY3_VALID}"), '3.8', 'base', False, 0, [], []),
+    (Path(f"{XSOAR_LINTER_PY3_VALID}"), '3.8', 'base', True, 0, [],
      ['test-module', 'kace-machines-list', 'kace-assets-list', 'kace-queues-list', 'kace-tickets-list']),
 
 
     # -------------------------------------------- For Invalid file -------------------------------------------------
 
     # -------------------- For Invalid file with support level base and long running True -----------------------
-    (Path(f"{XSOAR_LINTER_PY3_INVALID}"), 3.8, 'base', True, 1, [
+    (Path(f"{XSOAR_LINTER_PY3_INVALID}"), '3.8', 'base', True, 1, [
         'Print is found, Please remove all prints from the code.',
         "test-module command is not implemented in the python file, it is essential for every"
         " integration. Please add it to your code. For more information see: "
@@ -37,7 +37,7 @@ files = [
     ], []),
 
     # -------------------- For Invalid file with support level base and long running False -----------------------
-    (Path(f"{XSOAR_LINTER_PY3_INVALID}"), 3.8, 'base', False, 1, [
+    (Path(f"{XSOAR_LINTER_PY3_INVALID}"), '3.8', 'base', False, 1, [
         'Print is found, Please remove all prints from the code.',
         'Sleep is found, Please remove all sleep statements from the code.',
         'Invalid CommonServerPython import was found. Please change the import to: from CommonServerPython import *',
@@ -50,7 +50,7 @@ files = [
     ], ['kace-machines-list', 'kace-assets-list', 'kace-queues-list', 'kace-tickets-list', 'error']),
 
     # ------------- For Invalid file with support level certified partner and long running False ------------------
-    (Path(f"{XSOAR_LINTER_PY3_INVALID}"), 3.8, 'certified partner', False, 1,
+    (Path(f"{XSOAR_LINTER_PY3_INVALID}"), '3.8', 'certified partner', False, 1,
      ['Sys.exit use is found, Please use return instead.',
       'Sleep is found, Please remove all sleep statements from the code.',
       "test-module command is not implemented in the python file, it is essential for every"
@@ -59,7 +59,7 @@ files = [
       ], []),
 
     # ------------- For Invalid file with support level certified partner and long running True ---------------------
-    (Path(f"{XSOAR_LINTER_PY3_INVALID}"), 3.8, 'certified partner', True, 1,
+    (Path(f"{XSOAR_LINTER_PY3_INVALID}"), '3.8', 'certified partner', True, 1,
      ['Sys.exit use is found, Please use return instead.',
       "test-module command is not implemented in the python file, it is essential for every"
       " integration. Please add it to your code. For more information see: "
@@ -67,7 +67,7 @@ files = [
       ], []),
 
     # ------------- For Invalid file with support level community and long running False ------------------
-    (Path(f"{XSOAR_LINTER_PY3_INVALID}"), 3.8, 'community', False, 1,
+    (Path(f"{XSOAR_LINTER_PY3_INVALID}"), '3.8', 'community', False, 1,
      ['Print is found, Please remove all prints from the code.',
       "test-module command is not implemented in the python file, it is essential for every"
       " integration. Please add it to your code. For more information see: "
@@ -75,7 +75,7 @@ files = [
       ], []),
 
     # ------------- For Invalid file with default support level and long running False ------------------
-    (Path(f"{XSOAR_LINTER_PY3_INVALID}"), 3.8, '', False, 1,
+    (Path(f"{XSOAR_LINTER_PY3_INVALID}"), '3.8', '', False, 1,
      ['exit is found, Please remove all exit()', 'quit is found, Please remove all quit()',
       "test-module command is not implemented in the python file, it is essential for every"
       " integration. Please add it to your code. For more information see: "
@@ -83,7 +83,7 @@ files = [
       ], []),
 
     # ------------- For Invalid file with xsoar support level and long running False ------------------
-    (Path(f"{XSOAR_LINTER_PY3_INVALID}"), 3.8, 'xsoar', False, 1,
+    (Path(f"{XSOAR_LINTER_PY3_INVALID}"), '3.8', 'xsoar', False, 1,
      ['exit is found, Please remove all exit()', 'quit is found, Please remove all quit()',
       "test-module command is not implemented in the python file, it is essential for every"
       " integration. Please add it to your code. For more information see: "
@@ -94,18 +94,18 @@ files = [
     # -------------------------------- For Warning file which is relevant from partner level and bigger---------------
 
     # -------------------------------- For Warning file with support level partner------------------------------------
-    (Path(f"{XSOAR_LINTER_PY3_INVALID_WARNINGS_PARTNER}"), 3.8, 'partner', False, 4,
+    (Path(f"{XSOAR_LINTER_PY3_INVALID_WARNINGS_PARTNER}"), '3.8', 'partner', False, 4,
      ['try and except statements were not found in main function.',
       'return_error should be used in main function. Please add it.',
       'return_error used too many times, should be used only once in the code, in main function.'
       ], []),
 
     # -------------------------------- For Warning file with support level community-----------------------------------
-    (Path(f"{XSOAR_LINTER_PY3_INVALID_WARNINGS_PARTNER}"), 3.8, 'community', False, 0,
+    (Path(f"{XSOAR_LINTER_PY3_INVALID_WARNINGS_PARTNER}"), '3.8', 'community', False, 0,
      [], []),
 
     # -------------------------------- For Warning file with support level xsoar-----------------------------------
-    (Path(f"{XSOAR_LINTER_PY3_INVALID_WARNINGS_PARTNER}"), 3.8, 'xsoar', False, 4,
+    (Path(f"{XSOAR_LINTER_PY3_INVALID_WARNINGS_PARTNER}"), '3.8', 'xsoar', False, 4,
      ['return_error should be used in main function. Please add it.',
       'return_error used too many times, should be used only once in the code, in main function.'], []),
 
@@ -113,7 +113,7 @@ files = [
     # --------------------------------------- For Warning file -------------------------------------------------------
 
     # --------------------- For Warning file with support level certified partner -----------------------------------
-    (Path(f"{XSOAR_LINTER_PY3_INVALID_WARNINGS}"), 3.8, 'certified partner', False, 4,
+    (Path(f"{XSOAR_LINTER_PY3_INVALID_WARNINGS}"), '3.8', 'certified partner', False, 4,
      ['Demisto.log is found, Please remove all demisto.log usage and exchange it with',
       'Main function wasnt found in the file, Please add main()',
       'Do not use return_outputs function. Please return CommandResults object instead.',
@@ -123,7 +123,7 @@ files = [
       ], []),
     # --------------------- For Warning file with support level xsoar------------- -----------------------------------
 
-    (Path(f"{XSOAR_LINTER_PY3_INVALID_WARNINGS}"), 3.8, 'xsoar', False, 4,
+    (Path(f"{XSOAR_LINTER_PY3_INVALID_WARNINGS}"), '3.8', 'xsoar', False, 4,
      ['Function arguments are missing type annotations. Please add type annotations',
       'It is best practice to use .get when accessing the arg/params dict object rather then direct access.'], []),
 ]


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://github.com/demisto/etc/issues/45687)

## Description
- Update the methods to use `packaging.version.parse` for getting the python version and return string instead of float:
  - `get_python_version_from_image`
  - `get_python_exec`
  - `build_pylint_command`
  - `add_typing_module`
  - `_run_xsoar_linter`
  - `_docker_image_create`


- Update all the places using python version from float to string inside `demisto_sdk/commands/lint/`
- Update tests.

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
