### PR TITLE
workaround to from/to version in XSIAM 1.2 using the external prefix

### DIFF
--- a/TestSuite/pack.py
+++ b/TestSuite/pack.py
@@ -579,7 +579,7 @@ class Pack:
             yml = {
                 'id': 'parsing-rule',
                 'name': 'Parsing Rule',
-                'fromversion': 3.3,
+                'fromversion': '6.8.0',
                 'tags': 'tag',
                 'rules': '',
                 'samples': '',
@@ -613,7 +613,7 @@ class Pack:
             yml = {
                 'id': 'modeling-rule',
                 'name': 'Modeling Rule',
-                'fromversion': 3.3,
+                'fromversion': '6.8.0',
                 'tags': 'tag',
                 'rules': '',
                 'schema': '',

--- a/demisto_sdk/commands/common/content/objects/pack_objects/modeling_rule/modeling_rule.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/modeling_rule/modeling_rule.py
@@ -2,6 +2,7 @@ import shutil
 from typing import List, Optional, Union
 
 import demisto_client
+from packaging.version import Version
 from wcmatch.pathlib import Path
 
 from demisto_sdk.commands.common.constants import MODELING_RULE, FileType
@@ -33,12 +34,36 @@ class ModelingRule(YAMLContentUnifiedObject):
         return FileType.MODELING_RULE
 
     def dump(self, dest_dir: Optional[Union[Path, str]] = None) -> List[Path]:
+        # after XSIAM 1.2 is obsolete, we can clear this block and only export the file with the `external-` prefix.
+        # Issue: CIAC-4349
+
         created_files: List[Path] = []
         created_files.extend(super().dump(dest_dir=dest_dir))
         new_file_path = created_files[0]
-        if new_file_path.name.startswith('external-'):
-            copy_to_path = str(new_file_path).replace('external-', '')
+
+        if Version(self.get('fromversion', '0.0.0')) >= Version('6.10.0'):
+            # export XSIAM 1.3 items only with the external prefix
+            if not new_file_path.name.startswith('external-'):
+                move_to_path = new_file_path.parent / self.normalize_file_name()
+                shutil.move(new_file_path, move_to_path)
+                created_files.remove(new_file_path)
+                created_files.append(move_to_path)
+
+        elif Version(self.get('toversion', '99.99.99')) < Version('6.10.0'):
+            # export XSIAM 1.2 items only without the external prefix
+            if new_file_path.name.startswith('external-'):
+                move_to_path = Path(str(new_file_path).replace('external-', ''))
+                shutil.move(new_file_path, move_to_path)
+                created_files.remove(new_file_path)
+                created_files.append(move_to_path)
+
         else:
-            copy_to_path = f'{new_file_path.parent}/{self.normalize_file_name()}'
-        shutil.copyfile(new_file_path, copy_to_path)
+            # export 2 versions of the file, with/without the external prefix.
+            if new_file_path.name.startswith('external-'):
+                copy_to_path = str(new_file_path).replace('external-', '')
+            else:
+                copy_to_path = f'{new_file_path.parent}/{self.normalize_file_name()}'
+
+            shutil.copyfile(new_file_path, copy_to_path)
+
         return created_files

--- a/demisto_sdk/commands/common/content/objects/pack_objects/parsing_rule/parsing_rule.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/parsing_rule/parsing_rule.py
@@ -2,6 +2,7 @@ import shutil
 from typing import List, Optional, Union
 
 import demisto_client
+from packaging.version import Version
 from wcmatch.pathlib import Path
 
 from demisto_sdk.commands.common.constants import PARSING_RULE, FileType
@@ -33,12 +34,36 @@ class ParsingRule(YAMLContentUnifiedObject):
         return FileType.PARSING_RULE
 
     def dump(self, dest_dir: Optional[Union[Path, str]] = None) -> List[Path]:
+        # after XSIAM 1.2 is obsolete, we can clear this block and only export the file with the `external-` prefix.
+        # Issue: CIAC-4349
+
         created_files: List[Path] = []
         created_files.extend(super().dump(dest_dir=dest_dir))
         new_file_path = created_files[0]
-        if new_file_path.name.startswith('external-'):
-            copy_to_path = str(new_file_path).replace('external-', '')
+
+        if Version(self.get('fromversion', '0.0.0')) >= Version('6.10.0'):
+            # export XSIAM 1.3 items only with the external prefix
+            if not new_file_path.name.startswith('external-'):
+                move_to_path = new_file_path.parent / self.normalize_file_name()
+                shutil.move(new_file_path, move_to_path)
+                created_files.remove(new_file_path)
+                created_files.append(move_to_path)
+
+        elif Version(self.get('toversion', '99.99.99')) < Version('6.10.0'):
+            # export XSIAM 1.2 items only without the external prefix
+            if new_file_path.name.startswith('external-'):
+                move_to_path = Path(str(new_file_path).replace('external-', ''))
+                shutil.move(new_file_path, move_to_path)
+                created_files.remove(new_file_path)
+                created_files.append(move_to_path)
+
         else:
-            copy_to_path = f'{new_file_path.parent}/{self.normalize_file_name()}'
-        shutil.copyfile(new_file_path, copy_to_path)
+            # export 2 versions of the file, with/without the external prefix.
+            if new_file_path.name.startswith('external-'):
+                copy_to_path = str(new_file_path).replace('external-', '')
+            else:
+                copy_to_path = f'{new_file_path.parent}/{self.normalize_file_name()}'
+
+            shutil.copyfile(new_file_path, copy_to_path)
+
         return created_files

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/modeling_rule/modeling_rule_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/modeling_rule/modeling_rule_test.py
@@ -53,3 +53,42 @@ class TestModelingRule:
         unify_obj = get_yaml(obj._unify(modeling_rule._tmpdir_rule_path)[0])
         assert unify_obj['schema'] == '{\n    "test_audit_raw": {\n        "name": {\n            "type": "string",\n' \
                                       '            "is_array": false\n        }\n    }\n}'
+
+
+class TestModelingRules_XSIAM_1_3_Migration:
+    @staticmethod
+    def test_dump_XSIAM_1_2_rule(pack):
+        modeling_rule = pack.create_modeling_rule(
+            yml={
+                'id': 'modeling-rule',
+                'name': 'Modeling Rule',
+                'fromversion': '6.8.0',
+                'toversion': '6.99.99',
+                'tags': 'tag',
+                'rules': '',
+                'schema': '',
+            }
+        )
+        obj = ModelingRule(modeling_rule._tmpdir_rule_path)
+        created_files = obj.dump(modeling_rule._tmpdir_rule_path)
+
+        assert len(created_files) == 1
+        assert not created_files[0].name.startswith('external-')
+
+    @staticmethod
+    def test_dump_XSIAM_1_3_rule(pack):
+        modeling_rule = pack.create_modeling_rule(
+            yml={
+                'id': 'modeling-rule',
+                'name': 'Modeling Rule',
+                'fromversion': '6.10.0',
+                'tags': 'tag',
+                'rules': '',
+                'schema': '',
+            }
+        )
+        obj = ModelingRule(modeling_rule._tmpdir_rule_path)
+        created_files = obj.dump(modeling_rule._tmpdir_rule_path)
+
+        assert len(created_files) == 1
+        assert created_files[0].name.startswith('external-')

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/parsing_rule/parsing_rule_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/parsing_rule/parsing_rule_test.py
@@ -33,3 +33,42 @@ class TestParsingRule:
         parsing_rule = get_parsing_rule(pack, 'parsing_rule_name')
         obj = ParsingRule(parsing_rule._tmpdir_rule_path)
         assert not obj.is_unify()
+
+
+class TestParsingRules_XSIAM_1_3_Migration:
+    @staticmethod
+    def test_dump_XSIAM_1_2_rule(pack):
+        parsing_rule = pack.create_parsing_rule(
+            yml={
+                'id': 'parsing-rule',
+                'name': 'Parsing Rule',
+                'fromversion': '6.8.0',
+                'toversion': '6.99.99',
+                'tags': 'tag',
+                'rules': '',
+                'schema': '',
+            }
+        )
+        obj = ParsingRule(parsing_rule._tmpdir_rule_path)
+        created_files = obj.dump(parsing_rule._tmpdir_rule_path)
+
+        assert len(created_files) == 1
+        assert not created_files[0].name.startswith('external-')
+
+    @staticmethod
+    def test_dump_XSIAM_1_3_rule(pack):
+        parsing_rule = pack.create_parsing_rule(
+            yml={
+                'id': 'modeling-rule',
+                'name': 'Modeling Rule',
+                'fromversion': '6.10.0',
+                'tags': 'tag',
+                'rules': '',
+                'schema': '',
+            }
+        )
+        obj = ParsingRule(parsing_rule._tmpdir_rule_path)
+        created_files = obj.dump(parsing_rule._tmpdir_rule_path)
+
+        assert len(created_files) == 1
+        assert created_files[0].name.startswith('external-')


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
cleanup issue: https://jira-hq.paloaltonetworks.local/browse/CIAC-4349

## Description
workaround to the required from/to version fields in XSIAM 1.2 using the external prefix.

## Screenshots
pack files after the update:
<img width="624" alt="image" src="https://user-images.githubusercontent.com/30797606/197038269-4227b533-b4f2-4bcc-bee5-83a9edfd4277.png">
