### PR TITLE
Added space in the error message of non allowed category

### DIFF
--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -1721,7 +1721,7 @@ class Errors:
     @staticmethod
     @error_code_decorator
     def pack_metadata_non_approved_usecases(non_approved_usecases: set) -> str:
-        return f'The pack metadata contains non approved usecases: {", ".join(non_approved_usecases)}' \
+        return f'The pack metadata contains non approved usecases: {", ".join(non_approved_usecases)} ' \
                f'The list of approved use cases can be found in https://xsoar.pan.dev/docs/documentation/pack-docs#pack-keywords-tags-use-cases--categories'
 
     @staticmethod


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Added space in the error message of non allowed category.

## Screenshots
![Screen Shot 2022-08-29 at 10 46 54](https://user-images.githubusercontent.com/78307768/187151160-ad4cc6c3-b5f7-4472-bc1a-c4d8456a2c53.png)

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
