### PR TITLE
[Wizard] Make link_to_integration optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Added types to `find_type_by_path` under tools.py.
 * Fixed an issue where YAML files contained incorrect value type for `tests` key when running `format --deprecate`.
 * Added a deprecation message to the `tests:` section of yaml files when running `format --deprecate`.
+* Added use case for **validate** on *wizard* objects - set_playbook is mapped to all integrations.
 * Added the 'integration-get-indicators' commands to be ignored by the **verify_yml_commands_match_readme** validation, the validation will no longer fail if these commands are not in the readme file.
 * Added a new validation to the **validate** command to verify that if the phrase "breaking changes" is present in a pack release notes, a JSON file with the same name exists and contains the relevant breaking changes information.
 

--- a/demisto_sdk/commands/common/hook_validations/wizard.py
+++ b/demisto_sdk/commands/common/hook_validations/wizard.py
@@ -123,6 +123,8 @@ class WizardValidator(ContentEntityValidator):
         all_fetch_integrations_have_playbook = True
         integrations = self._fetching_integrations.copy()
         for link in self._set_playbooks.values():
+            if not link:  # handle case that a playbook was mapped to all integration
+                return True
             if link not in integrations:
                 error_message, error_code = Errors.wrong_link_in_wizard(link)
                 if self.handle_error(error_message, error_code, file_path=self.file_path):

--- a/demisto_sdk/commands/common/schemas/wizard.yml
+++ b/demisto_sdk/commands/common/schemas/wizard.yml
@@ -97,7 +97,6 @@ schema;playbook_schema:
       required: true
     link_to_integration:
       type: str
-      required: true
 
 schema;next_schema:
   type: map

--- a/demisto_sdk/commands/common/tests/wizards_test.py
+++ b/demisto_sdk/commands/common/tests/wizards_test.py
@@ -94,6 +94,8 @@ class TestWizardValidator:
                      'fetching_integrations': [{'name': 'exists'}]}}, False),
         ({'wizard': {'set_playbook': [{'name': 'exists', 'link_to_integration': 'exists'}],
                      'fetching_integrations': [{'name': 'exists'}]}}, True),
+        ({'wizard': {'set_playbook': [{'name': 'exists', 'link_to_integration': None}],
+                     'fetching_integrations': [{'name': 'exists'}]}}, True),
     ])
     def test_do_all_fetch_integrations_have_playbook(self, current_file, answer):
         validator = get_validator(current_file)


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
related: https://github.com/demisto/etc/issues/47460

## Description
The `link_to_integration` field was changed to be `optional` from the `platform` side - which changes existing validations a bit - if there's an `unmapped` playbook, it'll be mapped to all integrations that are not mapped.

## Must have
- [x] Tests