### PR TITLE
Datasets field in modeling rule metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fixed an issue in the **download** command, where an exception would be raised when downloading system playbooks.
 * Fixed an issue where the **upload** failed on playbooks containing a value that starts with `=`.
 * Fixed an issue where the **generate-unit-tests** failed to generate assertions, and generate unit tests when command names does not match method name.
+* Updated **create-content-artifacts** command to add the _datasets_ fields for modeling rules in packs' metadata.json files.
 ## 1.7.6
 
 * Fixed parsing of initialization arguments of client classes in the **generate-unit-tests** command.

--- a/demisto_sdk/commands/create_artifacts/content_artifacts_creator.py
+++ b/demisto_sdk/commands/create_artifacts/content_artifacts_creator.py
@@ -7,7 +7,7 @@ import time
 from concurrent.futures import as_completed
 from contextlib import contextmanager
 from shutil import make_archive, rmtree
-from typing import Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from packaging.version import parse
 from pebble import ProcessFuture, ProcessPool
@@ -30,11 +30,14 @@ from demisto_sdk.commands.common.content.objects.abstract_objects.text_object im
     TextObject
 from demisto_sdk.commands.common.content.objects.pack_objects import (
     JSONContentObject, Script, YAMLContentObject, YAMLContentUnifiedObject)
+from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.tools import (alternate_item_fields,
                                                arg_to_list, open_id_set_file,
                                                should_alternate_field_by_item)
 
 from .artifacts_report import ArtifactsReport, ObjectReport
+
+json = JSON_Handler()
 
 ####################
 # Global variables #
@@ -402,10 +405,11 @@ class ContentItemsHandler:
         })
 
     def add_modeling_rule_as_content_item(self, content_object: ContentObject):
+        schema: Dict[str, Any] = json.loads(content_object.get('schema', '{}'))
         self.content_items[ContentItems.MODELING_RULES].append({
             'name': content_object.get('name', ''),
             'description': content_object.get('description', ''),
-            'datasets': list(content_object.get('schema', {}).keys()),
+            'datasets': list(schema.keys()),
         })
 
     def add_correlation_rule_as_content_item(self, content_object: ContentObject):

--- a/demisto_sdk/commands/create_artifacts/content_artifacts_creator.py
+++ b/demisto_sdk/commands/create_artifacts/content_artifacts_creator.py
@@ -404,7 +404,8 @@ class ContentItemsHandler:
     def add_modeling_rule_as_content_item(self, content_object: ContentObject):
         self.content_items[ContentItems.MODELING_RULES].append({
             'name': content_object.get('name', ''),
-            'description': content_object.get('description', '')
+            'description': content_object.get('description', ''),
+            'datasets': list(content_object.get('schema', {}).keys()),
         })
 
     def add_correlation_rule_as_content_item(self, content_object: ContentObject):

--- a/demisto_sdk/commands/create_artifacts/tests/content_artifacts_creator_test.py
+++ b/demisto_sdk/commands/create_artifacts/tests/content_artifacts_creator_test.py
@@ -230,7 +230,7 @@ def test_contains_modeling_rule():
     cca.logger = logging_setup(0)
 
     with temp_dir() as temp:
-        packs_zipper = PacksZipper(pack_paths=str(TEST_DATA / 'TestModelingRule'),
+        packs_zipper = PacksZipper(pack_paths=str(TEST_DATA / PACKS_DIR / 'TestModelingRule'),
                                    output=temp,
                                    content_version='6.0.0',
                                    marketplace=MarketplaceVersions.MarketplaceV2.value,

--- a/demisto_sdk/commands/create_artifacts/tests/content_artifacts_creator_test.py
+++ b/demisto_sdk/commands/create_artifacts/tests/content_artifacts_creator_test.py
@@ -5,8 +5,9 @@ from pathlib import Path, PosixPath
 from shutil import copyfile, copytree, rmtree
 
 import pytest
-
-from demisto_sdk.commands.common.constants import PACKS_DIR, TEST_PLAYBOOKS_DIR, MarketplaceVersions
+from demisto_sdk.commands.common.constants import (PACKS_DIR,
+                                                   TEST_PLAYBOOKS_DIR,
+                                                   MarketplaceVersions)
 from demisto_sdk.commands.common.handlers import JSON_Handler, YAML_Handler
 from demisto_sdk.commands.common.logger import logging_setup
 from demisto_sdk.commands.common.tools import src_root

--- a/demisto_sdk/commands/create_artifacts/tests/content_artifacts_creator_test.py
+++ b/demisto_sdk/commands/create_artifacts/tests/content_artifacts_creator_test.py
@@ -232,13 +232,12 @@ def test_contains_modeling_rule():
     with temp_dir() as temp:
         packs_zipper = PacksZipper(pack_paths=str(TEST_DATA / PACKS_DIR / 'TestModelingRule'),
                                    output=temp,
-                                   content_version='6.0.0',
+                                   content_version='6.8.0',
                                    marketplace=MarketplaceVersions.MarketplaceV2.value,
                                    zip_all=False)
         packs_zipper.zip_packs()
         pack_metadata = packs_zipper.artifacts_manager.packs['TestModelingRule'].metadata
-        assert 'modelingrule' in pack_metadata.content_items
-        assert pack_metadata.content_items['modelingrule'] == ['okta_okta_raw']
+        assert pack_metadata.content_items['modelingrule'][0].get('datasets') == ['okta_okta_raw']
 
 
 def test_create_content_artifacts(mock_git):

--- a/demisto_sdk/commands/create_artifacts/tests/content_artifacts_creator_test.py
+++ b/demisto_sdk/commands/create_artifacts/tests/content_artifacts_creator_test.py
@@ -6,7 +6,7 @@ from shutil import copyfile, copytree, rmtree
 
 import pytest
 
-from demisto_sdk.commands.common.constants import PACKS_DIR, TEST_PLAYBOOKS_DIR
+from demisto_sdk.commands.common.constants import PACKS_DIR, TEST_PLAYBOOKS_DIR, MarketplaceVersions
 from demisto_sdk.commands.common.handlers import JSON_Handler, YAML_Handler
 from demisto_sdk.commands.common.logger import logging_setup
 from demisto_sdk.commands.common.tools import src_root
@@ -211,6 +211,34 @@ def test_contains_indicator_type():
                 "enhancementScriptNames": []
             }
         ]
+
+
+def test_contains_modeling_rule():
+    """
+    Given
+    - A pack with a modeling rule.
+
+    When
+    - Running zip-packs on it.
+
+    Then
+    - Ensure the zipped modeling rule information in the pack metadata includes the datasets.
+    """
+    import demisto_sdk.commands.create_artifacts.content_artifacts_creator as cca
+    from demisto_sdk.commands.zip_packs.packs_zipper import PacksZipper
+
+    cca.logger = logging_setup(0)
+
+    with temp_dir() as temp:
+        packs_zipper = PacksZipper(pack_paths=str(TEST_DATA / 'TestModelingRule'),
+                                   output=temp,
+                                   content_version='6.0.0',
+                                   marketplace=MarketplaceVersions.MarketplaceV2.value,
+                                   zip_all=False)
+        packs_zipper.zip_packs()
+        pack_metadata = packs_zipper.artifacts_manager.packs['TestModelingRule'].metadata
+        assert 'modelingrule' in pack_metadata.content_items
+        assert pack_metadata.content_items['modelingrule'] == ['okta_okta_raw']
 
 
 def test_create_content_artifacts(mock_git):

--- a/demisto_sdk/commands/create_artifacts/tests/content_artifacts_creator_test.py
+++ b/demisto_sdk/commands/create_artifacts/tests/content_artifacts_creator_test.py
@@ -5,6 +5,7 @@ from pathlib import Path, PosixPath
 from shutil import copyfile, copytree, rmtree
 
 import pytest
+
 from demisto_sdk.commands.common.constants import (PACKS_DIR,
                                                    TEST_PLAYBOOKS_DIR,
                                                    MarketplaceVersions)

--- a/demisto_sdk/tests/test_files/Packs/TestModelingRule/ModelingRules/modelingrule-OktaModelingRules.yml
+++ b/demisto_sdk/tests/test_files/Packs/TestModelingRule/ModelingRules/modelingrule-OktaModelingRules.yml
@@ -1,0 +1,51 @@
+name: Okta Modeling Rule
+id: okta_modeling_rule
+fromversion: 6.8.0
+tags: okta
+rules: >
+  [MODEL: dataset=okta_okta_raw, model=Audit]
+
+  filter eventType in ("app.ad.api.user_import.account_locked","app.app_instance.csr.generate")
+
+  | alter outcome_result = json_extract_scalar(outcome, "$.result")
+
+  | alter XDM.Audit.identity.uuid = json_extract_scalar(actor, "$.id"),
+          XDM.Audit.identity.type = json_extract_scalar(actor, "$.type"),
+  	XDM.Audit.identity.name = json_extract_scalar(client, "$.geographicalContext.city"),
+
+  	XDM.Audit.cloud_zone = json_extract_scalar(client, "$.zone"),
+
+  	XDM.Audit.triggeredby.ipv4 = json_extract_scalar(client,"$.ipAddress"),
+
+  	XDM.Audit.operation_type = eventType,
+
+  	XDM.Audit.outcome = if(outcome_result="SUCCESS", "SUCCESS", outcome_result="FAILURE", "FAILED", outcome_result="ALLOW", "SUCCESS", outcome_result="DENY", "FAILED", outcome_result="CHALLENGE", "PARTIAL", "UNKNOWN"),
+
+  	XDM.Audit.reason = json_extract_scalar(outcome, "$.reason"),
+      XDM.Audit.audited_resource.id = arraystring (arraymap (json_extract_array (`target`,"$."), json_extract_scalar ("@element", "$.alternateId")),","),
+  XDM.Audit.audited_resource.type = arraystring (arraymap (json_extract_array (`target`,"$."), json_extract_scalar ("@element", "$.type")),",");
+
+
+
+  [MODEL: dataset=okta_okta_raw, model=Auth]
+
+  filter eventType  in ("app.access_request.approver.approve")
+
+  | alter outcome_result = json_extract_scalar(outcome, "$.result")
+
+  | alter  XDM_Auth_Client_host_device_type = json_extract_scalar(Client, "$.device"),
+          XDM.Auth.Client.ipv4 = json_extract_scalar(Client, "$.ipAddress"),
+          XDM.Auth.Target.host.device_category = arraystring (arraymap (json_extract_array (`target`,"$."), json_extract_scalar ("@element", "$.type")),",");
+schema: >-
+  {
+      "okta_okta_raw": {
+          "client": {
+              "type": "string",
+              "is_array": false
+          },
+          "eventType": {
+              "type": "string",
+              "is_array": false
+          }
+      }
+  }


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CRTX-65421

## Description
Added the datasets field to modeling rules' information in the metadata.json.
@ilaner FYI - we'll need to update in the graph impl as well

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [x] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
