### PR TITLE
Add manual integration.

### DIFF
--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -2068,6 +2068,8 @@ class ServerContext:
         self.executed_in_current_round: Set[str] = set()
         self.prev_system_conf: dict = {}
         self.use_retries_mechanism: bool = use_retries_mechanism
+        if IS_XSIAM:
+            self.check_if_can_create_manual_alerts(self.client)
 
     def _execute_unmockable_tests(self):
         """
@@ -2199,6 +2201,17 @@ class ServerContext:
             raise
         finally:
             self.build_context.logging_module.execute_logs()
+
+    def check_if_can_create_manual_alerts(self, client):
+        body = {
+            'query': 'id:"Manual"'
+        }
+        try:
+            res_raw = demisto_client.generic_request_func(self=client, path='/settings/integration/search',
+                                                          method='POST', body=body)
+        except ApiException:
+            # todo: add reason
+            self.build_context.logging_module.exception(f'failed to get integration Manual configuration')
 
 
 def replace_external_playbook_configuration(client: DefaultApi, external_playbook_configuration: dict,

--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -2204,16 +2204,16 @@ class ServerContext:
 
     def check_if_can_create_manual_alerts(self, client):
         """
-        In XSIAM we can't create new incident/alert using API call.
+        In XSIAM we can't create a new incident/alert using API call.
         We need a correlation rule in order to create an alert.
-        We want to create alert manually, when we send an API call to XSIAM server to create new alert.
+        We want to create an alert manually, when we send an API call to XSIAM server to create a new alert.
         Server check which integration sent a new alert, if the request was sent manually and not from integration it
-        sets "sourceBrand" header to be "Manual". XSIAM Server looks for correlation rule for such sourceBrand,
-        and if there is no such correlation rule, no alert will be crated.
-        If there is correlation rule for "Manual" integration the allert will be created.
+        sets "sourceBrand" header to be "Manual". XSIAM Server looks for a correlation rule for such sourceBrand,
+        and if there is no such correlation rule, no alert will be created.
+        If there is a correlation rule for "Manual" integration the allert will be created.
 
         If this step fails please create an integration with id and name "Manual", set isFetch: true for such
-        integration and make sure that corresponding correlation rule created.
+        integration and make sure that the corresponding correlation rule is created.
         """
         body = {
             'query': 'id:"Manual"'

--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -2234,12 +2234,15 @@ class ServerContext:
         all_configurations = res['configurations']
         for instance in all_configurations:
             if instance.get('id') == "Manual":
-                self.build_context.logging_module.info('"Manual" integration found in XSIAM instance.')
+                self.build_context.logging_module.info('Server is able to create manual alerts '
+                                                       '("Manual" integration exists).')
                 return
 
         self.build_context.logging_module.warning('No "Manual" integration found in XSIAM instance. '
                                                   'Adding it in order to create Manual Correlation Rule.')
+        self.create_manual_integration()
 
+    def create_manual_integration(self):
         manual_integration = {
             "name": "Manual",
             "version": 1,

--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -2233,6 +2233,7 @@ class ServerContext:
         all_configurations = res['configurations']
         for instance in all_configurations:
             if instance.get('id') == "Manual":
+                self.build_context.logging_module.info('"Manual" integration found in XSIAM instance.')
                 return
 
         self.build_context.logging_module.error('No "Manual" integration found in XSIAM instance. '


### PR DESCRIPTION
## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
In XSIAM we can't create a new incident/alert using API call.
We need a correlation rule in order to create an alert.
We want to create an alert manually, when we send an API call to XSIAM server to create a new alert.
Server check which integration sent a new alert, if the request was sent manually and not from integration it
sets "sourceBrand" header to be "Manual". XSIAM Server looks for a correlation rule for such sourceBrand,
and if there is no such correlation rule, no alert will be created.
If there is a correlation rule for "Manual" integration the allert will be created.

If this step fails please create an integration with id and name "Manual", set isFetch: true for such
integration and make sure that the corresponding correlation rule is created.

## Must have
- [ ] Tests
- [x] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
