### PR TITLE
improve mypy parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Removed the validation of a subtype change in integrations and scripts from **validate**.
 * Fixed an issue where **download** did not behave as expected when prompting for a version update. Reported by @K-Yo
 * Added support for adoption release notes.
+* Fixed a bug where some mypy messages were not parsed properly in **lint**.
 
 ## 1.6.7
 

--- a/demisto_sdk/commands/lint/lint_manager.py
+++ b/demisto_sdk/commands/lint/lint_manager.py
@@ -960,8 +960,11 @@ class LintManager:
         for message in mypy_errors:
             if message:
                 file_path, line_number, column_number, _ = message.split(':', 3)
-                output_message = message.split('error:')[1].lstrip() if 'error' in message \
-                    else message.split('note:')[1].lstrip()
+                output_message = message  # default
+                for prefix in ('error:', 'note:'):
+                    if prefix in message:
+                        output_message = message.split(prefix)[1].lstrip()
+                        break
                 output = {
                     'linter': 'mypy',
                     'severity': errors.get('type'),


### PR DESCRIPTION
support mypy messages that have neither `note:` nor `error:`