### PR TITLE
ALLOWED REPOS were never checked

### DIFF
--- a/demisto_sdk/commands/common/git_content_config.py
+++ b/demisto_sdk/commands/common/git_content_config.py
@@ -105,7 +105,7 @@ class GitContentConfig:
             repo_name = parsed_git.repo
             if '@' in parsed_git.host:  # the library sometimes returns hostname as <username>@<hostname>
                 hostname = parsed_git.host.split('@')[1]  # to get proper hostname, without the username or tokens
-        if (self.repo_hostname, self.current_repository) not in GitContentConfig.ALLOWED_REPOS or \
+        if (self.repo_hostname, self.current_repository) not in GitContentConfig.ALLOWED_REPOS and \
            (self.repo_hostname, self.project_id) not in GitContentConfig.ALLOWED_REPOS:
             self._set_repo_config(hostname, organization, repo_name, project_id)  # type: ignore[arg-type]
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Condition was always true, we need to check `and`, not `or`.

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
