### PR TITLE
Validate - ignore readme on apiModule scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ the same as the last release note version.
 * Fixed an issue in the **lint** command where the *check-dependent-api-modules* argument was set to true by default.
 * Added a new command **generate-unit-tests**.
 * Fixed the destination path of the unified parsing/modeling rules in **create-content-artifacts** command.
-* Fixed an issue where the validation for readme existence ran on the `ApiModules` pack in the **validate** command.
+* Fixed an issue in the **validate** command, where we validated wrongfully the existence of readme file for the *ApiModules* pack.
 
 ## 1.6.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ the same as the last release note version.
 * Enhanced the message of alternative suggestion words shown when running **doc-review** command.
 * Fixed an issue in the **lint** command where the *check-dependent-api-modules* argument was set to true by default.
 * Added a new command **generate-unit-tests**.
+* Fixed an issue where the validation for readme existence ran on the `ApiModules` pack in the **validate** command.
 
 ## 1.6.3
 

--- a/demisto_sdk/commands/common/hook_validations/content_entity_validator.py
+++ b/demisto_sdk/commands/common/hook_validations/content_entity_validator.py
@@ -347,8 +347,10 @@ class ContentEntityValidator(BaseValidator):
                 validate_all: (bool) is the validation being run with -a
             Return:
                True if the readme file exits False with an error otherwise
+
+            Note: APIModules don't need readme file (issue 47965).
         """
-        if validate_all:
+        if validate_all or 'APIModules' in self.file_path:
             return True
 
         file_path = os.path.normpath(self.file_path)

--- a/demisto_sdk/commands/common/hook_validations/content_entity_validator.py
+++ b/demisto_sdk/commands/common/hook_validations/content_entity_validator.py
@@ -5,8 +5,8 @@ from distutils.version import LooseVersion
 from typing import Optional
 
 from demisto_sdk.commands.common.constants import (
-    DEFAULT_CONTENT_ITEM_FROM_VERSION, ENTITY_NAME_SEPARATORS,
-    EXCLUDED_DISPLAY_NAME_WORDS, FEATURE_BRANCHES,
+    API_MODULES_PACK, DEFAULT_CONTENT_ITEM_FROM_VERSION,
+    ENTITY_NAME_SEPARATORS, EXCLUDED_DISPLAY_NAME_WORDS, FEATURE_BRANCHES,
     GENERIC_OBJECTS_OLDEST_SUPPORTED_VERSION, OLDEST_SUPPORTED_VERSION,
     FileType)
 from demisto_sdk.commands.common.content import Content
@@ -350,7 +350,7 @@ class ContentEntityValidator(BaseValidator):
 
             Note: APIModules don't need readme file (issue 47965).
         """
-        if validate_all or 'APIModules' in self.file_path:
+        if validate_all or API_MODULES_PACK in self.file_path:
             return True
 
         file_path = os.path.normpath(self.file_path)

--- a/demisto_sdk/commands/common/tests/content_entity_validator_test.py
+++ b/demisto_sdk/commands/common/tests/content_entity_validator_test.py
@@ -200,10 +200,28 @@ def test_validate_readme_exists_not_checking_on_test_playbook(repo, mocker):
     - Validating if a readme file exists
 
     Then:
-    - Ensure that True is beeing returned since we dont validate a readme for test playbooks.
+    - Ensure that True is being returned since we don't validate a readme for test playbooks.
     """
     pack = repo.create_pack('TEST_PALYBOOK')
     test_playbook = pack.create_test_playbook('test_playbook1')
     structue_validator = StructureValidator(test_playbook.yml.path)
+    content_entity_validator = ContentEntityValidator(structue_validator)
+    assert content_entity_validator.validate_readme_exists()
+
+
+def test_validate_readme_exists_not_checking_on_api_modules(repo):
+    """
+    Given:
+    - An APIModules script
+
+    When:
+    - Validating if a readme file exists
+
+    Then:
+    - Ensure that True is being returned since we don't validate a readme for APIModules files.
+    """
+    pack = repo.create_pack('APIModules')
+    api_modules = pack.create_script('TestApiModule', readme=None)
+    structue_validator = StructureValidator(api_modules.yml.path)
     content_entity_validator = ContentEntityValidator(structue_validator)
     assert content_entity_validator.validate_readme_exists()

--- a/demisto_sdk/commands/common/tests/content_entity_validator_test.py
+++ b/demisto_sdk/commands/common/tests/content_entity_validator_test.py
@@ -1,6 +1,9 @@
+import os
+
 import pytest
 
-from demisto_sdk.commands.common.constants import EXCLUDED_DISPLAY_NAME_WORDS
+from demisto_sdk.commands.common.constants import (API_MODULES_PACK,
+                                                   EXCLUDED_DISPLAY_NAME_WORDS)
 from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
     ContentEntityValidator
 from demisto_sdk.commands.common.hook_validations.structure import \
@@ -220,8 +223,9 @@ def test_validate_readme_exists_not_checking_on_api_modules(repo):
     Then:
     - Ensure that True is being returned since we don't validate a readme for APIModules files.
     """
-    pack = repo.create_pack('APIModules')
+    pack = repo.create_pack(API_MODULES_PACK)
     api_modules = pack.create_script('TestApiModule', readme=None)
+    os.remove(api_modules.readme.path)
     structue_validator = StructureValidator(api_modules.yml.path)
     content_entity_validator = ContentEntityValidator(structue_validator)
     assert content_entity_validator.validate_readme_exists()


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://github.com/demisto/etc/issues/47965)

## Description
When changing an ApiModule it’s considered as a script and fails on validating with RM109 (FileType.SCRIPT is missing a README file). This PR fixed this issue.

## Screenshots
We can see that the issue was solved in this run (https://app.circleci.com/pipelines/github/demisto/content/156824/workflows/f0e2fcc8-ad5e-455e-8ad4-1e1e9d20828a/jobs/505454).
The RM109 error was not raised.

## Must have
- [x] Tests
