### PR TITLE
Removed CommonServerUserPython and PowerShell from unify ignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add to **validate** a validation for pack name to make sure it is unchanged.
 * Added a validation to the **validate** command that verifies that the version in the pack_metdata file is written in the correct format.
 * Fixed an issue in the **format** command where missing *fromVersion* field in indicator fields caused an error.
+* Removed CommonServerUserPython and CommonServerUserPowerShell from the ignored files in the unify command
 
 # 1.5.9
 * Added option to specify `External Playbook Configuration` to change inputs of Playbooks triggered as part of **test-content**

--- a/demisto_sdk/commands/unify/yml_unifier.py
+++ b/demisto_sdk/commands/unify/yml_unifier.py
@@ -265,9 +265,9 @@ class YmlUnifier:
         :rtype: str
         """
 
-        ignore_regex = (r'CommonServerPython\.py|CommonServerUserPython\.py|demistomock\.py|_test\.py'
+        ignore_regex = (r'CommonServerPython\.py|demistomock\.py|_test\.py'
                         r'|conftest\.py|__init__\.py|ApiModule\.py|vulture_whitelist\.py'
-                        r'|CommonServerPowerShell\.ps1|CommonServerUserPowerShell\.ps1|demistomock\.ps1|\.Tests\.ps1')
+                        r'|CommonServerPowerShell\.ps1|demistomock\.ps1|\.Tests\.ps1')
         if self.package_path.endswith('/'):
             self.package_path = self.package_path[:-1]  # remove the last / as we use os.path.join
         if self.package_path.endswith(os.path.join('Scripts', 'CommonServerPython')):


### PR DESCRIPTION
## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
None

## Description
The [CommonServerUserPython](https://xsoar.pan.dev/docs/reference/scripts/common-server-user-python) is common user-defined code that is merged into each script and integration during execution.

According to this definition, I would believe that I could unify this code, while at this moment we cannot.

## Screenshots
None

## Must have
- [ ] Tests (no relevant tests)
- [ ] Documentation (no relevant documentation)
- [X] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension
  - [X] N/A - Functionality cannot be implemented in the extension because **it does not have related code in the repository**
