### PR TITLE
feat: removed escape of forward slash in json files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+
+* Fixed a bug where any edited json file that contained a forward slash (`/`) escaped.
 * Added a new validation to **validate** command to verify that the metadata *currentVersion* is
 the same as the last release note version.
 * **Breaking change**: Fixed a typo in the **validate** `--quiet-bc-validation` flag (was `--quite-bc-validation`). @upstart-swiss

--- a/demisto_sdk/commands/common/handlers/json/ujson_handler.py
+++ b/demisto_sdk/commands/common/handlers/json/ujson_handler.py
@@ -33,7 +33,13 @@ class UJSON_Handler(XSOAR_Handler):
 
     def dump(self, obj: Any, fp: IO[str], indent=0, sort_keys=False):
         try:
-            ujson.dump(obj, fp, indent=indent, sort_keys=sort_keys)
+            ujson.dump(
+                obj,
+                fp,
+                indent=indent,
+                sort_keys=sort_keys,
+                escape_forward_slashes=False
+            )
         except ValueError as e:
             raise JSONDecodeError(e)
 
@@ -42,7 +48,8 @@ class UJSON_Handler(XSOAR_Handler):
             return ujson.dumps(
                 obj,
                 sort_keys=sort_keys,
-                indent=indent
+                indent=indent,
+                escape_forward_slashes=False
             )
         except ValueError as e:
             raise JSONDecodeError(e)

--- a/demisto_sdk/commands/common/handlers/tests/json_test.py
+++ b/demisto_sdk/commands/common/handlers/tests/json_test.py
@@ -10,7 +10,7 @@ class TestJSONHandler:
         slashes = '/' * slash_count
         url = f'https:{slashes}xsoar.com'
         dumped = JSON_Handler().dumps({'url': url})
-        assert url in dumped, 'Could not find the url im the dumped file. Maybe escaped char?'
+        assert url in dumped, 'Could not find the url in the dumped file. Maybe escaped char?'
 
     @pytest.mark.parametrize('slash_count', range(4))
     def test_no_escape_chars_dump(self, tmpdir, slash_count: int):

--- a/demisto_sdk/commands/common/handlers/tests/json_test.py
+++ b/demisto_sdk/commands/common/handlers/tests/json_test.py
@@ -1,0 +1,16 @@
+from demisto_sdk.commands.common.handlers import JSON_Handler
+
+
+class TestJSONHandler:
+    def test_no_escape_chars_dumps(self):
+        """Check that a dumped json has no escape chars"""
+        url = 'https://xsoar.com'
+        dumped = JSON_Handler().dumps({'url': url})
+        assert url in dumped, 'Could not find the url im the dumped file. Maybe escaped char?'
+
+    def test_no_escape_chars_dump(self, tmpdir):
+        """Check that a dumped json has no escape chars"""
+        file_ = tmpdir / 'file.json'
+        url = 'https://xsoar.com'
+        JSON_Handler().dump({'url': url}, file_.open('w+'))
+        assert url in file_.open().read()

--- a/demisto_sdk/commands/common/handlers/tests/json_test.py
+++ b/demisto_sdk/commands/common/handlers/tests/json_test.py
@@ -1,16 +1,22 @@
+import pytest
+
 from demisto_sdk.commands.common.handlers import JSON_Handler
 
 
 class TestJSONHandler:
-    def test_no_escape_chars_dumps(self):
+    @pytest.mark.parametrize('slash_count', range(4))
+    def test_no_escape_chars_dumps(self, slash_count: int):
         """Check that a dumped json has no escape chars"""
-        url = 'https://xsoar.com'
+        slashes = '/' * slash_count
+        url = f'https:{slashes}xsoar.com'
         dumped = JSON_Handler().dumps({'url': url})
         assert url in dumped, 'Could not find the url im the dumped file. Maybe escaped char?'
 
-    def test_no_escape_chars_dump(self, tmpdir):
+    @pytest.mark.parametrize('slash_count', range(4))
+    def test_no_escape_chars_dump(self, tmpdir, slash_count: int):
         """Check that a dumped json has no escape chars"""
         file_ = tmpdir / 'file.json'
-        url = 'https://xsoar.com'
+        slashes = '/' * slash_count
+        url = f'https:{slashes}xsoar.com'
         JSON_Handler().dump({'url': url}, file_.open('w+'))
         assert url in file_.open().read()


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/ultrajson/ultrajson/issues/110

## Description
a forward slash was esacpped, fixed it.

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
