### PR TITLE
Improve CI UT parallelization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,8 @@ jobs:
             path: test-results
         - store_artifacts:
             path: coverage_html_report
+        - store_artifacts:
+            path: test-results/junit.xml
         - run:
             name: Coveralls upload
             command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
               TEST_FILES=$(echo "$TEST_FILES" | circleci tests split --split-by=timings)
 
               mkdir test-results
-              poetry run pytest -v --cov=demisto_sdk --cov-report=html --junitxml=test-results/junit.xml $TEST_FILES
+              poetry run pytest -v --cov=demisto_sdk --cov-report=html --junitxml=test-results/junit.xml junit_family=xunit1 $TEST_FILES
         - store_test_results:
             path: test-results
         - store_artifacts:


### PR DESCRIPTION
Changing the junit-family value to `junit1`, which does include the file name, required for CircleCI parallelization.