### PR TITLE
Pytest handle container exit codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 * Fixed an issue in the **create-id-set** command where similar items from different marketplaces were reported as duplicated.
 * Fixed typo in demisto-sdk init
+* Fixed an issue where the **lint** command did not handle all container exit codes.
 
 # 1.5.9
 * Added option to specify `External Playbook Configuration` to change inputs of Playbooks triggered as part of **test-content**

--- a/demisto_sdk/commands/lint/linter.py
+++ b/demisto_sdk/commands/lint/linter.py
@@ -919,7 +919,7 @@ class Linter:
                     output = container_obj.logs().decode('utf-8')
                     exit_code = FAIL
                 else:
-                    logger.info(f"{log_prompt} - Finished errors found")
+                    logger.error(f"{log_prompt} - Finished errors found")
                     exit_code = FAIL
             elif container_exit_code in [3, 4]:
                 # 3-Internal error happened while executing tests
@@ -929,7 +929,7 @@ class Linter:
                 output = container_obj.logs().decode('utf-8')
             else:
                 # Any other container exit code
-                logger.info(f"{log_prompt} - Finished errors found")
+                logger.error(f"{log_prompt} - Finished errors found")
                 exit_code = FAIL
             # Remove container if not needed
             if keep_container:

--- a/demisto_sdk/commands/lint/linter.py
+++ b/demisto_sdk/commands/lint/linter.py
@@ -443,7 +443,7 @@ class Linter:
             logger.error(f"{log_prompt}- Finished, errors found")
             status = FAIL
         if exit_code & WARNING:
-            logger.info(f"{log_prompt} - Finished, warnings found")
+            logger.warning(f"{log_prompt} - Finished, warnings found")
             if not status:
                 status = WARNING
         # if pylint did not run and failure exit code has been returned from run commnad

--- a/demisto_sdk/commands/lint/linter.py
+++ b/demisto_sdk/commands/lint/linter.py
@@ -930,7 +930,7 @@ class Linter:
                 output = container_obj.logs().decode('utf-8')
             else:
                 # Any other container exit code
-                logger.error(f"{log_prompt} - Finished, errors found")
+                logger.error(f"{log_prompt} - Finished, docker container error found ({container_exit_code})")
                 exit_code = FAIL
             # Remove container if not needed
             if keep_container:

--- a/demisto_sdk/commands/lint/linter.py
+++ b/demisto_sdk/commands/lint/linter.py
@@ -390,11 +390,11 @@ class Linter:
         logger.info(f"{log_prompt} - Start")
         stdout, stderr, exit_code = run_command_os(command=build_flake8_command(lint_files, py_num),
                                                    cwd=self._content_repo)
-        logger.debug(f"{log_prompt} - Finished exit-code: {exit_code}")
-        logger.debug(f"{log_prompt} - Finished stdout: {RL if stdout else ''}{stdout}")
-        logger.debug(f"{log_prompt} - Finished stderr: {RL if stderr else ''}{stderr}")
+        logger.debug(f"{log_prompt} - Finished, exit-code: {exit_code}")
+        logger.debug(f"{log_prompt} - Finished, stdout: {RL if stdout else ''}{stdout}")
+        logger.debug(f"{log_prompt} - Finished, stderr: {RL if stderr else ''}{stderr}")
         if stderr or exit_code:
-            logger.info(f"{log_prompt}- Finished errors found")
+            logger.info(f"{log_prompt}- Finished, errors found")
             if stderr:
                 return FAIL, stderr
             else:
@@ -440,10 +440,10 @@ class Linter:
                 command=build_xsoar_linter_command(lint_files, py_num, self._facts.get('support_level', 'base')),
                 cwd=self._pack_abs_dir, env=myenv)
         if exit_code & FAIL_PYLINT:
-            logger.info(f"{log_prompt}- Finished errors found")
+            logger.info(f"{log_prompt}- Finished, errors found")
             status = FAIL
         if exit_code & WARNING:
-            logger.info(f"{log_prompt} - Finished warnings found")
+            logger.info(f"{log_prompt} - Finished, warnings found")
             if not status:
                 status = WARNING
         # if pylint did not run and failure exit code has been returned from run commnad
@@ -457,11 +457,11 @@ class Linter:
             else:
                 stdout = "Xsoar linter could not run, please make sure you have" \
                          " the necessary Pylint version for both py2 and py3"
-            logger.info(f"{log_prompt}- Finished errors found")
+            logger.info(f"{log_prompt}- Finished, errors found")
 
-        logger.debug(f"{log_prompt} - Finished exit-code: {exit_code}")
-        logger.debug(f"{log_prompt} - Finished stdout: {RL if stdout else ''}{stdout}")
-        logger.debug(f"{log_prompt} - Finished stderr: {RL if stderr else ''}{stderr}")
+        logger.debug(f"{log_prompt} - Finished, exit-code: {exit_code}")
+        logger.debug(f"{log_prompt} - Finished, stdout: {RL if stdout else ''}{stdout}")
+        logger.debug(f"{log_prompt} - Finished, stderr: {RL if stderr else ''}{stderr}")
 
         if not exit_code:
             logger.info(f"{log_prompt} - Successfully finished")
@@ -483,11 +483,11 @@ class Linter:
         logger.info(f"{log_prompt} - Start")
         stdout, stderr, exit_code = run_command_os(command=build_bandit_command(lint_files),
                                                    cwd=self._pack_abs_dir)
-        logger.debug(f"{log_prompt} - Finished exit-code: {exit_code}")
-        logger.debug(f"{log_prompt} - Finished stdout: {RL if stdout else ''}{stdout}")
-        logger.debug(f"{log_prompt} - Finished stderr: {RL if stderr else ''}{stderr}")
+        logger.debug(f"{log_prompt} - Finished, exit-code: {exit_code}")
+        logger.debug(f"{log_prompt} - Finished, stdout: {RL if stdout else ''}{stdout}")
+        logger.debug(f"{log_prompt} - Finished, stderr: {RL if stderr else ''}{stderr}")
         if stderr or exit_code:
-            logger.info(f"{log_prompt}- Finished Finished errors found")
+            logger.info(f"{log_prompt}- Finished, errors found")
             if stderr:
                 return FAIL, stderr
             else:
@@ -514,11 +514,11 @@ class Linter:
         with add_typing_module(lint_files=lint_files, python_version=py_num):
             mypy_command = build_mypy_command(files=lint_files, version=py_num, content_repo=self._content_repo)
             stdout, stderr, exit_code = run_command_os(command=mypy_command, cwd=self._pack_abs_dir)
-        logger.debug(f"{log_prompt} - Finished exit-code: {exit_code}")
-        logger.debug(f"{log_prompt} - Finished stdout: {RL if stdout else ''}{stdout}")
-        logger.debug(f"{log_prompt} - Finished stderr: {RL if stderr else ''}{stderr}")
+        logger.debug(f"{log_prompt} - Finished, exit-code: {exit_code}")
+        logger.debug(f"{log_prompt} - Finished, stdout: {RL if stdout else ''}{stdout}")
+        logger.debug(f"{log_prompt} - Finished, stderr: {RL if stderr else ''}{stderr}")
         if stderr or exit_code:
-            logger.info(f"{log_prompt}- Finished Finished errors found")
+            logger.info(f"{log_prompt}- Finished, errors found")
             if stderr:
                 return FAIL, stderr
             else:
@@ -546,11 +546,11 @@ class Linter:
                                                                                  pack_path=self._pack_abs_dir,
                                                                                  py_num=py_num),
                                                    cwd=self._pack_abs_dir)
-        logger.debug(f"{log_prompt} - Finished exit-code: {exit_code}")
-        logger.debug(f"{log_prompt} - Finished stdout: {RL if stdout else ''}{stdout}")
-        logger.debug(f"{log_prompt} - Finished stderr: {RL if stderr else ''}{stderr}")
+        logger.debug(f"{log_prompt} - Finished, exit-code: {exit_code}")
+        logger.debug(f"{log_prompt} - Finished, stdout: {RL if stdout else ''}{stdout}")
+        logger.debug(f"{log_prompt} - Finished, stderr: {RL if stderr else ''}{stderr}")
         if stderr or exit_code:
-            logger.info(f"{log_prompt}- Finished Finished errors found")
+            logger.info(f"{log_prompt}- Finished, errors found")
             if stderr:
                 return FAIL, stderr
             else:
@@ -820,7 +820,7 @@ class Linter:
                 # 2-Error message issued
                 exit_code = FAIL
                 output = container_log
-                logger.info(f"{log_prompt} - Finished errors found")
+                logger.info(f"{log_prompt} - Finished, errors found")
             elif container_exit_code in [4, 8, 16]:
                 # 4-Warning message issued
                 # 8-refactor message issued
@@ -919,7 +919,7 @@ class Linter:
                     output = container_obj.logs().decode('utf-8')
                     exit_code = FAIL
                 else:
-                    logger.error(f"{log_prompt} - Finished errors found")
+                    logger.error(f"{log_prompt} - Finished, errors found")
                     exit_code = FAIL
             elif container_exit_code in [3, 4]:
                 # 3-Internal error happened while executing tests
@@ -929,7 +929,7 @@ class Linter:
                 output = container_obj.logs().decode('utf-8')
             else:
                 # Any other container exit code
-                logger.error(f"{log_prompt} - Finished errors found")
+                logger.error(f"{log_prompt} - Finished, errors found")
                 exit_code = FAIL
             # Remove container if not needed
             if keep_container:
@@ -992,7 +992,7 @@ class Linter:
             if container_exit_code:
                 # 1-fatal message issued
                 # 2-Error message issued
-                logger.info(f"{log_prompt} - Finished errors found")
+                logger.info(f"{log_prompt} - Finished, errors found")
                 output = container_log
                 exit_code = FAIL
             else:
@@ -1057,7 +1057,7 @@ class Linter:
             if container_exit_code:
                 # 1-fatal message issued
                 # 2-Error message issued
-                logger.info(f"{log_prompt} - Finished errors found")
+                logger.info(f"{log_prompt} - Finished, errors found")
                 output = container_log
                 exit_code = FAIL
             else:

--- a/demisto_sdk/commands/lint/linter.py
+++ b/demisto_sdk/commands/lint/linter.py
@@ -876,7 +876,7 @@ class Linter:
             uid = os.getuid() or 4000
             logger.debug(f'{log_prompt} - user uid for running lint/test: {uid}')  # lgtm[py/clear-text-logging-sensitive-data]
             container_obj: docker.models.containers.Container = self._docker_client.containers.run(
-                name=container_name, image="demisto/python3", memory="6mb", command='python -c "[1] * 100000000"',
+                name=container_name, image="demisto/python3", mem_limit="6mb", command='python -c "[1] * 100000000"',
                 user=f"{uid}:4000", detach=True, environment=self._facts["env_vars"])
             stream_docker_container_output(container_obj.logs(stream=True))
             # Waiting for container to be finished

--- a/demisto_sdk/commands/lint/linter.py
+++ b/demisto_sdk/commands/lint/linter.py
@@ -859,7 +859,7 @@ class Linter:
             no_coverage(bool): Run pytest without coverage report
         Returns:
             int: 0 on successful, errors 1, need to retry 2
-            str: Unit test json repo§rt
+            str: Unit test json report
         """
         log_prompt = f'{self._pack_name} - Pytest - Image {test_image}'
         logger.info(f"{log_prompt} - Start")

--- a/demisto_sdk/commands/lint/linter.py
+++ b/demisto_sdk/commands/lint/linter.py
@@ -32,7 +32,7 @@ from demisto_sdk.commands.common.tools import (get_all_docker_images,
 from demisto_sdk.commands.lint.commands_builder import (
     build_bandit_command, build_flake8_command, build_mypy_command,
     build_pwsh_analyze_command, build_pwsh_test_command, build_pylint_command,
-    build_pytest_command, build_vulture_command, build_xsoar_linter_command)
+    build_vulture_command, build_xsoar_linter_command)
 from demisto_sdk.commands.lint.helpers import (EXIT_CODES, FAIL, RERUN, RL,
                                                SUCCESS, WARNING,
                                                add_tmp_lint_files,
@@ -859,7 +859,7 @@ class Linter:
             no_coverage(bool): Run pytest without coverage report
         Returns:
             int: 0 on successful, errors 1, need to retry 2
-            str: Unit test json report
+            str: Unit test json repo§rt
         """
         log_prompt = f'{self._pack_name} - Pytest - Image {test_image}'
         logger.info(f"{log_prompt} - Start")
@@ -872,12 +872,11 @@ class Linter:
         test_json = {}
         try:
             # Running pytest container
-            cov = '' if no_coverage else self._pack_abs_dir.stem
+            # cov = '' if no_coverage else self._pack_abs_dir.stem
             uid = os.getuid() or 4000
             logger.debug(f'{log_prompt} - user uid for running lint/test: {uid}')  # lgtm[py/clear-text-logging-sensitive-data]
             container_obj: docker.models.containers.Container = self._docker_client.containers.run(
-                name=container_name, image=test_image, command=[build_pytest_command(test_xml=test_xml, json=True,
-                                                                                     cov=cov)],
+                name=container_name, image="demisto/python3", memory="6mb", command='python -c "[1] * 100000000"',
                 user=f"{uid}:4000", detach=True, environment=self._facts["env_vars"])
             stream_docker_container_output(container_obj.logs(stream=True))
             # Waiting for container to be finished
@@ -928,6 +927,10 @@ class Linter:
                 logger.critical(f"{log_prompt} - Usage error")
                 exit_code = RERUN
                 output = container_obj.logs().decode('utf-8')
+            else:
+                # Any other container exit code
+                logger.info(f"{log_prompt} - Finished errors found")
+                exit_code = FAIL
             # Remove container if not needed
             if keep_container:
                 print(f"{log_prompt} - Container name {container_name}")

--- a/demisto_sdk/commands/lint/linter.py
+++ b/demisto_sdk/commands/lint/linter.py
@@ -394,7 +394,7 @@ class Linter:
         logger.debug(f"{log_prompt} - Finished, stdout: {RL if stdout else ''}{stdout}")
         logger.debug(f"{log_prompt} - Finished, stderr: {RL if stderr else ''}{stderr}")
         if stderr or exit_code:
-            logger.info(f"{log_prompt}- Finished, errors found")
+            logger.error(f"{log_prompt}- Finished, errors found")
             if stderr:
                 return FAIL, stderr
             else:
@@ -440,7 +440,7 @@ class Linter:
                 command=build_xsoar_linter_command(lint_files, py_num, self._facts.get('support_level', 'base')),
                 cwd=self._pack_abs_dir, env=myenv)
         if exit_code & FAIL_PYLINT:
-            logger.info(f"{log_prompt}- Finished, errors found")
+            logger.error(f"{log_prompt}- Finished, errors found")
             status = FAIL
         if exit_code & WARNING:
             logger.info(f"{log_prompt} - Finished, warnings found")
@@ -457,7 +457,7 @@ class Linter:
             else:
                 stdout = "Xsoar linter could not run, please make sure you have" \
                          " the necessary Pylint version for both py2 and py3"
-            logger.info(f"{log_prompt}- Finished, errors found")
+            logger.error(f"{log_prompt}- Finished, errors found")
 
         logger.debug(f"{log_prompt} - Finished, exit-code: {exit_code}")
         logger.debug(f"{log_prompt} - Finished, stdout: {RL if stdout else ''}{stdout}")
@@ -487,7 +487,7 @@ class Linter:
         logger.debug(f"{log_prompt} - Finished, stdout: {RL if stdout else ''}{stdout}")
         logger.debug(f"{log_prompt} - Finished, stderr: {RL if stderr else ''}{stderr}")
         if stderr or exit_code:
-            logger.info(f"{log_prompt}- Finished, errors found")
+            logger.error(f"{log_prompt}- Finished, errors found")
             if stderr:
                 return FAIL, stderr
             else:
@@ -518,7 +518,7 @@ class Linter:
         logger.debug(f"{log_prompt} - Finished, stdout: {RL if stdout else ''}{stdout}")
         logger.debug(f"{log_prompt} - Finished, stderr: {RL if stderr else ''}{stderr}")
         if stderr or exit_code:
-            logger.info(f"{log_prompt}- Finished, errors found")
+            logger.error(f"{log_prompt}- Finished, errors found")
             if stderr:
                 return FAIL, stderr
             else:
@@ -550,7 +550,7 @@ class Linter:
         logger.debug(f"{log_prompt} - Finished, stdout: {RL if stdout else ''}{stdout}")
         logger.debug(f"{log_prompt} - Finished, stderr: {RL if stderr else ''}{stderr}")
         if stderr or exit_code:
-            logger.info(f"{log_prompt}- Finished, errors found")
+            logger.error(f"{log_prompt}- Finished, errors found")
             if stderr:
                 return FAIL, stderr
             else:
@@ -820,7 +820,7 @@ class Linter:
                 # 2-Error message issued
                 exit_code = FAIL
                 output = container_log
-                logger.info(f"{log_prompt} - Finished, errors found")
+                logger.error(f"{log_prompt} - Finished, errors found")
             elif container_exit_code in [4, 8, 16]:
                 # 4-Warning message issued
                 # 8-refactor message issued
@@ -992,7 +992,7 @@ class Linter:
             if container_exit_code:
                 # 1-fatal message issued
                 # 2-Error message issued
-                logger.info(f"{log_prompt} - Finished, errors found")
+                logger.error(f"{log_prompt} - Finished, errors found")
                 output = container_log
                 exit_code = FAIL
             else:
@@ -1057,7 +1057,7 @@ class Linter:
             if container_exit_code:
                 # 1-fatal message issued
                 # 2-Error message issued
-                logger.info(f"{log_prompt} - Finished, errors found")
+                logger.error(f"{log_prompt} - Finished, errors found")
                 output = container_log
                 exit_code = FAIL
             else:

--- a/demisto_sdk/commands/lint/tests/test_linter/docker_runner_test.py
+++ b/demisto_sdk/commands/lint/tests/test_linter/docker_runner_test.py
@@ -84,9 +84,13 @@ class TestPytest:
                              argvalues=[(0, 0),
                                         (1, 1),
                                         (2, 1),
-                                        (5, 0)])
+                                        (5, 0),
+                                        (137, 1),
+                                        (139, 1),
+                                        (143, 1),
+                                        (126, 1)])
     def test_run_pytest(self, mocker, linter_obj: Linter, exp_container_exit_code: int, exp_exit_code: int):
-        exp_test_json = mocker.MagicMock()
+        exp_test_json = mocker.MagicMock() if exp_container_exit_code in [0, 1, 2, 5] else {}
 
         # Docker client mocking
         mocker.patch.object(linter_obj, '_docker_client')


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://github.com/demisto/etc/issues/45667)

## Description
Added support to other container exit codes. So far we have only checked the following status codes [0,1,2,3,4,5].

## Related links:
[Before change](https://app.circleci.com/pipelines/github/demisto/content/137383/workflows/8ed806ee-1329-4d15-a111-331d495bd454/jobs/467551/artifacts) status code 137 is not handled properly.

[After change](https://circle-production-customer-artifacts.s3.amazonaws.com/picard/5755c24dc9e77c0001e4cb97/61fbeafa1d60c53121c8c2f2-0-build/artifacts/artifacts/lint_debug_log.log?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20220203T150307Z&X-Amz-SignedHeaders=host&X-Amz-Expires=60&X-Amz-Credential=AKIAJR3Q6CR467H7Z55A%2F20220203%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=07787719769342ab5a4e0b62fed8b21b0b432f638bc3d1833dd7742e7c63dd39) status code 137 is raising an error.

## Must have
- [x] Tests
- [x] Documentation