### PR TITLE
Allow generate-docs to run on folders (Multiple files)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 * Updated the default general `fromVersion` value on **format** to `6.5.0`
 * Fixed an issue where the **validate** command did not fail when the integration yml file name was not the same as the folder containing it.
+* Allowed generate-docs command to get a whole pack and not just a single yml file.
 
 ## 1.7.0
 * Allowed JSON Handlers to accept kwargs, for custoimzing behavior.

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -1412,20 +1412,20 @@ def generate_docs(**kwargs):
         print_error(F'Output directory {output_path} was not found.')
         return 1
 
-    # Add support for input which is a pack and not a single yml file
-    if input_path and os.path.isdir(input_path) and os.path.basename(os.path.dirname(input_path)) == 'Packs':
+    # Add support for input which is a Playbooks directory and not a single yml file
+    if input_path and os.path.isdir(input_path) and os.path.basename(os.path.basename(input_path)) == 'Playbooks':
         for root, subdirs, files in os.walk(input_path):
             for file in files:
-                # Pack can contain non-yml files, so continue - this is not an error
+                # Playbooks directory can contain non-yml files, so continue - this is not an error
                 if not file.lower().endswith('.yml'):
                     continue
                 new_kwargs = copy.deepcopy(kwargs)
                 new_kwargs['input'] = f'{root}/{file}'
-                generate_docs_helper(new_kwargs, True)
+                generate_docs_helper(new_kwargs)
 
     # A single yml file
     elif input_path and os.path.isfile(input_path):
-        generate_docs_helper(kwargs, False)
+        generate_docs_helper(kwargs)
 
     else:
         print_error(F'Input {input_path} is not a valid yml file or a valid pack.')
@@ -1434,8 +1434,8 @@ def generate_docs(**kwargs):
     return 0
 
 
-def generate_docs_helper(kwargs, is_pack: bool):
-    """Helper function for supporting pack as an input and not only a single yml file."""
+def generate_docs_helper(kwargs):
+    """Helper function for supporting Playbooks directory as an input and not only a single yml file."""
 
     from demisto_sdk.commands.generate_docs.generate_integration_doc import \
         generate_integration_doc
@@ -1465,7 +1465,7 @@ def generate_docs_helper(kwargs, is_pack: bool):
             return 1
 
     file_type = find_type(kwargs.get('input', ''), ignore_sub_categories=True)
-    if not is_pack and file_type not in [FileType.INTEGRATION, FileType.SCRIPT, FileType.PLAYBOOK]:
+    if file_type not in [FileType.INTEGRATION, FileType.SCRIPT, FileType.PLAYBOOK]:
         print_error('File is not an Integration, Script or a Playbook.')
         return 1
 
@@ -1496,8 +1496,6 @@ def generate_docs_helper(kwargs, is_pack: bool):
         print(f'Start generating {file_type.value} documentation...')
         return generate_playbook_doc(input_path=input_path, output=output_path, permissions=permissions,
                                      limitations=limitations, verbose=verbose, custom_image_path=custom_image_path)
-    elif is_pack:  # Pack may contain yml files of other types
-        return 0
     else:
         print_error(f'File type {file_type.value} is not supported.')
         return 1

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -6,7 +6,7 @@ import sys
 import tempfile
 from configparser import ConfigParser, MissingSectionHeaderError
 from pathlib import Path
-from typing import IO, Any
+from typing import IO, Any, Dict
 
 import click
 import git
@@ -1393,7 +1393,7 @@ def generate_docs(**kwargs):
     """Generate documentation for integration, playbook or script from yaml file."""
 
     check_configuration_file('generate-docs', kwargs)
-    input_path_str: str = kwargs.get('input')
+    input_path_str: str = kwargs.get('input', '')
     if not (input_path := Path(input_path_str)).exists():
         print_error(f'input {input_path_str} does not exist')
         return 1
@@ -1422,7 +1422,7 @@ def generate_docs(**kwargs):
     return 0
 
 
-def _generate_docs_for_file(kwargs: dict[str, Any]):
+def _generate_docs_for_file(kwargs: Dict[str, Any]):
     """Helper function for supporting Playbooks directory as an input and not only a single yml file."""
 
     from demisto_sdk.commands.generate_docs.generate_integration_doc import \

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -27,7 +27,6 @@ from demisto_sdk.commands.split.ymlsplitter import YmlSplitter
 
 json = JSON_Handler()
 
-
 # Third party packages
 
 # Common tools
@@ -142,8 +141,7 @@ def main(config, version, release_notes):
             __version__ = get_distribution('demisto-sdk').version
         except DistributionNotFound:
             __version__ = 'dev'
-            print_warning(
-                'Cound not find the version of the demisto-sdk. This usually happens when running in a development environment.')
+            print_warning('Cound not find the version of the demisto-sdk. This usually happens when running in a development environment.')
         else:
             last_release = get_last_remote_release_version()
             print_warning(f'You are using demisto-sdk {__version__}.')
@@ -278,8 +276,7 @@ def extract_code(config, **kwargs):
     '-h', '--help'
 )
 @click.option(
-    "-i", "--input", help="The directory path to the files or path to the file to unify", required=True,
-    type=click.Path(dir_okay=True)
+    "-i", "--input", help="The directory path to the files or path to the file to unify", required=True, type=click.Path(dir_okay=True)
 )
 @click.option(
     "-o", "--output", help="The output dir to write the unified yml to", required=False
@@ -564,14 +561,12 @@ def validate(config, **kwargs):
 @click.option('-mp', '--marketplace', help='The marketplace the artifacts are created for, that '
                                            'determines which artifacts are created for each pack. '
                                            'Default is the XSOAR marketplace, that has all of the packs '
-                                           'artifacts.', default='xsoar',
-              type=click.Choice(['xsoar', 'marketplacev2', 'v2']))
+                                           'artifacts.', default='xsoar', type=click.Choice(['xsoar', 'marketplacev2', 'v2']))
 @click.option('-fbi', '--filter-by-id-set', is_flag=True,
               help='Whether to use the id set as content items guide, meaning only include in the packs the '
                    'content items that appear in the id set.', default=False, hidden=True)
 @click.option('-af', '--alternate-fields', is_flag=True,
-              help='Use the alternative fields if such are present in the yml or json of the content item.',
-              default=False, hidden=True)
+              help='Use the alternative fields if such are present in the yml or json of the content item.', default=False, hidden=True)
 def create_content_artifacts(**kwargs) -> int:
     """Generating the following artifacts:
        1. content_new - Contains all content objects of type json,yaml (from_version < 6.0.0)
@@ -686,10 +681,9 @@ def secrets(config, **kwargs):
                                             "--check-dependent-api-module flag.",
               type=click.Path(resolve_path=True),
               default='Tests/id_set.json')
-@click.option("-cdam", "--check-dependent-api-module", is_flag=True,
-              help="Run unit tests and lint on all packages that "
-                   "are dependent on the found "
-                   "modified api modules.", default=False)
+@click.option("-cdam", "--check-dependent-api-module", is_flag=True, help="Run unit tests and lint on all packages that "
+              "are dependent on the found "
+              "modified api modules.", default=False)
 @click.option("--time-measurements-dir", help="Specify directory for the time measurements report file",
               type=PathsParamType())
 def lint(**kwargs):
@@ -1394,8 +1388,7 @@ def init(**kwargs):
 @click.option(
     "--skip-breaking-changes", is_flag=True, help="Skip generating of breaking changes section.")
 @click.option(
-    "--custom-image-path",
-    help="A custom path to a playbook image. If not stated, a default link will be added to the file.")
+    "--custom-image-path", help="A custom path to a playbook image. If not stated, a default link will be added to the file.")
 def generate_docs(**kwargs):
     """Generate documentation for integration, playbook or script from yaml file."""
 

--- a/demisto_sdk/tests/integration_tests/generate_docs_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/generate_docs_integration_test.py
@@ -97,7 +97,8 @@ class TestPlaybooks:
         - Ensure integration dependencies exists.
         - Ensure Builtin not in dependencies.
         """
-        valid_playbook_with_dependencies = join(DEMISTO_SDK_PATH, "tests/test_files/Packs/DummyPack/Playbooks/DummyPlaybook.yml")
+        valid_playbook_with_dependencies = join(DEMISTO_SDK_PATH,
+                                                "tests/test_files/Packs/DummyPack/Playbooks/DummyPlaybook.yml")
         runner = CliRunner(mix_stderr=False)
         arguments = [
             GENERATE_DOCS_CMD,
@@ -131,7 +132,8 @@ class TestPlaybooks:
         - Ensure integration dependencies exists.
         - Ensure Builtin not in dependencies.
         """
-        valid_playbook_with_dependencies = join(DEMISTO_SDK_PATH, "tests/test_files/Packs/CortexXDR/Playbooks/Cortex_XDR_Incident_Handling.yml")
+        valid_playbook_with_dependencies = join(DEMISTO_SDK_PATH,
+                                                "tests/test_files/Packs/CortexXDR/Playbooks/Cortex_XDR_Incident_Handling.yml")
         runner = CliRunner(mix_stderr=False)
         arguments = [
             GENERATE_DOCS_CMD,
@@ -150,6 +152,51 @@ class TestPlaybooks:
             contents = readme_file.read()
             assert 'Builtin' not in contents
             assert '### Integrations\n* PaloAltoNetworks_XDR\n' in contents
+
+    def test_integration_generate_docs_positive_with_and_without_io(self, tmpdir):
+        """
+        Given
+        - Path to valid Playbook directory which contains two yml files to generate docs for.
+        - Path to directory to write the README.md files.
+        - The first playbook has inputs, the second does not have inputs.
+        - The first playbook has outputs, the second does not have outputs.
+
+        When
+        - Running the generate-docs command for both files.
+
+        Then
+        - Ensure two README.md are created.
+        - Ensure the first README.md has an inputs section.
+        - Ensure the second README.md does not have an inputs section.
+        - Ensure the first README.md has an outputs section.
+        - Ensure the second README.md does not have an outputs section.
+        """
+        valid_playbook_dir = join(DEMISTO_SDK_PATH, "tests/test_files/Playbooks")
+        runner = CliRunner(mix_stderr=False)
+        arguments = [
+            GENERATE_DOCS_CMD,
+            '-i', valid_playbook_dir,
+            '-o', tmpdir
+        ]
+        result = runner.invoke(main, arguments)
+        readme_path_1 = join(tmpdir, 'playbook-Test_playbook_README.md')
+        readme_path_2 = join(tmpdir, 'Playbooks.playbook-test_README.md')
+
+        assert result.exit_code == 0
+        assert 'Start generating playbook documentation...' in result.stdout
+        assert not result.stderr
+        assert not result.exception
+        assert Path(readme_path_1).exists()
+        with open(readme_path_1, 'r') as readme_file:
+            contents = readme_file.read()
+            assert '| **Name** | **Description** | **Default Value** | **Required** |' in contents
+            assert '| **Path** | **Description** | **Type** |' in contents
+
+        assert Path(readme_path_2).exists()
+        with open(readme_path_2, 'r') as readme_file:
+            contents = readme_file.read()
+            assert 'There are no inputs for this playbook.' in contents
+            assert 'There are no outputs for this playbook.' in contents
 
 
 @pytest.mark.skip(reason='Just place-holder stubs for later implementation')

--- a/demisto_sdk/tests/test_files/Playbooks/Playbooks.playbook-test.yml
+++ b/demisto_sdk/tests/test_files/Playbooks/Playbooks.playbook-test.yml
@@ -1,0 +1,170 @@
+id: Account Enrichment
+version: -1
+name: Account Enrichment
+fromversion: 5.0.0
+description: Enrich the accounts under the Account context key with details from relevant
+  integrations such as AD.
+starttaskid: "0"
+tasks:
+  "0":
+    id: "0"
+    taskid: 065b25dc-7aad-4356-8bee-261b189251b3
+    type: start
+    task:
+      id: 065b25dc-7aad-4356-8bee-261b189251b3
+      version: -1
+      name: ""
+      description: ""
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "4"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 162.5,
+          "y": 50
+        }
+      }
+    note: false
+  "1":
+    id: "1"
+    taskid: be4d8a4d-14b5-4541-8d40-1df25ef145c6
+    type: condition
+    task:
+      id: be4d8a4d-14b5-4541-8d40-1df25ef145c6
+      version: -1
+      name: Is AD configured?
+      description: Check if a given value exists in the context. Will return 'no'
+        for empty empty arrays. To be used mostly with DQ and selectors.
+      scriptName: Exists
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "3"
+      "yes":
+      - "2"
+    scriptarguments:
+      value:
+        simple: ${modules.brand(val === 'activedir')}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 370
+        }
+      }
+    note: false
+  "2":
+    id: "2"
+    taskid: c7455a4b-be90-45c3-83be-a290e2660432
+    type: regular
+    task:
+      id: c7455a4b-be90-45c3-83be-a290e2660432
+      version: -1
+      name: Query AD to get user details
+      description: Query “Active Directory” for the email address info
+      scriptName: ADGetUser
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "3"
+    scriptarguments:
+      attributes: {}
+      customFieldData:
+        simple: ${Account.Email.Address}
+      customFieldType:
+        simple: mail
+      dn: {}
+      email: {}
+      headers: {}
+      limit: {}
+      name: {}
+      nestedSearch: {}
+      userAccountControlOut: {}
+      username: {}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 162.5,
+          "y": 545
+        }
+      }
+    note: false
+    isoversize: false
+    isautoswitchedtoquietmode: false
+  "3":
+    id: "3"
+    taskid: 561f7e3c-e8cf-4f68-8bbe-64c7cb608995
+    type: title
+    task:
+      id: 561f7e3c-e8cf-4f68-8bbe-64c7cb608995
+      version: -1
+      name: User Enrichment Done
+      description: ""
+      type: title
+      iscommand: false
+      brand: ""
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 162.5,
+          "y": 720
+        }
+      }
+    note: false
+  "4":
+    id: "4"
+    taskid: 7e9ec3ab-29e0-458a-8a61-7ca559f4b428
+    type: condition
+    task:
+      id: 7e9ec3ab-29e0-458a-8a61-7ca559f4b428
+      version: -1
+      name: Check if there is an Email address
+      description: Check if there is an Email address.
+      scriptName: Exists
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "3"
+      "yes":
+      - "1"
+    scriptarguments:
+      value:
+        simple: ${Account.Email.Address}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 162.5,
+          "y": 195
+        }
+      }
+    note: false
+view: |-
+  {
+    "linkLabelsPosition": {},
+    "paper": {
+      "dimensions": {
+        "height": 735,
+        "width": 492.5,
+        "x": 50,
+        "y": 50
+      }
+    }
+  }
+inputs: []
+outputs: []
+tests:
+  - PagerDuty Test

--- a/demisto_sdk/tests/test_files/Playbooks/playbook-Test_playbook.yml
+++ b/demisto_sdk/tests/test_files/Playbooks/playbook-Test_playbook.yml
@@ -1,0 +1,205 @@
+id: Test playbook
+version: 11
+name: Test playbook
+starttaskid: "0"
+tasks:
+  "0":
+    id: "0"
+    taskid: df426ee9-d162-4855-8c5b-0fe6f415d31d
+    type: start
+    task:
+      id: df426ee9-d162-4855-8c5b-0fe6f415d31d
+      version: -1
+      name: ""
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "1"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 50
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "1":
+    id: "1"
+    taskid: ad563d96-52f2-45a6-8bfc-1e509f96bc7d
+    type: regular
+    task:
+      id: ad563d96-52f2-45a6-8bfc-1e509f96bc7d
+      version: -1
+      name: Gmail search
+      description: Searches for Gmail records of a specified Google user.
+      script: Gmail|||gmail-search
+      type: regular
+      iscommand: true
+      brand: Gmail
+    nexttasks:
+      '#none#':
+      - "2"
+    scriptarguments:
+      after: {}
+      before: {}
+      fields: {}
+      filename: {}
+      from: {}
+      has-attachments: {}
+      in: {}
+      include-spam-trash: {}
+      labels-ids: {}
+      max-results: {}
+      page-token: {}
+      query: {}
+      subject: {}
+      to: {}
+      user-id:
+        simple: koko@demisto.com
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 195
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "2":
+    id: "2"
+    taskid: b1ba6ee2-a80a-4fb3-8ba3-d689d599444c
+    type: regular
+    task:
+      id: b1ba6ee2-a80a-4fb3-8ba3-d689d599444c
+      version: -1
+      name: Read file
+      description: Load the contents of a file into context.
+      scriptName: ReadFile
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "4"
+    scriptarguments:
+      encoding: {}
+      entryID:
+        simple: entryId
+      maxFileSize: {}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 370
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "3":
+    id: "3"
+    taskid: c496302f-4d40-4412-86a8-da1c355b039b
+    type: title
+    task:
+      id: c496302f-4d40-4412-86a8-da1c355b039b
+      version: -1
+      name: Done
+      type: title
+      iscommand: false
+      brand: ""
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 720
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "4":
+    id: "4"
+    taskid: 38c6ac55-ffd2-47cc-81ab-cd80d63efe9c
+    type: playbook
+    task:
+      id: 38c6ac55-ffd2-47cc-81ab-cd80d63efe9c
+      version: -1
+      name: Get Original Email - Gmail
+      playbookName: Get Original Email - Gmail
+      type: playbook
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "3"
+    separatecontext: true
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 545
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+view: |-
+  {
+    "linkLabelsPosition": {},
+    "paper": {
+      "dimensions": {
+        "height": 735,
+        "width": 380,
+        "x": 50,
+        "y": 50
+      }
+    }
+  }
+inputs:
+- key: InputA
+  value:
+    complex:
+      root: File
+      accessor: Name
+  required: false
+  description: ""
+- key: InputB
+  value:
+    simple: johnnydepp@gmail.com
+  required: true
+  description: This is input b
+- key: ""
+  value: {}
+  required: false
+  description: ""
+  playbookInputQuery:
+    query: (type:ip or type:file or type:Domain or type:URL) -tags:pending_review
+      and (tags:approved_black or tags:approved_white or tags:approved_watchlist)
+    queryEntity: indicators
+    results: null
+    daterange:
+      fromdate: 0001-01-01T00:00:00Z
+      todate: 0001-01-01T00:00:00Z
+      period:
+        by: ""
+        byto: ""
+        byfrom: ""
+        tovalue: null
+        fromvalue: null
+        field: ""
+      fromdatelicenseval: 0001-01-01T00:00:00Z
+    runFromLastJobTime: false
+outputs:
+- contextPath: Email.To
+  description: The recipient of the email.
+  type: string
+- contextPath: FileData
+  type: string


### PR DESCRIPTION

## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
[fixes: link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-3311)

## Description
At the moment the only input allowed for generate-docs is a single file, we upgrade it to allow the command to work on a whole pack.

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
