### PR TITLE
validate after format fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fixed an issue in **upload** where list items were not uploaded.
 * Added a new validation to **validate** command to verify that *cliName* and *id* keys of the incident field or the indicator field are matches.
 * Added the flag '-x', '--xsiam' to **upload** command to upload XSIAM entities to XSIAM server.
+* Fixed an issue where **validate -i** run after **format -i** on an existing file in the repo instead of **validate -g**.
 
 ## 1.6.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
 ## Unreleased
+
+* Fixed an issue where `-vvv` flag did not print logs on debug level.
 * enhanced ***validate*** command to list all command names affected by a backward compatibility break, instead of only one.
 * Added a new flag to the **validate** command, allowing to run specific validations.
-* Fixed an issue where **validate -i** run after **format -i** on an existing file in the repo instead of **validate -g**.
+* Fixed an issue in **upload** where list items were not uploaded.
+* Added a new validation to **validate** command to verify that *cliName* and *id* keys of the incident field or the indicator field are matches.
 
 ## 1.6.5
 
@@ -51,6 +54,7 @@ the same as the last release note version.
 * Added support for running tests on XSIAM machines in the **test-content** command.
 * Fixed an issue where the **validate** command did not work properly when deleting non-content items.
 * Added the flag '-d', '--dependency' to **find-dependencies** command to get the content items that cause the dependencies between two packs.
+* Added a new validation to **validate** proper defaultvalue for checkbox fields.
 
 ## 1.6.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Added a new flag to the **validate** command, allowing to run specific validations.
 * Fixed an issue in **upload** where list items were not uploaded.
 * Added a new validation to **validate** command to verify that *cliName* and *id* keys of the incident field or the indicator field are matches.
-* Fixed an issue where **validate -i** run after **format -i** on an existing file in the repo instead of **validate -g**.
+* Added the flag '-x', '--xsiam' to **upload** command to upload XSIAM entities to XSIAM server.
 
 ## 1.6.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Fixed an issue in **upload** where list items were not uploaded.
 * Added a new validation to **validate** command to verify that *cliName* and *id* keys of the incident field or the indicator field are matches.
 * Added the flag '-x', '--xsiam' to **upload** command to upload XSIAM entities to XSIAM server.
-* Fixed an issue where **validate -i** run after **format -i** on an existing file in the repo instead of **validate -g**.
+* Fixed the integration field *isFetchEvents* to be in lowercase.
 
 ## 1.6.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added a new flag to the **validate** command, allowing to run specific validations.
 * Fixed an issue in **upload** where list items were not uploaded.
 * Added a new validation to **validate** command to verify that *cliName* and *id* keys of the incident field or the indicator field are matches.
+* Fixed an issue where **validate -i** run after **format -i** on an existing file in the repo instead of **validate -g**.
 
 ## 1.6.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 * enhanced ***validate*** command to list all command names affected by a backward compatibility break, instead of only one.
 * Added a new flag to the **validate** command, allowing to run specific validations.
+* Fixed an issue where **validate -i** run after **format -i** on an existing file in the repo instead of **validate -g**.
 
 ## 1.6.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Added a new validation to **validate** command to verify that *cliName* and *id* keys of the incident field or the indicator field are matches.
 * Added the flag '-x', '--xsiam' to **upload** command to upload XSIAM entities to XSIAM server.
 * Fixed the integration field *isFetchEvents* to be in lowercase.
+* Fixed an issue where **validate -i** run after **format -i** on an existing file in the repo instead of **validate -g**.
 
 ## 1.6.5
 

--- a/demisto_sdk/commands/format/tests/test_formatting_generic_test.py
+++ b/demisto_sdk/commands/format/tests/test_formatting_generic_test.py
@@ -4,6 +4,7 @@ from demisto_sdk.commands.common.constants import (
     FILETYPE_TO_DEFAULT_FROMVERSION, GENERAL_DEFAULT_FROMVERSION, FileType)
 from demisto_sdk.commands.format.format_constants import VERSION_6_0_0
 from demisto_sdk.commands.format.update_generic import BaseUpdate
+from demisto_sdk.commands.validate.validate_manager import ValidateManager
 
 
 class TestFormattingFromVersionKey:
@@ -140,3 +141,29 @@ class TestFormattingFromVersionKey:
         self.init_BaseUpdate(base_update)
         base_update.set_fromVersion('5.5.0')
         assert base_update.data.get(base_update.from_version_key) == GENERAL_DEFAULT_FROMVERSION
+
+
+@pytest.mark.parametrize("is_old_file, function_validate", [(False, 'run_validation_on_specific_files'),
+                         (True, 'run_validation_using_git')])
+def test_initiate_file_validator(mocker, is_old_file, function_validate):
+    """
+    Given
+        - New file
+        - Existing file in the repo
+    When
+        - Running validate on the file
+    Then
+        - Running validate -i on new files
+        - Running validate -g on modified files
+    """
+    mocker.patch.object(BaseUpdate, '__init__', return_value=None)
+    base_update = BaseUpdate()
+    base_update.no_validate = False
+    base_update.output_file = 'output_file_path'
+    base_update.validate_manager = ValidateManager
+    mocker.patch.object(BaseUpdate, 'is_old_file', return_value=is_old_file)
+
+    result = mocker.patch.object(ValidateManager, function_validate)
+
+    base_update.initiate_file_validator()
+    assert result.call_count == 1

--- a/demisto_sdk/commands/format/update_generic.py
+++ b/demisto_sdk/commands/format/update_generic.py
@@ -331,7 +331,10 @@ class BaseUpdate:
             return SKIP_RETURN_CODE
         else:
             self.validate_manager.file_path = self.output_file
-            validation_result = self.validate_manager.run_validation_on_specific_files()
+            if self.is_old_file(self.output_file):
+                validation_result = self.validate_manager.run_validation_using_git()
+            else:
+                validation_result = self.validate_manager.run_validation_on_specific_files()
 
             if not validation_result:
                 return ERROR_RETURN_CODE


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/47717

## Description
Update the validate flow after running format.
When you run format on an existing file in the repo, `validate -g` will run afterwards.
When you run format on a new file, `validate -i` will run afterwards.
 
## Screenshots
I changed the fromVersion field and run `demisto-sdk format -i Packs/Phishing/Layouts/layoutscontainer-Phishing_v_3.json` in my local env and now I see the error that @idovandijk got only in the build.

![Screen Shot 2022-05-03 at 14 42 03](https://user-images.githubusercontent.com/54398957/166446657-a1e348f1-d47c-455d-82ae-e62efae6374e.png)

## Must have
- [x] Tests
- [x] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
