### PR TITLE
Add LISTS_DIR constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Added the 'integration-get-indicators' commands to be ignored by the **verify_yml_commands_match_readme** validation, the validation will no longer fail if these commands are not in the readme file.
 * Added a new validation to the **validate** command to verify that if the phrase "breaking changes" is present in a pack release notes, a JSON file with the same name exists and contains the relevant breaking changes information.
 * Improved logs when running test playbooks (in a build).
+* Fixed an issue in **upload** did not include list-type content items. @nicolas-rdgs
 
 ## 1.6.6
 

--- a/demisto_sdk/commands/upload/uploader.py
+++ b/demisto_sdk/commands/upload/uploader.py
@@ -18,9 +18,10 @@ from demisto_sdk.commands.common.constants import (CLASSIFIERS_DIR,
                                                    INDICATOR_FIELDS_DIR,
                                                    INDICATOR_TYPES_DIR,
                                                    INTEGRATIONS_DIR, JOBS_DIR,
-                                                   LAYOUTS_DIR, PLAYBOOKS_DIR,
-                                                   REPORTS_DIR, SCRIPTS_DIR,
-                                                   LISTS_DIR, TEST_PLAYBOOKS_DIR,
+                                                   LAYOUTS_DIR, LISTS_DIR,
+                                                   PLAYBOOKS_DIR, REPORTS_DIR,
+                                                   SCRIPTS_DIR,
+                                                   TEST_PLAYBOOKS_DIR,
                                                    WIDGETS_DIR, FileType)
 from demisto_sdk.commands.common.content.errors import ContentFactoryError
 from demisto_sdk.commands.common.content.objects.abstract_objects import (

--- a/demisto_sdk/commands/upload/uploader.py
+++ b/demisto_sdk/commands/upload/uploader.py
@@ -20,7 +20,7 @@ from demisto_sdk.commands.common.constants import (CLASSIFIERS_DIR,
                                                    INTEGRATIONS_DIR, JOBS_DIR,
                                                    LAYOUTS_DIR, PLAYBOOKS_DIR,
                                                    REPORTS_DIR, SCRIPTS_DIR,
-                                                   TEST_PLAYBOOKS_DIR,
+                                                   LISTS_DIR, TEST_PLAYBOOKS_DIR,
                                                    WIDGETS_DIR, FileType)
 from demisto_sdk.commands.common.content.errors import ContentFactoryError
 from demisto_sdk.commands.common.content.objects.abstract_objects import (
@@ -81,6 +81,7 @@ CONTENT_ENTITY_UPLOAD_ORDER = [
     CLASSIFIERS_DIR,
     WIDGETS_DIR,
     LAYOUTS_DIR,
+    LISTS_DIR,
     JOBS_DIR,
     DASHBOARDS_DIR,
     REPORTS_DIR


### PR DESCRIPTION
Upload lists when the input is the content pack folder.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
n/a

## Description
When we upload a list directly this works but when its the entire content pack, the lists folder is ignored.

## Screenshots

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
