### PR TITLE
Added new validation for deprecated docker images

### DIFF
--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -105,6 +105,7 @@ ERROR_CODE = {
     "docker_not_on_the_latest_tag": {'code': "DO106", 'ui_applicable': True, 'related_field': 'dockerimage'},
     "non_existing_docker": {'code': "DO107", 'ui_applicable': True, 'related_field': 'dockerimage'},
     "dockerimage_not_in_yml_file": {'code': "DO108", 'ui_applicable': True, 'related_field': 'dockerimage'},
+    "deprecated_docker_error": {'code': "DO109", 'ui_applicable': True, 'related_field': 'dockerimage'},
 
     # DS - Descriptions
     "description_missing_in_beta_integration": {'code': "DS100", 'ui_applicable': False, 'related_field': ''},
@@ -971,6 +972,11 @@ class Errors:
                f'Please create or update to an updated versioned image\n' \
                f'You can check for the most updated version of {docker_image_tag} ' \
                f'here: https://hub.docker.com/r/{docker_image_name}/tags'
+
+    @staticmethod
+    @error_code_decorator
+    def deprecated_docker_error(docker_image_name, deprecated_reason):
+        return f'The docker image {docker_image_name} is deprecated - {deprecated_reason}'
 
     @staticmethod
     @error_code_decorator


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-2996

## Description
Added new validation for deprecated docker images
Added new error code

## Screenshots
```
[ERROR]: /Users/sberman/dev/demisto/content/Packs/CrowdStrikeFalconStreamingV2/Integrations/CrowdStrikeFalconStreamingV2/CrowdStrikeFalconStreamingV2.yml: [DO109] - The docker image demisto/aiohttp is deprecated - Use the demisto/py3-tools docker image instead.

```

## Must have
- [ ] Tests
- [ ] Documentation
