### PR TITLE
Fix download no-code-formatting for existing file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Fixed an issue in the **download** command, where an exception would be raised when downloading system playbooks.
 * Fixed an issue where the **upload** failed on playbooks containing a value that starts with `=`.
 * Fixed an issue where the **generate-unit-tests** failed to generate assertions, and generate unit tests when command names does not match method name.
+* Fixed an issue where the **download** command did not honor the `--no-code-formatting` flag properly. @maxgubler
+
 ## 1.7.6
 
 * Fixed parsing of initialization arguments of client classes in the **generate-unit-tests** command.

--- a/demisto_sdk/commands/download/downloader.py
+++ b/demisto_sdk/commands/download/downloader.py
@@ -755,7 +755,7 @@ class Downloader:
 
         extractor = YmlSplitter(input=file_path, output=temp_dir, file_type=file_type, base_name=base_name,
                                 no_logging=not self.log_verbose, no_pipenv=True, no_readme=True,
-                                no_auto_create_dir=True)
+                                no_auto_create_dir=True, no_code_formatting=self.no_code_formatting)
         extractor.extract_to_package_format()
 
         extracted_file_paths: list = get_child_files(temp_dir)

--- a/demisto_sdk/commands/download/tests/downloader_test.py
+++ b/demisto_sdk/commands/download/tests/downloader_test.py
@@ -442,6 +442,7 @@ class TestMergeExistingFile:
             downloader.num_merged_files = 0
             downloader.num_added_files = 0
             downloader.log_verbose = False
+            downloader.no_code_formatting = False
             downloader.merge_and_extract_existing_file(env.INTEGRATION_CUSTOM_CONTENT_OBJECT)
             stdout, _ = capsys.readouterr()
             assert 'Merged' in stdout
@@ -475,6 +476,7 @@ class TestMergeExistingFile:
             downloader.num_merged_files = 0
             downloader.num_added_files = 0
             downloader.log_verbose = False
+            downloader.no_code_formatting = False
             downloader.merge_and_extract_existing_file(env.INTEGRATION_CUSTOM_CONTENT_OBJECT)
             paths = [file['path'] for file in env.INTEGRATION_PACK_OBJECT['Test Integration']]
             for path in paths:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: #2422

## Description
This fix will have the sdk download command honor the --no-code-formatting flag for existing files.

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [x] N/A - Irrelevant
