### PR TITLE
fix bug in MP-106 validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-* Fixed an issue in the **validate** command where incident fields were not found in mappers even when they exist 
+* Fixed an issue in the **validate** command where incident fields were not found in mappers even when they exist
 * Added an ability to provide list of marketplace names as a param attribute to **validate** and **upload**
 * Added the file type to the error message when it is not supported.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Fixed an issue in the **validate** command where incident fields were not found in mappers even when they exist 
 * Added an ability to provide list of marketplace names as a param attribute to **validate** and **upload**
 * Added the file type to the error message when it is not supported.
 

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -2909,10 +2909,9 @@ def get_invalid_incident_fields_from_mapper(
         if mapping_type == "mapping-outgoing":
             # for inc timer type: "field.StartDate, and for using filters: "simple": "".
             if simple := inc_info.get('simple'):
-                simple = simple.lower()
                 if '.' in simple:
                     simple = simple.split('.')[0]
-                if simple not in content_fields:
+                if simple not in content_fields and simple.lower() not in content_fields:
                     non_existent_fields.append(inc_name)
 
     return non_existent_fields

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -2909,6 +2909,7 @@ def get_invalid_incident_fields_from_mapper(
         if mapping_type == "mapping-outgoing":
             # for inc timer type: "field.StartDate, and for using filters: "simple": "".
             if simple := inc_info.get('simple'):
+                simple = simple.lower()
                 if '.' in simple:
                     simple = simple.split('.')[0]
                 if simple not in content_fields:


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
fixes an issue where an incident field that actually exist in build in fields is not recognized correctly by the validation due to case-sensitive  