### PR TITLE
`--quiet-bc-validation` flag typo fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 # Changelog
-
+* **Breaking change**: Fixed a typo in the **validate** `--quiet-bc-validation` flag. @upstart-swiss
 * Dropped support for python 3.7: Demisto-SDK is now supported on Python 3.8 or newer.
 * Added an agrument to YAMLHandler, allowing to set a maximal width for YAML files.  This fixes an issue where a wrong default was used.
 * Added the detach mechanism to the **upload** command, If you set the --input-config-file flag, any files in the repo's SystemPacks folder will be detached.
 * Added the reattach mechanism to the **upload** command, If you set the --input-config-file flag, any detached item in your XSOAR instance that isn't currently in the repo's SystemPacks folder will be re-attached.
 * Fixed an issue in the **validate** command did not work properly when using the *-g* flag.
-* Fixed a typo in the **validate** `--quiet-bc-validation` flag. @upstart-swiss
 
 # 1.6.2
 * Added dependency validation support for core marketplacev2 packs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-* **Breaking change**: Fixed a typo in the **validate** `--quiet-bc-validation` flag. @upstart-swiss
+* **Breaking change**: Fixed a typo in the **validate** `--quiet-bc-validation` flag (was `--quite-bc-validation`). @upstart-swiss
 * Dropped support for python 3.7: Demisto-SDK is now supported on Python 3.8 or newer.
 * Added an agrument to YAMLHandler, allowing to set a maximal width for YAML files.  This fixes an issue where a wrong default was used.
 * Added the detach mechanism to the **upload** command, If you set the --input-config-file flag, any files in the repo's SystemPacks folder will be detached.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added the detach mechanism to the **upload** command, If you set the --input-config-file flag, any files in the repo's SystemPacks folder will be detached.
 * Added the reattach mechanism to the **upload** command, If you set the --input-config-file flag, any detached item in your XSOAR instance that isn't currently in the repo's SystemPacks folder will be re-attached.
 * Fixed an issue in the **validate** command did not work properly when using the *-g* flag.
+* Fixed a typo in the **validate** `--quiet-bc-validation` flag. @upstart-swiss
 
 # 1.6.2
 * Added dependency validation support for core marketplacev2 packs.

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -432,7 +432,7 @@ def zip_packs(**kwargs) -> int:
     '--print-pykwalify', is_flag=True,
     help='Whether to print the pykwalify log errors.')
 @click.option(
-    "--quite-bc-validation",
+    "--quiet-bc-validation",
     help="Set backwards compatibility validation's errors as warnings.",
     is_flag=True)
 @click.option(


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/demisto-sdk/issues/1975

## Description
* Fixed a typo in the **validate** `--quiet-bc-validation` flag. 
