### PR TITLE
Added "hint" to update-release-notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
-* Fixed an issue where **validate** failed to recognize integration tests that were missing from config.json
 
 ## Unreleased
 * Fixed an issue where **generate-docs** with `-c` argument updated sections of the incorrect commands.
 * Added IF113 error code to **ALLOWED_IGNORE_ERRORS**.
+* Fixed an issue where **validate** failed to recognize integration tests that were missing from config.json.
+* Added a hint when **update-release-notes fails**.
 
 ## 1.7.7
 * Fixed an issue where paybooks **generate-docs** didn't parse complex input values when no accessor field is given correctly.

--- a/demisto_sdk/commands/update_release_notes/update_rn_manager.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn_manager.py
@@ -229,7 +229,8 @@ class UpdateReleaseNotesManager:
         else:
             print_warning(f'Either no changes were found in {pack} pack '
                           f'or the changes found should not be documented in the release notes file.\n'
-                          f'If relevant changes were made, please commit the changes and rerun the command.')
+                          f'If relevant changes were made, please commit the changes and rerun the command.\n'
+                          f'hint: Make sure you are in the main path of the repo')
 
     def get_existing_rn(self, pack) -> Optional[str]:
         """ Gets the existing rn of the pack is exists.


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
This "warning" appears a lot when you are not in the main path (content)

## Screenshots
![image](https://user-images.githubusercontent.com/90556466/201022624-31dc1b9e-958d-44c5-923e-f914271eafbf.png)

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
