### PR TITLE
Dev-Bug - error when trying to get file dict of a deleted file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Updated the default general `fromVersion` value on **format** to `6.5.0`
 * Fixed an issue where the **validate** command did not fail when the integration yml file name was not the same as the folder containing it.
 * Added an option to have **generate-docs** take a Playbooks folder path as input, and generate docs for all playbooks in it.
+* Fixed an issue where **validate** did not properly detect deleted files.
 
 ## 1.7.0
 * Allowed JSON Handlers to accept kwargs, for custoimzing behavior.
@@ -64,7 +65,6 @@
 * Locked the dependency on Docker.
 * Removed a traceback line from the **init** command templates: BaseIntegration, BaseScript.
 * Updated the token in **_add_pr_comment** method from the content-bot token to the xsoar-bot token.
-* Fixed an issue in the **validate** command when validating deleted files.
 
 ## 1.6.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 * Locked the dependency on Docker.
 * Removed a traceback line from the **init** command templates: BaseIntegration, BaseScript.
 * Updated the token in **_add_pr_comment** method from the content-bot token to the xsoar-bot token.
+* Fixed an issue in the **validate** command when validating deleted files.
 
 ## 1.6.7
 

--- a/demisto_sdk/commands/common/hook_validations/base_validator.py
+++ b/demisto_sdk/commands/common/hook_validations/base_validator.py
@@ -18,7 +18,7 @@ from demisto_sdk.commands.common.errors import (ALLOWED_IGNORE_ERRORS,
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.tools import (
     find_type, get_file_displayed_name, get_json, get_pack_name,
-    get_relative_path_from_packs_dir, get_yaml)
+    get_relative_path_from_packs_dir, get_yaml, print_warning)
 
 json = JSON_Handler()
 
@@ -165,7 +165,10 @@ class BaseValidator:
                 file_path = str(file_path)
 
             file_name = os.path.basename(file_path)
-            self.check_file_flags(file_name, file_path)
+            try:
+                self.check_file_flags(file_name, file_path)
+            except FileNotFoundError:
+                print_warning(f'File {file_path} not found, cannot check its flags (deprecated, etc)')
 
             rel_file_path = get_relative_path_from_packs_dir(file_path)
 

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -1414,7 +1414,7 @@ def find_type(
             return None
         raise err
 
-    if file_type == 'yml':
+    if file_type == 'yml' or path.endswith('.yml'):
         if 'category' in _dict:
             if _dict.get('beta') and not ignore_sub_categories:
                 return FileType.BETA_INTEGRATION
@@ -1443,7 +1443,7 @@ def find_type(
         if 'global_rule_id' in _dict:
             return FileType.CORRELATION_RULE
 
-    if file_type == 'json':
+    if file_type == 'json' or path.endswith('.json'):
         if 'widgetType' in _dict:
             return FileType.WIDGET
 

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -1414,7 +1414,7 @@ def find_type(
             return None
         raise err
 
-    if file_type == 'yml' or path.endswith('.yml'):
+    if file_type == 'yml' or path.lower().endswith('.yml'):
         if 'category' in _dict:
             if _dict.get('beta') and not ignore_sub_categories:
                 return FileType.BETA_INTEGRATION
@@ -1443,7 +1443,7 @@ def find_type(
         if 'global_rule_id' in _dict:
             return FileType.CORRELATION_RULE
 
-    if file_type == 'json' or path.endswith('.json'):
+    if file_type == 'json' or path.lower().endswith('.json'):
         if 'widgetType' in _dict:
             return FileType.WIDGET
 

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -1859,7 +1859,7 @@ def test_validate_deleted_files(capsys, file_set, expected_output, expected_resu
     validate_manager = ValidateManager(check_is_unskipped=False, skip_conf_json=True)
     if added_files:
         mocker.patch('demisto_sdk.commands.validate.validate_manager._get_file_id', return_value='playbook')
-        mocker.patch('demisto_sdk.commands.validate.validate_manager.get_file', return_value={'id': 'id'})
+        mocker.patch('demisto_sdk.commands.validate.validate_manager.get_remote_file', return_value={'id': 'id'})
 
     result = validate_manager.validate_deleted_files(file_set, added_files)
 

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -1346,7 +1346,7 @@ class ValidateManager:
 
         """
         file_path = str(file_path)
-        file_dict = get_remote_file(file_path)
+        file_dict = get_remote_file(file_path, tag='master')
         file_type = find_type(file_path, file_dict)
         return file_type in FileType_ALLOWED_TO_DELETE or not file_type
 

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -102,8 +102,8 @@ from demisto_sdk.commands.common.tools import (
     _get_file_id, find_type, get_api_module_ids,
     get_api_module_integrations_set, get_content_path, get_file,
     get_pack_ignore_file_path, get_pack_name, get_pack_names_from_files,
-    get_relative_path_from_packs_dir, get_yaml, open_id_set_file,
-    run_command_os)
+    get_relative_path_from_packs_dir, get_remote_file, get_yaml,
+    open_id_set_file, run_command_os)
 from demisto_sdk.commands.create_id_set.create_id_set import IDSetCreator
 
 SKIPPED_FILES = ['CommonServerPython.py', 'CommonServerUserPython.py', 'demistomock.py']
@@ -859,9 +859,9 @@ class ValidateManager:
 
         validation_results.add(self.validate_modified_files(modified_files))
         validation_results.add(self.validate_added_files(added_files, modified_files))
+        validation_results.add(self.validate_deleted_files(deleted_files, added_files))
         validation_results.add(self.validate_changed_packs_unique_files(modified_files, added_files, old_format_files,
                                                                         changed_meta_files))
-        validation_results.add(self.validate_deleted_files(deleted_files, added_files))
 
         if old_format_files:
             click.secho(f'\n================= Running validation on old format files =================',
@@ -1345,11 +1345,12 @@ class ValidateManager:
 
         """
         file_path = str(file_path)
-        file_type = find_type(file_path)
+        file_dict = get_remote_file(file_path)
+        file_type = find_type(file_path, file_dict)
         return file_type in FileType_ALLOWED_TO_DELETE or not file_type
 
     @staticmethod
-    def was_file_renamed_but_labeled_as_deleted(file_path, added_files):
+    def was_file_renamed_but_labeled_as_deleted(deleted_file_path, added_files):
         """ Check if a file was renamed and not deleted (git false label the file as deleted)
         Args:
             file_path: The file path.
@@ -1358,15 +1359,16 @@ class ValidateManager:
 
         """
         if added_files:
-            file_path = str(file_path)
-            if file_type := find_type(file_path):
-                deleted_file_dict = get_file(file_path, file_type)
-                deleted_file_id = _get_file_id(file_path, deleted_file_dict)
+            deleted_file_path = str(deleted_file_path)
+            deleted_file_dict = get_remote_file(deleted_file_path)
+            if deleted_file_type := find_type(deleted_file_path, deleted_file_dict):
+                deleted_file_id = _get_file_id(deleted_file_type.value, deleted_file_dict)
                 if deleted_file_id:
                     for file in added_files:
                         file = str(file)
-                        file_dict = get_file(file, find_type(file))
-                        if deleted_file_id == _get_file_id(file, file_dict):
+                        file_type = find_type(file)
+                        file_dict = get_file(file, file_type.value)
+                        if deleted_file_id == _get_file_id(file_type.value, file_dict):
                             return True
         return False
 
@@ -1390,7 +1392,7 @@ class ValidateManager:
                     if not self.is_file_allowed_to_be_deleted(file_path):
                         file_path = str(file_path)
                         error_message, error_code = Errors.file_cannot_be_deleted(file_path)
-                        if self.handle_error(error_message, error_code, file_path):
+                        if self.handle_error(error_message, error_code, ''):
                             is_valid = False
 
         return is_valid

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -859,9 +859,9 @@ class ValidateManager:
 
         validation_results.add(self.validate_modified_files(modified_files))
         validation_results.add(self.validate_added_files(added_files, modified_files))
-        validation_results.add(self.validate_deleted_files(deleted_files, added_files))
         validation_results.add(self.validate_changed_packs_unique_files(modified_files, added_files, old_format_files,
                                                                         changed_meta_files))
+        validation_results.add(self.validate_deleted_files(deleted_files, added_files))
 
         if old_format_files:
             click.secho(f'\n================= Running validation on old format files =================',

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -1361,7 +1361,7 @@ class ValidateManager:
         """
         if added_files:
             deleted_file_path = str(deleted_file_path)
-            deleted_file_dict = get_remote_file(deleted_file_path)
+            deleted_file_dict = get_remote_file(deleted_file_path, tag='master')  # for detecting deleted files
             if deleted_file_type := find_type(deleted_file_path, deleted_file_dict):
                 deleted_file_id = _get_file_id(deleted_file_type.value, deleted_file_dict)
                 if deleted_file_id:
@@ -1393,7 +1393,7 @@ class ValidateManager:
                     if not self.is_file_allowed_to_be_deleted(file_path):
                         file_path = str(file_path)
                         error_message, error_code = Errors.file_cannot_be_deleted(file_path)
-                        if self.handle_error(error_message, error_code, ''):
+                        if self.handle_error(error_message, error_code, file_path):
                             is_valid = False
 
         return is_valid


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-3564)

## Description
Raised exception when trying to fetch a file that was deleted locally. Changed to `get_remote_file` , and updated `get_type` command to support files without file type (files that we can assume the `file_type` by the path suffix)

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
