### PR TITLE
Fix create content artifact filter by id set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-
+- Fixed an issue when filtering items using the ID set in the **create-content-artifacts** command.
 
 # 1.6.0
 * Fixed an issue in the **create-id-set** command where similar items from different marketplaces were reported as duplicated.

--- a/TestSuite/pack.py
+++ b/TestSuite/pack.py
@@ -177,9 +177,16 @@ class Pack:
             image: bytes = b''
     ) -> Script:
         if name is None:
-            name = f'script{len(self.integrations)}'
+            name = f'script{len(self.scripts)}'
         if yml is None:
-            yml = {}
+            yml = {
+                'commonfields': {'id': name, 'version': -1},
+                'name': name,
+                'comment': f'this is script {name}',
+                'type': 'python',
+                'subtype': 'python3',
+                'script': '-',
+            }
         script = Script(self._scripts_path, name, self._repo)
         script.build(
             code,

--- a/demisto_sdk/commands/common/content/objects/pack_objects/pack.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/pack.py
@@ -76,7 +76,7 @@ class Pack:
                 if is_object_in_id_set(object_id, self._pack_info_from_id_set):
                     yield content_object
                 else:
-                    logging.warning(f'Skipping object {object_path} with id "{object_id}" since its missing from '
+                    logging.warning(f'Skipping object {object_path} with id "{object_id}" since it\'s missing from '
                                     f'the given id set')
             else:
                 yield content_object

--- a/demisto_sdk/commands/common/content/objects/pack_objects/pack.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/pack.py
@@ -76,7 +76,7 @@ class Pack:
                 if is_object_in_id_set(object_id, self._pack_info_from_id_set):
                     yield content_object
                 else:
-                    logging.warning(f'Skipping object {object_path} with id {object_id} since its missing from '
+                    logging.warning(f'Skipping object {object_path} with id "{object_id}" since its missing from '
                                     f'the given id set')
             else:
                 yield content_object

--- a/demisto_sdk/commands/create_artifacts/content_artifacts_creator.py
+++ b/demisto_sdk/commands/create_artifacts/content_artifacts_creator.py
@@ -108,11 +108,11 @@ class ArtifactsManager:
         self.exit_code = EX_SUCCESS
 
         if self.filter_by_id_set:
-            packs_section_from_id_set = self.id_set.get('Packs', {})
+            self.packs_section_from_id_set = self.id_set.get('Packs', {})
             if self.pack_names == ['all']:
-                self.pack_names = list(packs_section_from_id_set.keys())
+                self.pack_names = list(self.packs_section_from_id_set.keys())
             else:
-                self.pack_names = list(set(packs_section_from_id_set.keys()).intersection(set(self.pack_names)))
+                self.pack_names = list(set(self.packs_section_from_id_set.keys()).intersection(set(self.pack_names)))
 
     def create_content_artifacts(self) -> int:
         with ArtifactsDirsHandler(self), ProcessPoolHandler(self) as pool:

--- a/demisto_sdk/tests/integration_tests/content_create_artifacts_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/content_create_artifacts_integration_test.py
@@ -125,13 +125,23 @@ def test_all_packs_creation(repo):
 
 
 def test_create_packs_with_filter_by_id_set(repo):
+    """
+    Given
+        - A pack with 2 scripts
+        - An ID set including only one script
+    When
+        - running the create-content-artifacts command.
+    Then
+        - Verify that only the script in the ID set is exported to the pack artifacts.
+    """
     pack = repo.create_pack('Joey')
     pack.pack_metadata.write_json(
         {
             'name': 'Joey',
         }
     )
-    script = pack.create_script('HowYouDoing')
+    script1 = pack.create_script('HowYouDoing')
+    script2 = pack.create_script('ShareFood')
     repo.id_set.write_json({
         'Packs': {
             'Joey': {
@@ -151,5 +161,6 @@ def test_create_packs_with_filter_by_id_set(repo):
         result = runner.invoke(main, [ARTIFACTS_CMD, '-a', dir_path, '--no-zip', '-fbi', '-idp', repo.id_set.path, '-p', 'Joey'])
         assert result.exit_code == 0
 
-    expected_script_path = Path(dir_path) / 'content_packs' / pack.name / 'Scripts' / f'script-{script.name}.yml'
-    assert expected_script_path.exists()
+    scripts_folder_path = Path(dir_path) / 'content_packs' / pack.name / 'Scripts'
+    assert (scripts_folder_path / f'script-{script1.name}.yml').exists()
+    assert not (scripts_folder_path / f'script-{script2.name}.yml').exists()

--- a/demisto_sdk/tests/integration_tests/content_create_artifacts_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/content_create_artifacts_integration_test.py
@@ -135,11 +135,9 @@ def test_create_packs_with_filter_by_id_set(repo):
         - Verify that only the script in the ID set is exported to the pack artifacts.
     """
     pack = repo.create_pack('Joey')
-    pack.pack_metadata.write_json(
-        {
-            'name': 'Joey',
-        }
-    )
+    pack.pack_metadata.write_json({
+        'name': 'Joey',
+    })
     script1 = pack.create_script('HowYouDoing')
     script2 = pack.create_script('ShareFood')
     repo.id_set.write_json({


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
related issue: https://github.com/demisto/etc/issues/46570
see `CommonScripts` pack v1.6.35 in MPv2

## Description
Fixed an issue when filtering items using the ID set in the **create-content-artifacts** command.

## Screenshots
failing test without the fix: There is a warning about the skipped item due to the bug.
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/30797606/153679641-d3973e7c-3a05-475c-b1e0-9898fa759d68.png">
