### PR TITLE
Run validate -a with Multiprocessing

### DIFF
--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -439,10 +439,15 @@ def zip_packs(**kwargs) -> int:
     "--allow-skipped",
     help="Don't fail on skipped integrations or when all test playbooks are skipped.",
     is_flag=True)
+@click.option(
+    "--without-multiprocessing",
+    help="run validate all without multiprocessing, for debugging purposes.",
+    is_flag=True, default=False)
 @pass_config
 def validate(config, **kwargs):
     """Validate your content files. If no additional flags are given, will validated only committed files."""
     from demisto_sdk.commands.validate.validate_manager import ValidateManager
+    run_with_mp = not kwargs.pop('without_multiprocessing')
     check_configuration_file('validate', kwargs)
     sys.path.append(config.configuration.env_dir)
 
@@ -479,6 +484,7 @@ def validate(config, **kwargs):
             debug_git=kwargs.get('debug_git'),
             include_untracked=kwargs.get('include_untracked'),
             quite_bc=kwargs.get('quite_bc_validation'),
+            run_with_multiprocessing=run_with_mp,
             check_is_unskipped=not kwargs.get('allow_skipped', False),
         )
         return validator.run_validation()

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -440,14 +440,14 @@ def zip_packs(**kwargs) -> int:
     help="Don't fail on skipped integrations or when all test playbooks are skipped.",
     is_flag=True)
 @click.option(
-    "--without-multiprocessing",
+    "--no-multiprocessing",
     help="run validate all without multiprocessing, for debugging purposes.",
     is_flag=True, default=False)
 @pass_config
 def validate(config, **kwargs):
     """Validate your content files. If no additional flags are given, will validated only committed files."""
     from demisto_sdk.commands.validate.validate_manager import ValidateManager
-    run_with_mp = not kwargs.pop('without_multiprocessing')
+    run_with_mp = not kwargs.pop('no_multiprocessing')
     check_configuration_file('validate', kwargs)
     sys.path.append(config.configuration.env_dir)
 
@@ -484,7 +484,7 @@ def validate(config, **kwargs):
             debug_git=kwargs.get('debug_git'),
             include_untracked=kwargs.get('include_untracked'),
             quite_bc=kwargs.get('quite_bc_validation'),
-            run_with_multiprocessing=run_with_mp,
+            multiprocessing=run_with_mp,
             check_is_unskipped=not kwargs.get('allow_skipped', False),
         )
         return validator.run_validation()

--- a/demisto_sdk/commands/common/hook_validations/readme.py
+++ b/demisto_sdk/commands/common/hook_validations/readme.py
@@ -4,6 +4,7 @@ import os
 import re
 import subprocess
 import tempfile
+from contextlib import contextmanager
 from functools import lru_cache
 from pathlib import Path
 from threading import Lock
@@ -535,7 +536,8 @@ class ReadMeValidator(BaseValidator):
         return is_valid
 
     @staticmethod
-    def start_mdx_server(handle_error: Optional[Callable] = None, file_path: Optional[str] = None) -> bool:
+    @contextmanager
+    def start_mdx_server(handle_error: Optional[Callable] = None, file_path: Optional[str] = None):
         with ReadMeValidator._MDX_SERVER_LOCK:
             if not ReadMeValidator._MDX_SERVER_PROCESS:
                 mdx_parse_server = Path(__file__).parent.parent / 'mdx-parse-server.js'
@@ -551,7 +553,14 @@ class ReadMeValidator(BaseValidator):
 
                     else:
                         raise Exception(error_message)
-        return True
+        yield True
+        ReadMeValidator.stop_mdx_server()
+
+    @staticmethod
+    def add_node_env_vars():
+        content_path = get_content_path()
+        node_modules_path = content_path / Path('node_modules')
+        os.environ['NODE_PATH'] = str(node_modules_path) + os.pathsep + os.getenv("NODE_PATH", "")
 
     @staticmethod
     def stop_mdx_server():
@@ -562,6 +571,3 @@ class ReadMeValidator(BaseValidator):
     @staticmethod
     def _get_error_lists():
         return FOUND_FILES_AND_ERRORS, FOUND_FILES_AND_IGNORED_ERRORS
-
-
-atexit.register(ReadMeValidator.stop_mdx_server)

--- a/demisto_sdk/commands/common/hook_validations/readme.py
+++ b/demisto_sdk/commands/common/hook_validations/readme.py
@@ -1,4 +1,3 @@
-import atexit
 import json
 import os
 import re

--- a/demisto_sdk/commands/common/tests/readme_test.py
+++ b/demisto_sdk/commands/common/tests/readme_test.py
@@ -53,15 +53,16 @@ def test_is_file_valid(mocker, current, answer):
 
 @pytest.mark.parametrize("current, answer", README_INPUTS)
 def test_is_file_valid_mdx_server(mocker, current, answer):
-    readme_validator = ReadMeValidator(current)
-    valid = readme_validator.are_modules_installed_for_verify(readme_validator.content_path)
-    if not valid:
-        pytest.skip('skipping mdx server test. ' + MDX_SKIP_NPM_MESSAGE)
-        return
-    mocker.patch.dict(os.environ, {'DEMISTO_README_VALIDATION': 'yes'})
-    assert readme_validator.is_valid_file() is answer
-    assert ReadMeValidator._MDX_SERVER_PROCESS is not None
-    ReadMeValidator.stop_mdx_server()
+    ReadMeValidator.add_node_env_vars()
+    with ReadMeValidator.start_mdx_server():
+        readme_validator = ReadMeValidator(current)
+        valid = readme_validator.are_modules_installed_for_verify(readme_validator.content_path)
+        if not valid:
+            pytest.skip('skipping mdx server test. ' + MDX_SKIP_NPM_MESSAGE)
+            return
+        mocker.patch.dict(os.environ, {'DEMISTO_README_VALIDATION': 'yes'})
+        assert readme_validator.is_valid_file() is answer
+        assert ReadMeValidator._MDX_SERVER_PROCESS is not None
 
 
 def test_are_modules_installed_for_verify_false_res(tmp_path):

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -96,7 +96,7 @@ class ValidateManager:
             validate_all=False, is_external_repo=False, skip_pack_rn_validation=False, print_ignored_errors=False,
             silence_init_prints=False, no_docker_checks=False, skip_dependencies=False, id_set_path=None, staged=False,
             create_id_set=False, json_file_path=None, skip_schema_check=False, debug_git=False, include_untracked=False,
-            pykwalify_logs=False, check_is_unskipped=True, quite_bc=False, run_with_multiprocessing=True
+            pykwalify_logs=False, check_is_unskipped=True, quite_bc=False, multiprocessing=True
     ):
         # General configuration
         self.skip_docker_checks = False
@@ -204,7 +204,7 @@ class ValidateManager:
             return 0
 
         else:
-            all_failing_files = '\n'.join(list(set(FOUND_FILES_AND_ERRORS)))
+            all_failing_files = '\n'.join(set(FOUND_FILES_AND_ERRORS))
             click.secho(f"\n=========== Found errors in the following files ===========\n\n{all_failing_files}\n",
                         fg="bright_red")
 

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -1,8 +1,10 @@
 import os
+from concurrent.futures._base import Future, as_completed
 from configparser import ConfigParser, MissingSectionHeaderError
-from typing import Optional, Set, Tuple
+from typing import Callable, List, Optional, Set, Tuple
 
 import click
+import pebble
 from colorama import Fore
 from git import InvalidGitRepositoryError
 from packaging import version
@@ -94,7 +96,7 @@ class ValidateManager:
             validate_all=False, is_external_repo=False, skip_pack_rn_validation=False, print_ignored_errors=False,
             silence_init_prints=False, no_docker_checks=False, skip_dependencies=False, id_set_path=None, staged=False,
             create_id_set=False, json_file_path=None, skip_schema_check=False, debug_git=False, include_untracked=False,
-            pykwalify_logs=False, check_is_unskipped=True, quite_bc=False
+            pykwalify_logs=False, check_is_unskipped=True, quite_bc=False, run_with_multiprocessing=True
     ):
         # General configuration
         self.skip_docker_checks = False
@@ -118,6 +120,7 @@ class ValidateManager:
         self.quite_bc = quite_bc
         self.check_is_unskipped = check_is_unskipped
         self.conf_json_data = {}
+        self.run_with_multiprocessing = run_with_multiprocessing
 
         if json_file_path:
             self.json_file_path = os.path.join(json_file_path, 'validate_outputs.json') if \
@@ -179,7 +182,7 @@ class ValidateManager:
             # also do not skip id set creation unless the flag is up
             self.skip_docker_checks = True
             self.skip_pack_rn_validation = True
-            self.print_percent = True
+            self.print_percent = not self.run_with_multiprocessing  # the Multiprocessing will mismatch the percent
             self.check_is_unskipped = False
 
         if no_docker_checks:
@@ -201,7 +204,7 @@ class ValidateManager:
             return 0
 
         else:
-            all_failing_files = '\n'.join(FOUND_FILES_AND_ERRORS)
+            all_failing_files = '\n'.join(list(set(FOUND_FILES_AND_ERRORS)))
             click.secho(f"\n=========== Found errors in the following files ===========\n\n{all_failing_files}\n",
                         fg="bright_red")
 
@@ -285,7 +288,7 @@ class ValidateManager:
             elif file_level == PathLevel.PACK:
                 click.secho(f'\n================= Validating pack {path} =================',
                             fg="bright_cyan")
-                files_validation_result.add(self.run_validations_on_pack(path))
+                files_validation_result.add(self.run_validations_on_pack(path)[0])
 
             else:
                 click.secho(f'\n================= Validating package {path} =================',
@@ -293,6 +296,22 @@ class ValidateManager:
                 files_validation_result.add(self.run_validation_on_package(path, error_ignore_list))
 
         return all(files_validation_result)
+
+    def wait_futures_complete(self, futures_list: List[Future], done_fn: Callable):
+        """Wait for all futures to complete, Raise exception if occurred.
+        Args:
+            futures_list: futures to wait for.
+            done_fn: Function to run on result.
+        Raises:
+            Exception: Raise caught exception for further cleanups.
+        """
+        for future in as_completed(futures_list):
+            try:
+                result = future.result()
+                done_fn(result[0], result[1])
+            except Exception as e:
+                click.secho(f'An error occurred while tried to collect result, Error: {e}', fg="bright_red")
+                raise
 
     def run_validation_on_all_packs(self):
         """Runs validations on all files in all packs in repo (-a option)
@@ -312,12 +331,22 @@ class ValidateManager:
         num_of_packs = len(all_packs)
         all_packs.sort(key=str.lower)
 
-        for pack_path in all_packs:
-            self.completion_percentage = format((count / num_of_packs) * 100, ".2f")  # type: ignore
-            all_packs_valid.add(self.run_validations_on_pack(pack_path))
-            count += 1
-
-        return all(all_packs_valid)
+        ReadMeValidator.add_node_env_vars()
+        with ReadMeValidator.start_mdx_server(handle_error=self.handle_error):
+            if self.run_with_multiprocessing:
+                with pebble.ProcessPool(max_workers=4) as executor:
+                    futures = []
+                    for pack_path in all_packs:
+                        futures.append(executor.schedule(self.run_validations_on_pack, args=(pack_path,)))
+                    self.wait_futures_complete(futures_list=futures,
+                                               done_fn=lambda x, y: (all_packs_valid.add(x),  # type: ignore
+                                                                     FOUND_FILES_AND_ERRORS.extend(y)))  # type: ignore
+            else:
+                for pack_path in all_packs:
+                    self.completion_percentage = format((count / num_of_packs) * 100, ".2f")  # type: ignore
+                    all_packs_valid.add(self.run_validations_on_pack(pack_path)[0])
+                    count += 1
+            return all(all_packs_valid)
 
     def run_validations_on_pack(self, pack_path):
         """Runs validation on all files in given pack. (i,g,a)
@@ -341,7 +370,7 @@ class ValidateManager:
             else:
                 self.ignored_files.add(content_entity_path)
 
-        return all(pack_entities_validation_results)
+        return all(pack_entities_validation_results), FOUND_FILES_AND_ERRORS
 
     def run_validation_on_content_entities(self, content_entity_dir_path, pack_error_ignore_list):
         """Gets non-pack folder and runs validation within it (Scripts, Integrations...)
@@ -524,6 +553,10 @@ class ValidateManager:
             return self.validate_description(file_path, pack_error_ignore_list)
 
         elif file_type == FileType.README:
+            if not self.validate_all:
+                ReadMeValidator.add_node_env_vars()
+                with ReadMeValidator.start_mdx_server(handle_error=self.handle_error):
+                    return self.validate_readme(file_path, pack_error_ignore_list)
             return self.validate_readme(file_path, pack_error_ignore_list)
 
         elif file_type == FileType.REPORT:

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -120,7 +120,7 @@ class ValidateManager:
         self.quite_bc = quite_bc
         self.check_is_unskipped = check_is_unskipped
         self.conf_json_data = {}
-        self.run_with_multiprocessing = run_with_multiprocessing
+        self.run_with_multiprocessing = multiprocessing
 
         if json_file_path:
             self.json_file_path = os.path.join(json_file_path, 'validate_outputs.json') if \

--- a/demisto_sdk/tests/integration_tests/validate_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/validate_integration_test.py
@@ -2995,7 +2995,8 @@ class TestAllFilesValidator:
 
         with ChangeCWD(repo.path):
             runner = CliRunner(mix_stderr=False)
-            result = runner.invoke(main, [VALIDATE_CMD, '-a', '--no-docker-checks', '--no-conf-json'],
+            result = runner.invoke(main, [VALIDATE_CMD, '-a', '--no-docker-checks', '--no-conf-json',
+                                          '--without-multiprocessing'],
                                    catch_exceptions=False)
             print(result.stdout)
 
@@ -3041,7 +3042,8 @@ class TestAllFilesValidator:
 
         with ChangeCWD(repo.path):
             runner = CliRunner(mix_stderr=False)
-            result = runner.invoke(main, [VALIDATE_CMD, '-a', '--no-docker-checks', '--no-conf-json'],
+            result = runner.invoke(main, [VALIDATE_CMD, '-a', '--no-docker-checks', '--no-conf-json',
+                                          '--without-multiprocessing'],
                                    catch_exceptions=False)
 
         assert 'Validating all files' in result.stdout

--- a/demisto_sdk/tests/integration_tests/validate_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/validate_integration_test.py
@@ -2996,7 +2996,7 @@ class TestAllFilesValidator:
         with ChangeCWD(repo.path):
             runner = CliRunner(mix_stderr=False)
             result = runner.invoke(main, [VALIDATE_CMD, '-a', '--no-docker-checks', '--no-conf-json',
-                                          '--without-multiprocessing'],
+                                          '--no-multiprocessing'],
                                    catch_exceptions=False)
             print(result.stdout)
 
@@ -3043,7 +3043,7 @@ class TestAllFilesValidator:
         with ChangeCWD(repo.path):
             runner = CliRunner(mix_stderr=False)
             result = runner.invoke(main, [VALIDATE_CMD, '-a', '--no-docker-checks', '--no-conf-json',
-                                          '--without-multiprocessing'],
+                                          '--no-multiprocessing'],
                                    catch_exceptions=False)
 
         assert 'Validating all files' in result.stdout


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Run the validate all command with Multiprocessing,
This downgrade the run-time of the validate all from ~30 m' to ~10 m'.
Added a parameter to disable this for debugging.

The multiprocessing broke some prints (the percent for example), but IMO the run time is more important here,
And the important prints - the files with the errors - are still there.

## Screenshots
Paste here any images that will help the reviewer
