### PR TITLE
Do not crash when unable to `_get_repository_properties`

### DIFF
--- a/demisto_sdk/commands/common/git_content_config.py
+++ b/demisto_sdk/commands/common/git_content_config.py
@@ -128,7 +128,8 @@ class GitContentConfig:
                 parsed_git = giturlparse.parse(url)
                 if parsed_git and parsed_git.host and parsed_git.repo:
                     return parsed_git
-        except (InvalidGitRepositoryError, AttributeError):
+        except Exception as e:
+            logger.debug(f'Could not get repository properties: {e}')
             return None
         return None
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-3466?filter=-1
## Description
Sometimes we are unable to get repo propeties. If this is the case, we should not crash, just to print a debug message and continue.

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
