### PR TITLE
fixing the way we generate the dev docker to run the pylint and pytest

### DIFF
--- a/demisto_sdk/commands/lint/templates/dockerfile.jinja2
+++ b/demisto_sdk/commands/lint/templates/dockerfile.jinja2
@@ -17,7 +17,9 @@ then apk add --no-cache --virtual .build-deps python3-dev gcc build-base; \
 elif echo "$OS_RELEASE" | grep -qi "Debian"; \
 then apt-get update && apt-get install -y --no-install-recommends gcc python3-dev;fi; \
 pip install --no-cache-dir -r /devwork/test-requirements.txt; \
-if echo "$OS_RELEASE" | grep -q "alpine"; then apk del .build-deps; fi;
+if echo "$OS_RELEASE" | grep -q "alpine"; then apk del .build-deps; \
+elif echo "$OS_RELEASE" | grep -qi "Debian"; \
+then apt-get update && apt-get autoremove -y gcc python3-dev;fi;
 {# Container entry point (Every command will start with /bin/sh) #}
 ENTRYPOINT ["/bin/sh", "-c"]
 {# Build for python based image #}

--- a/demisto_sdk/commands/lint/templates/dockerfile.jinja2
+++ b/demisto_sdk/commands/lint/templates/dockerfile.jinja2
@@ -19,7 +19,7 @@ then apt-get update && apt-get install -y --no-install-recommends gcc python3-de
 pip install --no-cache-dir -r /devwork/test-requirements.txt; \
 if echo "$OS_RELEASE" | grep -q "alpine"; then apk del .build-deps; \
 elif echo "$OS_RELEASE" | grep -qi "Debian"; \
-then apt-get update && apt-get autoremove -y gcc python3-dev;fi;
+then apt-get autoremove -y gcc python3-dev;fi;
 {# Container entry point (Every command will start with /bin/sh) #}
 ENTRYPOINT ["/bin/sh", "-c"]
 {# Build for python based image #}

--- a/demisto_sdk/commands/lint/templates/dockerfile.jinja2
+++ b/demisto_sdk/commands/lint/templates/dockerfile.jinja2
@@ -19,7 +19,7 @@ then apt-get update && apt-get install -y --no-install-recommends gcc python3-de
 pip install --no-cache-dir -r /devwork/test-requirements.txt; \
 if echo "$OS_RELEASE" | grep -q "alpine"; then apk del .build-deps; \
 elif echo "$OS_RELEASE" | grep -qi "Debian"; \
-then apt-get autoremove -y gcc python3-dev;fi;
+then apt-get purge -y --auto-remove gcc python3-dev; fi;
 {# Container entry point (Every command will start with /bin/sh) #}
 ENTRYPOINT ["/bin/sh", "-c"]
 {# Build for python based image #}

--- a/demisto_sdk/commands/lint/templates/dockerfile.jinja2
+++ b/demisto_sdk/commands/lint/templates/dockerfile.jinja2
@@ -13,7 +13,9 @@ RUN chmod -R 775 /devwork
 {# Install requirments and missing deps #}
 RUN printf "{{ pypi_packs | join('\\n') }}" > /devwork/test-requirements.txt
 RUN OS_RELEASE=$(cat /etc/os-release); if echo "$OS_RELEASE" | grep -q "alpine"; \
-then apk add --no-cache --virtual .build-deps python3-dev gcc build-base; fi; \
+then apk add --no-cache --virtual .build-deps python3-dev gcc build-base; \
+elif echo "$OS_RELEASE" | grep -qi "Debian"; \
+then apt-get update && apt-get install -y --no-install-recommends gcc python3-dev;fi; \
 pip install --no-cache-dir -r /devwork/test-requirements.txt; \
 if echo "$OS_RELEASE" | grep -q "alpine"; then apk del .build-deps; fi;
 {# Container entry point (Every command will start with /bin/sh) #}


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Content PR
https://github.com/demisto/content/pull/17746

## Description
After moving to debian bullseye installing pylint and pytest requires gcc to be installed

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
