### PR TITLE
use cache for installing in `pre-install-steps` CI step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,7 @@ references:
           pkg-manager: "poetry"
           args: "--extras build"
           pre-install-steps:
+            - cache-version: << pipeline.parameters.cache-version >>
             - run:
                 name: Check if pyproject.toml is consistent with poetry.lock
                 command: poetry lock --check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,8 +71,8 @@ references:
       - python/install-packages: 
           pkg-manager: "poetry"
           args: "--extras build"
+          cache-version: << pipeline.parameters.cache-version >>
           pre-install-steps:
-            - cache-version: << pipeline.parameters.cache-version >>
             - run:
                 name: Check if pyproject.toml is consistent with poetry.lock
                 command: poetry lock --check


### PR DESCRIPTION
reducing installation time from 2:30 minutes to 7 seconds (when cache is available)