### PR TITLE
Fix create-content-artifacts filter by id set

### DIFF
--- a/demisto_sdk/commands/common/content/objects/pack_objects/pack.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/pack.py
@@ -72,7 +72,7 @@ class Pack:
             # skip content items that are not displayed in the id set, if the corresponding flag is used
             if self._filter_items_by_id_set and content_object.type().value not in [FileType.RELEASE_NOTES.value,
                                                                                     FileType.RELEASE_NOTES_CONFIG.value]:
-                if is_object_in_id_set(content_object.get('name'), self._pack_info_from_id_set):
+                if is_object_in_id_set(content_object.get('id'), self._pack_info_from_id_set):
                     yield content_object
             else:
                 yield content_object

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -1782,7 +1782,7 @@ def get_all_incident_and_indicator_fields_from_id_set(id_set_file, entity_type):
     return fields_list
 
 
-def is_object_in_id_set(object_name, pack_info_from_id_set):
+def is_object_in_id_set(object_id, pack_info_from_id_set):
     """
         Check if the given object is part of the packs items that are present in the Packs section in the id set.
         This is assuming that the id set is based on the version that has, under each pack, the items it contains.
@@ -1796,8 +1796,8 @@ def is_object_in_id_set(object_name, pack_info_from_id_set):
 
     """
     content_items = pack_info_from_id_set.get('ContentItems', {})
-    for items_type, items_names in content_items.items():
-        if object_name in items_names:
+    for items_type, items_ids in content_items.items():
+        if object_id in items_ids:
             return True
     return False
 

--- a/demisto_sdk/tests/test_files/content_slim/Packs/Sample01/README.md
+++ b/demisto_sdk/tests/test_files/content_slim/Packs/Sample01/README.md
@@ -59,4 +59,22 @@ If you are interested in contributing, visit our contribution process [here](htt
 
 Thank you for contributing to Cortex XSOAR.
 
+If you are interested in contributing, visit our contribution process [here](https://xsoar.pan.dev/docs/contributing/contributing).#### This pack was co-authored by:
+ - Contributor1
+ - Contributor2
+
+Thank you for contributing to Cortex XSOAR.
+
+If you are interested in contributing, visit our contribution process [here](https://xsoar.pan.dev/docs/contributing/contributing).#### This pack was co-authored by:
+ - Contributor1
+ - Contributor2
+
+Thank you for contributing to Cortex XSOAR.
+
+If you are interested in contributing, visit our contribution process [here](https://xsoar.pan.dev/docs/contributing/contributing).#### This pack was co-authored by:
+ - Contributor1
+ - Contributor2
+
+Thank you for contributing to Cortex XSOAR.
+
 If you are interested in contributing, visit our contribution process [here](https://xsoar.pan.dev/docs/contributing/contributing).

--- a/demisto_sdk/tests/test_files/content_slim/Packs/Sample01/README.md
+++ b/demisto_sdk/tests/test_files/content_slim/Packs/Sample01/README.md
@@ -59,22 +59,4 @@ If you are interested in contributing, visit our contribution process [here](htt
 
 Thank you for contributing to Cortex XSOAR.
 
-If you are interested in contributing, visit our contribution process [here](https://xsoar.pan.dev/docs/contributing/contributing).#### This pack was co-authored by:
- - Contributor1
- - Contributor2
-
-Thank you for contributing to Cortex XSOAR.
-
-If you are interested in contributing, visit our contribution process [here](https://xsoar.pan.dev/docs/contributing/contributing).#### This pack was co-authored by:
- - Contributor1
- - Contributor2
-
-Thank you for contributing to Cortex XSOAR.
-
-If you are interested in contributing, visit our contribution process [here](https://xsoar.pan.dev/docs/contributing/contributing).#### This pack was co-authored by:
- - Contributor1
- - Contributor2
-
-Thank you for contributing to Cortex XSOAR.
-
 If you are interested in contributing, visit our contribution process [here](https://xsoar.pan.dev/docs/contributing/contributing).


### PR DESCRIPTION
fix create-content-artifacts to filter pack items by id_set using id and not name.