### PR TITLE
Add continueonerrortype to Playbook Schema

### DIFF
--- a/demisto_sdk/commands/common/schemas/playbook.yml
+++ b/demisto_sdk/commands/common/schemas/playbook.yml
@@ -251,7 +251,7 @@ mapping:
           continueonerror:
             type: bool
           continueonerrortype:
-            typ: str
+            type: str
             enum: ["errorPath", ""]
           reputationcalc:
             type: int

--- a/demisto_sdk/commands/common/schemas/playbook.yml
+++ b/demisto_sdk/commands/common/schemas/playbook.yml
@@ -250,6 +250,9 @@ mapping:
               - type: str
           continueonerror:
             type: bool
+          continueonerrortype:
+            typ: str
+            enum: ["errorPath", ""]
           reputationcalc:
             type: int
           separatecontext:


### PR DESCRIPTION
This is a new field in Demisto 6.8. A little disappointed to start seeing this error on demisto-sdk 😅

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Add the new field from Demisto 6.8 to the schema

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
