### PR TITLE
dev-bug - missing commas in template list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Improved the detection of errors in **doc-review** command.
 * The **validate** command now checks if a readme file is empty, only for packs that contain playbooks or were written by a partner
 * The **validate** command now makes sure common contextPath values (e.g. `DBotScore.Score`) have a non-empty description, and **format** populates them automatically.
-
+* Fixed a bug where **doc-review** command failed on existing templates
 # 1.6.1
 * Added the '--use-packs-known-words' argument to the **doc-review** command
 * Added YAML_Loader to handle yaml files in a standard way across modules, replacing PYYAML.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 * Improved the detection of errors in **doc-review** command.
 * The **validate** command now checks if a readme file is empty, only for packs that contain playbooks or were written by a partner
 * The **validate** command now makes sure common contextPath values (e.g. `DBotScore.Score`) have a non-empty description, and **format** populates them automatically.
-* Fixed a bug where **doc-review** command failed on existing templates
+* Fixed a bug where **doc-review** command failed on existing templates.
+
 # 1.6.1
 * Added the '--use-packs-known-words' argument to the **doc-review** command
 * Added YAML_Loader to handle yaml files in a standard way across modules, replacing PYYAML.

--- a/demisto_sdk/commands/doc_reviewer/rn_checker.py
+++ b/demisto_sdk/commands/doc_reviewer/rn_checker.py
@@ -43,8 +43,8 @@ class ReleaseNotesChecker:
         'Improved implementation',
         'Updated the Docker image to',
         'You can now',
-        'Deprecated. '
-        'Deprecated the '
+        'Deprecated. ',
+        'Deprecated the ',
 
         # full line
         'Documentation and metadata improvements.',


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/45254

## Description
missing commas in template list, resulting in one long wrong template

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
