### PR TITLE
remove validate env

### DIFF
--- a/demisto_sdk/commands/lint/helpers.py
+++ b/demisto_sdk/commands/lint/helpers.py
@@ -61,23 +61,6 @@ RL = '\n'
 logger = logging.getLogger('demisto-sdk')
 
 
-def validate_env() -> None:
-    """Packs which use python2 will need to be run inside virtual environment including python2 as main
-    and the specified req
-    """
-    wrn_msg = 'demisto-sdk lint not in virtual environment, Python2 lints will fail, use "source .hooks/bootstrap"' \
-              ' to create the virtual environment'
-    command = "python -c \"import sys; print('{}.{}'.format(sys.version_info[0], sys.version_info[1]))\""
-    stdout, stderr, exit_code = run_command_os(command, cwd=Path().cwd())
-    if "2" not in stdout:
-        print_warning(wrn_msg)
-    else:
-        stdout, stderr, exit_code = run_command_os("pip3 freeze", cwd=Path().cwd())
-        for req in PYTHON2_REQ:
-            if req not in stdout:
-                print_warning(wrn_msg)
-
-
 def build_skipped_exit_code(no_flake8: bool, no_bandit: bool, no_mypy: bool, no_pylint: bool, no_vulture: bool,
                             no_xsoar_linter: bool,
                             no_test: bool, no_pwsh_analyze: bool, no_pwsh_test: bool, docker_engine: bool) -> float:

--- a/demisto_sdk/commands/lint/helpers.py
+++ b/demisto_sdk/commands/lint/helpers.py
@@ -25,7 +25,6 @@ from packaging.version import parse
 # Local packages
 from demisto_sdk.commands.common.constants import (TYPE_PWSH, TYPE_PYTHON,
                                                    DemistoException)
-from demisto_sdk.commands.common.tools import print_warning, run_command_os
 from demisto_sdk.commands.lint.docker_helper import init_global_docker_client
 
 # Python2 requirements

--- a/demisto_sdk/commands/lint/lint_manager.py
+++ b/demisto_sdk/commands/lint/lint_manager.py
@@ -36,7 +36,7 @@ from demisto_sdk.commands.lint.helpers import (EXIT_CODES, FAIL, PWSH_CHECKS,
                                                PY_CHCEKS,
                                                build_skipped_exit_code,
                                                generate_coverage_report,
-                                               get_test_modules, validate_env)
+                                               get_test_modules)
 from demisto_sdk.commands.lint.linter import Linter
 
 json = JSON_Handler()
@@ -122,8 +122,6 @@ class LintManager:
             "test_modules": None,
             "docker_engine": True
         }
-        # Check env requirements satisfied - bootstrap in use
-        validate_env()
         # Get content repo object
         is_external_repo = False
         try:

--- a/demisto_sdk/commands/lint/tests/helper_test.py
+++ b/demisto_sdk/commands/lint/tests/helper_test.py
@@ -7,15 +7,6 @@ from demisto_sdk.commands.lint.helpers import (generate_coverage_report,
                                                split_warnings_errors)
 
 
-def test_validate_env(mocker) -> None:
-    from demisto_sdk.commands.lint import helpers
-    mocker.patch.object(helpers, 'run_command_os')
-    helpers.run_command_os.side_effect = [('python2', '', ''), ('flake8, mypy, vultue', '', '')]
-    helpers.validate_env()
-
-    assert helpers.run_command_os.call_count == 2
-
-
 EXIT_CODES = {
     "flake8": 0b1,
     "xsoar_linter": 0b1000000000,

--- a/demisto_sdk/commands/lint/tests/helper_test.py
+++ b/demisto_sdk/commands/lint/tests/helper_test.py
@@ -6,7 +6,6 @@ import pytest
 from demisto_sdk.commands.lint.helpers import (generate_coverage_report,
                                                split_warnings_errors)
 
-
 EXIT_CODES = {
     "flake8": 0b1,
     "xsoar_linter": 0b1000000000,


### PR DESCRIPTION

## Description
Python 2 is no longer required by lint, so this step is redundant.