### PR TITLE
move BC validation to base validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Fixed an issue in the **validate** command where backward compatability validations prevent other validations from running.
 * Fixed an issue in the **format** command where fail when executed from environment without mdx server available.
 * Added `Added a`, `Added an` to the list of allowed changelog prefixes.
 * Added support for Indicator Types/Reputations in the **upload** command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-* Fixed an issue in **validate**, where backward-compatability failures prevented other validations from running.
+* Fixed an issue in **validate**, where backward-compatibility failures prevented other validations from running.
 
 ## 1.7.3
 

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -70,6 +70,8 @@ ERROR_CODE = {
     "breaking_backwards_command": {'code': "BC102", 'ui_applicable': False, 'related_field': 'contextPath'},
     "breaking_backwards_arg_changed": {'code': "BC103", 'ui_applicable': False, 'related_field': 'name'},
     "breaking_backwards_command_arg_changed": {'code': "BC104", 'ui_applicable': False, 'related_field': 'args'},
+    "file_id_changed": {'code': "BC105", 'ui_applicable': False, 'related_field': 'id'},
+    "from_version_modified": {'code': "BC106", 'ui_applicable': False, 'related_field': 'fromversion'},
 
     # CJ - conf.json
     "description_missing_from_conf_json": {'code': "CJ100", 'ui_applicable': False, 'related_field': ''},
@@ -394,8 +396,6 @@ ERROR_CODE = {
     # ST - Structures
     "structure_doesnt_match_scheme": {'code': "ST100", 'ui_applicable': False, 'related_field': ''},
     "file_id_contains_slashes": {'code': "ST101", 'ui_applicable': False, 'related_field': 'id'},
-    "file_id_changed": {'code': "ST102", 'ui_applicable': False, 'related_field': 'id'},
-    "from_version_modified": {'code': "ST103", 'ui_applicable': False, 'related_field': 'fromversion'},
     "wrong_file_extension": {'code': "ST104", 'ui_applicable': False, 'related_field': ''},
     "invalid_file_path": {'code': "ST105", 'ui_applicable': False, 'related_field': ''},
     "invalid_package_structure": {'code': "ST106", 'ui_applicable': False, 'related_field': ''},

--- a/demisto_sdk/commands/common/hook_validations/field_base_validator.py
+++ b/demisto_sdk/commands/common/hook_validations/field_base_validator.py
@@ -77,6 +77,7 @@ class FieldBaseValidator(ContentEntityValidator):
 
         is_bc_broke = any(
             [
+                super().is_backward_compatible(),
                 self.is_changed_type(),
                 self.is_changed_from_version(),
             ]

--- a/demisto_sdk/commands/common/hook_validations/incident_type.py
+++ b/demisto_sdk/commands/common/hook_validations/incident_type.py
@@ -26,6 +26,7 @@ class IncidentTypeValidator(ContentEntityValidator):
 
         is_bc_broke = any(
             [
+                super().is_backward_compatible(),
                 self.is_changed_from_version()
             ]
         )

--- a/demisto_sdk/commands/common/hook_validations/integration.py
+++ b/demisto_sdk/commands/common/hook_validations/integration.py
@@ -76,6 +76,7 @@ class IntegrationValidator(ContentEntityValidator):
             return True
 
         answers = [
+            super().is_backward_compatible(),
             self.no_change_to_context_path(),
             self.no_removed_integration_parameters(),
             self.no_added_required_fields(),

--- a/demisto_sdk/commands/common/hook_validations/mapper.py
+++ b/demisto_sdk/commands/common/hook_validations/mapper.py
@@ -58,6 +58,7 @@ class MapperValidator(ContentEntityValidator):
         """Check whether the Mapper is backward compatible or not, update the _is_valid field to determine that"""
 
         answers = [
+            super().is_backward_compatible(),
             self.is_field_mapping_removed(),
         ]
         return not any(answers)

--- a/demisto_sdk/commands/common/hook_validations/script.py
+++ b/demisto_sdk/commands/common/hook_validations/script.py
@@ -56,6 +56,7 @@ class ScriptValidator(ContentEntityValidator):
             return True
 
         is_breaking_backwards = [
+            super().is_backward_compatible(),
             self.is_context_path_changed(),
             self.is_added_required_args(),
             self.is_arg_changed(),
@@ -63,12 +64,6 @@ class ScriptValidator(ContentEntityValidator):
             self.is_changed_subtype()
         ]
 
-        # Add sane-doc-report exception
-        # Sane-doc-report uses docker and every fix/change requires a docker tag change,
-        # thus it won't be backwards compatible.
-        # All other tests should be False (i.e. no problems)
-        if self.file_path == 'Scripts/SaneDocReport/SaneDocReport.yml':
-            return not any(is_breaking_backwards[1:])
         return not any(is_breaking_backwards)
 
     def is_valid_file(self, validate_rn=True):

--- a/demisto_sdk/commands/common/hook_validations/structure.py
+++ b/demisto_sdk/commands/common/hook_validations/structure.py
@@ -21,8 +21,6 @@ from demisto_sdk.commands.common.hook_validations.base_validator import (
     BaseValidator, error_codes)
 from demisto_sdk.commands.common.tools import (get_remote_file,
                                                is_file_path_in_pack)
-from demisto_sdk.commands.format.format_constants import \
-    OLD_FILE_DEFAULT_1_FROMVERSION
 
 json = JSON_Handler()
 yaml = YAML_Handler()
@@ -91,11 +89,6 @@ class StructureValidator(BaseValidator):
                 self.is_valid_scheme(),
                 self.is_file_id_without_slashes(),
             ]
-
-            if self.old_file:  # In case the file is modified
-                click.secho(f'Validating backwards compatibility for {self.file_path}')
-                answers.append(self.is_id_not_modified())
-                answers.append(self.is_valid_fromversion_on_modified())
 
             return all(answers)
 
@@ -197,54 +190,6 @@ class StructureValidator(BaseValidator):
         file_id = self.get_file_id_from_loaded_file_data(self.current_file)
         if file_id and '/' in file_id:
             error_message, error_code = Errors.file_id_contains_slashes()
-            if self.handle_error(error_message, error_code, file_path=self.file_path):
-                self.is_valid = False
-                return False
-
-        return True
-
-    @error_codes('ST102')
-    def is_id_not_modified(self):
-        # type: () -> bool
-        """Check if the ID of the file has been changed.
-
-
-        Returns:
-            (bool): Whether the file's ID has been modified or not.
-        """
-        if not self.old_file:
-            return True
-
-        old_version_id = self.get_file_id_from_loaded_file_data(self.old_file)
-        new_file_id = self.get_file_id_from_loaded_file_data(self.current_file)
-        if not (new_file_id == old_version_id):
-            error_message, error_code = Errors.file_id_changed(old_version_id, new_file_id)
-            if self.handle_error(error_message, error_code, file_path=self.file_path):
-                return False
-
-        # True - the id has not changed.
-        return True
-
-    @error_codes('ST103')
-    def is_valid_fromversion_on_modified(self):
-        # type: () -> bool
-        """Check that the fromversion property was not changed on existing Content files.
-
-        Returns:
-            (bool): Whether the files' fromversion as been modified or not.
-        """
-        if not self.old_file:
-            return True
-
-        from_version_new = self.current_file.get("fromversion") or self.current_file.get("fromVersion")
-        from_version_old = self.old_file.get("fromversion") or self.old_file.get("fromVersion")
-
-        # if in old file there was no fromversion ,format command will add from version key with 1.0.0
-        if not from_version_old and from_version_new == OLD_FILE_DEFAULT_1_FROMVERSION:
-            return True
-
-        if from_version_old != from_version_new:
-            error_message, error_code = Errors.from_version_modified()
             if self.handle_error(error_message, error_code, file_path=self.file_path):
                 self.is_valid = False
                 return False

--- a/demisto_sdk/commands/common/tests/structure_test.py
+++ b/demisto_sdk/commands/common/tests/structure_test.py
@@ -115,31 +115,6 @@ class TestStructureValidator:
         validator = StructureValidator(file_path=path, predefined_scheme='reputation')
         assert validator.is_valid_scheme() is answer
 
-    INPUTS_VALID_FROM_VERSION_MODIFIED = [
-        (VALID_TEST_PLAYBOOK_PATH, INVALID_PLAYBOOK_PATH, False),
-        (INVALID_PLAYBOOK_PATH, VALID_PLAYBOOK_ID_PATH, False),
-        (INVALID_PLAYBOOK_PATH, INVALID_PLAYBOOK_PATH, True)
-    ]
-
-    @pytest.mark.parametrize('path, old_file_path, answer', INPUTS_VALID_FROM_VERSION_MODIFIED)
-    def test_fromversion_update_validation_yml_structure(self, path, old_file_path, answer):
-        validator = StructureValidator(file_path=path)
-        with open(old_file_path) as f:
-            validator.old_file = yaml.load(f)
-            assert validator.is_valid_fromversion_on_modified() is answer
-
-    INPUTS_IS_ID_MODIFIED = [
-        (INVALID_PLAYBOOK_PATH, VALID_PLAYBOOK_ID_PATH, False, "Didn't find the id as updated in file"),
-        (VALID_PLAYBOOK_ID_PATH, VALID_PLAYBOOK_ID_PATH, True, "Found the ID as changed although it is not")
-    ]
-
-    @pytest.mark.parametrize("current_file, old_file, answer, error", INPUTS_IS_ID_MODIFIED)
-    def test_is_id_not_modified(self, current_file, old_file, answer, error):
-        validator = StructureValidator(file_path=current_file)
-        with open(old_file) as f:
-            validator.old_file = yaml.load(f)
-            assert validator.is_id_not_modified() is answer, error
-
     POSITIVE_ERROR = "Didn't find a slash in the ID even though it contains a slash."
     NEGATIVE_ERROR = "found a slash in the ID even though it not contains a slash."
     INPUTS_IS_FILE_WITHOUT_SLASH = [


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

related to:
https://github.com/demisto/content/pull/20360

## Description
structure validation should not contain BC checks.
Even if BC is breaking (intentionally), we still want to run all potential validations

