### PR TITLE
Dev-Task - generate-docs auto-generate link to playbook image

### DIFF
--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -1378,6 +1378,8 @@ def init(**kwargs):
     "--old-version", help="Path of the old integration version yml file.")
 @click.option(
     "--skip-breaking-changes", is_flag=True, help="Skip generating of breaking changes section.")
+@click.option(
+    "--custom-image-link", help="A custom link to a playbook image. If not stated, a default link will be added to the file.")
 def generate_docs(**kwargs):
     """Generate documentation for integration, playbook or script from yaml file."""
     from demisto_sdk.commands.generate_docs.generate_integration_doc import \
@@ -1397,6 +1399,7 @@ def generate_docs(**kwargs):
     verbose: bool = kwargs.get('verbose', False)
     old_version: str = kwargs.get('old_version', '')
     skip_breaking_changes: bool = kwargs.get('skip_breaking_changes', False)
+    custom_image_link: str = kwargs.get('custom_image_link', '')
 
     # validate inputs
     if input_path and not os.path.isfile(input_path):
@@ -1447,7 +1450,7 @@ def generate_docs(**kwargs):
                                    limitations=limitations, insecure=insecure, verbose=verbose)
     elif file_type == FileType.PLAYBOOK:
         return generate_playbook_doc(input_path=input_path, output=output_path, permissions=permissions,
-                                     limitations=limitations, verbose=verbose)
+                                     limitations=limitations, verbose=verbose, custom_image_link=custom_image_link)
     else:
         print_error(f'File type {file_type.value} is not supported.')
         return 1

--- a/demisto_sdk/commands/generate_docs/generate_playbook_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_playbook_doc.py
@@ -9,7 +9,7 @@ from demisto_sdk.commands.generate_docs.common import (
 
 
 def generate_playbook_doc(input_path: str, output: str = None, permissions: str = None, limitations: str = None,
-                          verbose: bool = False):
+                          verbose: bool = False, custom_image_link: str = None):
     try:
         playbook = get_yaml(input_path)
         if not output:  # default output dir will be the dir of the input file
@@ -55,7 +55,7 @@ def generate_playbook_doc(input_path: str, output: str = None, permissions: str 
             doc.extend(generate_numbered_section('Known Limitations', limitations))
 
         doc.append('## Playbook Image\n---')
-        doc.append(f'![{_name}](Insert the link to your image here)')
+        doc.append(generate_image_link(_name, custom_image_link))
 
         doc_text = '\n'.join(doc)
 
@@ -229,3 +229,16 @@ def get_input_data(input_section: Dict) -> str:
         return default_value.get('simple')
 
     return ''
+
+
+def generate_image_link(playbook_name, custom_image_link):
+    """
+    Adding an image link to the playbook README.
+    """
+    if custom_image_link:
+        playbook_image_path = custom_image_link
+    else:
+        playbook_image_path = playbook_name.replace(' ', '_')
+        playbook_image_path = './../doc_files/' + playbook_image_path + '.png'
+
+    return f'![{playbook_name}]({playbook_image_path})'

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -342,6 +342,17 @@ def test_get_input_data_complex():
     assert _value == 'File.Name'
 
 
+@pytest.mark.parametrize('playbook_name, custom_image_link, expected_result',
+                         [('playbook name', '', '![playbook name](./../doc_files/playbook_name.png)'),
+                          ('playbook name', 'custom_link', '![playbook name](custom_link)')])
+def test_generate_image_link(playbook_name, custom_image_link, expected_result):
+    from demisto_sdk.commands.generate_docs.generate_playbook_doc import \
+        generate_image_link
+
+    output = generate_image_link(playbook_name, custom_image_link)
+
+    assert output == expected_result
+
 # script tests
 
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-897)

## Description
Adding auto-generated image link to the playbook README. There will be a default link, and a custom one can be added via new flag: `--custom-link`

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
