### PR TITLE
fix debug logging level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Removed the validation of a subtype change in integrations and scripts from **validate**.
+* Fixed an issue where coverage reports used the wrong logging level, marking debug logs as errors.
 
 ## 1.6.7
 

--- a/demisto_sdk/commands/coverage_analyze/helpers.py
+++ b/demisto_sdk/commands/coverage_analyze/helpers.py
@@ -34,7 +34,7 @@ def fix_file_path(coverage_file: str, code_file_absolute_path: str):
         cursor = sql_connection.cursor()
         index = cursor.execute('SELECT count(*) FROM file').fetchall()[0][0]
         if not index == 1:
-            logger.error('unexpected file list in coverage report')
+            logger.debug('unexpected file list in coverage report')
         else:
             cursor.execute('UPDATE file SET path = ? WHERE id = ?', (code_file_absolute_path, 1))
             sql_connection.commit()

--- a/demisto_sdk/commands/coverage_analyze/tests/helpers_test.py
+++ b/demisto_sdk/commands/coverage_analyze/tests/helpers_test.py
@@ -299,7 +299,7 @@ class TestFixFilePath:
 
         assert len(caplog.records) == 2
         assert caplog.records[0].msg == 'unexpected file list in coverage report'
-        assert caplog.records[0].levelname == 'ERROR'
+        assert caplog.records[0].levelname == 'DEBUG'
         assert caplog.records[1].msg == 'removing coverage report for some_path'
         assert caplog.records[1].levelname == 'DEBUG'
         assert not os.path.exists(dot_cov_file_path)

--- a/demisto_sdk/commands/lint/helpers.py
+++ b/demisto_sdk/commands/lint/helpers.py
@@ -488,7 +488,7 @@ def coverage_report_editor(coverage_file, code_file_absolute_path):
         cursor = sql_connection.cursor()
         index = cursor.execute('SELECT count(*) FROM file').fetchall()[0][0]
         if not index == 1:
-            logger.error('unexpected file list in coverage report')
+            logger.debug('unexpected file list in coverage report')
         else:
             cursor.execute('UPDATE file SET path = ? WHERE id = ?', (code_file_absolute_path, 1))
             sql_connection.commit()


### PR DESCRIPTION
`unexpected file list in coverage report` should be logged using the `DEBUG` level, not `ERROR`.