### PR TITLE
Improvements in the release_guide.md 

### DIFF
--- a/docs/release_guide.md
+++ b/docs/release_guide.md
@@ -19,6 +19,7 @@ In order to release a new version of `demisto-sdk` to the public follow these st
 9) In Demisto's content-private repository create a new branch and go to the build configuration file [**config.yml**](https://github.com/demisto/content-private/blob/master/.github/workflows/config.yml) and update the SDK installation command by replacing the line: `pip3 install demisto-sdk` with this line: `pip3 install git+https://github.com/demisto/demisto-sdk.git@release-branch-name.`
 10) Open a PR for that content-private branch, and verify the build triggered is green. Note that **this PR is for SDK version check only, and it shouldn't be merged**, after build is finished successfully - you should discard this change and close the PR.
 
+**Note:** You can run the builds in steps: 5, 6, 8, 10 at the same time (no need to wait for one to finish before starting the other).
 
 ### Release process:
 1) Click [Here](https://github.com/demisto/demisto-sdk/releases/new) (alternatively: visit the [SDK github page](https://github.com/demisto/demisto-sdk), click on **releases**, and then **Draft a new release**)
@@ -28,6 +29,8 @@ In order to release a new version of `demisto-sdk` to the public follow these st
 5) Update [**dev-requirements-py3.txt**](https://github.com/demisto/content/blob/master/dev-requirements-py3.txt) again, this time with the newly-released version (rather than the branch), e.g demisto-sdk==x.x.x.
 6) Wait for the build to finish, or force merge your PR to the Content repository.
 7) Update **CHANGELOG.md** file - change the `# Changelog` header to the release version in the format `# X.X.X` e.g. `# 1.0.0`, and create a new `# Changelog` header at the top of the file.
-8) Announce regarding the SDK release in the dmst-content-team slack channel - mention the release version, paste the `CHANGELOG` contents for this release, and add a link to demisto-sdk in pypi. 
+8) Announce regarding the SDK release in the **dmst-content-team** slack channel - mention the release version, paste the `CHANGELOG` contents for this release, and add a link to demisto-sdk in pypi. 
 
 Your release was completed successfully!
+
+**Note:** Don't forget to discard any unnecessary PR or branch you opened during the release process. 

--- a/docs/release_guide.md
+++ b/docs/release_guide.md
@@ -16,10 +16,10 @@ In order to release a new version of `demisto-sdk` to the public follow these st
   **Note:** if you're on `content-internal-dist/master`, a notification will be sent to the content-team slack channel. The destination channel can be set via argument.
   Wait until the nightly sdk completes. 
   **Note:** you should discard this change and delete the branch after the build is finished successfully.
-9) In Demisto's content-private repository create a new branch and go to the build configuration file [**config.yml**](https://github.com/demisto/content-private/blob/master/.github/workflows/config.yml) and update the SDK installation command by replacing the line: `pip3 install demisto-sdk` with this line: `pip3 install git+https://github.com/demisto/demisto-sdk.git@release-branch-name.`
-10) Open a PR for that content-private branch, and verify the build triggered is green. Note that **this PR is for SDK version check only, and it shouldn't be merged**, after build is finished successfully - you should discard this change and close the PR.
+9) In Demisto's content-private repository create a new branch and go to the build configuration file [**config.yml**](https://github.com/demisto/content-private/blob/master/.github/workflows/config.yml) and update the SDK installation command by replacing `pip3 install demisto-sdk` with `pip3 install git+https://github.com/demisto/demisto-sdk.git@<sdk-release-branch-name>.`
+10) Open a PR for that content-private branch, and verify the build triggered is green. Note that **this PR is for SDK version check only, and it shouldn't be merged**, once the build is successful, discard this change and close the PR.
 
-**Note:** You can run the builds in steps: 5, 6, 8, 10 at the same time (no need to wait for one to finish before starting the other).
+**Note:** Steps 5, 6, 8, 10 can be performed at the same time (no need to wait for one to finish before starting the other).
 
 ### Release process:
 1) Click [Here](https://github.com/demisto/demisto-sdk/releases/new) (alternatively: visit the [SDK github page](https://github.com/demisto/demisto-sdk), click on **releases**, and then **Draft a new release**)

--- a/docs/release_guide.md
+++ b/docs/release_guide.md
@@ -6,16 +6,19 @@ In order to release a new version of `demisto-sdk` to the public follow these st
 3) Make sure that both `sdk-nightly` and `sdk-master` builds passed.
    * If **new SDK commits** were pushed after the nightly tests have started, manually trigger the sdk nightly build again as written in step 4. This will test sdk master on content branch.
    * If **no new SDK commits** were done after the nightly tests, skip step 4.
-4) Enter the content repo, and run `./Utils/gitlab_triggers/trigger_content_nightly_build.sh -ct <GitLab_token> -b <release_branch_name>`.
+4) Enter the content repo, open a new branch and update the version of the SDK in Demisto's Content repository by updating the demisto-sdk version in the [**dev-requirements-py3.txt**](https://github.com/demisto/content/blob/master/dev-requirements-py3.txt) file. Use the release branch first - replace the `demisto-sdk==version` line with this line: `git+https://github.com/demisto/demisto-sdk.git@release-branch-name.`
+5) Push your branch to remote, and run `./Utils/gitlab_triggers/trigger_content_nightly_build.sh -ct <GitLab_token> -b <your_branch_name>`.
   **Note:** if you're on `content/master`, a notification will be sent to the content-team slack channel. The destination channel can be set via argument.
   Wait until the nightly sdk completes (around 2-3h, mostly for validation)
-5) Enter the content-internal-dist repo, and run `./.gitlab/trigger_content_gold_nightly_build.sh -ct <GitLab_token> -b <release_branch_name>`.
+6) Open a PR for that content branch, and verify that the build triggered is green. Note that in order to trigger the build, opening the PR is required.
+7) Enter the content-internal-dist repo, open a new branch and update the demisto-sdk version in the [**.gitlab-ci.yml**](https://code.pan.run/xsoar/content-internal-dist/-/blob/master/.gitlab/.gitlab-ci.yml) file. Use the release branch - replace the `pip3 install git+https://github.com/demisto/demisto-sdk.git@master` line with this line: `pip3 install git+https://github.com/demisto/demisto-sdk.git@release-branch-name.`
+8) Push your branch to remote, and run `./.gitlab/trigger_content_gold_nightly_build.sh -ct <GitLab_token> -b <your_branch_name>`.
   **Note:** if you're on `content-internal-dist/master`, a notification will be sent to the content-team slack channel. The destination channel can be set via argument.
-  Wait until the nightly sdk completes
-6) In Demisto's content-private repository create a new branch and go to the build configuration file [**config.yml**](https://github.com/demisto/content-private/blob/master/.github/workflows/config.yml) and update the SDK installation command by replacing the line: `pip3 install demisto-sdk` with this line: `pip3 install git+https://github.com/demisto/demisto-sdk.git@release-branch-name.`
-7) Open a PR for that content-private branch, and verify the build triggered is green. Note that **this PR is for SDK version check only, and it shouldn't be merged**, after build is finished successfully - you should discard this change and close the PR.
-8) Create a new content branch and update the version of the SDK in Demisto's Content repository by updating the demisto-sdk version in the [**dev-requirements-py3.txt**](https://github.com/demisto/content/blob/master/dev-requirements-py3.txt) file. Use the release branch first - replace the `demisto-sdk==version` line with this line: `git+https://github.com/demisto/demisto-sdk.git@release-branch-name.`
-9) Open a PR for that content branch, and verify that the build triggered is green. Note that in order to trigger the build, opening the PR is required.
+  Wait until the nightly sdk completes. 
+  **Note:** you should discard this change and delete the branch after the build is finished successfully.
+9) In Demisto's content-private repository create a new branch and go to the build configuration file [**config.yml**](https://github.com/demisto/content-private/blob/master/.github/workflows/config.yml) and update the SDK installation command by replacing the line: `pip3 install demisto-sdk` with this line: `pip3 install git+https://github.com/demisto/demisto-sdk.git@release-branch-name.`
+10) Open a PR for that content-private branch, and verify the build triggered is green. Note that **this PR is for SDK version check only, and it shouldn't be merged**, after build is finished successfully - you should discard this change and close the PR.
+
 
 ### Release process:
 1) Click [Here](https://github.com/demisto/demisto-sdk/releases/new) (alternatively: visit the [SDK github page](https://github.com/demisto/demisto-sdk), click on **releases**, and then **Draft a new release**)
@@ -24,7 +27,7 @@ In order to release a new version of `demisto-sdk` to the public follow these st
 4) Make sure the relevant nightly SDK build passed (step 3 on the previous section), then click **Publish release**. Your release will go through a deploy build (follow it on the [CI website](https://app.circleci.com/pipelines/github/demisto/demisto-sdk). If the build is successful, your release will be public 🎉.
 5) Update [**dev-requirements-py3.txt**](https://github.com/demisto/content/blob/master/dev-requirements-py3.txt) again, this time with the newly-released version (rather than the branch), e.g demisto-sdk==x.x.x.
 6) Wait for the build to finish, or force merge your PR to the Content repository.
-7) Announce regarding the SDK release in the content-team slack channel.
-8) Update **CHANGELOG.md** file - change the `# Changelog` header to the release version in the format `# X.X.X` e.g. `# 1.0.0`, and create a new `# Changelog` header at the top of the file.
+7) Update **CHANGELOG.md** file - change the `# Changelog` header to the release version in the format `# X.X.X` e.g. `# 1.0.0`, and create a new `# Changelog` header at the top of the file.
+8) Announce regarding the SDK release in the dmst-content-team slack channel - mention the release version, paste the `CHANGELOG` contents for this release, and add a link to demisto-sdk in pypi. 
 
 Your release was completed successfully!

--- a/docs/release_guide.md
+++ b/docs/release_guide.md
@@ -14,7 +14,7 @@ In order to release a new version of `demisto-sdk` to the public follow these st
 7) Enter the content-internal-dist repo, open a new branch and update the demisto-sdk version in the [**.gitlab-ci.yml**](https://code.pan.run/xsoar/content-internal-dist/-/blob/master/.gitlab/.gitlab-ci.yml) file. Use the release branch - replace the `pip3 install git+https://github.com/demisto/demisto-sdk.git@master` line with this line: `pip3 install git+https://github.com/demisto/demisto-sdk.git@release-branch-name.`
 8) Push your branch to remote, and run `./.gitlab/trigger_content_gold_nightly_build.sh -ct <GitLab_token> -b <new_internal_dist_branch_name>`.
   **Note:** if you're on `content-internal-dist/master`, a notification will be sent to the content-team slack channel. The destination channel can be set via argument.
-  Wait until the nightly sdk completes. 
+  Wait until the nightly sdk completes.
   **Note:** you should discard this change and delete the branch after the build is finished successfully.
 9) In Demisto's content-private repository create a new branch and go to the build configuration file [**config.yml**](https://github.com/demisto/content-private/blob/master/.github/workflows/config.yml) and update the SDK installation command by replacing `pip3 install demisto-sdk` with `pip3 install git+https://github.com/demisto/demisto-sdk.git@<sdk-release-branch-name>.`
 10) Open a PR for that content-private branch, and verify the build triggered is green. Note that **this PR is for SDK version check only, and it shouldn't be merged**, once the build is successful, discard this change and close the PR.
@@ -29,8 +29,8 @@ In order to release a new version of `demisto-sdk` to the public follow these st
 5) Update [**dev-requirements-py3.txt**](https://github.com/demisto/content/blob/master/dev-requirements-py3.txt) again, this time with the newly-released version (rather than the branch), e.g demisto-sdk==x.x.x.
 6) Wait for the build to finish, or force merge your PR to the Content repository.
 7) Update **CHANGELOG.md** file - change the `# Changelog` header to the release version in the format `# X.X.X` e.g. `# 1.0.0`, and create a new `# Changelog` header at the top of the file.
-8) Announce regarding the SDK release in the **dmst-content-team** slack channel - mention the release version, paste the `CHANGELOG` contents for this release, and add a link to demisto-sdk in pypi. 
+8) Announce regarding the SDK release in the **dmst-content-team** slack channel - mention the release version, paste the `CHANGELOG` contents for this release, and add a link to demisto-sdk in pypi.
 
 Your release was completed successfully!
 
-**Note:** Don't forget to discard any unnecessary PR or branch you opened during the release process. 
+**Note:** Don't forget to discard any unnecessary PR or branch you opened during the release process.

--- a/docs/release_guide.md
+++ b/docs/release_guide.md
@@ -4,7 +4,7 @@ In order to release a new version of `demisto-sdk` to the public follow these st
 1) Make sure the **CHANGELOG.md** file is in order and is updated with all the changes in the current release.
 2) Create a new release branch on the sdk repo, formatted as `X.X.X`, e.g. `1.0.0`.
 3) Make sure that both `sdk-nightly` and `sdk-master` builds passed.
-   * If **new SDK commits** were pushed after the nightly tests have started, manually trigger the sdk nightly build again as written in step 4. This will test sdk master on content branch.
+   * If **new SDK commits** were pushed after the nightly tests had started, manually trigger the sdk nightly build again as written in step 4. This will test sdk master on content branch.
    * If **no new SDK commits** were done after the nightly tests, skip step 4.
 4) Enter the content repo, open a new branch and update the version of the SDK in Demisto's Content repository by updating the demisto-sdk version in the [**dev-requirements-py3.txt**](https://github.com/demisto/content/blob/master/dev-requirements-py3.txt) file. Use the release branch first - replace the `demisto-sdk==version` line with this line: `git+https://github.com/demisto/demisto-sdk.git@release-branch-name.`
 5) Push your branch to remote, and run `./Utils/gitlab_triggers/trigger_content_nightly_build.sh -ct <GitLab_token> -b <your_branch_name>`.

--- a/docs/release_guide.md
+++ b/docs/release_guide.md
@@ -7,12 +7,12 @@ In order to release a new version of `demisto-sdk` to the public follow these st
    * If **new SDK commits** were pushed after the nightly tests had started, manually trigger the sdk nightly build again as written in step 4. This will test sdk master on content branch.
    * If **no new SDK commits** were done after the nightly tests, skip step 4.
 4) Enter the content repo, open a new branch and update the version of the SDK in Demisto's Content repository by updating the demisto-sdk version in the [**dev-requirements-py3.txt**](https://github.com/demisto/content/blob/master/dev-requirements-py3.txt) file. Use the release branch first - replace the `demisto-sdk==version` line with this line: `git+https://github.com/demisto/demisto-sdk.git@release-branch-name.`
-5) Push your branch to remote, and run `./Utils/gitlab_triggers/trigger_content_nightly_build.sh -ct <GitLab_token> -b <your_branch_name>`.
+5) Push your branch to remote, and run `./Utils/gitlab_triggers/trigger_content_nightly_build.sh -ct <GitLab_token> -b <new_content_branch_name>`.
   **Note:** if you're on `content/master`, a notification will be sent to the content-team slack channel. The destination channel can be set via argument.
   Wait until the nightly sdk completes (around 2-3h, mostly for validation)
 6) Open a PR for that content branch, and verify that the build triggered is green. Note that in order to trigger the build, opening the PR is required.
 7) Enter the content-internal-dist repo, open a new branch and update the demisto-sdk version in the [**.gitlab-ci.yml**](https://code.pan.run/xsoar/content-internal-dist/-/blob/master/.gitlab/.gitlab-ci.yml) file. Use the release branch - replace the `pip3 install git+https://github.com/demisto/demisto-sdk.git@master` line with this line: `pip3 install git+https://github.com/demisto/demisto-sdk.git@release-branch-name.`
-8) Push your branch to remote, and run `./.gitlab/trigger_content_gold_nightly_build.sh -ct <GitLab_token> -b <your_branch_name>`.
+8) Push your branch to remote, and run `./.gitlab/trigger_content_gold_nightly_build.sh -ct <GitLab_token> -b <new_internal_dist_branch_name>`.
   **Note:** if you're on `content-internal-dist/master`, a notification will be sent to the content-team slack channel. The destination channel can be set via argument.
   Wait until the nightly sdk completes. 
   **Note:** you should discard this change and delete the branch after the build is finished successfully.


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Updated the release_guide.md so that it will be clearer that the scripts should be triggered on the branch of the release version of the SDK.

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
