### PR TITLE
Fix bug with array mapping

### DIFF
--- a/demisto_sdk/commands/update_xsoar_config_file/update_xsoar_config_file.py
+++ b/demisto_sdk/commands/update_xsoar_config_file/update_xsoar_config_file.py
@@ -131,7 +131,7 @@ class XSOARConfigFileUpdater:
         """
         config_file_info = self.get_xsoar_config_data()
         if config_file_info.get(section_name):
-            config_file_info[section_name].append(data_to_update)
+            config_file_info[section_name] += [data_to_update] if isinstance(data_to_update, dict) else data_to_update
         else:
             config_file_info[section_name] = [data_to_update] if isinstance(data_to_update, dict) else data_to_update
         self.set_xsoar_config_data(config_file_info=config_file_info)


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
This fixes a bug where the array of marketplace packs returned by the command

```
demisto-sdk xsoar-config-file-update -all --file-path xsoar_config.json
```

 was being placed within the existing marketplace array in the xsoar_config.json.

This created invalid JSON.

## Screenshots

```
{
    "custom_packs": [
        {
            "id": "PWN_IndicatorBlockingRequest",
            "url": "https://github.com/nericksen/xsoar-content/raw/release/artifacts/uploadable_packs/PWN_IndicatorBlockingRequest.zip"
        },
        {
            "id": "PWN_Utilities",
            "url": "https://github.com/nericksen/xsoar-content/raw/release/artifacts/uploadable_packs/PWN_Utilities.zip"
        }
    ],
    "marketplace_packs": [
        {
            "id": "FeedJSON",
            "version": "*"
        },
        {
            "id": "GoogleCloudStorage",
            "version": "*"
        },
        {
            "id": "GitHub",
            "version": "*"
        },
        {
            "id": "DemistoRESTAPI",
            "version": "*"
        },
        {
            "id": "GraphQL",
            "version": "*"
        },
        [
           {
               "id": "AnotherPack",
                "version": "*"
            }
         ]
     ]
}
```

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
