### PR TITLE
Dev Task - Remove support for the flag *maintenance* in the command **update-release-notes**

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 * Fixed a bug where **validate** command failed when the word demisto is in the repo README file.
 * Added support for adding test-playbooks to the zip file result in *create-content-artifacts* command for marketplacev2.
 * Fixed an issue in **find-dependencies** where using the argument *-o* without the argument *--all-packs-dependencies* did not print a proper warning.
+* Removed support for the flag *maintenance* in the command **update-release-notes**.
+* Added a validation for banned templets in the **doc-review** command.
 # 1.6.1
 * Added the '--use-packs-known-words' argument to the **doc-review** command
 * Added YAML_Loader to handle yaml files in a standard way across modules, replacing PYYAML.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@
 * Added support for adding test-playbooks to the zip file result in *create-content-artifacts* command for marketplacev2.
 * Fixed an issue in **find-dependencies** where using the argument *-o* without the argument *--all-packs-dependencies* did not print a proper warning.
 * Added a **validate** check to prevent deletion of files whose deletion is not supported by the XSOAR marketplace.
-* Removed support for the flag *maintenance* in the command **update-release-notes**.
-* Added a validation for banned templets in the **doc-review** command.
+* Removed the support in the *maintenance* option of the *-u* flag in the **update-release-notes** command.
+* Added validation for forbidden words and phrases in the **doc-review** command.
 
 # 1.6.1
 * Added the '--use-packs-known-words' argument to the **doc-review** command

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -1500,8 +1500,8 @@ def merge_id_sets(**kwargs):
     "-i", "--input", help="The relative path of the content pack. For example Packs/Pack_Name"
 )
 @click.option(
-    '-u', '--update-type', help="The type of update being done. [major, minor, revision, maintenance, documentation]",
-    type=click.Choice(['major', 'minor', 'revision', 'maintenance', 'documentation'])
+    '-u', '--update-type', help="The type of update being done. [major, minor, revision, documentation]",
+    type=click.Choice(['major', 'minor', 'revision', 'documentation'])
 )
 @click.option(
     '-v', '--version', help="Bump to a specific version.", type=VersionParamType()

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -1129,7 +1129,6 @@ class Errors:
     def release_notes_file_empty():
         return "Your release notes file is empty, please complete it\nHaving empty release notes " \
                "looks bad in the product UI.\nIf the change you made was minor, please use " \
-               "\"Maintenance and stability enhancements.\" for general changes, or use " \
                "\"Documentation and metadata improvements.\" for changes to documentation."
 
     @staticmethod

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -1134,8 +1134,9 @@ class Errors:
     @error_code_decorator
     def release_notes_file_empty():
         return "Your release notes file is empty, please complete it\nHaving empty release notes " \
-               "looks bad in the product UI.\nIf the change you made was minor, please use " \
-               "\"Documentation and metadata improvements.\" for changes to documentation."
+               "looks bad in the product UI.\nMake sure the release notes explicitly describe what changes were made, even if they are minor.\n" \
+               "For changes to documentation you can use " \
+               "\"Documentation and metadata improvements.\" "
 
     @staticmethod
     @error_code_decorator

--- a/demisto_sdk/commands/doc_reviewer/rn_checker.py
+++ b/demisto_sdk/commands/doc_reviewer/rn_checker.py
@@ -44,13 +44,14 @@ class ReleaseNotesChecker:
         'You can now',
         'Deprecated. ',
         'Deprecated the ',
+
+        # full line
+        'Documentation and metadata improvements.',
     }
 
     BANNED_TEMPLATES = {
-        'documentation and metadata improvements.',
-        'metadata improvements and documentation.',
         'maintenance and stability enhancements.',
-        'stability enhancements and maintenance .',
+        'stability enhancements and maintenance.',
     }
 
     def __init__(self, rn_file_path: str = None, rn_file_content: List = [], template_examples: bool = False):
@@ -82,6 +83,8 @@ class ReleaseNotesChecker:
         return good_line
 
     def check_if_using_banned_template(self, line):
+        line = line.lstrip(' -')
+        line = line.rstrip()
         for temp in self.BANNED_TEMPLATES:
             if line.lower() == temp:
                 return True

--- a/demisto_sdk/commands/doc_reviewer/rn_checker.py
+++ b/demisto_sdk/commands/doc_reviewer/rn_checker.py
@@ -27,8 +27,7 @@ def print_template_examples():
     click.secho('\n\nDocker Updates:', fg='bright_cyan')
     click.echo('\n - Updated the Docker image to: *demisto/python3:3.9.1.15759*.')
     click.secho('\n\nGeneral Changes:', fg='bright_cyan')
-    click.secho('Note: Use these if the change has no visible impact on the user, '
-                'but please try to refrain from using these if possible!', fg='yellow')
+    click.secho('Note: Do not these even if the change has no visible impact on the user:', fg='yellow')
     click.echo('\n - Maintenance and stability enhancements.')
     click.echo('\n - Documentation and metadata improvements.')
     click.echo('\n\nFor additional information see: https://xsoar.pan.dev/docs/documentation/release-notes')
@@ -45,10 +44,13 @@ class ReleaseNotesChecker:
         'You can now',
         'Deprecated. ',
         'Deprecated the ',
+    }
 
-        # full line
-        'Documentation and metadata improvements.',
-        'Maintenance and stability enhancements.',
+    BANNED_TEMPLATES = {
+        'documentation and metadata improvements.',
+        'metadata improvements and documentation.',
+        'maintenance and stability enhancements.',
+        'stability enhancements and maintenance .',
     }
 
     def __init__(self, rn_file_path: str = None, rn_file_content: List = [], template_examples: bool = False):
@@ -79,6 +81,12 @@ class ReleaseNotesChecker:
                 break
         return good_line
 
+    def check_if_using_banned_template(self, line):
+        for temp in self.BANNED_TEMPLATES:
+            if line.lower() == temp:
+                return True
+        return False
+
     def print_notes(self):
         """Print the review about the RN"""
         for line in self.notes:
@@ -98,6 +106,10 @@ class ReleaseNotesChecker:
             if not self.check_templates(line):
                 self.add_note(line, 'Line is not using one of our templates, consider '
                                     'changing it to fit our standard.\n     '
+                                    'For more information run: `demisto-sdk doc-review --templates` or view our '
+                                    'documentation at: https://xsoar.pan.dev/docs/documentation/release-notes')
+            if self.check_if_using_banned_template(line):
+                self.add_note(line, 'Line is using one of our banned templates, consider changing it to fit our standard.\n'
                                     'For more information run: `demisto-sdk doc-review --templates` or view our '
                                     'documentation at: https://xsoar.pan.dev/docs/documentation/release-notes')
 

--- a/demisto_sdk/commands/doc_reviewer/rn_checker.py
+++ b/demisto_sdk/commands/doc_reviewer/rn_checker.py
@@ -51,7 +51,7 @@ class ReleaseNotesChecker:
 
     BANNED_TEMPLATES = {
         'maintenance and stability enhancements.',
-        'stability enhancements and maintenance.',
+        'stability and maintenance enhancements.',
     }
 
     def __init__(self, rn_file_path: str = None, rn_file_content: List = [], template_examples: bool = False):
@@ -112,7 +112,7 @@ class ReleaseNotesChecker:
                                     'For more information run: `demisto-sdk doc-review --templates` or view our '
                                     'documentation at: https://xsoar.pan.dev/docs/documentation/release-notes')
             if self.check_if_using_banned_template(line):
-                self.add_note(line, 'Line is using one of our banned templates, consider changing it to fit our standard.\n'
+                self.add_note(line, 'Line is using one of our banned templates, please change it to fit our standard.\n'
                                     'For more information run: `demisto-sdk doc-review --templates` or view our '
                                     'documentation at: https://xsoar.pan.dev/docs/documentation/release-notes')
 

--- a/demisto_sdk/commands/doc_reviewer/rn_checker.py
+++ b/demisto_sdk/commands/doc_reviewer/rn_checker.py
@@ -27,8 +27,8 @@ def print_template_examples():
     click.secho('\n\nDocker Updates:', fg='bright_cyan')
     click.echo('\n - Updated the Docker image to: *demisto/python3:3.9.1.15759*.')
     click.secho('\n\nGeneral Changes:', fg='bright_cyan')
-    click.secho('Note: Do not these even if the change has no visible impact on the user:', fg='yellow')
-    click.echo('\n - Maintenance and stability enhancements.')
+    click.secho('Note: Use these if the change has no visible impact on the user, '
+                'but please try to refrain from using these if possible!', fg='yellow')
     click.echo('\n - Documentation and metadata improvements.')
     click.echo('\n\nFor additional information see: https://xsoar.pan.dev/docs/documentation/release-notes')
 

--- a/demisto_sdk/commands/update_release_notes/README.md
+++ b/demisto_sdk/commands/update_release_notes/README.md
@@ -20,7 +20,6 @@ In case of a private repo and an un-configured 'DEMISTO_SDK_GITHUB_TOKEN' remote
     - major
     - minor
     - revision
-    - maintenance (revision)
     - documentation (revision)
 
 * **-g, --use-git**

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -174,31 +174,6 @@ class TestRNUpdate(unittest.TestCase):
         assert expected_result == release_notes
 
     @mock.patch.object(UpdateRN, 'get_master_version')
-    def test_build_rn_template_file__maintenance(self, mock_master):
-        """
-            Given:
-                - a dict of changed items, with a deprecated maintenance rn update
-            When:
-                - we want to produce a release notes template for files without descriptions like :
-                'Connections', 'Incident Types', 'Indicator Types', 'Layouts', 'Incident Fields'
-            Then:
-                - return a markdown string
-        """
-        expected_result = "\n#### Integrations\n##### Hello World Integration\n" \
-                          "- %%UPDATE_RN%%\n"
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
-        mock_master.return_value = '1.0.0'
-        update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='maintenance',
-                             modified_files_in_pack={'HelloWorld'},
-                             added_files=set())
-        changed_items = {
-            ("Hello World Integration", FileType.INTEGRATION): {"description": "", "is_new_file": False},
-        }
-        release_notes = update_rn.build_rn_template(changed_items)
-        assert expected_result == release_notes
-
-    @mock.patch.object(UpdateRN, 'get_master_version')
     def test_build_rn_template_file__documentation(self, mock_master):
         """
             Given:

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -185,7 +185,7 @@ class TestRNUpdate(unittest.TestCase):
                 - return a markdown string
         """
         expected_result = "\n#### Integrations\n##### Hello World Integration\n" \
-                          "- Maintenance and stability enhancements.\n"
+                          "- %%UPDATE_RN%%\n"
         from demisto_sdk.commands.update_release_notes.update_rn import \
             UpdateRN
         mock_master.return_value = '1.0.0'
@@ -202,7 +202,7 @@ class TestRNUpdate(unittest.TestCase):
     def test_build_rn_template_file__documentation(self, mock_master):
         """
             Given:
-                - a dict of changed items, with a maintenance rn update
+                - a dict of changed items, with a documentation rn update
             When:
                 - we want to produce a release notes template for files without descriptions like :
                 'Connections', 'Incident Types', 'Indicator Types', 'Layouts', 'Incident Fields'

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -177,7 +177,7 @@ class TestRNUpdate(unittest.TestCase):
     def test_build_rn_template_file__maintenance(self, mock_master):
         """
             Given:
-                - a dict of changed items, with a maintenance rn update
+                - a dict of changed items, with a deprecated maintenance rn update
             When:
                 - we want to produce a release notes template for files without descriptions like :
                 'Connections', 'Incident Types', 'Indicator Types', 'Layouts', 'Incident Fields'

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -461,7 +461,8 @@ class UpdateRN:
                                  f"then consider bumping to a new Minor version.")
             new_version = '.'.join(version)
         elif self.update_type == 'maintenance':
-            raise ValueError("The *maintenance* flag is depracetad. Please use the *revision* option. ")
+            raise ValueError("The *maintenance* option is no longer supported."
+                             " Please use the \"revision\" option and make sure to provide informative release notes.")
         if pre_release:
             new_version = new_version + '_prerelease'
         data_dictionary['currentVersion'] = new_version

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -451,7 +451,8 @@ class UpdateRN:
             version[2] = '0'
             new_version = '.'.join(version)
         # We validate the input via click
-        elif self.update_type in ['revision', 'maintenance', 'documentation']:
+
+        elif self.update_type in ['revision', 'documentation']:
             version = current_version.split('.')
             version[2] = str(int(version[2]) + 1)
             if int(version[2]) > 99:
@@ -459,6 +460,8 @@ class UpdateRN:
                                  f"Please verify the currentVersion is correct. If it is, "
                                  f"then consider bumping to a new Minor version.")
             new_version = '.'.join(version)
+        elif self.update_type == 'maintenance':
+            raise ValueError("The *maintenance* flag is depracetad. Please use the *revision* option. ")
         if pre_release:
             new_version = new_version + '_prerelease'
         data_dictionary['currentVersion'] = new_version
@@ -565,9 +568,7 @@ class UpdateRN:
                 rn_desc += '\n'
             else:
                 rn_desc = f'##### {content_name}\n'
-                if self.update_type == 'maintenance':
-                    rn_desc += '- Maintenance and stability enhancements.\n'
-                elif self.update_type == 'documentation':
+                if self.update_type == 'documentation':
                     rn_desc += '- Documentation and metadata improvements.\n'
                 else:
                     rn_desc += f'- {text or "%%UPDATE_RN%%"}\n'


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/46957

## Description
Remove the support for the flag *maintenance* in the command **update-release-notes**, and added a validation for banned templates

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
