### PR TITLE
Fix steps which the working directory is content

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,10 @@ references:
           cache-version: << pipeline.parameters.cache-version >>
 
     install_demisto_sdk: &install_demisto_sdk
+      - run:
+          name: Configure to set poetry in project.
+          command: poetry config virtualenvs.in-project true --local
+
       - python/install-packages:
           pkg-manager: "poetry"
           args: "--no-dev"
@@ -207,32 +211,35 @@ jobs:
             environment:
               CI_COMMIT_BRANCH: "master"
             command: |
+              ./~/project/.venv/bin/activate
               cd content
-              poetry run demisto-sdk -v
-              poetry run demisto-sdk create-id-set -o ./Tests/id_set.json --fail-duplicates
+              demisto-sdk -v
+              demisto-sdk create-id-set -o ./Tests/id_set.json --fail-duplicates
         - run:
             name: Merge Id Set
             when: always
             environment:
               CI_COMMIT_BRANCH: "master"
             command: |
+              source ./.venv/bin/activate
               cd content
-              poetry run demisto-sdk -v
+              demisto-sdk -v
               export CIRCLE_ARTIFACTS="/home/circleci/project/artifacts"
 
-              poetry run gsutil cp gs://marketplace-dist/content/private_id_set.json $CIRCLE_ARTIFACTS/unified_id_set.json
-              poetry run demisto-sdk merge-id-sets -i1 ./Tests/id_set.json -i2 $CIRCLE_ARTIFACTS/unified_id_set.json -o $CIRCLE_ARTIFACTS/unified_id_set.json --fail-duplicates
+              gsutil cp gs://marketplace-dist/content/private_id_set.json $CIRCLE_ARTIFACTS/unified_id_set.json
+              demisto-sdk merge-id-sets -i1 ./Tests/id_set.json -i2 $CIRCLE_ARTIFACTS/unified_id_set.json -o $CIRCLE_ARTIFACTS/unified_id_set.json --fail-duplicates
         - run:
             name: Test validate files and yaml
             when: always
             environment:
               CI_COMMIT_BRANCH: "master"
             command: |
+              source ./.venv/bin/activate
               cd content
-              poetry run demisto-sdk -v
+              demisto-sdk -v
               export ARTIFACTS_FOLDER="/home/circleci/project/artifacts"
 
-              poetry run ./Tests/scripts/validate.sh
+              ./Tests/scripts/validate.sh
   test-lint:
       docker:
         - image: devdemisto/content-build:3.0.0.27979
@@ -291,11 +298,12 @@ jobs:
             name: Test Create Content Artifacts
             when: always
             command: |
+              source ./.venv/bin/activate
               cd content
-              poetry run demisto-sdk -v
+              demisto-sdk -v
               mkdir ./tmp
 
-              poetry run demisto-sdk create-content-artifacts -a ./tmp
+              demisto-sdk create-content-artifacts -a ./tmp
         - store_artifacts:
             path: content/tmp
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,7 +283,7 @@ jobs:
             name: Test Create Content Artifacts
             when: always
             command: |
-              poetry shell
+              source $(poetry env info --path)/bin/activate
               cd content
               demisto-sdk -v
               mkdir ./tmp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,6 @@ jobs:
         - python/install-packages:
             pkg-manager: "poetry"
             cache-version: << pipeline.parameters.cache-version >>
-        - run: "poetry shell"
         - <<: *install_node_ci
         - run:
             name: pytest
@@ -107,7 +106,7 @@ jobs:
               TEST_FILES=$(echo "$TEST_FILES" | circleci tests split --split-by=timings)
 
               mkdir test-results
-              pytest -v --cov=demisto_sdk --cov-report=html --junitxml=test-results/junit.xml $TEST_FILES
+              poetry run pytest -v --cov=demisto_sdk --cov-report=html --junitxml=test-results/junit.xml $TEST_FILES
         - store_test_results:
             path: test-results
         - store_artifacts:
@@ -136,7 +135,6 @@ jobs:
         - python/install-packages:
             pkg-manager: "poetry"
             cache-version: << pipeline.parameters.cache-version >>
-        - run: poetry shell
         - <<: *install_node_ci
         - run:
             name: pytest
@@ -146,7 +144,7 @@ jobs:
               TEST_FILES=$(circleci tests glob "demisto_sdk/tests/integration_tests/**/*_test.py")
 
               mkdir integration-test-results
-              pytest -v --junitxml=integration-test-results/junit.xml $TEST_FILES
+              poetry run pytest -v --junitxml=integration-test-results/junit.xml $TEST_FILES
         - store_test_results:
             path: integration-test-results
 
@@ -163,7 +161,7 @@ jobs:
             name: create cache key for pre-commit
             command: |
               cp .pre-commit-config.yaml pre-commit-cache-key.txt
-              python --version --version >> pre-commit-cache-key.txt
+              poetry run python --version --version >> pre-commit-cache-key.txt
               cat poetry.lock >> pre-commit-cache-key.txt
         - restore_cache:
             keys:
@@ -171,8 +169,8 @@ jobs:
         - run:
             name: Pre-commit
             command: |
-              pre-commit --version
-              pre-commit run -a
+              poetry run pre-commit --version
+              poetry run pre-commit run -a
         - save_cache:
             key: v1-pc-cache-{{ checksum "pre-commit-cache-key.txt" }}
             paths:
@@ -210,8 +208,8 @@ jobs:
               CI_COMMIT_BRANCH: "master"
             command: |
               cd content
-              demisto-sdk -v
-              demisto-sdk create-id-set -o ./Tests/id_set.json --fail-duplicates
+              poetry run demisto-sdk -v
+              poetry run demisto-sdk create-id-set -o ./Tests/id_set.json --fail-duplicates
         - run:
             name: Merge Id Set
             when: always
@@ -219,11 +217,11 @@ jobs:
               CI_COMMIT_BRANCH: "master"
             command: |
               cd content
-              demisto-sdk -v
+              poetry run demisto-sdk -v
               export CIRCLE_ARTIFACTS="/home/circleci/project/artifacts"
 
-              gsutil cp gs://marketplace-dist/content/private_id_set.json $CIRCLE_ARTIFACTS/unified_id_set.json
-              demisto-sdk merge-id-sets -i1 ./Tests/id_set.json -i2 $CIRCLE_ARTIFACTS/unified_id_set.json -o $CIRCLE_ARTIFACTS/unified_id_set.json --fail-duplicates
+              poetry run gsutil cp gs://marketplace-dist/content/private_id_set.json $CIRCLE_ARTIFACTS/unified_id_set.json
+              poetry run demisto-sdk merge-id-sets -i1 ./Tests/id_set.json -i2 $CIRCLE_ARTIFACTS/unified_id_set.json -o $CIRCLE_ARTIFACTS/unified_id_set.json --fail-duplicates
         - run:
             name: Test validate files and yaml
             when: always
@@ -231,10 +229,10 @@ jobs:
               CI_COMMIT_BRANCH: "master"
             command: |
               cd content
-              demisto-sdk -v
+              poetry run demisto-sdk -v
               export ARTIFACTS_FOLDER="/home/circleci/project/artifacts"
 
-              ./Tests/scripts/validate.sh
+              poetry run ./Tests/scripts/validate.sh
   test-lint:
       docker:
         - image: devdemisto/content-build:3.0.0.27979
@@ -289,16 +287,15 @@ jobs:
         - attach_workspace:
             at: ~/project
         - <<: *install_demisto_sdk
-        - run: poetry shell
         - run:
             name: Test Create Content Artifacts
             when: always
             command: |
               cd content
-              demisto-sdk -v
+              poetry run demisto-sdk -v
               mkdir ./tmp
 
-              demisto-sdk create-content-artifacts -a ./tmp
+              poetry run demisto-sdk create-content-artifacts -a ./tmp
         - store_artifacts:
             path: content/tmp
   build:
@@ -350,7 +347,7 @@ jobs:
       - run:
           name: Run Slack Notifier
           command: |
-            python3 demisto_sdk/utils/circle-ci/circle_ci_slack_notifier.py -wd $CIRCLE_WORKFLOW_ID -st $SLACK_TOKEN
+            poetry run python3 demisto_sdk/utils/circle-ci/circle_ci_slack_notifier.py -wd $CIRCLE_WORKFLOW_ID -st $SLACK_TOKEN
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,10 +48,6 @@ references:
           cache-version: << pipeline.parameters.cache-version >>
 
     install_demisto_sdk: &install_demisto_sdk
-      - run:
-          name: Configure to set poetry in project.
-          command: poetry config virtualenvs.in-project true --local
-
       - python/install-packages:
           pkg-manager: "poetry"
           args: "--no-dev"
@@ -59,7 +55,9 @@ references:
           pre-install-steps:
             - run:
                 name: export demisto-sdk to path
-                command: echo 'export PYTHONPATH="${PYTHONPATH}:${HOME}/project"' >> $BASH_ENV
+                command: |
+                  echo 'export PYTHONPATH="${PYTHONPATH}:${HOME}/project"' >> $BASH_ENV
+                  poetry config virtualenvs.in-project true --local
       - <<: *install_node_ci
 
     install_build_dependencies: &install_build_dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ references:
             - run:
                 name: export demisto-sdk to path
                 command: echo 'export PYTHONPATH="${PYTHONPATH}:${HOME}/project"' >> $BASH_ENV
-      - poetry shell
+      - run: poetry shell
       - <<: *install_node_ci
 
     install_build_dependencies: &install_build_dependencies
@@ -345,7 +345,7 @@ jobs:
       - python/install-packages:
           pkg-manager: "poetry"
           cache-version: << pipeline.parameters.cache-version >>
-      - poetry shell
+      - run: poetry shell
       - run:
           name: Run Slack Notifier
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,8 +250,6 @@ jobs:
             when: always
             no_output_timeout: 20m
             command: |
-              pip3 uninstall virtualenv -y && pip3 install virtualenv==16.7.7
-              cd ~/project
               source $(poetry env info --path)/bin/activate
 
               export SDK_LINT_FILES_CHANGED=$(git diff master... --name-only -- demisto_sdk/commands/lint)
@@ -261,7 +259,7 @@ jobs:
                   exit 0
               fi
               cd content
-              echo "lint files changed running lint"
+              echo "lint files changed. running lint"
               # python file (CommonServerPython lint is running over python 3 and 2)
               # we use `demisto-sdk` because we're inside content local env and not on poetry local env
               demisto-sdk lint -i ./Packs/Base/Scripts/CommonServerPython

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,7 @@ jobs:
             environment:
               CI_COMMIT_BRANCH: "master"
             command: |
-              poetry shell
+              source $(poetry env info --path)/bin/activate
               cd content
               demisto-sdk -v
               demisto-sdk create-id-set -o ./Tests/id_set.json --fail-duplicates
@@ -217,7 +217,7 @@ jobs:
             environment:
               CI_COMMIT_BRANCH: "master"
             command: |
-              poetry shell
+              source $(poetry env info --path)/bin/activate
               cd content
               demisto-sdk -v
               export CIRCLE_ARTIFACTS="/home/circleci/project/artifacts"
@@ -230,7 +230,7 @@ jobs:
             environment:
               CI_COMMIT_BRANCH: "master"
             command: |
-              poetry shell
+              source $(poetry env info --path)/bin/activate
               cd content
               demisto-sdk -v
               export ARTIFACTS_FOLDER="/home/circleci/project/artifacts"
@@ -238,7 +238,7 @@ jobs:
               ./Tests/scripts/validate.sh
   test-lint:
       docker:
-        - image: devdemisto/content-build:3.0.0.27979
+        - image: << pipeline.parameters.global-docker-image >>
       steps:
         - checkout
         - setup_remote_docker:
@@ -252,6 +252,8 @@ jobs:
             command: |
               pip3 uninstall virtualenv -y && pip3 install virtualenv==16.7.7
               cd ~/project
+              source $(poetry env info --path)/bin/activate
+
               export SDK_LINT_FILES_CHANGED=$(git diff master... --name-only -- demisto_sdk/commands/lint)
 
               if [[ -z "${SDK_LINT_FILES_CHANGED}" ]]; then
@@ -259,19 +261,6 @@ jobs:
                   exit 0
               fi
               cd content
-              echo "installing venv"
-              NO_HOOKS=1 SETUP_PY2=yes .hooks/bootstrap >> /tmp/lint_env_installation.log
-              echo "finished script installation"
-              source ./venv/bin/activate
-              pip3 install -r .circleci/build-requirements.txt >> /tmp/lint_env_installation.log
-              
-              # installing local sdk inside venv
-              
-              # uninstall demisto-sdk that installed from content (could be dependency conflict between them)
-              pip3 uninstall -y demisto-sdk
-              pip3 install ~/project >> /tmp/lint_env_installation.log
-              demisto-sdk -v
-              echo ""
               echo "lint files changed running lint"
               # python file (CommonServerPython lint is running over python 3 and 2)
               # we use `demisto-sdk` because we're inside content local env and not on poetry local env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,9 +55,7 @@ references:
           pre-install-steps:
             - run:
                 name: export demisto-sdk to path
-                command: |
-                  echo 'export PYTHONPATH="${PYTHONPATH}:${HOME}/project"' >> $BASH_ENV
-                  poetry config virtualenvs.in-project true --local
+                command: echo 'export PYTHONPATH="${PYTHONPATH}:${HOME}/project"' >> $BASH_ENV
       - <<: *install_node_ci
 
     install_build_dependencies: &install_build_dependencies
@@ -209,7 +207,7 @@ jobs:
             environment:
               CI_COMMIT_BRANCH: "master"
             command: |
-              ./~/project/.venv/bin/activate
+              poetry shell
               cd content
               demisto-sdk -v
               demisto-sdk create-id-set -o ./Tests/id_set.json --fail-duplicates
@@ -219,7 +217,7 @@ jobs:
             environment:
               CI_COMMIT_BRANCH: "master"
             command: |
-              source ./.venv/bin/activate
+              poetry shell
               cd content
               demisto-sdk -v
               export CIRCLE_ARTIFACTS="/home/circleci/project/artifacts"
@@ -232,7 +230,7 @@ jobs:
             environment:
               CI_COMMIT_BRANCH: "master"
             command: |
-              source ./.venv/bin/activate
+              poetry shell
               cd content
               demisto-sdk -v
               export ARTIFACTS_FOLDER="/home/circleci/project/artifacts"
@@ -296,7 +294,7 @@ jobs:
             name: Test Create Content Artifacts
             when: always
             command: |
-              source ./.venv/bin/activate
+              poetry shell
               cd content
               demisto-sdk -v
               mkdir ./tmp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,6 @@ references:
             - run:
                 name: export demisto-sdk to path
                 command: echo 'export PYTHONPATH="${PYTHONPATH}:${HOME}/project"' >> $BASH_ENV
-      - run: poetry shell
       - <<: *install_node_ci
 
     install_build_dependencies: &install_build_dependencies
@@ -89,6 +88,7 @@ jobs:
         - python/install-packages:
             pkg-manager: "poetry"
             cache-version: << pipeline.parameters.cache-version >>
+        - run: "poetry shell"
         - <<: *install_node_ci
         - run:
             name: pytest
@@ -136,6 +136,7 @@ jobs:
         - python/install-packages:
             pkg-manager: "poetry"
             cache-version: << pipeline.parameters.cache-version >>
+        - run: poetry shell
         - <<: *install_node_ci
         - run:
             name: pytest
@@ -288,6 +289,7 @@ jobs:
         - attach_workspace:
             at: ~/project
         - <<: *install_demisto_sdk
+        - run: poetry shell
         - run:
             name: Test Create Content Artifacts
             when: always
@@ -345,7 +347,6 @@ jobs:
       - python/install-packages:
           pkg-manager: "poetry"
           cache-version: << pipeline.parameters.cache-version >>
-      - run: poetry shell
       - run:
           name: Run Slack Notifier
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,11 +291,12 @@ jobs:
             name: Test Create Content Artifacts
             when: always
             command: |
+              poetry shell
               cd content
-              poetry run demisto-sdk -v
+              demisto-sdk -v
               mkdir ./tmp
 
-              poetry run demisto-sdk create-content-artifacts -a ./tmp
+              demisto-sdk create-content-artifacts -a ./tmp
         - store_artifacts:
             path: content/tmp
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,6 @@ jobs:
             environment:
               CI_COMMIT_BRANCH: "master"
             command: |
-              poetry shell
               cd content
               demisto-sdk -v
               demisto-sdk create-id-set -o ./Tests/id_set.json --fail-duplicates
@@ -217,7 +216,6 @@ jobs:
             environment:
               CI_COMMIT_BRANCH: "master"
             command: |
-              poetry shell
               cd content
               demisto-sdk -v
               export CIRCLE_ARTIFACTS="/home/circleci/project/artifacts"
@@ -230,7 +228,6 @@ jobs:
             environment:
               CI_COMMIT_BRANCH: "master"
             command: |
-              poetry shell
               cd content
               demisto-sdk -v
               export ARTIFACTS_FOLDER="/home/circleci/project/artifacts"
@@ -294,7 +291,6 @@ jobs:
             name: Test Create Content Artifacts
             when: always
             command: |
-              poetry shell
               cd content
               demisto-sdk -v
               mkdir ./tmp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,7 @@ references:
             - run:
                 name: export demisto-sdk to path
                 command: echo 'export PYTHONPATH="${PYTHONPATH}:${HOME}/project"' >> $BASH_ENV
+      - poetry shell
       - <<: *install_node_ci
 
     install_build_dependencies: &install_build_dependencies
@@ -106,7 +107,7 @@ jobs:
               TEST_FILES=$(echo "$TEST_FILES" | circleci tests split --split-by=timings)
 
               mkdir test-results
-              poetry run pytest -v --cov=demisto_sdk --cov-report=html --junitxml=test-results/junit.xml $TEST_FILES
+              pytest -v --cov=demisto_sdk --cov-report=html --junitxml=test-results/junit.xml $TEST_FILES
         - store_test_results:
             path: test-results
         - store_artifacts:
@@ -144,7 +145,7 @@ jobs:
               TEST_FILES=$(circleci tests glob "demisto_sdk/tests/integration_tests/**/*_test.py")
 
               mkdir integration-test-results
-              poetry run pytest -v --junitxml=integration-test-results/junit.xml $TEST_FILES
+              pytest -v --junitxml=integration-test-results/junit.xml $TEST_FILES
         - store_test_results:
             path: integration-test-results
 
@@ -161,7 +162,7 @@ jobs:
             name: create cache key for pre-commit
             command: |
               cp .pre-commit-config.yaml pre-commit-cache-key.txt
-              poetry run python --version --version >> pre-commit-cache-key.txt
+              python --version --version >> pre-commit-cache-key.txt
               cat poetry.lock >> pre-commit-cache-key.txt
         - restore_cache:
             keys:
@@ -169,8 +170,8 @@ jobs:
         - run:
             name: Pre-commit
             command: |
-              poetry run pre-commit --version
-              poetry run pre-commit run -a
+              pre-commit --version
+              pre-commit run -a
         - save_cache:
             key: v1-pc-cache-{{ checksum "pre-commit-cache-key.txt" }}
             paths:
@@ -344,10 +345,11 @@ jobs:
       - python/install-packages:
           pkg-manager: "poetry"
           cache-version: << pipeline.parameters.cache-version >>
+      - poetry shell
       - run:
           name: Run Slack Notifier
           command: |
-            poetry run python3 demisto_sdk/utils/circle-ci/circle_ci_slack_notifier.py -wd $CIRCLE_WORKFLOW_ID -st $SLACK_TOKEN
+            python3 demisto_sdk/utils/circle-ci/circle_ci_slack_notifier.py -wd $CIRCLE_WORKFLOW_ID -st $SLACK_TOKEN
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,32 +207,35 @@ jobs:
             environment:
               CI_COMMIT_BRANCH: "master"
             command: |
+              poetry shell
               cd content
-              poetry run demisto-sdk -v
-              poetry run demisto-sdk create-id-set -o ./Tests/id_set.json --fail-duplicates
+              demisto-sdk -v
+              demisto-sdk create-id-set -o ./Tests/id_set.json --fail-duplicates
         - run:
             name: Merge Id Set
             when: always
             environment:
               CI_COMMIT_BRANCH: "master"
             command: |
+              poetry shell
               cd content
-              poetry run demisto-sdk -v
+              demisto-sdk -v
               export CIRCLE_ARTIFACTS="/home/circleci/project/artifacts"
 
-              poetry run gsutil cp gs://marketplace-dist/content/private_id_set.json $CIRCLE_ARTIFACTS/unified_id_set.json
-              poetry run demisto-sdk merge-id-sets -i1 ./Tests/id_set.json -i2 $CIRCLE_ARTIFACTS/unified_id_set.json -o $CIRCLE_ARTIFACTS/unified_id_set.json --fail-duplicates
+              gsutil cp gs://marketplace-dist/content/private_id_set.json $CIRCLE_ARTIFACTS/unified_id_set.json
+              demisto-sdk merge-id-sets -i1 ./Tests/id_set.json -i2 $CIRCLE_ARTIFACTS/unified_id_set.json -o $CIRCLE_ARTIFACTS/unified_id_set.json --fail-duplicates
         - run:
             name: Test validate files and yaml
             when: always
             environment:
               CI_COMMIT_BRANCH: "master"
             command: |
+              poetry shell
               cd content
-              poetry run demisto-sdk -v
+              demisto-sdk -v
               export ARTIFACTS_FOLDER="/home/circleci/project/artifacts"
 
-              poetry run ./Tests/scripts/validate.sh
+              ./Tests/scripts/validate.sh
   test-lint:
       docker:
         - image: devdemisto/content-build:3.0.0.27979

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,6 +241,7 @@ jobs:
         - image: << pipeline.parameters.global-docker-image >>
       steps:
         - checkout
+        - <<: *install_demisto_sdk
         - setup_remote_docker:
             version: 20.10.12
         - attach_workspace:
@@ -250,6 +251,7 @@ jobs:
             when: always
             no_output_timeout: 20m
             command: |
+
               source $(poetry env info --path)/bin/activate
 
               export SDK_LINT_FILES_CHANGED=$(git diff master... --name-only -- demisto_sdk/commands/lint)

--- a/demisto_sdk/commands/lint/linter.py
+++ b/demisto_sdk/commands/lint/linter.py
@@ -204,7 +204,6 @@ class Linter:
         logger.info(f"{log_prompt} - Using yaml file {self._yml_file}")
         # Parsing pack yaml - in order to verify if check needed
         try:
-
             script_obj: Dict = {}
             yml_obj: Dict = YAML_Handler().load(self._yml_file)
             if isinstance(yml_obj, dict):


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Due to recent change in content that runs poetry, we shouldn't use `poetry run` when running from content (because it will try to run in `content` env).
Instead, we activate the demisto-sdk env before.
## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
