### PR TITLE
Content path reform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Fixed an issue when various **demisto-sdk** commands fails when running from a **content** subdirectory.
+* Fixed an issue when running from a subdirectory of a content repo failed.
 
 ## 1.7.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fixed an issue when various **demisto-sdk** commands fails when running from a **content** subdirectory.
+
 ## 1.7.2
 
 * Fixed an issue in the **validate** command where incident fields were not found in mappers even when they exist

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -14,8 +14,9 @@ from pkg_resources import DistributionNotFound, get_distribution
 
 from demisto_sdk.commands.common.configuration import Configuration
 from demisto_sdk.commands.common.constants import (
-    ALL_PACKS_DEPENDENCIES_DEFAULT_PATH, ENV_DEMISTO_SDK_MARKETPLACE,
+    ENV_DEMISTO_SDK_MARKETPLACE,
     MODELING_RULES_DIR, PARSING_RULES_DIR, FileType, MarketplaceVersions)
+from demisto_sdk.commands.common.content_constant_paths import ALL_PACKS_DEPENDENCIES_DEFAULT_PATH
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.tools import (find_type,
                                                get_last_remote_release_version,

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -13,10 +13,12 @@ import git
 from pkg_resources import DistributionNotFound, get_distribution
 
 from demisto_sdk.commands.common.configuration import Configuration
-from demisto_sdk.commands.common.constants import (
-    ENV_DEMISTO_SDK_MARKETPLACE,
-    MODELING_RULES_DIR, PARSING_RULES_DIR, FileType, MarketplaceVersions)
-from demisto_sdk.commands.common.content_constant_paths import ALL_PACKS_DEPENDENCIES_DEFAULT_PATH
+from demisto_sdk.commands.common.constants import (ENV_DEMISTO_SDK_MARKETPLACE,
+                                                   MODELING_RULES_DIR,
+                                                   PARSING_RULES_DIR, FileType,
+                                                   MarketplaceVersions)
+from demisto_sdk.commands.common.content_constant_paths import \
+    ALL_PACKS_DEPENDENCIES_DEFAULT_PATH
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.tools import (find_type,
                                                get_last_remote_release_version,

--- a/demisto_sdk/commands/common/constants.py
+++ b/demisto_sdk/commands/common/constants.py
@@ -3,6 +3,9 @@ from distutils.version import LooseVersion
 from enum import Enum
 from functools import reduce
 from typing import Dict, List
+from demisto_sdk.commands.common.tools import get_content_path
+
+CONTENT_PATH = get_content_path()
 
 CAN_START_WITH_DOT_SLASH = '(?:./)?'
 NOT_TEST = '(?!Test)'
@@ -231,7 +234,7 @@ SIEM_ONLY_ENTITIES = [
 CONTENT_FILE_ENDINGS = ['py', 'yml', 'png', 'json', 'md']
 
 IGNORED_PACKS_IN_DEPENDENCY_CALC = ['NonSupported', 'Base']  # Packs that are ignored when calculating dependencies
-ALL_PACKS_DEPENDENCIES_DEFAULT_PATH = './all_packs_dependencies.json'
+ALL_PACKS_DEPENDENCIES_DEFAULT_PATH = f'{CONTENT_PATH}/all_packs_dependencies.json'
 ALLOWED_EMPTY_PACKS = ['Cortex911']  # Packs that are allowed to be without content items in the id_set
 
 CUSTOM_CONTENT_FILE_ENDINGS = ['yml', 'json']
@@ -443,8 +446,8 @@ TEST_FILES_REGEX = r'.*test_files.*'
 DOCS_REGEX = r'.*docs.*'
 IMAGE_REGEX = r'.*\.png$'
 DESCRIPTION_REGEX = r'.*\.md'
-SCHEMA_REGEX = 'Tests/schemas/.*.yml'
-CONF_PATH = 'Tests/conf.json'
+SCHEMA_REGEX = f'{CONTENT_PATH}Tests/schemas/.*.yml'
+CONF_PATH = f'{CONTENT_PATH}Tests/conf.json'
 
 PACKS_DIR_REGEX = fr'{CAN_START_WITH_DOT_SLASH}{PACKS_DIR}'
 PACK_DIR_REGEX = fr'{PACKS_DIR_REGEX}\/([^\\\/]+)'
@@ -1388,8 +1391,8 @@ LAYOUT_AND_MAPPER_BUILT_IN_FIELDS = ['indicatortype', 'source', 'comment', 'aggr
                                      'detectedhosts', 'modified', 'expiration', 'timestamp', 'shortdesc',
                                      'short_description', 'description', 'Tags', 'blocked']
 
-DEFAULT_ID_SET_PATH = "./Tests/id_set.json"
-MP_V2_ID_SET_PATH = "./Tests/id_set_mp_v2.json"
+DEFAULT_ID_SET_PATH = f'{CONTENT_PATH}/Tests/id_set.json'
+MP_V2_ID_SET_PATH = f'{CONTENT_PATH}/Tests/id_set_mp_v2.json'
 METADATA_FILE_NAME = 'pack_metadata.json'
 
 CONTEXT_OUTPUT_README_TABLE_HEADER = '| **Path** | **Type** | **Description** |'

--- a/demisto_sdk/commands/common/constants.py
+++ b/demisto_sdk/commands/common/constants.py
@@ -3,9 +3,9 @@ from distutils.version import LooseVersion
 from enum import Enum
 from functools import reduce
 from typing import Dict, List
-from demisto_sdk.commands.common.tools import get_content_path
+from demisto_sdk.commands.common.content import Content
 
-CONTENT_PATH = get_content_path()
+CONTENT_PATH = Content.git()
 
 CAN_START_WITH_DOT_SLASH = '(?:./)?'
 NOT_TEST = '(?!Test)'

--- a/demisto_sdk/commands/common/constants.py
+++ b/demisto_sdk/commands/common/constants.py
@@ -3,9 +3,6 @@ from distutils.version import LooseVersion
 from enum import Enum
 from functools import reduce
 from typing import Dict, List
-from demisto_sdk.commands.common.content import Content
-
-CONTENT_PATH = Content.git()
 
 CAN_START_WITH_DOT_SLASH = '(?:./)?'
 NOT_TEST = '(?!Test)'
@@ -234,7 +231,6 @@ SIEM_ONLY_ENTITIES = [
 CONTENT_FILE_ENDINGS = ['py', 'yml', 'png', 'json', 'md']
 
 IGNORED_PACKS_IN_DEPENDENCY_CALC = ['NonSupported', 'Base']  # Packs that are ignored when calculating dependencies
-ALL_PACKS_DEPENDENCIES_DEFAULT_PATH = f'{CONTENT_PATH}/all_packs_dependencies.json'
 ALLOWED_EMPTY_PACKS = ['Cortex911']  # Packs that are allowed to be without content items in the id_set
 
 CUSTOM_CONTENT_FILE_ENDINGS = ['yml', 'json']
@@ -446,8 +442,7 @@ TEST_FILES_REGEX = r'.*test_files.*'
 DOCS_REGEX = r'.*docs.*'
 IMAGE_REGEX = r'.*\.png$'
 DESCRIPTION_REGEX = r'.*\.md'
-SCHEMA_REGEX = f'{CONTENT_PATH}Tests/schemas/.*.yml'
-CONF_PATH = f'{CONTENT_PATH}Tests/conf.json'
+SCHEMA_REGEX = 'Tests/schemas/.*.yml'
 
 PACKS_DIR_REGEX = fr'{CAN_START_WITH_DOT_SLASH}{PACKS_DIR}'
 PACK_DIR_REGEX = fr'{PACKS_DIR_REGEX}\/([^\\\/]+)'
@@ -1391,8 +1386,6 @@ LAYOUT_AND_MAPPER_BUILT_IN_FIELDS = ['indicatortype', 'source', 'comment', 'aggr
                                      'detectedhosts', 'modified', 'expiration', 'timestamp', 'shortdesc',
                                      'short_description', 'description', 'Tags', 'blocked']
 
-DEFAULT_ID_SET_PATH = f'{CONTENT_PATH}/Tests/id_set.json'
-MP_V2_ID_SET_PATH = f'{CONTENT_PATH}/Tests/id_set_mp_v2.json'
 METADATA_FILE_NAME = 'pack_metadata.json'
 
 CONTEXT_OUTPUT_README_TABLE_HEADER = '| **Path** | **Type** | **Description** |'

--- a/demisto_sdk/commands/common/content_constant_paths.py
+++ b/demisto_sdk/commands/common/content_constant_paths.py
@@ -1,0 +1,11 @@
+from demisto_sdk.commands.common.tools import get_content_path
+from pathlib import Path
+
+CONTENT_PATH = Path(get_content_path())
+
+ALL_PACKS_DEPENDENCIES_DEFAULT_PATH = CONTENT_PATH / 'all_packs_dependencies.json'
+
+CONF_PATH = CONTENT_PATH / 'Tests' / 'conf.json'
+
+DEFAULT_ID_SET_PATH = CONTENT_PATH / 'Tests' / 'id_set.json'
+MP_V2_ID_SET_PATH = CONTENT_PATH / 'Tests' / 'id_set_mp_v2.json'

--- a/demisto_sdk/commands/common/content_constant_paths.py
+++ b/demisto_sdk/commands/common/content_constant_paths.py
@@ -1,5 +1,6 @@
-from demisto_sdk.commands.common.tools import get_content_path
 from pathlib import Path
+
+from demisto_sdk.commands.common.tools import get_content_path
 
 CONTENT_PATH = Path(get_content_path())
 

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -6,9 +6,10 @@ import decorator
 from requests import Response
 
 from demisto_sdk.commands.common.constants import (
-    BETA_INTEGRATION_DISCLAIMER, CONF_PATH, FILETYPE_TO_DEFAULT_FROMVERSION,
+    BETA_INTEGRATION_DISCLAIMER, FILETYPE_TO_DEFAULT_FROMVERSION,
     INTEGRATION_CATEGORIES, PACK_METADATA_DESC, PACK_METADATA_NAME, FileType,
     MarketplaceVersions)
+from demisto_sdk.commands.common.content_constant_paths import CONF_PATH
 
 FOUND_FILES_AND_ERRORS: list = []
 FOUND_FILES_AND_IGNORED_ERRORS: list = []

--- a/demisto_sdk/commands/common/hook_validations/conf_json.py
+++ b/demisto_sdk/commands/common/hook_validations/conf_json.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 
-from demisto_sdk.commands.common.constants import (API_MODULES_PACK, CONF_PATH,
+from demisto_sdk.commands.common.constants import (API_MODULES_PACK,
                                                    FileType)
+from demisto_sdk.commands.common.content_constant_paths import CONF_PATH
 from demisto_sdk.commands.common.errors import Errors
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.hook_validations.base_validator import (
@@ -18,7 +19,6 @@ class ConfJsonValidator(BaseValidator):
         _is_valid (bool): Whether the conf.json file current state is valid or not.
         conf_data (dict): The data from the conf.json file in our repo.
     """
-    CONF_PATH = "./Tests/conf.json"
     DYNAMIC_SECTION_TAG = 'dynamic-section'
 
     def __init__(self, ignored_errors=None, print_as_warnings=False, suppress_print=False, json_file_path=None, specific_validations=None):
@@ -28,7 +28,7 @@ class ConfJsonValidator(BaseValidator):
         self.conf_data = self.load_conf_file()
 
     def load_conf_file(self):
-        with open(self.CONF_PATH) as data_file:
+        with open(CONF_PATH) as data_file:
             return json.load(data_file)
 
     def is_valid_conf_json(self):

--- a/demisto_sdk/commands/common/hook_validations/conf_json.py
+++ b/demisto_sdk/commands/common/hook_validations/conf_json.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
-from demisto_sdk.commands.common.constants import (API_MODULES_PACK,
-                                                   FileType)
+from demisto_sdk.commands.common.constants import API_MODULES_PACK, FileType
 from demisto_sdk.commands.common.content_constant_paths import CONF_PATH
 from demisto_sdk.commands.common.errors import Errors
 from demisto_sdk.commands.common.handlers import JSON_Handler

--- a/demisto_sdk/commands/common/hook_validations/content_entity_validator.py
+++ b/demisto_sdk/commands/common/hook_validations/content_entity_validator.py
@@ -12,8 +12,8 @@ from demisto_sdk.commands.common.constants import (
     ENTITY_NAME_SEPARATORS, EXCLUDED_DISPLAY_NAME_WORDS, FEATURE_BRANCHES,
     FROM_TO_VERSION_REGEX, GENERIC_OBJECTS_OLDEST_SUPPORTED_VERSION,
     OLDEST_SUPPORTED_VERSION, FileType)
-from demisto_sdk.commands.common.content_constant_paths import CONF_PATH
 from demisto_sdk.commands.common.content import Content
+from demisto_sdk.commands.common.content_constant_paths import CONF_PATH
 from demisto_sdk.commands.common.errors import Errors
 from demisto_sdk.commands.common.git_util import GitUtil
 from demisto_sdk.commands.common.handlers import JSON_Handler, YAML_Handler

--- a/demisto_sdk/commands/common/hook_validations/content_entity_validator.py
+++ b/demisto_sdk/commands/common/hook_validations/content_entity_validator.py
@@ -12,6 +12,7 @@ from demisto_sdk.commands.common.constants import (
     ENTITY_NAME_SEPARATORS, EXCLUDED_DISPLAY_NAME_WORDS, FEATURE_BRANCHES,
     FROM_TO_VERSION_REGEX, GENERIC_OBJECTS_OLDEST_SUPPORTED_VERSION,
     OLDEST_SUPPORTED_VERSION, FileType)
+from demisto_sdk.commands.common.content_constant_paths import CONF_PATH
 from demisto_sdk.commands.common.content import Content
 from demisto_sdk.commands.common.errors import Errors
 from demisto_sdk.commands.common.git_util import GitUtil
@@ -32,7 +33,6 @@ logger = logging.getLogger("demisto-sdk")
 
 class ContentEntityValidator(BaseValidator):
     DEFAULT_VERSION = -1
-    CONF_PATH = "./Tests/conf.json"
 
     def __init__(self, structure_validator, ignored_errors=None, print_as_warnings=False, skip_docker_check=False,
                  suppress_print=False, json_file_path=None, oldest_supported_version=None):
@@ -170,7 +170,7 @@ class ContentEntityValidator(BaseValidator):
         return True
 
     def _load_conf_file(self):
-        with open(self.CONF_PATH) as data_file:
+        with open(CONF_PATH) as data_file:
             return json.load(data_file)
 
     @error_codes('CJ104,CJ102')

--- a/demisto_sdk/commands/common/update_id_set.py
+++ b/demisto_sdk/commands/common/update_id_set.py
@@ -19,14 +19,14 @@ import networkx
 from demisto_sdk.commands.common.constants import (
     CLASSIFIERS_DIR, COMMON_TYPES_PACK, CORRELATION_RULES_DIR, DASHBOARDS_DIR,
     DEFAULT_CONTENT_ITEM_FROM_VERSION, DEFAULT_CONTENT_ITEM_TO_VERSION,
-    GENERIC_DEFINITIONS_DIR, GENERIC_FIELDS_DIR,
-    GENERIC_MODULES_DIR, GENERIC_TYPES_DIR, INCIDENT_FIELDS_DIR,
-    INCIDENT_TYPES_DIR, INDICATOR_FIELDS_DIR, INDICATOR_TYPES_DIR, JOBS_DIR,
-    LAYOUTS_DIR, LISTS_DIR, MAPPERS_DIR, MODELING_RULES_DIR,
-    PARSING_RULES_DIR, REPORTS_DIR, SCRIPTS_DIR, TEST_PLAYBOOKS_DIR,
-    TRIGGER_DIR, WIDGETS_DIR, WIZARDS_DIR, XSIAM_DASHBOARDS_DIR,
-    XSIAM_REPORTS_DIR, FileType, MarketplaceVersions)
-from demisto_sdk.commands.common.content_constant_paths import DEFAULT_ID_SET_PATH, MP_V2_ID_SET_PATH
+    GENERIC_DEFINITIONS_DIR, GENERIC_FIELDS_DIR, GENERIC_MODULES_DIR,
+    GENERIC_TYPES_DIR, INCIDENT_FIELDS_DIR, INCIDENT_TYPES_DIR,
+    INDICATOR_FIELDS_DIR, INDICATOR_TYPES_DIR, JOBS_DIR, LAYOUTS_DIR,
+    LISTS_DIR, MAPPERS_DIR, MODELING_RULES_DIR, PARSING_RULES_DIR, REPORTS_DIR,
+    SCRIPTS_DIR, TEST_PLAYBOOKS_DIR, TRIGGER_DIR, WIDGETS_DIR, WIZARDS_DIR,
+    XSIAM_DASHBOARDS_DIR, XSIAM_REPORTS_DIR, FileType, MarketplaceVersions)
+from demisto_sdk.commands.common.content_constant_paths import (
+    DEFAULT_ID_SET_PATH, MP_V2_ID_SET_PATH)
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.tools import (LOG_COLORS, find_type,
                                                get_current_repo,
@@ -2020,7 +2020,7 @@ def merge_id_sets(first_id_set_dict: dict, second_id_set_dict: dict, print_logs:
     return united_id_set, []
 
 
-def re_create_id_set(id_set_path: Optional[str] = DEFAULT_ID_SET_PATH.as_posix(), pack_to_create=None,  # noqa : C901
+def re_create_id_set(id_set_path: Optional[Path] = DEFAULT_ID_SET_PATH, pack_to_create=None,  # noqa : C901
                      objects_to_create: list = None, print_logs: bool = True, fail_on_duplicates: bool = False,
                      marketplace: str = ''):
     """Re create the id-set
@@ -2039,9 +2039,9 @@ def re_create_id_set(id_set_path: Optional[str] = DEFAULT_ID_SET_PATH.as_posix()
     """
     if id_set_path == "":
         if marketplace == MarketplaceVersions.MarketplaceV2.value:
-            id_set_path = MP_V2_ID_SET_PATH.as_posix()
+            id_set_path = MP_V2_ID_SET_PATH
         else:
-            id_set_path = DEFAULT_ID_SET_PATH.as_posix()
+            id_set_path = DEFAULT_ID_SET_PATH
 
     if not objects_to_create:
         if marketplace == MarketplaceVersions.MarketplaceV2.value:

--- a/demisto_sdk/commands/common/update_id_set.py
+++ b/demisto_sdk/commands/common/update_id_set.py
@@ -19,13 +19,14 @@ import networkx
 from demisto_sdk.commands.common.constants import (
     CLASSIFIERS_DIR, COMMON_TYPES_PACK, CORRELATION_RULES_DIR, DASHBOARDS_DIR,
     DEFAULT_CONTENT_ITEM_FROM_VERSION, DEFAULT_CONTENT_ITEM_TO_VERSION,
-    DEFAULT_ID_SET_PATH, GENERIC_DEFINITIONS_DIR, GENERIC_FIELDS_DIR,
+    GENERIC_DEFINITIONS_DIR, GENERIC_FIELDS_DIR,
     GENERIC_MODULES_DIR, GENERIC_TYPES_DIR, INCIDENT_FIELDS_DIR,
     INCIDENT_TYPES_DIR, INDICATOR_FIELDS_DIR, INDICATOR_TYPES_DIR, JOBS_DIR,
-    LAYOUTS_DIR, LISTS_DIR, MAPPERS_DIR, MODELING_RULES_DIR, MP_V2_ID_SET_PATH,
+    LAYOUTS_DIR, LISTS_DIR, MAPPERS_DIR, MODELING_RULES_DIR,
     PARSING_RULES_DIR, REPORTS_DIR, SCRIPTS_DIR, TEST_PLAYBOOKS_DIR,
     TRIGGER_DIR, WIDGETS_DIR, WIZARDS_DIR, XSIAM_DASHBOARDS_DIR,
     XSIAM_REPORTS_DIR, FileType, MarketplaceVersions)
+from demisto_sdk.commands.common.content_constant_paths import DEFAULT_ID_SET_PATH, MP_V2_ID_SET_PATH
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.tools import (LOG_COLORS, find_type,
                                                get_current_repo,
@@ -2019,7 +2020,7 @@ def merge_id_sets(first_id_set_dict: dict, second_id_set_dict: dict, print_logs:
     return united_id_set, []
 
 
-def re_create_id_set(id_set_path: Optional[str] = DEFAULT_ID_SET_PATH, pack_to_create=None,  # noqa : C901
+def re_create_id_set(id_set_path: Optional[str] = DEFAULT_ID_SET_PATH.as_posix(), pack_to_create=None,  # noqa : C901
                      objects_to_create: list = None, print_logs: bool = True, fail_on_duplicates: bool = False,
                      marketplace: str = ''):
     """Re create the id-set
@@ -2038,9 +2039,9 @@ def re_create_id_set(id_set_path: Optional[str] = DEFAULT_ID_SET_PATH, pack_to_c
     """
     if id_set_path == "":
         if marketplace == MarketplaceVersions.MarketplaceV2.value:
-            id_set_path = MP_V2_ID_SET_PATH
+            id_set_path = MP_V2_ID_SET_PATH.as_posix()
         else:
-            id_set_path = DEFAULT_ID_SET_PATH
+            id_set_path = DEFAULT_ID_SET_PATH.as_posix()
 
     if not objects_to_create:
         if marketplace == MarketplaceVersions.MarketplaceV2.value:

--- a/demisto_sdk/commands/create_id_set/create_id_set.py
+++ b/demisto_sdk/commands/create_id_set/create_id_set.py
@@ -4,10 +4,9 @@ from typing import Optional
 
 from genericpath import exists
 
-from demisto_sdk.commands.common.constants import (DEFAULT_ID_SET_PATH,
-                                                   GENERIC_COMMANDS_NAMES,
-                                                   MP_V2_ID_SET_PATH,
+from demisto_sdk.commands.common.constants import (GENERIC_COMMANDS_NAMES,
                                                    MarketplaceVersions)
+from demisto_sdk.commands.common.content_constant_paths import DEFAULT_ID_SET_PATH, MP_V2_ID_SET_PATH
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.tools import open_id_set_file
 from demisto_sdk.commands.common.update_id_set import re_create_id_set

--- a/demisto_sdk/commands/create_id_set/create_id_set.py
+++ b/demisto_sdk/commands/create_id_set/create_id_set.py
@@ -1,12 +1,14 @@
 import os
 from collections import OrderedDict
+from pathlib import Path
 from typing import Optional
 
 from genericpath import exists
 
 from demisto_sdk.commands.common.constants import (GENERIC_COMMANDS_NAMES,
                                                    MarketplaceVersions)
-from demisto_sdk.commands.common.content_constant_paths import DEFAULT_ID_SET_PATH, MP_V2_ID_SET_PATH
+from demisto_sdk.commands.common.content_constant_paths import (
+    DEFAULT_ID_SET_PATH, MP_V2_ID_SET_PATH)
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.tools import open_id_set_file
 from demisto_sdk.commands.common.update_id_set import re_create_id_set
@@ -16,7 +18,7 @@ json = JSON_Handler()
 
 class IDSetCreator:
 
-    def __init__(self, output: Optional[str] = '', input: Optional[str] = None, print_logs: bool = True,
+    def __init__(self, output: Optional[Path] = None, input: Optional[Path] = None, print_logs: bool = True,
                  fail_duplicates: bool = False, marketplace: str = ''):
         """IDSetCreator
 
@@ -84,7 +86,7 @@ class IDSetCreator:
         return command_name_to_implemented_integration_map
 
     def save_id_set(self):
-        if self.output == "":
+        if not self.output:
             self.output = MP_V2_ID_SET_PATH if self.marketplace == MarketplaceVersions.MarketplaceV2.value \
                 else DEFAULT_ID_SET_PATH
         if self.output:

--- a/demisto_sdk/commands/format/update_generic_yml.py
+++ b/demisto_sdk/commands/format/update_generic_yml.py
@@ -9,6 +9,7 @@ from demisto_sdk.commands.common.constants import (ENTITY_TYPE_TO_DIR,
                                                    PLAYBOOK,
                                                    TEST_PLAYBOOKS_DIR,
                                                    FileType)
+from demisto_sdk.commands.common.content_constant_paths import CONF_PATH
 from demisto_sdk.commands.common.handlers import JSON_Handler, YAML_Handler
 from demisto_sdk.commands.common.tools import (
     _get_file_id, find_type, get_entity_id_by_entity_type,
@@ -35,7 +36,6 @@ class BaseUpdateYML(BaseUpdate):
         'PlaybookYMLFormat': '',
         'TestPlaybookYMLFormat': '',
     }
-    CONF_PATH = "./Tests/conf.json"
 
     def __init__(self,
                  input: str = '',
@@ -61,7 +61,7 @@ class BaseUpdateYML(BaseUpdate):
         Returns:
             The content of the json file
         """
-        with open(self.CONF_PATH) as data_file:
+        with open(CONF_PATH) as data_file:
             return json.load(data_file)
 
     def get_id_and_version_path_object(self):
@@ -205,7 +205,7 @@ class BaseUpdateYML(BaseUpdate):
             conf_json_content = self._load_conf_file()
         except FileNotFoundError:
             if self.verbose:
-                click.secho(f'Unable to find {self.CONF_PATH} - skipping update.', fg='yellow')
+                click.secho(f'Unable to find {CONF_PATH} - skipping update.', fg='yellow')
             return
         conf_json_test_configuration = conf_json_content['tests']
         content_item_id = _get_file_id(file_type, self.data)
@@ -232,7 +232,7 @@ class BaseUpdateYML(BaseUpdate):
 
     def _save_to_conf_json(self, conf_json_content: Dict) -> None:
         """Save formatted JSON data to destination file."""
-        with open(self.CONF_PATH, 'w') as file:
+        with open(CONF_PATH, 'w') as file:
             json.dump(conf_json_content, file, indent=4)
 
     def update_deprecate(self, file_type=None):

--- a/demisto_sdk/commands/generate_docs/generate_script_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_script_doc.py
@@ -1,7 +1,7 @@
 import os
 import random
 
-from demisto_sdk.commands.common.constants import DEFAULT_ID_SET_PATH
+from demisto_sdk.commands.common.content_constant_paths import DEFAULT_ID_SET_PATH
 from demisto_sdk.commands.common.tools import (get_from_version, get_yaml,
                                                open_id_set_file, print_error,
                                                print_warning)

--- a/demisto_sdk/commands/generate_docs/generate_script_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_script_doc.py
@@ -1,7 +1,8 @@
 import os
 import random
 
-from demisto_sdk.commands.common.content_constant_paths import DEFAULT_ID_SET_PATH
+from demisto_sdk.commands.common.content_constant_paths import \
+    DEFAULT_ID_SET_PATH
 from demisto_sdk.commands.common.tools import (get_from_version, get_yaml,
                                                open_id_set_file, print_error,
                                                print_warning)
@@ -52,7 +53,7 @@ def generate_script_doc(input_path, examples, output: str = None, permissions: s
 
         # get the script usages by the id set
         if not os.path.isfile(DEFAULT_ID_SET_PATH):
-            id_set_creator = IDSetCreator(output='', print_logs=False)
+            id_set_creator = IDSetCreator(print_logs=False)
             id_set, _, _ = id_set_creator.create_id_set()
         else:
             id_set = open_id_set_file(DEFAULT_ID_SET_PATH)

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -10,13 +10,15 @@ from pathlib import Path
 from typing import Any, Optional, Tuple, Union
 
 from demisto_sdk.commands.common.constants import (
-    ALL_FILES_VALIDATION_IGNORE_WHITELIST, DEFAULT_ID_SET_PATH,
-    DEPRECATED_REGEXES, IGNORED_PACK_NAMES, RN_HEADER_BY_FILE_TYPE, FileType)
+    ALL_FILES_VALIDATION_IGNORE_WHITELIST, DEPRECATED_REGEXES,
+    IGNORED_PACK_NAMES, RN_HEADER_BY_FILE_TYPE, FileType)
 from demisto_sdk.commands.common.content import Content
 from demisto_sdk.commands.common.content.objects.pack_objects import (
     Integration, Playbook, Script)
 from demisto_sdk.commands.common.content.objects.pack_objects.abstract_pack_objects.yaml_content_object import \
     YAMLContentObject
+from demisto_sdk.commands.common.content_constant_paths import \
+    DEFAULT_ID_SET_PATH
 from demisto_sdk.commands.common.git_util import GitUtil
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.tools import (LOG_COLORS, find_type,
@@ -818,7 +820,7 @@ def get_file_description(path, file_type) -> str:
 
 def update_api_modules_dependents_rn(pre_release: bool, update_type: Union[str, None],
                                      added: Union[list, set], modified: Union[list, set],
-                                     id_set_path: Optional[str] = None, text: str = '') -> set:
+                                     id_set_path: Optional[Path] = None, text: str = '') -> set:
     """ Updates release notes for any pack that depends on API module that has changed.
 
         :param

--- a/demisto_sdk/commands/update_release_notes/update_rn_manager.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn_manager.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from typing import Optional, Tuple
 
 import git
@@ -20,7 +21,7 @@ from demisto_sdk.commands.validate.validate_manager import ValidateManager
 class UpdateReleaseNotesManager:
     def __init__(self, user_input: Optional[str] = None, update_type: Optional[str] = None,
                  pre_release: bool = False, is_all: Optional[bool] = False, text: Optional[str] = None,
-                 specific_version: Optional[str] = None, id_set_path: Optional[str] = None,
+                 specific_version: Optional[str] = None, id_set_path: Optional[Path] = None,
                  prev_ver: Optional[str] = None, is_force: bool = False, is_bc: bool = False):
         self.given_pack = user_input
         self.changed_packs_from_git: set = set()

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -11,8 +11,8 @@ from mock import patch
 import demisto_sdk.commands.validate.validate_manager
 from demisto_sdk.commands.common import tools
 from demisto_sdk.commands.common.constants import (
-    FILETYPE_TO_DEFAULT_FROMVERSION, PACKS_PACK_META_FILE_NAME,
-    TEST_PLAYBOOK, FileType)
+    FILETYPE_TO_DEFAULT_FROMVERSION, PACKS_PACK_META_FILE_NAME, TEST_PLAYBOOK,
+    FileType)
 from demisto_sdk.commands.common.content_constant_paths import CONF_PATH
 from demisto_sdk.commands.common.errors import Errors
 from demisto_sdk.commands.common.git_util import GitUtil

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -11,8 +11,9 @@ from mock import patch
 import demisto_sdk.commands.validate.validate_manager
 from demisto_sdk.commands.common import tools
 from demisto_sdk.commands.common.constants import (
-    CONF_PATH, FILETYPE_TO_DEFAULT_FROMVERSION, PACKS_PACK_META_FILE_NAME,
+    FILETYPE_TO_DEFAULT_FROMVERSION, PACKS_PACK_META_FILE_NAME,
     TEST_PLAYBOOK, FileType)
+from demisto_sdk.commands.common.content_constant_paths import CONF_PATH
 from demisto_sdk.commands.common.errors import Errors
 from demisto_sdk.commands.common.git_util import GitUtil
 from demisto_sdk.commands.common.handlers import JSON_Handler

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -986,7 +986,7 @@ class TestValidators:
         old_format_files = {f"{git_path()}/demisto_sdk/tests/test_files/script-valid.yml",
                             f"{git_path()}/demisto_sdk/tests/test_files/integration-test.yml"}
         assert not validate_manager.validate_no_old_format(old_format_files)
-        assert handle_error_mock.call_count == 3
+        assert handle_error_mock.call_count == 2
 
     def test_validate_no_old_format_deprecated_content(self, repo):
         """

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -14,12 +14,14 @@ from demisto_sdk.commands.common import tools
 from demisto_sdk.commands.common.configuration import Configuration
 from demisto_sdk.commands.common.constants import (
     API_MODULES_PACK, AUTHOR_IMAGE_FILE_NAME, CONTENT_ENTITIES_DIRS,
-    DEFAULT_CONTENT_ITEM_TO_VERSION, DEFAULT_ID_SET_PATH, GENERIC_FIELDS_DIR,
-    GENERIC_TYPES_DIR, IGNORED_PACK_NAMES, OLDEST_SUPPORTED_VERSION, PACKS_DIR,
+    DEFAULT_CONTENT_ITEM_TO_VERSION, GENERIC_FIELDS_DIR, GENERIC_TYPES_DIR,
+    IGNORED_PACK_NAMES, OLDEST_SUPPORTED_VERSION, PACKS_DIR,
     PACKS_PACK_META_FILE_NAME, SKIP_RELEASE_NOTES_FOR_TYPES,
     VALIDATION_USING_GIT_IGNORABLE_DATA, FileType, FileType_ALLOWED_TO_DELETE,
     PathLevel)
 from demisto_sdk.commands.common.content import Content
+from demisto_sdk.commands.common.content_constant_paths import \
+    DEFAULT_ID_SET_PATH
 from demisto_sdk.commands.common.errors import (FOUND_FILES_AND_ERRORS,
                                                 FOUND_FILES_AND_IGNORED_ERRORS,
                                                 PRESET_ERROR_TO_CHECK,

--- a/demisto_sdk/tests/integration_tests/format_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/format_integration_test.py
@@ -201,7 +201,6 @@ def test_integration_format_configuring_conf_json_no_interactive_positive(tmp_pa
     conf_json_path = str(tmp_path / 'conf.json')
     with open(conf_json_path, 'w') as file:
         json.dump(CONF_JSON_ORIGINAL_CONTENT, file, indent=4)
-    BaseUpdateYML.CONF_PATH = conf_json_path
 
     test_playbooks = ['test1', 'test2']
     saved_file_path = str(tmp_path / os.path.basename(destination_path))
@@ -244,7 +243,6 @@ def test_integration_format_configuring_conf_json_positive(mocker,
     conf_json_path = str(tmp_path / 'conf.json')
     with open(conf_json_path, 'w') as file:
         json.dump(CONF_JSON_ORIGINAL_CONTENT, file, indent=4)
-    BaseUpdateYML.CONF_PATH = conf_json_path
     mocker.patch.object(BaseUpdate, 'set_default_from_version', return_value=None)
 
     test_playbooks = ['test1', 'test2']
@@ -290,7 +288,6 @@ def test_integration_format_configuring_conf_json_negative(tmp_path: PosixPath,
     conf_json_path = str(tmp_path / 'conf.json')
     with open(conf_json_path, 'w') as file:
         json.dump(CONF_JSON_ORIGINAL_CONTENT, file, indent=4)
-    BaseUpdateYML.CONF_PATH = conf_json_path
 
     saved_file_path = str(tmp_path / os.path.basename(destination_path))
     runner = CliRunner()

--- a/demisto_sdk/tests/integration_tests/format_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/format_integration_test.py
@@ -176,12 +176,14 @@ def test_integration_format_yml_with_no_test_no_interactive_positive(tmp_path: P
 
 
 @pytest.mark.parametrize('source_path,destination_path,formatter,yml_title,file_type', YML_FILES_WITH_TEST_PLAYBOOKS)
-def test_integration_format_configuring_conf_json_no_interactive_positive(tmp_path: PosixPath,
-                                                                          source_path: str,
-                                                                          destination_path: str,
-                                                                          formatter: BaseUpdateYML,
-                                                                          yml_title: str,
-                                                                          file_type: str):
+def test_integration_format_configuring_conf_json_no_interactive_positive(
+        mocker,
+        tmp_path: PosixPath,
+        source_path: str,
+        destination_path: str,
+        formatter: BaseUpdateYML,
+        yml_title: str,
+        file_type: str):
     """
         Given
         - A yml file (integration, playbook or script) with no tests playbooks configured that are not configured
@@ -198,7 +200,8 @@ def test_integration_format_configuring_conf_json_no_interactive_positive(tmp_pa
             added to conf.json for each test playbook configured in the yml under 'tests' key
     """
     # Setting up conf.json
-    conf_json_path = str(tmp_path / 'conf.json')
+    conf_json_path = tmp_path / 'conf.json'
+    mocker.patch('demisto_sdk.commands.format.update_generic_yml.CONF_PATH', conf_json_path)
     with open(conf_json_path, 'w') as file:
         json.dump(CONF_JSON_ORIGINAL_CONTENT, file, indent=4)
 
@@ -240,7 +243,8 @@ def test_integration_format_configuring_conf_json_positive(mocker,
         -  Ensure message is not prompt in the second time
     """
     # Setting up conf.json
-    conf_json_path = str(tmp_path / 'conf.json')
+    conf_json_path = tmp_path / 'conf.json'
+    mocker.patch('demisto_sdk.commands.format.update_generic_yml.CONF_PATH', conf_json_path)
     with open(conf_json_path, 'w') as file:
         json.dump(CONF_JSON_ORIGINAL_CONTENT, file, indent=4)
     mocker.patch.object(BaseUpdate, 'set_default_from_version', return_value=None)
@@ -265,12 +269,14 @@ def test_integration_format_configuring_conf_json_positive(mocker,
 
 
 @pytest.mark.parametrize('source_path,destination_path,formatter,yml_title,file_type', YML_FILES_WITH_TEST_PLAYBOOKS)
-def test_integration_format_configuring_conf_json_negative(tmp_path: PosixPath,
-                                                           source_path: str,
-                                                           destination_path: str,
-                                                           formatter: BaseUpdateYML,
-                                                           yml_title: str,
-                                                           file_type: str):
+def test_integration_format_configuring_conf_json_negative(
+        mocker,
+        tmp_path: PosixPath,
+        source_path: str,
+        destination_path: str,
+        formatter: BaseUpdateYML,
+        yml_title: str,
+        file_type: str):
     """
         Given
         - A yml file (integration, playbook or script) with no tests playbooks configured that are not configured
@@ -285,7 +291,9 @@ def test_integration_format_configuring_conf_json_negative(tmp_path: PosixPath,
         -  Ensure conf.json is not modified
     """
     # Setting up conf.json
-    conf_json_path = str(tmp_path / 'conf.json')
+    conf_json_path = tmp_path / 'conf.json'
+    mocker.patch('demisto_sdk.commands.format.update_generic_yml.CONF_PATH', conf_json_path)
+
     with open(conf_json_path, 'w') as file:
         json.dump(CONF_JSON_ORIGINAL_CONTENT, file, indent=4)
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-3590?filter=-2

## Description
This PR solves the issue of running `demisto-sdk` commands from subdirectories of content outside content repo with `DEMISTO_SDK_CONTENT_PATH` env variable preconfigures.
In addition, moved to use pathlib instead of relative path strings.

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
