### PR TITLE
[Fix] merge-id-sets fails when a key is missing in a set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Removed the validation of a subtype change in integrations and scripts from **validate**.
 * Fixed an issue where **download** did not behave as expected when prompting for a version update. Reported by @K-Yo
 * Added support for adoption release notes.
+* Fixed an issue where **merge-id-sets** failed when a key was missing in one id-set.json.
 * Fixed a bug where some mypy messages were not parsed properly in **lint**.
 * Fixed an issue where coverage reports used the wrong logging level, marking debug logs as errors.
 * Added a new validation to the **validate** command, to check when the discouraged `http` prefixes are used when setting defaultvalue, rather than `https`.

--- a/demisto_sdk/commands/common/update_id_set.py
+++ b/demisto_sdk/commands/common/update_id_set.py
@@ -1960,7 +1960,8 @@ class IDSet:
         if not IDSetType.has_value(object_type):
             raise ValueError(f'Invalid IDSetType {object_type}')
 
-        self._id_set_dict.setdefault(object_type, []).append(obj) if obj not in self._id_set_dict[object_type] else None
+        if obj not in self._id_set_dict.get(object_type):
+            self._id_set_dict.setdefault(object_type, []).append(obj)
 
     def add_pack_to_id_set_packs(self, object_type: IDSetType, obj_name, obj_value):
         self._id_set_dict.setdefault(object_type, {}).update({obj_name: obj_value})

--- a/demisto_sdk/commands/common/update_id_set.py
+++ b/demisto_sdk/commands/common/update_id_set.py
@@ -1960,7 +1960,7 @@ class IDSet:
         if not IDSetType.has_value(object_type):
             raise ValueError(f'Invalid IDSetType {object_type}')
 
-        if obj not in self._id_set_dict.get(object_type):
+        if obj not in self._id_set_dict.get(object_type, {}):
             self._id_set_dict.setdefault(object_type, []).append(obj)
 
     def add_pack_to_id_set_packs(self, object_type: IDSetType, obj_name, obj_value):


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Fixed an issue where **merge-id-sets** failed when a key was missing in one id-set.json.