### PR TITLE
Readme validation bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,10 @@ jobs:
             cache-version: << pipeline.parameters.cache-version >>
         - <<: *install_node_ci
         - run:
+            name: Run Pytest collection
+            command: |
+              poetry run pytest --collect-only .
+        - run:
             name: pytest
             no_output_timeout: 15m
             command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Fixed an issue where the **upload** failed on playbooks containing a value that starts with `=`.
 * Fixed an issue where the **generate-unit-tests** failed to generate assertions, and generate unit tests when command names does not match method name.
 * Added a new check to **validate**, making sure playbook task values are passed as references.
+* Fixed an issue where **validate** printed blank space in case of validation failed and ignored.
+
 ## 1.7.6
 
 * Fixed parsing of initialization arguments of client classes in the **generate-unit-tests** command.

--- a/demisto_sdk/commands/common/hook_validations/readme.py
+++ b/demisto_sdk/commands/common/hook_validations/readme.py
@@ -375,7 +375,9 @@ class ReadMeValidator(BaseValidator):
             if error_code and error_message:  # error was found
                 formatted_error = self.handle_error(error_message, error_code, file_path=self.file_path,
                                                     should_print=should_print_error)
-                error_list.append(formatted_error)
+                # if error is None it should be ignored
+                if formatted_error:
+                    error_list.append(formatted_error)
 
         return error_list
 

--- a/demisto_sdk/commands/common/tests/readme_test.py
+++ b/demisto_sdk/commands/common/tests/readme_test.py
@@ -90,7 +90,8 @@ def test_relative_url_not_valid():
     captured_output = io.StringIO()
     sys.stdout = captured_output  # redirect stdout.
     absolute_urls = ["https://www.good.co.il", "https://example.com", "https://github.com/demisto/content/blob/123",
-                     "github.com/demisto/content/blob/123/Packs/FeedOffice365/doc_files/test.png", "https://hreftesting.com"]
+                     "github.com/demisto/content/blob/123/Packs/FeedOffice365/doc_files/test.png",
+                     "https://hreftesting.com"]
     relative_urls = ["relative1.com", "www.relative2.com", "hreftesting.com", "www.hreftesting.com"]
     readme_validator = ReadMeValidator(INVALID_MD)
     result = readme_validator.verify_readme_relative_urls()
@@ -537,3 +538,19 @@ def test_verify_readme_image_paths(mocker):
     assert 'please repair it:\n' \
            '![Identity with High Risk Score](https://github.com/demisto/test3.png)' \
            not in captured_output
+
+
+def test_check_readme_relative_image_paths(mocker):
+    readme_validator = ReadMeValidator(IMAGES_MD, ignored_errors={IMAGES_MD: 'RM108'})
+    mocker.patch.object(GitUtil, 'get_current_working_branch', return_value='branch_name')
+    with requests_mock.Mocker() as m:
+        # Mock get requests
+        m.get('https://github.com/demisto/test1.png',
+              status_code=404, text="Test1", reason='just because')
+        m.get('https://github.com/demisto/content/raw/test2.png',
+              status_code=404, text="Test2")
+        m.get('https://github.com/demisto/test3.png',
+              status_code=200, text="Test3")
+        formatted_errors = readme_validator.check_readme_relative_image_paths()
+
+    assert len(formatted_errors) == 0

--- a/demisto_sdk/commands/common/tests/readme_test.py
+++ b/demisto_sdk/commands/common/tests/readme_test.py
@@ -541,6 +541,19 @@ def test_verify_readme_image_paths(mocker):
 
 
 def test_check_readme_relative_image_paths(mocker):
+    """
+
+    Given
+        - A README file (not pack README) with invalid relative image
+         paths and invalid absolute image paths in it.
+    When
+        - Run validate on README file and ignoring RM108 error
+    Then
+        - Ensure:
+            - Validation pass.
+            - nothing is printed as error.
+
+    """
     readme_validator = ReadMeValidator(IMAGES_MD, ignored_errors={IMAGES_MD: 'RM108'})
     mocker.patch.object(GitUtil, 'get_current_working_branch', return_value='branch_name')
     with requests_mock.Mocker() as m:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-3999)

## Description
Ignoring RM108 fails but doesn't output anything, now fixed.

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
