### PR TITLE
ignore devcontainer folder in validate

### DIFF
--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -1705,7 +1705,7 @@ class ValidateManager:
             - true if the file type is supported, false otherwise
         """
         irrelevant_file_output = '', '', True
-        if file_path.split(os.path.sep)[0] in ('.gitlab', '.circleci', '.github'):
+        if file_path.split(os.path.sep)[0] in ('.gitlab', '.circleci', '.github', '.devcontainer'):
             return irrelevant_file_output
 
         file_type = find_type(file_path)


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
We want to ignore `.devcontainer` folder in validate as we ignor `.github`, `circleci`, etc...
## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
