### PR TITLE
Remove Class-Scoped Initialization of git_util

### DIFF
--- a/demisto_sdk/commands/common/hook_validations/pack_unique_files.py
+++ b/demisto_sdk/commands/common/hook_validations/pack_unique_files.py
@@ -26,10 +26,8 @@ from demisto_sdk.commands.common.constants import (  # PACK_METADATA_PRICE,
     PACK_METADATA_USE_CASES, PACKS_PACK_IGNORE_FILE_NAME,
     PACKS_PACK_META_FILE_NAME, PACKS_README_FILE_NAME,
     PACKS_WHITELIST_FILE_NAME, VERSION_REGEX)
-from demisto_sdk.commands.common.content import Content
 from demisto_sdk.commands.common.content.objects.pack_objects.pack import Pack
 from demisto_sdk.commands.common.errors import Errors
-from demisto_sdk.commands.common.git_util import GitUtil
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.hook_validations.base_validator import (
     BaseValidator, error_codes)
@@ -73,14 +71,9 @@ class PackUniqueFilesValidator(BaseValidator):
     """PackUniqueFilesValidator is designed to validate the correctness of content pack's files structure.
     Existence and validity of this files is essential."""
 
-    git_util = GitUtil(repo=Content.git())
-    main_branch = git_util.handle_prev_ver()[1]
-    if not main_branch.startswith('origin'):
-        main_branch = 'origin/' + main_branch
-
     def __init__(self, pack, pack_path=None, validate_dependencies=False, ignored_errors=None, print_as_warnings=False,
                  should_version_raise=False, id_set_path=None, suppress_print=False, private_repo=False,
-                 skip_id_set_creation=False, prev_ver=main_branch, json_file_path=None, support=None,
+                 skip_id_set_creation=False, prev_ver='master', json_file_path=None, support=None,
                  specific_validations=None):
         """Inits the content pack validator with pack's name, pack's path, and unique files to content packs such as:
         secrets whitelist file, pack-ignore file, pack-meta file and readme file
@@ -671,7 +664,7 @@ class PackUniqueFilesValidator(BaseValidator):
                 click.secho("Running on master branch - skipping price change validation", fg="yellow")
             return None
         try:
-            old_meta_file_content = current_repo.git.show(f'{self.main_branch}:{metadata_file_path}')
+            old_meta_file_content = current_repo.git.show(f'{self.prev_ver}:{metadata_file_path}')
 
         except GitCommandError as e:
             if not self.suppress_print:

--- a/demisto_sdk/commands/common/hook_validations/pack_unique_files.py
+++ b/demisto_sdk/commands/common/hook_validations/pack_unique_files.py
@@ -230,7 +230,8 @@ class PackUniqueFilesValidator(BaseValidator):
 
     def validate_pack_readme_images(self):
         readme_file_path = os.path.join(self.pack_path, self.readme_file)
-        readme_validator = ReadMeValidator(readme_file_path, ignored_errors=self.ignored_errors, specific_validations=self.specific_validations)
+        readme_validator = ReadMeValidator(readme_file_path, ignored_errors=self.ignored_errors,
+                                           specific_validations=self.specific_validations)
         errors = readme_validator.check_readme_relative_image_paths(is_pack_readme=True)
         errors += readme_validator.check_readme_absolute_image_paths(is_pack_readme=True)
         if errors:
@@ -241,7 +242,8 @@ class PackUniqueFilesValidator(BaseValidator):
     @error_codes('RM112')
     def validate_pack_readme_relative_urls(self):
         readme_file_path = os.path.join(self.pack_path, self.readme_file)
-        readme_validator = ReadMeValidator(readme_file_path, ignored_errors=self.ignored_errors, specific_validations=self.specific_validations)
+        readme_validator = ReadMeValidator(readme_file_path, ignored_errors=self.ignored_errors,
+                                           specific_validations=self.specific_validations)
         errors = readme_validator.check_readme_relative_url_paths(is_pack_readme=True)
         if errors:
             self._errors.extend(errors)

--- a/demisto_sdk/commands/format/tests/test_formatting_generic_test.py
+++ b/demisto_sdk/commands/format/tests/test_formatting_generic_test.py
@@ -195,6 +195,7 @@ def test_initiate_file_validator(mocker, is_old_file, function_validate):
     mocker.patch.object(BaseUpdate, '__init__', return_value=None)
     base_update = BaseUpdate()
     base_update.no_validate = False
+    base_update.prev_ver = ''
     base_update.output_file = 'output_file_path'
     base_update.validate_manager = ValidateManager
     mocker.patch.object(BaseUpdate, 'is_old_file', return_value=is_old_file)

--- a/demisto_sdk/commands/format/update_description.py
+++ b/demisto_sdk/commands/format/update_description.py
@@ -29,7 +29,7 @@ class DescriptionFormat(BaseUpdate):
                  verbose: bool = False,
                  update_docker: bool = False,
                  **kwargs):
-        super().__init__(input, output, path, from_version, no_validate, verbose=verbose, **kwargs)
+        super().__init__(input=input, output=output, path=path, from_version=from_version, no_validate=no_validate, verbose=verbose, **kwargs)
         description_type = input.replace('_description.md', '.yml')
         self.is_beta = False
         file_type = find_type(description_type)


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [breaks contribution-management](https://github.com/demisto/contribution-management/runs/7833468935?check_suite_focus=true)

## Description
- change the `BaseUpdate` class to actually consider `prev_ver` (typically the branch to diff against) when fetching the old version of a file
- remove the unnecessary class-scoped initialization of the `git_util` in the `PackUniqueFilesValidator` class whose sole purpose was to determine a default value for the class initialization parameter of `prev_ver` - replaced the dynamically determined default value with `master`

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
