### PR TITLE
Fixed destination path for unified parsing/modeling rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ the same as the last release note version.
 * Enhanced the message of alternative suggestion words shown when running **doc-review** command.
 * Fixed an issue in the **lint** command where the *check-dependent-api-modules* argument was set to true by default.
 * Added a new command **generate-unit-tests**.
+* Fixed the destination path of the unified parsing/modeling rules in **create-content-artifacts** command.
 
 ## 1.6.3
 

--- a/demisto_sdk/commands/create_artifacts/content_artifacts_creator.py
+++ b/demisto_sdk/commands/create_artifacts/content_artifacts_creator.py
@@ -1044,7 +1044,9 @@ def dump_link_files(artifact_manager: ArtifactsManager, content_object: ContentO
 def calc_relative_packs_dir(artifact_manager: ArtifactsManager, content_object: ContentObject) -> Path:
     relative_pack_path = artifact_manager.get_relative_pack_path(content_object)
     if ((INTEGRATIONS_DIR in relative_pack_path.parts and relative_pack_path.parts[-2] != INTEGRATIONS_DIR) or
-            (SCRIPTS_DIR in relative_pack_path.parts and relative_pack_path.parts[-2] != SCRIPTS_DIR)):
+            (SCRIPTS_DIR in relative_pack_path.parts and relative_pack_path.parts[-2] != SCRIPTS_DIR) or
+            (PARSING_RULES_DIR in relative_pack_path.parts and relative_pack_path.parts[-2] != PARSING_RULES_DIR) or
+            (MODELING_RULES_DIR in relative_pack_path.parts and relative_pack_path.parts[-2] != MODELING_RULES_DIR)):
         relative_pack_path = relative_pack_path.parent.parent
     else:
         relative_pack_path = relative_pack_path.parent


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Fixed the destination path when unifying parsing/modeling rules to be in the parent directory.

Succesefull uploaded pack: https://code.pan.run/xsoar/content/-/pipelines/2749831