### PR TITLE
warn of missing inferred files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Removed PYYAML library (using only ruamel instead).
 * Fixed an issue when filtering items using the ID set in the **create-content-artifacts** command.
 * Fixed an issue in the **generate-docs** command where tables were generated with an empty description column.
+* Added warning when inferred files are missing. 
 
 # 1.6.0
 * Fixed an issue in the **create-id-set** command where similar items from different marketplaces were reported as duplicated.

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 from distutils.version import LooseVersion
+from pathlib import Path
 from typing import Optional, Tuple, Union
 
 from demisto_sdk.commands.common.constants import (
@@ -70,11 +71,20 @@ class UpdateRN:
             :return
                 The new file path if was changed
         """
+        def validate_new_path(expected_path: str):
+            if not Path(expected_path).exists():
+                print_warning(f"file {file_path} implies the existence of {str(expected_path)}, which is missing. "
+                              f"Did you mistype {file_path}?")
+
         if file_path.endswith('_image.png'):
-            return file_path.replace('_image.png', '.yml')
+            new_path = file_path.replace('_image.png', '.yml')
+            validate_new_path(new_path)
+            return new_path
 
         elif file_path.endswith('_description.md'):
-            return file_path.replace('_description.md', '.yml')
+            new_path = file_path.replace('_description.md', '.yml')
+            validate_new_path(new_path)
+            return new_path
 
         return file_path
 
@@ -118,7 +128,8 @@ class UpdateRN:
             file_name, file_type = self.get_changed_file_name_and_type(packfile)
             if 'yml' in packfile and file_type in [FileType.INTEGRATION, FileType.BETA_INTEGRATION,
                                                    FileType.SCRIPT] and packfile not in self.added_files:
-                docker_image_name: Optional[str] = check_docker_image_changed(main_branch=self.main_branch, packfile=packfile)
+                docker_image_name: Optional[str] = check_docker_image_changed(main_branch=self.main_branch,
+                                                                              packfile=packfile)
             else:
                 docker_image_name = None
             changed_files[(file_name, file_type)] = {


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Added a warning when a file is inferred (for example, `foo_description.md` implies the existance of `foo.yml`), but does not exist. 
