### PR TITLE
added a more informative message in case of validating image in the w…

### DIFF
--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -1038,8 +1038,11 @@ class Errors:
     @error_code_decorator
     def invalid_image_name_or_location():
         return "The image file name or location is invalid\n" \
-               "If you're trying to add an integration image, make sure the image name looks like the following: <integration_name>_image.png and located in your integration folder: Packs/<MyPack>/Integrations/<MyIntegration>. For more info: https://xsoar.pan.dev/docs/integrations/package-dir#the-directory-structure-is-as-follows.\n" \
-               "If you're trying to add author image, make sure the image name looks like the following: Author_image.png and located in the pack root path. For more info: https://xsoar.pan.dev/docs/packs/packs-format#author_imagepng\n" \
+               "If you're trying to add an integration image, make sure the image name looks like the following:<integration_name>_image.png and located in" \
+               "your integration folder: Packs/<MyPack>/Integrations/<MyIntegration>. For more info: " \
+               "https://xsoar.pan.dev/docs/integrations/package-dir#the-directory-structure-is-as-follows.\n" \
+               "If you're trying to add author image, make sure the image name looks like the following: Author_image.png and located in the pack root path." \
+               "For more info: https://xsoar.pan.dev/docs/packs/packs-format#author_imagepng\n" \
                "Otherwise, any other image should be located under the 'Doc_files' dir."
 
     @staticmethod

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -1041,7 +1041,7 @@ class Errors:
                "If you're trying to add integation image, make sure the image name looks like the following: <integration_name>_image.png\n" \
                "If you're trying to add autho image, make sure the image name looks like the following: author_image.png and located in the pack root path.\n" \
                "Otherwise, any other image should be located under the 'doc_file' dir."
-               
+
     @staticmethod
     @error_code_decorator
     def description_missing_from_conf_json(problematic_instances):

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -160,6 +160,7 @@ ERROR_CODE = {
     "invalid_image_name": {'code': "IM107", 'ui_applicable': False, 'related_field': 'image'},
     "image_is_empty": {'code': "IM108", 'ui_applicable': True, 'related_field': 'image'},
     "author_image_is_missing": {'code': "IM109", 'ui_applicable': True, 'related_field': 'image'},
+    "invalid_image_name_or_location": {'code': "IM110", 'ui_applicable': True, 'related_field': 'image'},
 
     # IN - Integrations
     "wrong_display_name": {'code': "IN100", 'ui_applicable': True, 'related_field': '<parameter-name>.display'},
@@ -1033,6 +1034,14 @@ class Errors:
     def author_image_is_missing(image_path: str):
         return f'Partners must provide a non-empty author image under the path {image_path}.'
 
+    @staticmethod
+    @error_code_decorator
+    def invalid_image_name_or_location():
+        return "The image's file name or location is invalid\n" \
+               "If you're trying to add integation image, make sure the image name looks like the following: <integration_name>_image.png\n" \
+               "If you're trying to add autho image, make sure the image name looks like the following: author_image.png and located in the pack root path.\n" \
+               "Otherwise, any other image should be located under the 'doc_file' dir."
+               
     @staticmethod
     @error_code_decorator
     def description_missing_from_conf_json(problematic_instances):

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -1037,10 +1037,10 @@ class Errors:
     @staticmethod
     @error_code_decorator
     def invalid_image_name_or_location():
-        return "The image's file name or location is invalid\n" \
-               "If you're trying to add integation image, make sure the image name looks like the following: <integration_name>_image.png\n" \
-               "If you're trying to add autho image, make sure the image name looks like the following: author_image.png and located in the pack root path.\n" \
-               "Otherwise, any other image should be located under the 'doc_file' dir."
+        return "The image file name or location is invalid\n" \
+               "If you're trying to add an integration image, make sure the image name looks like the following: <integration_name>_image.png and located in your integration folder: Packs/<MyPack>/Integrations/<MyIntegration>. For more info: https://xsoar.pan.dev/docs/integrations/package-dir#the-directory-structure-is-as-follows.\n" \
+               "If you're trying to add author image, make sure the image name looks like the following: Author_image.png and located in the pack root path. For more info: https://xsoar.pan.dev/docs/packs/packs-format#author_imagepng\n" \
+               "Otherwise, any other image should be located under the 'Doc_files' dir."
 
     @staticmethod
     @error_code_decorator

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -1824,3 +1824,20 @@ def test_validate_pack_name(repo):
     assert validator_obj.is_valid_pack_name('Packs/original_pack/file', None)
     assert validator_obj.is_valid_pack_name('Packs/original_pack/file', 'Packs/original_pack/file')
     assert not validator_obj.is_valid_pack_name('Packs/original_pack/file', 'Packs/original_pack_v2/file')
+
+
+def test_image_error(capsys):
+    """
+    Given
+            a image that isn't located in the right folder.
+    When
+            Validating the file
+    Then
+            Ensure an error is raised, and  the right error is given.
+    """
+    validate_manager = ValidateManager()
+    validate_manager.run_validations_on_file(IGNORED_PNG, None)
+    stdout = capsys.readouterr().out
+    expected_string, expected_code = Errors.invalid_image_name_or_location()
+    assert expected_string in stdout
+    assert expected_code in stdout

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -450,6 +450,8 @@ class ValidateManager:
             return True
         elif file_type is None:
             error_message, error_code = Errors.file_type_not_supported()
+            if str(file_path).endswith('.png'):
+                error_message, error_code = Errors.invalid_image_name_or_location()
             if self.handle_error(error_message=error_message, error_code=error_code, file_path=file_path,
                                  drop_line=True):
                 return False
@@ -1463,6 +1465,8 @@ class ValidateManager:
 
         if not file_type:
             error_message, error_code = Errors.file_type_not_supported()
+            if str(file_path).endswith('.png'):
+                error_message, error_code = Errors.invalid_image_name_or_location()
             self.handle_error(error_message, error_code, file_path=file_path)
             return '', '', False
 

--- a/demisto_sdk/tests/integration_tests/validate_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/validate_integration_test.py
@@ -2835,7 +2835,7 @@ class TestImageValidation:
         with ChangeCWD(pack.repo_path):
             runner = CliRunner(mix_stderr=False)
             result = runner.invoke(main, [VALIDATE_CMD, '-i', NOT_VALID_IMAGE_PATH], catch_exceptions=False)
-        assert 'The file type is not supported in the validate command.' in result.stdout
+        assert "The image's file name or location is invalid" in result.stdout
         assert result.exit_code == 1
 
 

--- a/demisto_sdk/tests/integration_tests/validate_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/validate_integration_test.py
@@ -2835,7 +2835,7 @@ class TestImageValidation:
         with ChangeCWD(pack.repo_path):
             runner = CliRunner(mix_stderr=False)
             result = runner.invoke(main, [VALIDATE_CMD, '-i', NOT_VALID_IMAGE_PATH], catch_exceptions=False)
-        assert "The image's file name or location is invalid" in result.stdout
+        assert "The image file name or location is invalid" in result.stdout
         assert result.exit_code == 1
 
 


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
[fixes: link to the issue](https://github.com/demisto/etc/issues/46436)

## Description
Added a more informative message to the particular case when .png files are added with wrong names / in the wrong places instead of the generic error message mentioned in the issue. 
