### PR TITLE
Bugfix: downloading system playbooks from XSOAR instance raises an exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Fixed an issue  in the **download** command, where an exception would be raised when downloading system playbooks.
 * Fixed an issue where the **upload** failed on playbooks containing a value that starts with `=`.
 * Fixed an issue where the **generate-unit-tests** failed to generate assertions, and generate unit tests when command names does not match method name.
 ## 1.7.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-* Fixed an issue  in the **download** command, where an exception would be raised when downloading system playbooks.
+* Fixed an issue in the **download** command, where an exception would be raised when downloading system playbooks.
 * Fixed an issue where the **upload** failed on playbooks containing a value that starts with `=`.
 * Fixed an issue where the **generate-unit-tests** failed to generate assertions, and generate unit tests when command names does not match method name.
 ## 1.7.6

--- a/demisto_sdk/commands/download/downloader.py
+++ b/demisto_sdk/commands/download/downloader.py
@@ -338,7 +338,7 @@ class Downloader:
                 api_response = demisto_client.generic_request_func(self.client, endpoint, req_type, body=req_body)
                 system_items_list = ast.literal_eval(api_response[0])
 
-            self.arrange_response(system_items_list)
+            system_items_list = self.arrange_response(system_items_list)
 
             for item in system_items_list:  # type: ignore
                 file_name: str = self.build_file_name(item)

--- a/demisto_sdk/commands/download/downloader.py
+++ b/demisto_sdk/commands/download/downloader.py
@@ -357,7 +357,7 @@ class Downloader:
             self.handle_max_retry_error(e)
             return False
         except Exception as e:
-            print_color(f'Exception raised when fetching custom content:\n{e}', LOG_COLORS.NATIVE)
+            print_color(f'Exception raised when fetching system content:\n{e}', LOG_COLORS.NATIVE)
             return False
 
     def get_custom_content_objects(self) -> List[dict]:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
No issue raised, but fixes ability to download XSOAR system content playbooks.

## Description
### Problem
When attempting to download a system playbook from an XSOAR instance, the following exception occurs:
```
Exception raised when fetching custom content:
'str' object has no attribute 'get'
```
### Root Cause
The error occurs because the result of `self.arrange_response(system_items_list)` is not assigned back to `system_items_list`.

When subsequently iterating through `system_items_list` (`for item in system_items_list:`), the `item` variable is referencing the key (e.g., `"playbooks"`).

Thus, `self.build_file_name(item)` raises an exception when attempting to invoke the `get()` method on the `str` object that is passed to it.

### Replicating the bug
After setting the appropriate environment variables (`DEMISTO_BASE_URL` and `DEMISTO_API_KEY`), run:
```
demisto-sdk download --system --item-type Playbook --input "<SYSTEM_PLAYBOOK_NAME>" --output "<OUTPUT_DIR>"
```
For example:
```
demisto-sdk download --system --item-type Playbook --input "Access Investigation - Generic" --output "Packs/SystemPack"
```

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
