### PR TITLE
Dev bug - get dependencies - using the argument -o without the argument --all-packs-dependencies did not print a proper warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Fixed a bug where **doc-review** command failed on existing templates.
 * Fixed a bug where **validate** command failed when the word demisto is in the repo README file.
 * Added support for adding test-playbooks to the zip file result in *create-content-artifacts* command for marketplacev2.
-
+* Fixed an issue in **find-dependencies** where using the argument *-o* without the argument *--all-packs-dependencies* did not print a proper warning.
 # 1.6.1
 * Added the '--use-packs-known-words' argument to the **doc-review** command
 * Added YAML_Loader to handle yaml files in a standard way across modules, replacing PYYAML.

--- a/demisto_sdk/commands/find_dependencies/README.md
+++ b/demisto_sdk/commands/find_dependencies/README.md
@@ -19,7 +19,7 @@ This command is used in order to find the dependencies between packs and to upda
 * **--all-packs-dependencies**
   Return a json file with ALL content packs dependencies. The json file will be saved under the path given in the '--output-path' argument.
 * **-o, --output-path**
-  The destination path for the packs dependencies json file. This argument is only relevant for when using the '--all-packs-dependecies' flag.
+  The destination path for the packs dependencies json file. This argument only works  when using either the `--all-packs-dependencies` or `--get-dependent-on` flags.
 
 **Examples**:
 `demisto-sdk find-dependencies -i Integrations/MyInt`

--- a/demisto_sdk/commands/find_dependencies/README.md
+++ b/demisto_sdk/commands/find_dependencies/README.md
@@ -16,6 +16,10 @@ This command is used in order to find the dependencies between packs and to upda
   Whether to print the log to the console.
 * **--use-pack-metadata**
   Whether to update the dependencies from the pack metadata.
+* **--all-packs-dependencies**
+  Return a json file with ALL content packs dependencies. The json file will be saved under the path given in the '--output-path' argument.
+* **-o, --output-path**
+  The destination path for the packs dependencies json file. This argument is only relevant for when using the '--all-packs-dependecies' flag.
 
 **Examples**:
 `demisto-sdk find-dependencies -i Integrations/MyInt`

--- a/demisto_sdk/commands/find_dependencies/find_dependencies.py
+++ b/demisto_sdk/commands/find_dependencies/find_dependencies.py
@@ -2046,6 +2046,9 @@ class PackDependencies:
 
     @staticmethod
     def check_arguments_find_dependencies(input_paths, all_packs_dependencies, output_path, get_dependent_on):
+        if output_path and not all_packs_dependencies and not get_dependent_on:
+            print_warning("You used the '--output-path' argument, which is only relevant for when using the"
+                          " '--all-packs-dependencies' or '--get-dependent-on' flags. Ignoring this argument.")
         if not input_paths:
             if not all_packs_dependencies:
                 print_error("Please provide an input path. The path should be formatted as 'Packs/<some pack name>'. "
@@ -2077,9 +2080,6 @@ class PackDependencies:
         if all_packs_dependencies and not output_path:
             print_error("Please insert path for the generated output using --output-path")
             sys.exit(1)
-        if output_path and not all_packs_dependencies and not get_dependent_on:
-            print_warning("You used the '--output-path' argument, which is only relevant for when using the"
-                          " '--all-packs-dependencies' or '--get-dependent-on' flags. Ignoring this argument.")
 
     @staticmethod
     def find_dependencies_manager(

--- a/demisto_sdk/commands/find_dependencies/find_dependencies.py
+++ b/demisto_sdk/commands/find_dependencies/find_dependencies.py
@@ -2047,7 +2047,7 @@ class PackDependencies:
     @staticmethod
     def check_arguments_find_dependencies(input_paths, all_packs_dependencies, output_path, get_dependent_on):
         if output_path and not all_packs_dependencies and not get_dependent_on:
-            print_warning("You used the '--output-path' argument, which is only relevant for when using the"
+            print_warning("You used the '--output-path' argument, which only works when using either the"
                           " '--all-packs-dependencies' or '--get-dependent-on' flags. Ignoring this argument.")
         if not input_paths:
             if not all_packs_dependencies:

--- a/demisto_sdk/commands/find_dependencies/find_dependencies_command.md
+++ b/demisto_sdk/commands/find_dependencies/find_dependencies_command.md
@@ -10,7 +10,7 @@ This command is used for calculating pack dependencies and updating the pack met
 * **--no-update** Use to find the pack dependencies without updating the pack metadata.
 * **-v, --verbose** Whether to print the log to the console.
 * **--all-packs-dependencies** Return a json file with ALL content packs dependencies. The json file will be saved under the path given in the '--output-path' argument.
-* **-o, --output-path** The destination path for the packs dependencies json file. This argument is only relevant for when using the '--all-packs-dependecies' flag.
+* **-o, --output-path** The destination path for the packs dependencies json file. This argument only works  when using either the `--all-packs-dependencies` or `--get-dependent-on` flags.
 **Examples**:
 `demisto-sdk find-dependencies -i Packs/ImpossibleTraveler`
 Navigate to content repository root folder before running find-dependencies command.

--- a/demisto_sdk/commands/find_dependencies/find_dependencies_command.md
+++ b/demisto_sdk/commands/find_dependencies/find_dependencies_command.md
@@ -9,7 +9,8 @@ This command is used for calculating pack dependencies and updating the pack met
 * **-ids, --id_set_path** ID set json full path, mainly for skipping creation of id set.
 * **--no-update** Use to find the pack dependencies without updating the pack metadata.
 * **-v, --verbose** Whether to print the log to the console.
-
+* **--all-packs-dependencies** Return a json file with ALL content packs dependencies. The json file will be saved under the path given in the '--output-path' argument.
+* **-o, --output-path** The destination path for the packs dependencies json file. This argument is only relevant for when using the '--all-packs-dependecies' flag.
 **Examples**:
 `demisto-sdk find-dependencies -i Packs/ImpossibleTraveler`
 Navigate to content repository root folder before running find-dependencies command.


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/47212

## Description
using the argument -o without the argument --all-packs-dependencies did not print a proper warning

## Screenshots
<img width="969" alt="image" src="https://user-images.githubusercontent.com/93524335/157663000-f2b38039-2064-49b5-aa95-6fe359380976.png">

the warning that should be printed:
![image](https://user-images.githubusercontent.com/93524335/157663537-1b90e178-ffe1-4ad1-b827-2f6f04f9088d.png)


## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
