### PR TITLE
Handle empty command arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ the same as the last release note version.
 * Added support for Parsing/Modeling Rule content item in the **unify** command.
 * Added the integration name, the commands name and the script name to the known words by default when running the **doc-review** command.
 * Added an argument '-c' '--custom' to the **unify** command, if True will append to the unified yml name/display/id the custom label provided
+* Fixed an issue where *None* arguments in integration commands cause the **validate** and **format** commands to fail unexpectedly.
 
 # 1.6.3
 * **Breaking change**: Fixed a typo in the **validate** `--quiet-bc-validation` flag (was `--quite-bc-validation`). @upstart-swiss

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -448,7 +448,8 @@ class Errors:
     @staticmethod
     @error_code_decorator
     def empty_command_arguments(command_name):
-        return f"The arguments of the integration command `{command_name}` are None."
+        return f"The arguments of the integration command `{command_name}` can not be None. If the command has no arguments, " \
+               f"use `arguments: []` or remove the `arguments` field."
 
     @staticmethod
     @error_code_decorator

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -448,7 +448,7 @@ class Errors:
     @staticmethod
     @error_code_decorator
     def empty_command_arguments(command_name):
-        return f"The integration command: {command_name} has None as arguments."
+        return f"The arguments of the integration command `{command_name}` are None."
 
     @staticmethod
     @error_code_decorator

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -224,6 +224,7 @@ ERROR_CODE = {
     "changed_integration_yml_fields": {'code': "IN147", "ui_applicable": False, 'related_field': 'script'},
     "parameter_is_malformed": {'code': "IN148", 'ui_applicable': False, 'related_field': 'configuration'},
     'empty_outputs_common_paths': {'code': 'IN149', 'ui_applicable': False, 'related_field': 'contextOutput'},
+    "empty_command_arguments": {'code': 'IN150', 'ui_applicable': False, 'related_field': 'arguments'},
 
     # IT - Incident Types
     "incident_type_integer_field": {'code': "IT100", 'ui_applicable': True, 'related_field': ''},
@@ -443,6 +444,11 @@ class Errors:
     @staticmethod
     def suggest_fix(file_path: str, *args: Any, cmd: str = 'format') -> str:
         return f'To fix the problem, try running `demisto-sdk {cmd} -i {file_path} {" ".join(args)}`'
+
+    @staticmethod
+    @error_code_decorator
+    def empty_command_arguments(command_name):
+        return f"The integration command: {command_name} has None as arguments."
 
     @staticmethod
     @error_code_decorator

--- a/demisto_sdk/commands/common/hook_validations/integration.py
+++ b/demisto_sdk/commands/common/hook_validations/integration.py
@@ -570,7 +570,7 @@ class IntegrationValidator(ContentEntityValidator):
         for command in commands:
             # If this happens, an error message will be shown from is_valid_default_argument(), but still need to check
             # for it here to avoid crash
-            if command.get('arguments') is None:
+            if command.get('arguments', []) is None:
                 continue
             arg_names = []  # type: list
             for arg in command.get('arguments', []):

--- a/demisto_sdk/commands/common/hook_validations/integration.py
+++ b/demisto_sdk/commands/common/hook_validations/integration.py
@@ -385,6 +385,13 @@ class IntegrationValidator(ContentEntityValidator):
 
         for command in commands:
             default_args = set()
+            if command.get('arguments') is None:
+                error_message, error_code = Errors.empty_command_arguments(command.get('name'))
+                if self.handle_error(error_message, error_code, file_path=self.file_path,
+                                     suggested_fix=Errors.suggest_fix(self.file_path)):
+                    is_valid = False  # do not break the main loop as there can be multiple invalid commands
+                    continue
+
             for arg in command.get('arguments', []):
                 if arg.get('default'):
                     default_args.add(arg.get('name'))
@@ -561,6 +568,10 @@ class IntegrationValidator(ContentEntityValidator):
         commands = self.current_file.get('script', {}).get('commands', [])
         does_not_have_duplicate_args = True
         for command in commands:
+            # If this happens, an error message will be shown from is_valid_default_argument(), but still need to check
+            # for it here to avoid crash
+            if command.get('arguments') is None:
+                continue
             arg_names = []  # type: list
             for arg in command.get('arguments', []):
                 arg_name = arg.get('name')

--- a/demisto_sdk/commands/common/hook_validations/integration.py
+++ b/demisto_sdk/commands/common/hook_validations/integration.py
@@ -385,7 +385,7 @@ class IntegrationValidator(ContentEntityValidator):
 
         for command in commands:
             default_args = set()
-            if command.get('arguments') is None:
+            if command.get('arguments', []) is None:
                 error_message, error_code = Errors.empty_command_arguments(command.get('name'))
                 if self.handle_error(error_message, error_code, file_path=self.file_path,
                                      suggested_fix=Errors.suggest_fix(self.file_path)):

--- a/demisto_sdk/commands/common/tests/integration_test.py
+++ b/demisto_sdk/commands/common/tests/integration_test.py
@@ -386,11 +386,15 @@ class TestIntegrationValidator:
     MULTIPLE_DEFAULT_ARGS_INVALID_1 = [
         {"name": "msgraph-list-users",
          "arguments": [{"name": "users", "required": False, "default": True}, {"name": "verbose", "default": True}]}]
+    NONE_ARGS_INVALID = [
+        {"name": "msgraph-list-users",
+         "arguments": None}]
 
     DEFAULT_ARGS_INPUTS = [
         (MULTIPLE_DEFAULT_ARGS_1, True),
         (MULTIPLE_DEFAULT_ARGS_2, True),
         (MULTIPLE_DEFAULT_ARGS_INVALID_1, False),
+        (NONE_ARGS_INVALID, False),
     ]
 
     @pytest.mark.parametrize("current, answer", DEFAULT_ARGS_INPUTS)
@@ -400,7 +404,7 @@ class TestIntegrationValidator:
 
         When: running is_valid_default_argument command.
 
-        Then: Validate that up to 1 default arg name yields True, else yields False.
+        Then: Validate that up to 1 default arg name yields True and that the arguments are not None, else yields False.
         """
         current = {"script": {"commands": current}}
         structure = mock_structure("", current)

--- a/demisto_sdk/commands/format/update_generic.py
+++ b/demisto_sdk/commands/format/update_generic.py
@@ -197,11 +197,16 @@ class BaseUpdate:
                 else:
                     sequence = schema.get(field, {}).get('sequence', [])
                     if sequence and sequence[0].get('mapping'):
-                        for list_element in data[field]:
-                            self.recursive_remove_unnecessary_keys(
-                                sequence[0].get('mapping'),
-                                list_element
-                            )
+                        if data[field] is None:
+                            if self.verbose:
+                                print(f'Adding value to {field} field')
+                            data[field] = []
+                        else:
+                            for list_element in data[field]:
+                                self.recursive_remove_unnecessary_keys(
+                                    sequence[0].get('mapping'),
+                                    list_element
+                                )
 
     def regex_matching_key(self, field, schema_keys):
         """

--- a/demisto_sdk/commands/format/update_generic.py
+++ b/demisto_sdk/commands/format/update_generic.py
@@ -199,7 +199,7 @@ class BaseUpdate:
                     if sequence and sequence[0].get('mapping'):
                         if data[field] is None:
                             if self.verbose:
-                                print(f'Adding value to {field} field')
+                                print(f'Adding an empty array - `[]` as the value of the `{field}` field')
                             data[field] = []
                         else:
                             for list_element in data[field]:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/47517

## Description
- Fixes an issue where when command arguments were left empty, both `format` and `validate` would fail unexpectedly.
- After the fix, the `format` command will add `[]` to the empty arguments, and the `validate` command will show an indicative error.
