### PR TITLE
[Dev-Bug] - Validate Deleted Files crashes when using flag -g

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Added an agrument to YAMLHandler, allowing to set a maximal width for YAML files.  This fixes an issue where a wrong default was used.
 * Added the detach mechanism to the **upload** command, If you set the --input-config-file flag, any files in the repo's SystemPacks folder will be detached.
 * Added the reattach mechanism to the **upload** command, If you set the --input-config-file flag, any detached item in your XSOAR instance that isn't currently in the repo's SystemPacks folder will be re-attached.
-
+* Fixed an issue in the **validate** command did not work properly when with the *-g* flag.
 # 1.6.2
 * Added dependency validation support for core marketplacev2 packs.
 * Fixed an issue in **update-release-notes** where suggestion fix failed in validation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Added the detach mechanism to the **upload** command, If you set the --input-config-file flag, any files in the repo's SystemPacks folder will be detached.
 * Added the reattach mechanism to the **upload** command, If you set the --input-config-file flag, any detached item in your XSOAR instance that isn't currently in the repo's SystemPacks folder will be re-attached.
 * Fixed an issue in the **validate** command did not work properly when with the *-g* flag.
+
 # 1.6.2
 * Added dependency validation support for core marketplacev2 packs.
 * Fixed an issue in **update-release-notes** where suggestion fix failed in validation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Added an agrument to YAMLHandler, allowing to set a maximal width for YAML files.  This fixes an issue where a wrong default was used.
 * Added the detach mechanism to the **upload** command, If you set the --input-config-file flag, any files in the repo's SystemPacks folder will be detached.
 * Added the reattach mechanism to the **upload** command, If you set the --input-config-file flag, any detached item in your XSOAR instance that isn't currently in the repo's SystemPacks folder will be re-attached.
-* Fixed an issue in the **validate** command did not work properly when with the *-g* flag.
+* Fixed an issue in the **validate** command did not work properly when using the *-g* flag.
 
 # 1.6.2
 * Added dependency validation support for core marketplacev2 packs.

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -1802,7 +1802,7 @@ def test_job_unexpected_field_values_in_non_feed_job(repo, capsys,
 @pytest.mark.parametrize('file_set,expected_output,expected_result,added_files',
                          (({'mock_file_description.md'}, "[BA115]", False, set()),
                           (set(), "", True, set()),
-                          ({PosixPath('doc_files/image.png')}, "", True, {'added_file.yml'}),
+                          ({PosixPath('doc_files/image.png')}, "", True, {PosixPath('added_file.py')}),
                           ({'doc_files/image.png'}, "", True, set()),
                           ({'mock_playbook.yml'}, "", True, {'renamed_mock_playbook.yml'})))
 def test_validate_deleted_files(capsys, file_set, expected_output, expected_result, added_files, mocker):

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -1802,9 +1802,9 @@ def test_job_unexpected_field_values_in_non_feed_job(repo, capsys,
 @pytest.mark.parametrize('file_set,expected_output,expected_result,added_files',
                          (({'mock_file_description.md'}, "[BA115]", False, set()),
                           (set(), "", True, set()),
-                          ({PosixPath('doc_files/image.png')}, "", True, {PosixPath('added_file.py')}),
                           ({'doc_files/image.png'}, "", True, set()),
-                          ({'mock_playbook.yml'}, "", True, {'renamed_mock_playbook.yml'})))
+                          ({'mock_playbook.yml'}, "", True, {'renamed_mock_playbook.yml'}),
+                          ({PosixPath('mock_playbook.yml')}, "", True, {PosixPath('renamed_mock_playbook.yml')}),))
 def test_validate_deleted_files(capsys, file_set, expected_output, expected_result, added_files, mocker):
     """
     Given

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -78,7 +78,7 @@ from demisto_sdk.tests.test_files.validate_integration_test_valid_types import \
     INCIDENT_FIELD
 from TestSuite.pack import Pack
 from TestSuite.test_tools import ChangeCWD
-
+from pathlib import PosixPath
 
 class TestValidators:
     CREATED_DIRS = list()  # type: list[str]
@@ -1802,6 +1802,7 @@ def test_job_unexpected_field_values_in_non_feed_job(repo, capsys,
 @pytest.mark.parametrize('file_set,expected_output,expected_result,added_files',
                          (({'mock_file_description.md'}, "[BA115]", False, set()),
                           (set(), "", True, set()),
+                          ({PosixPath('doc_files/image.png')}, "", True, {'added_file.yml'}),
                           ({'doc_files/image.png'}, "", True, set()),
                           ({'mock_playbook.yml'}, "", True, {'renamed_mock_playbook.yml'})))
 def test_validate_deleted_files(capsys, file_set, expected_output, expected_result, added_files, mocker):

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -2,6 +2,7 @@ import json
 import os
 import sys
 from io import StringIO
+from pathlib import Path
 from shutil import copyfile
 from typing import Any, List, Optional, Type, Union
 
@@ -78,7 +79,7 @@ from demisto_sdk.tests.test_files.validate_integration_test_valid_types import \
     INCIDENT_FIELD
 from TestSuite.pack import Pack
 from TestSuite.test_tools import ChangeCWD
-from pathlib import PosixPath
+
 
 class TestValidators:
     CREATED_DIRS = list()  # type: list[str]
@@ -1804,7 +1805,7 @@ def test_job_unexpected_field_values_in_non_feed_job(repo, capsys,
                           (set(), "", True, set()),
                           ({'doc_files/image.png'}, "", True, set()),
                           ({'mock_playbook.yml'}, "", True, {'renamed_mock_playbook.yml'}),
-                          ({PosixPath('mock_playbook.yml')}, "", True, {PosixPath('renamed_mock_playbook.yml')}),))
+                          ({Path('mock_playbook.yml')}, "", True, {Path('renamed_mock_playbook.yml')})))
 def test_validate_deleted_files(capsys, file_set, expected_output, expected_result, added_files, mocker):
     """
     Given

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -1204,6 +1204,8 @@ class ValidateManager:
             deleted_file_id = _get_file_id(file_path, deleted_file_dict)
             if deleted_file_id:
                 for file in added_files:
+                    if not isinstance(file, str):
+                        file = file.as_posix()
                     file_dict = get_file(file, find_type(file))
                     if deleted_file_id == _get_file_id(file, file_dict):
                         return True

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -1198,6 +1198,8 @@ class ValidateManager:
 
         """
         if added_files:
+            if not isinstance(file_path, str):
+                file_path = file_path.as_posix()
             deleted_file_dict = get_file(file_path, find_type(file_path))
             deleted_file_id = _get_file_id(file_path, deleted_file_dict)
             if deleted_file_id:
@@ -1214,10 +1216,12 @@ class ValidateManager:
 
         is_valid = True
         for file_path in deleted_files:
+            if not isinstance(file_path, str):
+                file_path = file_path.as_posix()
             if not self.was_file_renamed_but_labeled_as_deleted(file_path, added_files):
                 if not self.is_file_allowed_to_be_deleted(file_path):
                     error_message, error_code = Errors.file_cannot_be_deleted(file_path)
-                    if self.handle_error(error_message, error_code, file_path=self.file_path):
+                    if self.handle_error(error_message, error_code, file_path):
                         is_valid = False
 
         return is_valid

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -1207,7 +1207,6 @@ class ValidateManager:
                     file_dict = get_file(file, find_type(file))
                     if deleted_file_id == _get_file_id(file, file_dict):
                         return True
-
         return False
 
     def validate_deleted_files(self, deleted_files, added_files) -> bool:

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -1198,14 +1198,12 @@ class ValidateManager:
 
         """
         if added_files:
-            if not isinstance(file_path, str):
-                file_path = file_path.as_posix()
+            file_path = str(file_path)
             deleted_file_dict = get_file(file_path, find_type(file_path))
             deleted_file_id = _get_file_id(file_path, deleted_file_dict)
             if deleted_file_id:
                 for file in added_files:
-                    if not isinstance(file, str):
-                        file = file.as_posix()
+                    file = str(file)
                     file_dict = get_file(file, find_type(file))
                     if deleted_file_id == _get_file_id(file, file_dict):
                         return True
@@ -1218,8 +1216,7 @@ class ValidateManager:
 
         is_valid = True
         for file_path in deleted_files:
-            if not isinstance(file_path, str):
-                file_path = file_path.as_posix()
+            file_path = str(file_path)
             if not self.was_file_renamed_but_labeled_as_deleted(file_path, added_files):
                 if not self.is_file_allowed_to_be_deleted(file_path):
                     error_message, error_code = Errors.file_cannot_be_deleted(file_path)


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/47503

## Description
Validate Deleted Files crashes when using flag -g due to git returning file_paths as PosixPath

## Screenshots
![image](https://user-images.githubusercontent.com/93524335/159226909-569b15cc-8463-4844-94a5-581898a82593.png)


## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
