### PR TITLE
Lowercased field name in IF113 suggestion

### DIFF
--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -2258,8 +2258,8 @@ class Errors:
         return f"To fix the problem, add pack name prefix to the field name. " \
                f"You can use the pack name or one of the prefixes found in the itemPrefix field in the pack_metadata. " \
                f"Example: {pack_prefix} {field_name}.\n" \
-               f"Also make sure to update the field id and cliName accordingly. " \
-               f"Example: cliName: {pack_prefix.replace(' ', '').lower()}{field_name.replace(' ', '')}, "
+               f"Also, make sure to update the field id and cliName accordingly. " \
+               f"Example: cliName: {pack_prefix.replace(' ', '').lower()}{field_name.replace(' ', '').lower()}."
 
     @staticmethod
     @error_code_decorator


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)


## Description
When using `itemPrefix` field in `pack_metadata.json` and the field name is invalid (error code `IF113`), the suggestion incorrectly prompts the contributor to set the `cliName` to a value which includes uppercase letters.

An example of this can be found [here](https://app.circleci.com/pipelines/github/demisto/content/177075/workflows/ca8e64c7-4135-4c2f-b8b7-ab624495c92a/jobs/543370?invite=true#step-108-144):

```
[ERROR]: Packs/Vectra_AI/IncidentFields/incidentfield-Certainty_Score.json: [IF113] - Field name: Certainty Score is invalid. Field name must start with the relevant pack name.
To fix the problem, add pack name prefix to the field name. You can use the pack name or one of the prefixes found in the itemPrefix field in the pack_metadata. Example: Vectra AI Certainty Score.
Also make sure to update the field id and cliName accordingly. Example: cliName: vectraaiCertaintyScore
```

The correct message in this case should be:

```
Also make sure to update the field id and cliName accordingly. Example: cliName: vectraaicertaintyscore
```

This PR was opened to fix this issue.