### PR TITLE
Remove duplicate SIEM integration identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## Unreleased
 * Updated the logs shown during the docker build step.
+* Removed duplicate identifiers for XSIAM integrations.
 
 
 ## 1.6.6

--- a/demisto_sdk/commands/common/constants.py
+++ b/demisto_sdk/commands/common/constants.py
@@ -147,16 +147,6 @@ class FileType(Enum):
     WIZARD = 'wizard'
 
 
-XSIAM_CONTENT_ITEMS_TYPES = [
-    FileType.PARSING_RULE,
-    FileType.MODELING_RULE,
-    FileType.CORRELATION_RULE,
-    FileType.XSIAM_DASHBOARD,
-    FileType.XSIAM_REPORT,
-    FileType.TRIGGER,
-
-]
-
 RN_HEADER_BY_FILE_TYPE = {
     FileType.PLAYBOOK: 'Playbooks',
     FileType.INTEGRATION: 'Integrations',

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -11,8 +11,7 @@ from typing import Optional, Tuple, Union
 
 from demisto_sdk.commands.common.constants import (
     ALL_FILES_VALIDATION_IGNORE_WHITELIST, DEFAULT_ID_SET_PATH,
-    IGNORED_PACK_NAMES, RN_HEADER_BY_FILE_TYPE, XSIAM_CONTENT_ITEMS_TYPES,
-    FileType)
+    IGNORED_PACK_NAMES, RN_HEADER_BY_FILE_TYPE, SIEM_ONLY_ENTITIES, FileType)
 from demisto_sdk.commands.common.content import Content
 from demisto_sdk.commands.common.git_util import GitUtil
 from demisto_sdk.commands.common.handlers import JSON_Handler
@@ -579,7 +578,7 @@ class UpdateRN:
             else:
                 rn_desc += f'- {text or "%%UPDATE_RN%%"}'
 
-            if from_version and from_version != '' and _type not in XSIAM_CONTENT_ITEMS_TYPES:
+            if from_version and from_version != '' and _type not in SIEM_ONLY_ENTITIES:
                 # for now, we decided not to add this description for XSIAM entities (issue 40020)
                 rn_desc += f' (Available from Cortex XSOAR {from_version}).\n'
 

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -578,7 +578,7 @@ class UpdateRN:
             else:
                 rn_desc += f'- {text or "%%UPDATE_RN%%"}'
 
-            if from_version and from_version != '' and _type not in SIEM_ONLY_ENTITIES:
+            if from_version and from_version != '' and _type and _type.value not in SIEM_ONLY_ENTITIES:
                 # for now, we decided not to add this description for XSIAM entities (issue 40020)
                 rn_desc += f' (Available from Cortex XSOAR {from_version}).\n'
 


### PR DESCRIPTION

## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Remove duplicate SIEM integration identifiers

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
