### PR TITLE
remove remote tags and use cases from validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Updated the logs shown during the docker build step.
 * Removed a false warning about configuring the `GITLAB_TOKEN` environment variable when it's not needed.
 * Removed duplicate identifiers for XSIAM integrations.
-
+* Updated the *tags* and *use cases* in pack metadata validation to use the local files only.
 * Fixed the error message in checkbox validation where the defaultvalue is wrong and added the name of the variable that should be fixed.
 
 ## 1.6.6

--- a/demisto_sdk/commands/common/hook_validations/pack_unique_files.py
+++ b/demisto_sdk/commands/common/hook_validations/pack_unique_files.py
@@ -537,13 +537,14 @@ class PackUniqueFilesValidator(BaseValidator):
         Return:
              bool: True if the usecases are approved, otherwise False
         """
+        if tools.is_external_repository():
+            return True
+
         non_approved_usecases = set()
         try:
-            approved_usecases = tools.get_approved_usecases()
             pack_meta_file_content = self._read_metadata_content()
             current_usecases = tools.get_current_usecases()
-            non_approved_usecases = set(pack_meta_file_content[PACK_METADATA_USE_CASES]) - set(
-                approved_usecases + current_usecases)
+            non_approved_usecases = set(pack_meta_file_content[PACK_METADATA_USE_CASES]) - set(current_usecases)
             if non_approved_usecases:
                 if self._add_error(
                         Errors.pack_metadata_non_approved_usecases(non_approved_usecases), self.pack_meta_file):
@@ -576,12 +577,14 @@ class PackUniqueFilesValidator(BaseValidator):
         Return:
              bool: True if the tags are approved, otherwise False
         """
+        if tools.is_external_repository():
+            return True
+
         non_approved_tags = set()
         try:
-            approved_tags = tools.get_approved_tags()
             pack_meta_file_content = self._read_metadata_content()
             current_tags = tools.get_current_tags()
-            non_approved_tags = set(pack_meta_file_content[PACK_METADATA_TAGS]) - set(approved_tags + current_tags)
+            non_approved_tags = set(pack_meta_file_content[PACK_METADATA_TAGS]) - set(current_tags)
             if non_approved_tags:
                 if self._add_error(Errors.pack_metadata_non_approved_tags(non_approved_tags), self.pack_meta_file):
                     return False

--- a/demisto_sdk/commands/common/tests/pack_unique_files_test.py
+++ b/demisto_sdk/commands/common/tests/pack_unique_files_test.py
@@ -332,7 +332,7 @@ class TestPackUniqueFilesValidator:
 
     @pytest.mark.parametrize('tags, is_valid, branch_tags', [
         ([], True, []),
-        (['Machine Learning', 'Spam'], True, []),
+        (['Machine Learning', 'Spam'], True, ['Machine Learning', 'Spam']),
         (['NonApprovedTag', 'GDPR'], False, ['GDPR']),
     ])
     def test_is_approved_tags(self, repo, tags, is_valid, branch_tags, mocker):

--- a/demisto_sdk/commands/common/tests/pack_unique_files_test.py
+++ b/demisto_sdk/commands/common/tests/pack_unique_files_test.py
@@ -294,10 +294,8 @@ class TestPackUniqueFilesValidator:
 
     @pytest.mark.parametrize('usecases, is_valid, branch_usecases', [
         ([], True, []),
-        (['Phishing', 'Malware'], True, []),
-        (['NonApprovedUsecase', 'Case Management'], False, []),
-        (['NewUseCase'], True, ['NewUseCase']),
-        (['NewUseCase1, NewUseCase2'], False, ['NewUseCase1'])
+        (['Phishing', 'Malware'], True, ['Phishing', 'Malware']),
+        (['NonApprovedUsecase', 'Case Management'], False, ['Case Management']),
     ])
     def test_is_approved_usecases(self, repo, usecases, is_valid, branch_usecases, mocker):
         """
@@ -305,9 +303,6 @@ class TestPackUniqueFilesValidator:
             - Case A: Pack without usecases
             - Case B: Pack with approved usecases (Phishing and Malware)
             - Case C: Pack with non-approved usecase (NonApprovedUsecase) and approved usecase (Case Management)
-            - Case D: Pack with approved usecase (NewUseCase) located in my branch only
-            - Case E: Pack with non-approved usecase (NewUseCase2) and approved usecase (NewUseCase1)
-            located in my branch only
 
         When:
             - Validating approved usecases
@@ -317,9 +312,6 @@ class TestPackUniqueFilesValidator:
             - Case B: Ensure validation passes as both usecases are approved
             - Case C: Ensure validation fails as it contains a non-approved usecase (NonApprovedUsecase)
                       Verify expected error is printed
-            - Case D: Ensure validation passes as usecase is approved on the same branch
-            - Case E: Ensure validation fails as it contains a non-approved usecase (NewUseCase2)
-                      Verify expected error is printed
         """
         self.restart_validator()
         pack_name = 'PackName'
@@ -327,7 +319,7 @@ class TestPackUniqueFilesValidator:
         pack.pack_metadata.write_json({
             PACK_METADATA_USE_CASES: usecases,
             PACK_METADATA_SUPPORT: XSOAR_SUPPORT,
-            PACK_METADATA_TAGS: []
+            PACK_METADATA_TAGS: [],
         })
         mocker.patch.object(tools, 'is_external_repository', return_value=False)
         mocker.patch.object(tools, 'get_dict_from_file', return_value=({'approved_list': branch_usecases}, 'json'))
@@ -341,9 +333,7 @@ class TestPackUniqueFilesValidator:
     @pytest.mark.parametrize('tags, is_valid, branch_tags', [
         ([], True, []),
         (['Machine Learning', 'Spam'], True, []),
-        (['NonApprovedTag', 'GDPR'], False, []),
-        (['NewTag'], True, ['NewTag']),
-        (['NewTag1, NewTag2'], False, ['NewTag1'])
+        (['NonApprovedTag', 'GDPR'], False, ['GDPR']),
     ])
     def test_is_approved_tags(self, repo, tags, is_valid, branch_tags, mocker):
         """
@@ -351,9 +341,6 @@ class TestPackUniqueFilesValidator:
             - Case A: Pack without tags
             - Case B: Pack with approved tags (Machine Learning and Spam)
             - Case C: Pack with non-approved tags (NonApprovedTag) and approved tags (GDPR)
-            - Case D: Pack with approved tags (NewTag) located in my branch only
-            - Case E: Pack with non-approved tags (NewTag) and approved tags (NewTag)
-            located in my branch only
         When:
             - Validating approved tags
 
@@ -362,9 +349,6 @@ class TestPackUniqueFilesValidator:
             - Case B: Ensure validation passes as both tags are approved
             - Case C: Ensure validation fails as it contains a non-approved tags (NonApprovedTag)
                       Verify expected error is printed
-            - Case D: Ensure validation passes as tags is approved on the same branch
-            - Case E: Ensure validation fails as it contains a non-approved tag (NewTag2)
-                      Verify expected error is printed
         """
         self.restart_validator()
         pack_name = 'PackName'
@@ -372,7 +356,7 @@ class TestPackUniqueFilesValidator:
         pack.pack_metadata.write_json({
             PACK_METADATA_USE_CASES: [],
             PACK_METADATA_SUPPORT: XSOAR_SUPPORT,
-            PACK_METADATA_TAGS: tags
+            PACK_METADATA_TAGS: tags,
         })
         mocker.patch.object(tools, 'is_external_repository', return_value=False)
         mocker.patch.object(tools, 'get_dict_from_file', return_value=({'approved_list': branch_tags}, 'json'))


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
related to: https://code.pan.run/xsoar/content/-/jobs/12959981

## Description
When validating the pack metadata, we don't need to check the remote tags and use cases file.
We should use the local lists when running against the content repository and skip the validation when running against an external repository.
