### PR TITLE
review-docs -g functionality 

### DIFF
--- a/demisto_sdk/commands/doc_reviewer/doc_reviewer.py
+++ b/demisto_sdk/commands/doc_reviewer/doc_reviewer.py
@@ -150,7 +150,7 @@ class DocReviewer:
             ) in self.SUPPORTED_FILE_TYPES:
                 self.files.append(file)
 
-    def get_files_to_run_on(self, file_path):
+    def get_files_to_run_on(self, file_path=None):
         """Get all the relevant files that the spell-check could work on"""
         if self.git_util:
             self.get_files_from_git()
@@ -198,8 +198,11 @@ class DocReviewer:
         if len(self.SUPPORTED_FILE_TYPES) == 1:
             click.secho('Running only on release notes', fg='bright_cyan')
 
-        for file_path in self.file_paths:
-            self.get_files_to_run_on(file_path)
+        if self.file_paths:
+            for file_path in self.file_paths:
+                self.get_files_to_run_on(file_path)
+        else:
+            self.get_files_to_run_on()
 
         # no eligible files found
         if not self.files:


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/45688

## Description
there was a prev change that removed the functionality of the -g arg in the doc review. 
fixed this bug. 


## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
