### PR TITLE
fix flaky PB110 validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Fixed an issue where **validate** command failed when trying to validate whether a version of a content item used in a playbook is valid.
 * Added a new validation to the **validate** command to verify that the docker in use is not deprecated.
 * Added support for multiple ApiModules in the **unify** command
 * Added slack notifier for build failures on the master branch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-* Fixed an issue where **validate** command failed when trying to validate whether the **fromversion** of a content item used in a playbook is valid compared to the **fromversion** of the playbook.
+* Fixed an issue where **validate** command sometimes failed when trying to validate whether the **fromversion** of a sub-playbook used in a playbook is valid compared to the **fromversion** of the playbook in cases where there are several sub-playbooks with the same ID.
 * Added a new validation to the **validate** command to verify that the docker in use is not deprecated.
 * Added support for multiple ApiModules in the **unify** command
 * Added slack notifier for build failures on the master branch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-* Fixed an issue where **validate** command sometimes failed when trying to validate whether the **fromversion** of a sub-playbook used in a playbook is valid compared to the **fromversion** of the playbook in cases where there are several sub-playbooks with the same ID.
+* Fixed an issue where the **validate** command sometimes returned a false negative in cases where there are several sub-playbooks with the same ID.
 * Added a new validation to the **validate** command to verify that the docker in use is not deprecated.
 * Added support for multiple ApiModules in the **unify** command
 * Added slack notifier for build failures on the master branch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-* Fixed an issue where **validate** command failed when trying to validate whether a version of a content item used in a playbook is valid.
+* Fixed an issue where **validate** command failed when trying to validate whether the **fromversion** of a content item used in a playbook is valid compared to the **fromversion** of the playbook.
 * Added a new validation to the **validate** command to verify that the docker in use is not deprecated.
 * Added support for multiple ApiModules in the **unify** command
 * Added slack notifier for build failures on the master branch.

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -1357,7 +1357,7 @@ class Errors:
         main_playbook: str, entities_names_and_version: str, main_playbook_version: str, content_sub_type: str
     ):
         return f"Playbook {main_playbook} with 'fromversion' {main_playbook_version} uses the following" \
-               f" {content_sub_type} along with their invalid 'fromversion': [{entities_names_and_version}]. " \
+               f" {content_sub_type} with an invalid 'fromversion': [{entities_names_and_version}]. " \
                f"The 'fromversion' of the {content_sub_type} should be {main_playbook_version} or lower."
 
     @staticmethod

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -1353,10 +1353,12 @@ class Errors:
 
     @staticmethod
     @error_code_decorator
-    def content_entity_version_not_match_playbook_version(main_playbook, entities_names, main_playbook_version):
-        return f"Playbook {main_playbook} with version {main_playbook_version} uses {entities_names} " \
-               f"with a version that does not match the main playbook version. The from version of" \
-               f" {entities_names} should be {main_playbook_version} or lower."
+    def content_entity_version_not_match_playbook_version(
+        main_playbook: str, entities_names_and_version: str, main_playbook_version: str, content_sub_type: str
+    ):
+        return f"Playbook {main_playbook} with 'fromversion' {main_playbook_version} uses the following" \
+               f" {content_sub_type} along with their invalid 'fromversion': [{entities_names_and_version}]. " \
+               f"The 'fromversion' of the {content_sub_type} should be {main_playbook_version} or lower."
 
     @staticmethod
     @error_code_decorator

--- a/demisto_sdk/commands/common/hook_validations/id.py
+++ b/demisto_sdk/commands/common/hook_validations/id.py
@@ -584,7 +584,7 @@ class IDSetValidations(BaseValidator):
             invalid_entities_error_msg = ', '.join(
                 [
                     f'{file_path}: {entity_version}'
-                    for file_path, entity_version in invalid_entries_path_to_version
+                    for entity_version, file_path in invalid_entries_path_to_version
                 ]
             )
             error_message, error_code = Errors.content_entity_version_not_match_playbook_version(

--- a/demisto_sdk/commands/common/hook_validations/id.py
+++ b/demisto_sdk/commands/common/hook_validations/id.py
@@ -5,6 +5,7 @@ from distutils.version import LooseVersion
 from typing import Dict, Optional, Tuple
 
 import click
+from packaging.version import Version
 
 import demisto_sdk.commands.common.constants as constants
 from demisto_sdk.commands.common.configuration import Configuration
@@ -543,14 +544,14 @@ class IDSetValidations(BaseValidator):
                 main_playbook_data=main_playbook_data
             )
             return all(task_data.get('skipunavailable', False) for task_data in tasks_data) \
-                if tasks_data and LooseVersion(main_playbook_version) >= LooseVersion('6.0.0') else False
+                if tasks_data and Version(main_playbook_version) >= Version('6.0.0') else False
 
         def is_minimum_version_valid(_min_version) -> bool:
             """
             In case we have more than one entity with the same ID,
             verify that the one with the minimum version is valid.
             """
-            return LooseVersion(_min_version) <= LooseVersion(main_playbook_version)
+            return Version(_min_version) <= Version(main_playbook_version)
 
         implemented_entity_list_from_playbook = set(implemented_entity_list_from_playbook)
         implemented_ids_in_id_set = set()
@@ -569,7 +570,7 @@ class IDSetValidations(BaseValidator):
                     else:
                         if min_version_to_path := entity_ids_with_min_version.get(entity_name):
                             min_version, _ = min_version_to_path
-                            if LooseVersion(from_version) < LooseVersion(min_version):
+                            if Version(from_version) < Version(min_version):
                                 entity_ids_with_min_version[entity_name] = (
                                     from_version, entity_data.get('file_path')
                                 )

--- a/demisto_sdk/commands/common/hook_validations/id.py
+++ b/demisto_sdk/commands/common/hook_validations/id.py
@@ -554,7 +554,7 @@ class IDSetValidations(BaseValidator):
 
         implemented_entity_list_from_playbook = set(implemented_entity_list_from_playbook)
         implemented_ids_in_id_set = set()
-        
+
         implemented_entity_name_to_entities: Dict[str, list] = {}
         for entity in entity_set_from_id_set:
             entity_id = list(entity.keys())[0]

--- a/demisto_sdk/commands/common/hook_validations/id.py
+++ b/demisto_sdk/commands/common/hook_validations/id.py
@@ -538,9 +538,6 @@ class IDSetValidations(BaseValidator):
         implemented_entities = implemented_entity_list_from_playbook.copy()
         is_valid = True, None
         for entity_data_dict in entity_set_from_id_set:
-            if not implemented_entities:
-                break
-
             entity_id = list(entity_data_dict.keys())[0]
             all_entity_fields = entity_data_dict[entity_id]
             entity_name = entity_id if entity_id in implemented_entity_list_from_playbook else all_entity_fields.get(

--- a/demisto_sdk/commands/common/hook_validations/id.py
+++ b/demisto_sdk/commands/common/hook_validations/id.py
@@ -580,52 +580,6 @@ class IDSetValidations(BaseValidator):
 
         return is_valid
 
-        # entity_status: dict = {}
-        # invalid_entities_path_and_version: dict = {}
-        # implemented_entities = implemented_entity_list_from_playbook.copy()
-        # is_valid = True, None
-        # for entities in entity_set_from_id_set:
-        #     entity_id = list(entities.keys())[0]
-        #     all_entity_fields = entities[entity_id]
-        #     entity_name = entity_id if entity_id in implemented_entity_list_from_playbook else all_entity_fields.get(
-        #         "name")
-        #     is_entity_used_in_playbook = entity_name in implemented_entity_list_from_playbook
-        #
-        #     if is_entity_used_in_playbook:
-        #         tasks_data = get_script_or_sub_playbook_tasks_from_playbook(searched_entity_name=entity_name,
-        #                                                                     main_playbook_data=main_playbook_data)
-        #
-        #         entity_version = all_entity_fields.get("fromversion", "")
-        #         is_version_valid = not entity_version or LooseVersion(entity_version) <= LooseVersion(
-        #             main_playbook_version)
-        #         skip_unavailable = all(task_data.get('skipunavailable', False) for task_data in tasks_data) \
-        #             if tasks_data and LooseVersion(main_playbook_version) >= LooseVersion('6.0.0') else False
-        #
-        #         # if entities with miss-matched versions were found and skipunavailable is
-        #         # not set or main playbook fromversion is below 6.0.0, fail the validation
-        #         sub_entity_file_path = all_entity_fields.get('file_path') or ''
-        #         if is_version_valid or skip_unavailable:
-        #             entity_status[entity_id] = True
-        #         else:
-        #             status = entity_status.setdefault(entity_id, False)
-        #             if not status:
-        #                 invalid_entities_path_and_version[sub_entity_file_path] = entity_version
-        #         if entity_name in implemented_entities:
-        #             implemented_entities.remove(entity_name)
-        # invalid_version_entities = [entity_name for entity_name, status in entity_status.items() if not status]
-        #
-        # if invalid_version_entities:
-        #     invalid_entities_error_msg = ', '.join(
-        #         [
-        #             f'{file_path}: {entity_version}'
-        #             for file_path, entity_version in invalid_entities_path_and_version.items()
-        #         ]
-        #     )
-        #     error_message, error_code = Errors.content_entity_version_not_match_playbook_version(
-        #         playbook_name, invalid_entities_error_msg, main_playbook_version, content_sub_type)
-        #     if self.handle_error(error_message, error_code, file_path):
-        #         is_valid = False, error_message
-
     @error_codes('PB111')
     def is_playbook_integration_version_valid(self, playbook_integration_commands, playbook_version, playbook_name,
                                               file_path):

--- a/demisto_sdk/commands/common/hook_validations/id.py
+++ b/demisto_sdk/commands/common/hook_validations/id.py
@@ -2,7 +2,8 @@ import os
 import re
 from collections import OrderedDict
 from distutils.version import LooseVersion
-from typing import Tuple, Optional
+from typing import Dict, Optional, Tuple
+
 import click
 
 import demisto_sdk.commands.common.constants as constants
@@ -505,9 +506,16 @@ class IDSetValidations(BaseValidator):
         return commands_to_integration
 
     @error_codes('PB110,PB117')
-    def is_entity_version_match_playbook_version(self, implemented_entity_list_from_playbook,
-                                                 main_playbook_version, entity_set_from_id_set,
-                                                 playbook_name, file_path, main_playbook_data, content_sub_type) -> Tuple[bool, Optional[str]]:
+    def is_entity_version_match_playbook_version(
+        self,
+        implemented_entity_list_from_playbook,
+        main_playbook_version,
+        entity_set_from_id_set,
+        playbook_name,
+        file_path,
+        main_playbook_data,
+        content_sub_type
+    ) -> Tuple[bool, Optional[str]]:
         """Check if the playbook's version match playbook's entities (script or sub-playbook)
         Goes over the relevant entity set from id_set and check if the version of this entity match is equal or lower
         to the main playbook's version.
@@ -527,7 +535,7 @@ class IDSetValidations(BaseValidator):
             content_sub_type (str): content sub type, whether its entity list are sub-playbooks or scripts.
 
         Returns:
-            bool. Whether the playbook's version match playbook's entities.
+            Tuple[bool, Optional[str]]. Whether the playbook's version match playbook's entities and error message.
         """
         def get_skip_unavailable(_entity_name) -> bool:
             tasks_data = get_script_or_sub_playbook_tasks_from_playbook(
@@ -547,7 +555,7 @@ class IDSetValidations(BaseValidator):
         implemented_entity_list_from_playbook = set(implemented_entity_list_from_playbook)
         implemented_ids_in_id_set = set()
 
-        entity_names_and_data = {}
+        entity_names_and_data: Dict[str, list] = {}
         for entity in entity_set_from_id_set:
             entity_id = list(entity.keys())[0]
             entity_data = entity.get(entity_id)

--- a/demisto_sdk/commands/common/hook_validations/id.py
+++ b/demisto_sdk/commands/common/hook_validations/id.py
@@ -554,8 +554,8 @@ class IDSetValidations(BaseValidator):
 
         implemented_entity_list_from_playbook = set(implemented_entity_list_from_playbook)
         implemented_ids_in_id_set = set()
-
-        entity_names_and_data: Dict[str, list] = {}
+        
+        implemented_entity_name_to_entities: Dict[str, list] = {}
         for entity in entity_set_from_id_set:
             entity_id = list(entity.keys())[0]
             entity_data = entity.get(entity_id)
@@ -563,13 +563,13 @@ class IDSetValidations(BaseValidator):
             if entity_name in implemented_entity_list_from_playbook:
                 # ignore entities which do not have fromversion.
                 if entity_data.get('fromversion'):
-                    if entity_name not in entity_names_and_data:
-                        entity_names_and_data[entity_name] = []
-                    entity_names_and_data[entity_name].append(entity_data)
+                    if entity_name not in implemented_entity_name_to_entities:
+                        implemented_entity_name_to_entities[entity_name] = []
+                    implemented_entity_name_to_entities[entity_name].append(entity_data)
                 implemented_ids_in_id_set.add(entity_name)
 
         invalid_entries_path_to_version = {}
-        for entity_name, entities in entity_names_and_data.items():
+        for entity_name, entities in implemented_entity_name_to_entities.items():
             # get entity with the minimum version
             min_version_entity = min(entities, key=lambda _entity: LooseVersion(_entity.get('fromversion')))
             if not (is_minimum_version_valid(min_version_entity) or get_skip_unavailable(entity_name)):

--- a/demisto_sdk/commands/common/hook_validations/id.py
+++ b/demisto_sdk/commands/common/hook_validations/id.py
@@ -540,8 +540,6 @@ class IDSetValidations(BaseValidator):
         implemented_entities = implemented_entity_list_from_playbook.copy()
         is_valid = True, None
         for entity_data_dict in entity_set_from_id_set:
-            if not implemented_entities:
-                break
             entity_id = list(entity_data_dict.keys())[0]
             all_entity_fields = entity_data_dict[entity_id]
             entity_name = entity_id if entity_id in implemented_entity_list_from_playbook else all_entity_fields.get(

--- a/demisto_sdk/commands/common/hook_validations/id.py
+++ b/demisto_sdk/commands/common/hook_validations/id.py
@@ -558,15 +558,15 @@ class IDSetValidations(BaseValidator):
 
                 # if entities with miss-matched versions were found and skipunavailable is
                 # not set or main playbook fromversion is below 6.0.0, fail the validation
-                file_path = all_entity_fields.get('file_path') or ''
+                sub_entity_file_path = all_entity_fields.get('file_path') or ''
                 if is_version_valid or skip_unavailable:
                     entity_status[entity_id] = True
                     if file_path in invalid_entities_path_and_version:
-                        invalid_entities_path_and_version.pop(file_path)
+                        invalid_entities_path_and_version.pop(sub_entity_file_path)
                 else:
-                    entity_status.setdefault(entity_id, False)
-                    if not entity_status.get(entity_id, False):
-                        invalid_entities_path_and_version[file_path] = entity_version
+                    status = entity_status.setdefault(entity_id, False)
+                    if not status:
+                        invalid_entities_path_and_version[sub_entity_file_path] = entity_version
                 if entity_name in implemented_entities:
                     implemented_entities.remove(entity_name)
         invalid_version_entities = [entity_name for entity_name, status in entity_status.items() if not status]

--- a/demisto_sdk/commands/common/tests/id_test.py
+++ b/demisto_sdk/commands/common/tests/id_test.py
@@ -1728,7 +1728,7 @@ class TestPlaybookEntitiesVersionsValid:
                 playbook_with_valid_integration_version, playbook.yml.path)
             assert is_integration_version_invalid
 
-    def test_playbook_sub_playbook_exist(self, repo, mocker):
+    def test_playbook_sub_playbook_exist(self, repo):
         """
 
         Given
@@ -1750,7 +1750,7 @@ class TestPlaybookEntitiesVersionsValid:
                 self.playbook_with_valid_sub_playbook_name, pack.path)
             assert is_subplaybook_name_exist
 
-    def test_playbook_sub_playbook_not_exist(self, repo, mocker):
+    def test_playbook_sub_playbook_not_exist(self, repo):
         """
 
         Given

--- a/demisto_sdk/commands/common/tests/id_test.py
+++ b/demisto_sdk/commands/common/tests/id_test.py
@@ -1559,7 +1559,7 @@ class TestPlaybookEntitiesVersionsValid:
             # all playbook's entities has valid versions
             is_playbook_version_valid, error = self.validator._are_playbook_entities_versions_valid(
                 self.playbook_with_valid_versions, playbook.yml.path)
-            assert is_playbook_version_valid
+            assert is_playbook_version_valid, error
             assert error is None
 
             # playbook uses scripts with invalid versions

--- a/demisto_sdk/commands/common/tests/id_test.py
+++ b/demisto_sdk/commands/common/tests/id_test.py
@@ -1415,33 +1415,6 @@ class TestPlaybookEntitiesVersionsValid:
     id_set = {
         'playbooks': [
             {
-                'playbook_dup': {
-                    'name': 'test',
-                    'fromversion': "5.0.0",
-                    'toversion': "5.9.9",
-                    "file_path": playbook_path,
-                    "command_to_integration": {
-                        "test-command": [
-                            "Integration_version_4",
-                            "Integration_version_5"
-                        ]
-                    }
-                }
-            },
-            {
-                'playbook_dup': {
-                    'name': 'test',
-                    'fromversion': "6.0.0",
-                    "file_path": playbook_path,
-                    "command_to_integration": {
-                        "test-command": [
-                            "Integration_version_4",
-                            "Integration_version_5"
-                        ]
-                    }
-                }
-            },
-            {
                 'SubPlaybook_version_5': {
                     'name': 'SubPlaybook_version_5',
                     'fromversion': "5.0.0",
@@ -1481,7 +1454,47 @@ class TestPlaybookEntitiesVersionsValid:
                         ]
                     }
                 }
-            }
+            },
+            {
+                'playbook_dup': {
+                    'name': 'test',
+                    'fromversion': "6.5.0",
+                    "file_path": playbook_path,
+                    "command_to_integration": {
+                        "test-command": [
+                            "Integration_version_4",
+                            "Integration_version_5"
+                        ]
+                    }
+                }
+            },
+            {
+                'playbook_dup': {
+                    'name': 'test',
+                    'fromversion': "5.0.0",
+                    'toversion': "5.9.9",
+                    "file_path": playbook_path,
+                    "command_to_integration": {
+                        "test-command": [
+                            "Integration_version_4",
+                            "Integration_version_5"
+                        ]
+                    }
+                }
+            },
+            {
+                'playbook_dup': {
+                    'name': 'test',
+                    'fromversion': "6.0.0",
+                    "file_path": playbook_path,
+                    "command_to_integration": {
+                        "test-command": [
+                            "Integration_version_4",
+                            "Integration_version_5"
+                        ]
+                    }
+                }
+            },
         ],
         'integrations': [
             {
@@ -1514,7 +1527,7 @@ class TestPlaybookEntitiesVersionsValid:
         ],
     }
 
-    def test_are_playbook_entities_versions_valid_scripts_and_subplaybooks(self, repo, mocker):
+    def test_are_playbook_entities_versions_valid_scripts_and_subplaybooks(self, repo):
         """
 
         Given
@@ -1559,7 +1572,7 @@ class TestPlaybookEntitiesVersionsValid:
                 self.playbook_with_invalid_sub_playbook_version_from_version_5_0_0, playbook.yml.path)
             assert not is_sub_playbook_version_invalid
 
-    def test_are_playbook_entities_versions_valid_skip_unavailable(self, repo, mocker):
+    def test_are_playbook_entities_versions_valid_skip_unavailable(self, repo):
         """
         Given
             - an id_set file


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-3227)

## Description
1) Fixed an issue in the ```PB110``` validation where if we have more than one playbook-id, the validation could fail based on the looping order of those playbook-ids
2) enhance the validation error message
3) refactor the validation logic to be not prone to errors (but the validation itself should behave the same)

error message example:

```
[ERROR]: Packs/CommonPlaybooks/Playbooks/playbook-Search_And_Delete_Emails_-_Generic_-_v2_6_1.yml: [PB110] - Playbook Phishing Investigation - Generic v2 with 'fromversion' 6.0.0 uses the following sub-playbooks along with their invalid 'fromversion': [Packs/CommonPlaybooks/Playbooks/playbook-Search_And_Delete_Emails_-_Generic_-_v2_6_1.yml: 6.1.0]. The 'fromversion' of the sub-playbooks should be 6.0.0 or lower.
```

## Must have
- [x] Tests