### PR TITLE
fix relative split output resolving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Removed PYYAML library (using only ruamel instead).
 * Fixed an issue when filtering items using the ID set in the **create-content-artifacts** command.
 * Fixed an issue in the **generate-docs** command where tables were generated with an empty description column.
+* Fixed an issue in the **split** command where splitting failed when using relative input/output paths.
 
 # 1.6.0
 * Fixed an issue in the **create-id-set** command where similar items from different marketplaces were reported as duplicated.

--- a/demisto_sdk/commands/split/tests/ymlsplitter_test.py
+++ b/demisto_sdk/commands/split/tests/ymlsplitter_test.py
@@ -2,6 +2,7 @@ import base64
 import os
 from pathlib import Path
 
+from TestSuite.test_tools import ChangeCWD
 from demisto_sdk.commands.common.configuration import Configuration
 from demisto_sdk.commands.common.constants import DEFAULT_IMAGE_BASE64
 from demisto_sdk.commands.common.handlers import YAML_Handler
@@ -12,7 +13,6 @@ yaml = YAML_Handler()
 
 
 def test_extract_long_description(tmpdir):
-
     # Test when script
     extractor = YmlSplitter(input=f'{git_path()}/demisto_sdk/tests/test_files/script-test_script.yml',
                             output='', file_type='script', no_demisto_mock=False,
@@ -30,7 +30,6 @@ def test_extract_long_description(tmpdir):
 
 
 def test_extract_image(tmpdir):
-
     # Test when script
     extractor = YmlSplitter(input=f'{git_path()}/demisto_sdk/tests/test_files/script-test_script.yml',
                             output='', file_type='script')
@@ -130,6 +129,18 @@ def test_get_output_path():
                             output=out)
     res = extractor.get_output_path()
     assert res == Path(out + "/Zoom")
+
+
+def test_get_output_path_relative(repo):
+    pack = repo.create_pack()
+    integration = pack.create_integration()
+
+    with ChangeCWD(repo.path):
+        extractor = YmlSplitter(input=integration.yml.rel_path, file_type='integration')
+
+    output_path = extractor.get_output_path()
+    assert output_path.is_absolute()
+    assert output_path.relative_to(pack.path) == Path(integration.path).relative_to(pack.path)
 
 
 def test_get_output_path_empty_output():

--- a/demisto_sdk/commands/split/tests/ymlsplitter_test.py
+++ b/demisto_sdk/commands/split/tests/ymlsplitter_test.py
@@ -2,12 +2,12 @@ import base64
 import os
 from pathlib import Path
 
-from TestSuite.test_tools import ChangeCWD
 from demisto_sdk.commands.common.configuration import Configuration
 from demisto_sdk.commands.common.constants import DEFAULT_IMAGE_BASE64
 from demisto_sdk.commands.common.handlers import YAML_Handler
 from demisto_sdk.commands.common.legacy_git_tools import git_path
 from demisto_sdk.commands.split.ymlsplitter import YmlSplitter
+from TestSuite.test_tools import ChangeCWD
 
 yaml = YAML_Handler()
 

--- a/demisto_sdk/commands/split/ymlsplitter.py
+++ b/demisto_sdk/commands/split/ymlsplitter.py
@@ -76,7 +76,7 @@ class YmlSplitter:
     def get_output_path(self):
         """Get processed output path
         """
-        output_path = self.output
+        output_path = Path(self.output).resolve()
         if self.autocreate_dir and output_path.name in {'Integrations', 'Scripts'}:
             code_name = self.yml_data.get("name")
             if not code_name:

--- a/demisto_sdk/commands/split/ymlsplitter.py
+++ b/demisto_sdk/commands/split/ymlsplitter.py
@@ -54,8 +54,8 @@ class YmlSplitter:
                  no_common_server: bool = False, no_auto_create_dir: bool = False, configuration: Configuration = None,
                  base_name: str = '', no_readme: bool = False, no_pipenv: bool = False,
                  no_logging: bool = False, no_basic_fmt: bool = False, new_module_file: bool = False):
-        self.input = Path(input)
-        self.output = Path(output) if output else Path(self.input.parent)
+        self.input = Path(input).resolve()
+        self.output = (Path(output) if output else Path(self.input.parent)).resolve()
         self.demisto_mock = not no_demisto_mock
         self.common_server = not no_common_server
         self.file_type = file_type
@@ -76,7 +76,7 @@ class YmlSplitter:
     def get_output_path(self):
         """Get processed output path
         """
-        output_path = Path(self.output).resolve()
+        output_path = Path(self.output)
         if self.autocreate_dir and output_path.name in {'Integrations', 'Scripts'}:
             code_name = self.yml_data.get("name")
             if not code_name:


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/46777
fixes: https://github.com/demisto/demisto-sdk/issues/1893

## Description
yml-splitter no longer fails on relative paths.

## Must have
- [ ] Tests
- [ ] Documentation
