### PR TITLE
fix item filtering in create-content-artifacts

### DIFF
--- a/demisto_sdk/commands/common/content/objects/pack_objects/pack.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/pack.py
@@ -85,7 +85,7 @@ class Pack:
                                                                                     ]:
 
                 object_id = content_object.get_id()
-                if is_object_in_id_set(object_id, self._pack_info_from_id_set):
+                if is_object_in_id_set(object_id, content_object.type().value, self._pack_info_from_id_set):
                     yield content_object
                 else:
                     logging.warning(f'Skipping object {object_path} with id "{object_id}" since it\'s missing from '

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -2046,7 +2046,7 @@ def is_object_in_id_set(object_id, item_type, pack_info_from_id_set):
     """
     content_items = pack_info_from_id_set.get('ContentItems', {})
     items_ids = content_items.get(item_type_to_content_items_header(item_type), [])
-    # logging.warning(f'checking {object_id} as {item_type} (known as {item_type_to_content_items_header(item_type)}) in {items_ids}')
+
     return object_id in items_ids
 
 

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -2019,24 +2019,35 @@ def get_all_incident_and_indicator_fields_from_id_set(id_set_file, entity_type):
     return fields_list
 
 
-def is_object_in_id_set(object_id, pack_info_from_id_set):
+def item_type_to_content_items_header(item_type):
+    converter = {
+        "incidenttype": "incidentType",
+        "indicatortype": "indicatorType",
+        "indicatorfield": "indicatorField",
+        "incidentfield": "incidentField",
+        "layoutscontainer": "layout",
+    }
+
+    return f'{converter.get(item_type, item_type)}s'
+
+
+def is_object_in_id_set(object_id, item_type, pack_info_from_id_set):
     """
         Check if the given object is part of the packs items that are present in the Packs section in the id set.
         This is assuming that the id set is based on the version that has, under each pack, the items it contains.
 
     Args:
         object_name: name of object of interest.
-        pack: the pack this object should belong to.
-        packs_section_from_id_set: the section under the key Packs in the previously given id set.
+        object_type: type of object of interest.
+        packs_section_from_id_set: the pack object under the key Packs in the previously given id set.
 
     Returns:
 
     """
     content_items = pack_info_from_id_set.get('ContentItems', {})
-    for items_type, items_ids in content_items.items():
-        if object_id in items_ids:
-            return True
-    return False
+    items_ids = content_items.get(item_type_to_content_items_header(item_type), [])
+    # logging.warning(f'checking {object_id} as {item_type} (known as {item_type_to_content_items_header(item_type)}) in {items_ids}')
+    return object_id in items_ids
 
 
 def is_string_uuid(string_to_check: str):

--- a/demisto_sdk/commands/create_artifacts/tests/content_artifacts_creator_test.py
+++ b/demisto_sdk/commands/create_artifacts/tests/content_artifacts_creator_test.py
@@ -9,8 +9,7 @@ import pytest
 from demisto_sdk.commands.common.constants import PACKS_DIR, TEST_PLAYBOOKS_DIR
 from demisto_sdk.commands.common.handlers import JSON_Handler, YAML_Handler
 from demisto_sdk.commands.common.logger import logging_setup
-from demisto_sdk.commands.common.tools import (is_object_in_id_set,
-                                               open_id_set_file, src_root)
+from demisto_sdk.commands.common.tools import src_root
 from TestSuite.test_tools import ChangeCWD
 
 json = JSON_Handler()
@@ -352,24 +351,6 @@ def test_sign_packs_failure(repo, capsys, key, tool):
     captured = capsys.readouterr()
     assert 'Failed to sign packs. In order to do so, you need to provide both signature_key and ' \
            'sign_directory arguments.' in captured.out
-
-
-def test_is_object_in_id_set():
-    """
-    Given:
-        - Pack object.
-        - filtered id set.
-    When:
-        - filter-by-id-set flag is on and we are checking if the pack's items exsit in the id set.
-    Then:
-        - Return if the item is in the id set or not.
-
-    """
-    id_set = open_id_set_file(PARTIAL_ID_SET_PATH)
-    packs_section = id_set.get('Packs')
-    pack_name = 'Sample1'
-    assert not is_object_in_id_set('indicator', packs_section[pack_name])
-    assert is_object_in_id_set('scripts-sample_packs', packs_section[pack_name])
 
 
 @pytest.fixture()

--- a/demisto_sdk/commands/find_dependencies/find_dependencies.py
+++ b/demisto_sdk/commands/find_dependencies/find_dependencies.py
@@ -2700,7 +2700,7 @@ def remove_items_from_packs_section(id_set: dict, excluded_items_by_pack: dict) 
         for item_type, item_name in pack_items:
             item_type = item_type_to_content_items_header(item_type)
             try:
-                pack_content_items.get(f'{item_type}s', []).remove(item_name)
+                pack_content_items.get(item_type, []).remove(item_name)
             except ValueError:  # This content item has already been excluded from the id_set
                 pass
 

--- a/demisto_sdk/commands/find_dependencies/find_dependencies.py
+++ b/demisto_sdk/commands/find_dependencies/find_dependencies.py
@@ -16,13 +16,10 @@ from demisto_sdk.commands.common.constants import (
     DEFAULT_CONTENT_ITEM_TO_VERSION, GENERIC_COMMANDS_NAMES,
     IGNORED_PACKS_IN_DEPENDENCY_CALC, PACKS_DIR)
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.common.tools import (ProcessPoolHandler,
-                                               get_content_id_set,
-                                               get_content_path, get_pack_name,
-                                               is_external_repository,
-                                               print_error, print_success,
-                                               print_warning,
-                                               wait_futures_complete)
+from demisto_sdk.commands.common.tools import (
+    ProcessPoolHandler, get_content_id_set, get_content_path, get_pack_name,
+    is_external_repository, item_type_to_content_items_header, print_error,
+    print_success, print_warning, wait_futures_complete)
 from demisto_sdk.commands.common.update_id_set import (
     merge_id_sets, update_excluded_items_dict)
 from demisto_sdk.commands.create_id_set.create_id_set import (IDSetCreator,
@@ -2710,17 +2707,6 @@ def remove_items_from_packs_section(id_set: dict, excluded_items_by_pack: dict) 
         # if no content items left, remove the pack from the id_set
         if pack not in constants.ALLOWED_EMPTY_PACKS and not sum(pack_content_items.values(), []):
             packs_section_from_id_set.pop(pack)
-
-
-def item_type_to_content_items_header(item_type):
-    converter = {
-        "incidenttype": "incidentType",
-        "indicatortype": "indicatorType",
-        "indicatorfield": "indicatorField",
-        "incidentfield": "incidentField"
-    }
-
-    return converter.get(item_type, item_type)
 
 
 def remove_items_from_content_entities_sections(id_set: dict, excluded_items_by_type: dict):


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Fixed an issue where in the `create-content-artifacts` command where item filtering did not exclude some items.

related to: https://panw-global.slack.com/archives/G011E63JXPB/p1656252244205309