### PR TITLE
Update isort Config and All Import Lines

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,9 +26,7 @@ repos:
       rev: 5.10.1
       hooks:
           - id: isort
-            args: [--atomic]
             types: [python]
-            verbose: true
             exclude: demisto_sdk/commands/init/templates/.*
     - repo: https://github.com/asottile/pyupgrade
       rev: v2.31.1

--- a/TestSuite/integration.py
+++ b/TestSuite/integration.py
@@ -4,8 +4,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from demisto_sdk.commands.common.handlers import YAML_Handler
-from demisto_sdk.commands.unify.integration_script_unifier import \
-    IntegrationScriptUnifier
+from demisto_sdk.commands.unify.integration_script_unifier import IntegrationScriptUnifier
 from TestSuite.file import File
 from TestSuite.test_tools import suite_join_path
 from TestSuite.yml import YAML

--- a/TestSuite/job.py
+++ b/TestSuite/job.py
@@ -2,8 +2,7 @@ from json.decoder import JSONDecodeError
 from pathlib import Path
 from typing import List, Optional
 
-from demisto_sdk.commands.common.constants import (
-    FILETYPE_TO_DEFAULT_FROMVERSION, FileType)
+from demisto_sdk.commands.common.constants import FILETYPE_TO_DEFAULT_FROMVERSION, FileType
 from TestSuite.json_based import JSONBased
 
 

--- a/TestSuite/pack.py
+++ b/TestSuite/pack.py
@@ -1,14 +1,9 @@
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from demisto_sdk.commands.common.constants import (CORRELATION_RULES_DIR,
-                                                   DEFAULT_IMAGE_BASE64,
-                                                   MODELING_RULES_DIR,
-                                                   PARSING_RULES_DIR,
-                                                   TRIGGER_DIR,
-                                                   XDRC_TEMPLATE_DIR,
-                                                   XSIAM_DASHBOARDS_DIR,
-                                                   XSIAM_REPORTS_DIR)
+from demisto_sdk.commands.common.constants import (CORRELATION_RULES_DIR, DEFAULT_IMAGE_BASE64, MODELING_RULES_DIR,
+                                                   PARSING_RULES_DIR, TRIGGER_DIR, XDRC_TEMPLATE_DIR,
+                                                   XSIAM_DASHBOARDS_DIR, XSIAM_REPORTS_DIR)
 from TestSuite.correlation_rule import CorrelationRule
 from TestSuite.file import File
 from TestSuite.integration import Integration

--- a/TestSuite/wizard.py
+++ b/TestSuite/wizard.py
@@ -1,8 +1,7 @@
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from demisto_sdk.commands.common.constants import (
-    FILETYPE_TO_DEFAULT_FROMVERSION, FileType)
+from demisto_sdk.commands.common.constants import FILETYPE_TO_DEFAULT_FROMVERSION, FileType
 from TestSuite.json_based import JSONBased
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -71,8 +71,7 @@ def repo(request: FixtureRequest, tmp_path_factory: TempPathFactory) -> Repo:
 
 @pytest.fixture(scope='module')
 def module_repo(request: FixtureRequest, tmp_path_factory: TempPathFactory) -> Repo:
-    from demisto_sdk.commands.find_dependencies.tests.find_dependencies_test import \
-        working_repo
+    from demisto_sdk.commands.find_dependencies.tests.find_dependencies_test import working_repo
 
     return working_repo(get_repo(request, tmp_path_factory))
 

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -14,21 +14,13 @@ import git
 from pkg_resources import DistributionNotFound, get_distribution
 
 from demisto_sdk.commands.common.configuration import Configuration
-from demisto_sdk.commands.common.constants import (ENV_DEMISTO_SDK_MARKETPLACE,
-                                                   MODELING_RULES_DIR,
-                                                   PARSING_RULES_DIR, FileType,
-                                                   MarketplaceVersions)
-from demisto_sdk.commands.common.content_constant_paths import \
-    ALL_PACKS_DEPENDENCIES_DEFAULT_PATH
+from demisto_sdk.commands.common.constants import (ENV_DEMISTO_SDK_MARKETPLACE, MODELING_RULES_DIR, PARSING_RULES_DIR,
+                                                   FileType, MarketplaceVersions)
+from demisto_sdk.commands.common.content_constant_paths import ALL_PACKS_DEPENDENCIES_DEFAULT_PATH
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.common.tools import (find_type,
-                                               get_last_remote_release_version,
-                                               get_release_note_entries,
-                                               is_external_repository,
-                                               print_error, print_success,
-                                               print_warning)
-from demisto_sdk.commands.content_graph.interface.neo4j.neo4j_graph import \
-    Neo4jContentGraphInterface
+from demisto_sdk.commands.common.tools import (find_type, get_last_remote_release_version, get_release_note_entries,
+                                               is_external_repository, print_error, print_success, print_warning)
+from demisto_sdk.commands.content_graph.interface.neo4j.neo4j_graph import Neo4jContentGraphInterface
 from demisto_sdk.commands.split.ymlsplitter import YmlSplitter
 
 json = JSON_Handler()
@@ -324,8 +316,7 @@ def unify(**kwargs):
     if marketplace := kwargs.get('marketplace'):
         os.environ[ENV_DEMISTO_SDK_MARKETPLACE] = marketplace.lower()
     if file_type == FileType.GENERIC_MODULE:
-        from demisto_sdk.commands.unify.generic_module_unifier import \
-            GenericModuleUnifier
+        from demisto_sdk.commands.unify.generic_module_unifier import GenericModuleUnifier
 
         # pass arguments to GenericModule unifier and call the command
         generic_module_unifier = GenericModuleUnifier(**kwargs)
@@ -335,8 +326,7 @@ def unify(**kwargs):
         rule_unifier = RuleUnifier(**kwargs)
         rule_unifier.unify()
     else:
-        from demisto_sdk.commands.unify.integration_script_unifier import \
-            IntegrationScriptUnifier
+        from demisto_sdk.commands.unify.integration_script_unifier import IntegrationScriptUnifier
 
         # pass arguments to YML unifier and call the command
         yml_unifier = IntegrationScriptUnifier(**kwargs, custom=custom)
@@ -363,9 +353,7 @@ def zip_packs(**kwargs) -> int:
     """Generating zipped packs that are ready to be uploaded to Cortex XSOAR machine."""
     from demisto_sdk.commands.common.logger import logging_setup
     from demisto_sdk.commands.upload.uploader import Uploader
-    from demisto_sdk.commands.zip_packs.packs_zipper import (EX_FAIL,
-                                                             EX_SUCCESS,
-                                                             PacksZipper)
+    from demisto_sdk.commands.zip_packs.packs_zipper import EX_FAIL, EX_SUCCESS, PacksZipper
     logging_setup(3)
     check_configuration_file('zip-packs', kwargs)
 
@@ -584,8 +572,7 @@ def create_content_artifacts(**kwargs) -> int:
        5. uploadable_packs - Contains zipped packs that are ready to be uploaded to Cortex XSOAR machine.
     """
     from demisto_sdk.commands.common.logger import logging_setup
-    from demisto_sdk.commands.create_artifacts.content_artifacts_creator import \
-        ArtifactsManager
+    from demisto_sdk.commands.create_artifacts.content_artifacts_creator import ArtifactsManager
     logging_setup(3)
     check_configuration_file('create-content-artifacts', kwargs)
     if marketplace := kwargs.get('marketplace'):
@@ -774,8 +761,7 @@ def lint(**kwargs):
     default='https://storage.googleapis.com/marketplace-dist-dev/code-coverage-reports/coverage-min.json', type=str
 )
 def coverage_analyze(**kwargs):
-    from demisto_sdk.commands.coverage_analyze.coverage_report import \
-        CoverageReport
+    from demisto_sdk.commands.coverage_analyze.coverage_report import CoverageReport
     try:
         no_degradation_check = kwargs['allowed_coverage_degradation_percentage'] == 100.0
         no_min_coverage_enforcement = kwargs['no_min_coverage_enforcement']
@@ -940,8 +926,7 @@ def upload(**kwargs):
     * Note: Uploading classifiers to Cortex XSOAR is available from version 6.0.0 and up. *
     """
     from demisto_sdk.commands.upload.uploader import ConfigFileParser, Uploader
-    from demisto_sdk.commands.zip_packs.packs_zipper import (EX_FAIL,
-                                                             PacksZipper)
+    from demisto_sdk.commands.zip_packs.packs_zipper import EX_FAIL, PacksZipper
     keep_zip = kwargs.pop('keep_zip')
     is_zip = kwargs.pop('zip', False)
     config_file_path = kwargs.pop('input_config_file')
@@ -1058,8 +1043,7 @@ def xsoar_config_file_update(**kwargs):
     Add automatically all the installed MarketPlace Packs to the marketplace_packs section in XSOAR Configuration File.
     Add a Pack to both marketplace_packs and custom_packs sections in the Configuration File.
     """
-    from demisto_sdk.commands.update_xsoar_config_file.update_xsoar_config_file import \
-        XSOARConfigFileUpdater
+    from demisto_sdk.commands.update_xsoar_config_file.update_xsoar_config_file import XSOARConfigFileUpdater
     file_updater: XSOARConfigFileUpdater = XSOARConfigFileUpdater(**kwargs)
     return file_updater.update()
 
@@ -1134,8 +1118,7 @@ def run_playbook(**kwargs):
     Example: DEMISTO_API_KEY=<API KEY> demisto-sdk run-playbook -p 'p_name' -u
     'https://demisto.local'.
     """
-    from demisto_sdk.commands.run_playbook.playbook_runner import \
-        PlaybookRunner
+    from demisto_sdk.commands.run_playbook.playbook_runner import PlaybookRunner
     check_configuration_file('run-playbook', kwargs)
     playbook_runner = PlaybookRunner(**kwargs)
     return playbook_runner.run_playbook()
@@ -1170,8 +1153,7 @@ def run_playbook(**kwargs):
     "--insecure", help="Skip certificate validation.", is_flag=True)
 def run_test_playbook(**kwargs):
     """Run a test playbooks in your instance."""
-    from demisto_sdk.commands.run_test_playbook.test_playbook_runner import \
-        TestPlaybookRunner
+    from demisto_sdk.commands.run_test_playbook.test_playbook_runner import TestPlaybookRunner
     check_configuration_file('run-test-playbook', kwargs)
     test_playbook_runner = TestPlaybookRunner(**kwargs)
     return test_playbook_runner.manage_and_run_test_playbooks()
@@ -1234,8 +1216,7 @@ def generate_outputs(**kwargs):
     file/UI/PyCharm. This script auto generates the YAML for a command from the JSON result of the relevant API call
     In addition you can supply examples files and generate the context description directly in the YML from those examples.
     """
-    from demisto_sdk.commands.generate_outputs.generate_outputs import \
-        run_generate_outputs
+    from demisto_sdk.commands.generate_outputs.generate_outputs import run_generate_outputs
     check_configuration_file('generate-outputs', kwargs)
     return run_generate_outputs(**kwargs)
 
@@ -1291,8 +1272,7 @@ def generate_outputs(**kwargs):
     "-u", "--upload", help="Whether to upload the test playbook after the generation.", is_flag=True)
 def generate_test_playbook(**kwargs):
     """Generate test playbook from integration or script"""
-    from demisto_sdk.commands.generate_test_playbook.test_playbook_generator import \
-        PlaybookTestsGenerator
+    from demisto_sdk.commands.generate_test_playbook.test_playbook_generator import PlaybookTestsGenerator
     check_configuration_file('generate-test-playbook', kwargs)
     file_type: FileType = find_type(kwargs.get('input', ''), ignore_sub_categories=True)
     if file_type not in [FileType.INTEGRATION, FileType.SCRIPT]:
@@ -1436,12 +1416,9 @@ def generate_docs(**kwargs):
 def _generate_docs_for_file(kwargs: Dict[str, Any]):
     """Helper function for supporting Playbooks directory as an input and not only a single yml file."""
 
-    from demisto_sdk.commands.generate_docs.generate_integration_doc import \
-        generate_integration_doc
-    from demisto_sdk.commands.generate_docs.generate_playbook_doc import \
-        generate_playbook_doc
-    from demisto_sdk.commands.generate_docs.generate_script_doc import \
-        generate_script_doc
+    from demisto_sdk.commands.generate_docs.generate_integration_doc import generate_integration_doc
+    from demisto_sdk.commands.generate_docs.generate_playbook_doc import generate_playbook_doc
+    from demisto_sdk.commands.generate_docs.generate_script_doc import generate_script_doc
 
     # Extract all the necessary arguments
     input_path: str = kwargs.get('input', '')
@@ -1528,8 +1505,7 @@ def _generate_docs_for_file(kwargs: Dict[str, Any]):
 def create_id_set(**kwargs):
     """Create the content dependency tree by ids."""
     from demisto_sdk.commands.create_id_set.create_id_set import IDSetCreator
-    from demisto_sdk.commands.find_dependencies.find_dependencies import \
-        remove_dependencies_from_id_set
+    from demisto_sdk.commands.find_dependencies.find_dependencies import remove_dependencies_from_id_set
 
     check_configuration_file('create-id-set', kwargs)
     id_set_creator = IDSetCreator(**kwargs)
@@ -1569,8 +1545,7 @@ def create_id_set(**kwargs):
 )
 def merge_id_sets(**kwargs):
     """Merge two id_sets"""
-    from demisto_sdk.commands.common.update_id_set import \
-        merge_id_sets_from_files
+    from demisto_sdk.commands.common.update_id_set import merge_id_sets_from_files
     check_configuration_file('merge-id-sets', kwargs)
     first = kwargs['id_set1']
     second = kwargs['id_set2']
@@ -1629,8 +1604,7 @@ def merge_id_sets(**kwargs):
     is_flag=True)
 def update_release_notes(**kwargs):
     """Auto-increment pack version and generate release notes template."""
-    from demisto_sdk.commands.update_release_notes.update_rn_manager import \
-        UpdateReleaseNotesManager
+    from demisto_sdk.commands.update_release_notes.update_rn_manager import UpdateReleaseNotesManager
     check_configuration_file('update-release-notes', kwargs)
     if kwargs.get('force') and not kwargs.get('input'):
         print_error('Please add a specific pack in order to force a release notes update.')
@@ -1683,8 +1657,7 @@ def update_release_notes(**kwargs):
                                          "dependency of the searched pack ", required=False)
 def find_dependencies(**kwargs):
     """Find pack dependencies and update pack metadata."""
-    from demisto_sdk.commands.find_dependencies.find_dependencies import \
-        PackDependencies
+    from demisto_sdk.commands.find_dependencies.find_dependencies import PackDependencies
     check_configuration_file('find-dependencies', kwargs)
     update_pack_metadata = not kwargs.get('no_update')
     input_paths = kwargs.get('input')  # since it can be multiple, received as a tuple
@@ -1766,8 +1739,7 @@ def postman_codegen(
 ):
     """Generates a Cortex XSOAR integration given a Postman collection 2.1 JSON file."""
     from demisto_sdk.commands.common.logger import logging_setup
-    from demisto_sdk.commands.postman_codegen.postman_codegen import \
-        postman_to_autogen_configuration
+    from demisto_sdk.commands.postman_codegen.postman_codegen import postman_to_autogen_configuration
     from demisto_sdk.commands.split.ymlsplitter import YmlSplitter
 
     if verbose:
@@ -1829,8 +1801,7 @@ def generate_integration(input: IO, output: Path, verbose: bool):
     which is generated by commands like postman-codegen
     """
     from demisto_sdk.commands.common.logger import logging_setup
-    from demisto_sdk.commands.generate_integration.code_generator import \
-        IntegrationGeneratorConfig
+    from demisto_sdk.commands.generate_integration.code_generator import IntegrationGeneratorConfig
     if verbose:
         logging_setup(verbose=3)
 
@@ -1876,8 +1847,7 @@ def openapi_codegen(**kwargs):
     In the first run of the command, an integration configuration file is created, which can be modified.
     Then, the command is run a second time with the integration configuration to generate the actual integration files.
     """
-    from demisto_sdk.commands.openapi_codegen.openapi_codegen import \
-        OpenAPIIntegration
+    from demisto_sdk.commands.openapi_codegen.openapi_codegen import OpenAPIIntegration
     check_configuration_file('openapi-codegen', kwargs)
     if not kwargs.get('output_dir'):
         output_dir = os.getcwd()
@@ -2023,8 +1993,7 @@ def test_content(**kwargs):
     run test playbook on the created investigation using mock if possible.
     Collect the result and give a report.
     """
-    from demisto_sdk.commands.test_content.execute_test_content import \
-        execute_test_content
+    from demisto_sdk.commands.test_content.execute_test_content import execute_test_content
     check_configuration_file('test-content', kwargs)
     execute_test_content(**kwargs)
 
@@ -2107,8 +2076,7 @@ def integration_diff(**kwargs):
     """
     Checks for differences between two versions of an integration, and verified that the new version covered the old version.
     """
-    from demisto_sdk.commands.integration_diff.integration_diff_detector import \
-        IntegrationDiffDetector
+    from demisto_sdk.commands.integration_diff.integration_diff_detector import IntegrationDiffDetector
     integration_diff_detector = IntegrationDiffDetector(
         new=kwargs.get('new', ''),
         old=kwargs.get('old', ''),
@@ -2141,8 +2109,7 @@ def generate_yml_from_python(**kwargs):
     """
     Checks for differences between two versions of an integration, and verified that the new version covered the old version.
     """
-    from demisto_sdk.commands.generate_yml_from_python.generate_yml import \
-        YMLGenerator
+    from demisto_sdk.commands.generate_yml_from_python.generate_yml import YMLGenerator
 
     yml_generator = YMLGenerator(filename=kwargs.get('input', ''), verbose=kwargs.get('verbose', False),
                                  force=kwargs.get('force', False))
@@ -2239,8 +2206,7 @@ def generate_unit_tests(input_path: str = '',
     klara_logger = logging.getLogger('PYSCA')
     klara_logger.propagate = False
     from demisto_sdk.commands.common.logger import logging_setup
-    from demisto_sdk.commands.generate_unit_tests.generate_unit_tests import \
-        run_generate_unit_tests
+    from demisto_sdk.commands.generate_unit_tests.generate_unit_tests import run_generate_unit_tests
     logging_setup(verbose=verbose,  # type: ignore[arg-type]
                   quiet=quiet,  # type: ignore[arg-type]
                   log_path=log_path)  # type: ignore[arg-type]
@@ -2268,8 +2234,7 @@ def generate_unit_tests(input_path: str = '',
 )
 @pass_config
 def error_code(config, **kwargs):
-    from demisto_sdk.commands.error_code_info.error_code_info import \
-        generate_error_code_information
+    from demisto_sdk.commands.error_code_info.error_code_info import generate_error_code_information
     check_configuration_file('error-code-info', kwargs)
     sys.path.append(config.configuration.env_dir)
 

--- a/demisto_sdk/commands/common/MDXServer.py
+++ b/demisto_sdk/commands/common/MDXServer.py
@@ -10,8 +10,7 @@ import docker.errors
 import docker.models.containers
 
 from demisto_sdk.commands.common.constants import DEPENDENCIES_DOCKER
-from demisto_sdk.commands.common.docker_helper import (
-    get_docker, init_global_docker_client)
+from demisto_sdk.commands.common.docker_helper import get_docker, init_global_docker_client
 from demisto_sdk.commands.common.errors import Errors
 
 EXPECTED_SUCCESS_MESSAGE = 'MDX server is listening on port'

--- a/demisto_sdk/commands/common/content/content.py
+++ b/demisto_sdk/commands/common/content/content.py
@@ -7,19 +7,12 @@ from typing import Any, Iterator
 from git import InvalidGitRepositoryError, Repo
 from wcmatch.pathlib import Path
 
-from demisto_sdk.commands.common.constants import (DOCUMENTATION,
-                                                   DOCUMENTATION_DIR,
-                                                   PACKS_DIR,
-                                                   TEST_PLAYBOOKS_DIR)
+from demisto_sdk.commands.common.constants import DOCUMENTATION, DOCUMENTATION_DIR, PACKS_DIR, TEST_PLAYBOOKS_DIR
 from demisto_sdk.commands.common.content.objects.pack_objects.pack import Pack
-from demisto_sdk.commands.common.content.objects.pack_objects.playbook.playbook import \
-    Playbook
-from demisto_sdk.commands.common.content.objects.pack_objects.script.script import \
-    Script
-from demisto_sdk.commands.common.content.objects.root_objects import (
-    ContentDescriptor, Documentation)
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects.pack_objects.playbook.playbook import Playbook
+from demisto_sdk.commands.common.content.objects.pack_objects.script.script import Script
+from demisto_sdk.commands.common.content.objects.root_objects import ContentDescriptor, Documentation
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 
 logger = logging.getLogger('demisto-sdk')
 

--- a/demisto_sdk/commands/common/content/objects/pack_objects/__init__.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/__init__.py
@@ -5,8 +5,7 @@ import inspect
 
 from .abstract_pack_objects.json_content_object import JSONContentObject
 from .abstract_pack_objects.yaml_content_object import YAMLContentObject
-from .abstract_pack_objects.yaml_unify_content_object import \
-    YAMLContentUnifiedObject
+from .abstract_pack_objects.yaml_unify_content_object import YAMLContentUnifiedObject
 from .author_image.author_image import AuthorImage
 from .change_log.change_log import ChangeLog
 from .classifier.classifier import Classifier, ClassifierMapper, OldClassifier

--- a/demisto_sdk/commands/common/content/objects/pack_objects/abstract_pack_objects/json_content_object.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/abstract_pack_objects/json_content_object.py
@@ -4,14 +4,10 @@ from typing import List, Optional, Union
 from packaging.version import LegacyVersion, Version, parse
 from wcmatch.pathlib import Path
 
-from demisto_sdk.commands.common.constants import (
-    DEFAULT_CONTENT_ITEM_FROM_VERSION, DEFAULT_CONTENT_ITEM_TO_VERSION)
-from demisto_sdk.commands.common.content.objects.abstract_objects import \
-    JSONObject
-from demisto_sdk.commands.common.content.objects.pack_objects.change_log.change_log import \
-    ChangeLog
-from demisto_sdk.commands.common.content.objects.pack_objects.readme.readme import \
-    Readme
+from demisto_sdk.commands.common.constants import DEFAULT_CONTENT_ITEM_FROM_VERSION, DEFAULT_CONTENT_ITEM_TO_VERSION
+from demisto_sdk.commands.common.content.objects.abstract_objects import JSONObject
+from demisto_sdk.commands.common.content.objects.pack_objects.change_log.change_log import ChangeLog
+from demisto_sdk.commands.common.content.objects.pack_objects.readme.readme import Readme
 from demisto_sdk.commands.common.tools import get_json
 
 

--- a/demisto_sdk/commands/common/content/objects/pack_objects/abstract_pack_objects/yaml_content_object.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/abstract_pack_objects/yaml_content_object.py
@@ -4,14 +4,10 @@ from typing import List, Optional, Union
 from packaging.version import LegacyVersion, Version, parse
 from wcmatch.pathlib import EXTGLOB, Path
 
-from demisto_sdk.commands.common.constants import (
-    DEFAULT_CONTENT_ITEM_FROM_VERSION, DEFAULT_CONTENT_ITEM_TO_VERSION)
-from demisto_sdk.commands.common.content.objects.abstract_objects import \
-    YAMLObject
-from demisto_sdk.commands.common.content.objects.pack_objects.change_log.change_log import \
-    ChangeLog
-from demisto_sdk.commands.common.content.objects.pack_objects.readme.readme import \
-    Readme
+from demisto_sdk.commands.common.constants import DEFAULT_CONTENT_ITEM_FROM_VERSION, DEFAULT_CONTENT_ITEM_TO_VERSION
+from demisto_sdk.commands.common.content.objects.abstract_objects import YAMLObject
+from demisto_sdk.commands.common.content.objects.pack_objects.change_log.change_log import ChangeLog
+from demisto_sdk.commands.common.content.objects.pack_objects.readme.readme import Readme
 
 
 class YAMLContentObject(YAMLObject):

--- a/demisto_sdk/commands/common/content/objects/pack_objects/abstract_pack_objects/yaml_unify_content_object.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/abstract_pack_objects/yaml_unify_content_object.py
@@ -5,8 +5,7 @@ from wcmatch.pathlib import EXTMATCH, Path
 
 import demisto_sdk.commands.common.content.errors as exc
 from demisto_sdk.commands.common.constants import ENTITY_TYPE_TO_DIR, FileType
-from demisto_sdk.commands.unify.integration_script_unifier import \
-    IntegrationScriptUnifier
+from demisto_sdk.commands.unify.integration_script_unifier import IntegrationScriptUnifier
 from demisto_sdk.commands.unify.rule_unifier import RuleUnifier
 
 from .yaml_content_object import YAMLContentObject

--- a/demisto_sdk/commands/common/content/objects/pack_objects/author_image/author_image.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/author_image/author_image.py
@@ -2,8 +2,7 @@ from typing import Union
 
 from wcmatch.pathlib import Path
 
-from demisto_sdk.commands.common.content.objects.abstract_objects import \
-    TextObject
+from demisto_sdk.commands.common.content.objects.abstract_objects import TextObject
 
 
 class AuthorImage(TextObject):

--- a/demisto_sdk/commands/common/content/objects/pack_objects/change_log/change_log.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/change_log/change_log.py
@@ -3,8 +3,7 @@ from typing import Union
 from wcmatch.pathlib import Path
 
 from demisto_sdk.commands.common.constants import FileType
-from demisto_sdk.commands.common.content.objects.abstract_objects.text_object import \
-    TextObject
+from demisto_sdk.commands.common.content.objects.abstract_objects.text_object import TextObject
 
 
 class ChangeLog(TextObject):

--- a/demisto_sdk/commands/common/content/objects/pack_objects/contributors/contributors.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/contributors/contributors.py
@@ -3,8 +3,7 @@ from typing import Union
 from wcmatch.pathlib import Path
 
 from demisto_sdk.commands.common.constants import FileType
-from demisto_sdk.commands.common.content.objects.abstract_objects import \
-    TextObject
+from demisto_sdk.commands.common.content.objects.abstract_objects import TextObject
 
 
 class Contributors(TextObject):

--- a/demisto_sdk/commands/common/content/objects/pack_objects/doc_file/doc_file.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/doc_file/doc_file.py
@@ -2,8 +2,7 @@ from typing import Union
 
 from wcmatch.pathlib import Path
 
-from demisto_sdk.commands.common.content.objects.abstract_objects import \
-    TextObject
+from demisto_sdk.commands.common.content.objects.abstract_objects import TextObject
 
 
 class DocFile(TextObject):

--- a/demisto_sdk/commands/common/content/objects/pack_objects/indicator_field/indicator_field.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/indicator_field/indicator_field.py
@@ -4,8 +4,7 @@ from typing import Union
 import demisto_client
 from wcmatch.pathlib import Path
 
-from demisto_sdk.commands.common.constants import (INCIDENT_FIELD,
-                                                   INDICATOR_FIELD, FileType)
+from demisto_sdk.commands.common.constants import INCIDENT_FIELD, INDICATOR_FIELD, FileType
 from demisto_sdk.commands.common.content.objects.pack_objects.abstract_pack_objects.json_content_object import \
     JSONContentObject
 from demisto_sdk.commands.common.handlers import JSON_Handler

--- a/demisto_sdk/commands/common/content/objects/pack_objects/indicator_type/indicator_type.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/indicator_type/indicator_type.py
@@ -4,9 +4,7 @@ from typing import Union
 import demisto_client
 from wcmatch.pathlib import Path
 
-from demisto_sdk.commands.common.constants import (INDICATOR_TYPE,
-                                                   OLD_INDICATOR_TYPE,
-                                                   FileType)
+from demisto_sdk.commands.common.constants import INDICATOR_TYPE, OLD_INDICATOR_TYPE, FileType
 from demisto_sdk.commands.common.content.objects.pack_objects.abstract_pack_objects.json_content_object import \
     JSONContentObject
 from demisto_sdk.commands.common.handlers import JSON_Handler

--- a/demisto_sdk/commands/common/content/objects/pack_objects/pack.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/pack.py
@@ -7,30 +7,32 @@ import demisto_client
 import regex
 from wcmatch.pathlib import Path
 
-from demisto_sdk.commands.common.constants import (
-    CLASSIFIERS_DIR, CONNECTIONS_DIR, CORRELATION_RULES_DIR, DASHBOARDS_DIR,
-    DEPRECATED_DESC_REGEX, DEPRECATED_NO_REPLACE_DESC_REGEX, DOC_FILES_DIR,
-    GENERIC_DEFINITIONS_DIR, GENERIC_FIELDS_DIR, GENERIC_MODULES_DIR,
-    GENERIC_TYPES_DIR, INCIDENT_FIELDS_DIR, INCIDENT_TYPES_DIR,
-    INDICATOR_FIELDS_DIR, INDICATOR_TYPES_DIR, INTEGRATIONS_DIR, JOBS_DIR,
-    LAYOUTS_DIR, LISTS_DIR, MODELING_RULES_DIR, PACK_NAME_DEPRECATED_REGEX,
-    PACK_VERIFY_KEY, PARSING_RULES_DIR, PLAYBOOKS_DIR, PRE_PROCESS_RULES_DIR,
-    RELEASE_NOTES_DIR, REPORTS_DIR, SCRIPTS_DIR, TEST_PLAYBOOKS_DIR, TOOLS_DIR,
-    TRIGGER_DIR, WIDGETS_DIR, WIZARDS_DIR, XDRC_TEMPLATE_DIR,
-    XSIAM_DASHBOARDS_DIR, XSIAM_REPORTS_DIR, FileType)
-from demisto_sdk.commands.common.content.objects.pack_objects import (
-    AgentTool, AuthorImage, Classifier, ClassifierMapper, Connection,
-    Contributors, CorrelationRule, Dashboard, DocFile, GenericDefinition,
-    GenericField, GenericModule, GenericType, IncidentField, IncidentType,
-    IndicatorField, IndicatorType, Integration, Job, LayoutObject, Lists,
-    ModelingRule, OldClassifier, PackIgnore, PackMetaData, ParsingRule,
-    Playbook, PreProcessRule, Readme, ReleaseNote, ReleaseNoteConfig, Report,
-    Script, SecretIgnore, Trigger, Widget, Wizard, XDRCTemplate,
-    XSIAMDashboard, XSIAMReport)
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
-from demisto_sdk.commands.common.tools import (get_demisto_version,
-                                               is_object_in_id_set)
+from demisto_sdk.commands.common.constants import (CLASSIFIERS_DIR, CONNECTIONS_DIR, CORRELATION_RULES_DIR,
+                                                   DASHBOARDS_DIR, DEPRECATED_DESC_REGEX,
+                                                   DEPRECATED_NO_REPLACE_DESC_REGEX, DOC_FILES_DIR,
+                                                   GENERIC_DEFINITIONS_DIR, GENERIC_FIELDS_DIR, GENERIC_MODULES_DIR,
+                                                   GENERIC_TYPES_DIR, INCIDENT_FIELDS_DIR, INCIDENT_TYPES_DIR,
+                                                   INDICATOR_FIELDS_DIR, INDICATOR_TYPES_DIR, INTEGRATIONS_DIR,
+                                                   JOBS_DIR, LAYOUTS_DIR, LISTS_DIR, MODELING_RULES_DIR,
+                                                   PACK_NAME_DEPRECATED_REGEX, PACK_VERIFY_KEY, PARSING_RULES_DIR,
+                                                   PLAYBOOKS_DIR, PRE_PROCESS_RULES_DIR, RELEASE_NOTES_DIR, REPORTS_DIR,
+                                                   SCRIPTS_DIR, TEST_PLAYBOOKS_DIR, TOOLS_DIR, TRIGGER_DIR, WIDGETS_DIR,
+                                                   WIZARDS_DIR, XDRC_TEMPLATE_DIR, XSIAM_DASHBOARDS_DIR,
+                                                   XSIAM_REPORTS_DIR, FileType)
+from demisto_sdk.commands.common.content.objects.pack_objects import (AgentTool, AuthorImage, Classifier,
+                                                                      ClassifierMapper, Connection, Contributors,
+                                                                      CorrelationRule, Dashboard, DocFile,
+                                                                      GenericDefinition, GenericField, GenericModule,
+                                                                      GenericType, IncidentField, IncidentType,
+                                                                      IndicatorField, IndicatorType, Integration, Job,
+                                                                      LayoutObject, Lists, ModelingRule, OldClassifier,
+                                                                      PackIgnore, PackMetaData, ParsingRule, Playbook,
+                                                                      PreProcessRule, Readme, ReleaseNote,
+                                                                      ReleaseNoteConfig, Report, Script, SecretIgnore,
+                                                                      Trigger, Widget, Wizard, XDRCTemplate,
+                                                                      XSIAMDashboard, XSIAMReport)
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
+from demisto_sdk.commands.common.tools import get_demisto_version, is_object_in_id_set
 from demisto_sdk.commands.test_content import tools
 
 TURN_VERIFICATION_ERROR_MSG = "Can not set the pack verification configuration key,\nIn the server - go to Settings -> troubleshooting\

--- a/demisto_sdk/commands/common/content/objects/pack_objects/pack_ignore/pack_ignore.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/pack_ignore/pack_ignore.py
@@ -2,8 +2,7 @@ from typing import Union
 
 from wcmatch.pathlib import Path
 
-from demisto_sdk.commands.common.content.objects.abstract_objects import \
-    TextObject
+from demisto_sdk.commands.common.content.objects.abstract_objects import TextObject
 
 
 class PackIgnore(TextObject):

--- a/demisto_sdk/commands/common/content/objects/pack_objects/pack_metadata/pack_metadata.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/pack_metadata/pack_metadata.py
@@ -6,16 +6,12 @@ from typing import Dict, List, Union
 from packaging.version import Version, parse
 from wcmatch.pathlib import Path
 
-from demisto_sdk.commands.common.constants import (PACKS_PACK_META_FILE_NAME,
-                                                   XSOAR_AUTHOR, XSOAR_SUPPORT,
-                                                   XSOAR_SUPPORT_URL,
-                                                   ContentItems)
-from demisto_sdk.commands.common.content.objects.abstract_objects import \
-    JSONObject
+from demisto_sdk.commands.common.constants import (PACKS_PACK_META_FILE_NAME, XSOAR_AUTHOR, XSOAR_SUPPORT,
+                                                   XSOAR_SUPPORT_URL, ContentItems)
+from demisto_sdk.commands.common.content.objects.abstract_objects import JSONObject
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.tools import get_core_pack_list
-from demisto_sdk.commands.find_dependencies.find_dependencies import \
-    PackDependencies
+from demisto_sdk.commands.find_dependencies.find_dependencies import PackDependencies
 
 json = JSON_Handler()
 

--- a/demisto_sdk/commands/common/content/objects/pack_objects/playbook/playbook.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/playbook/playbook.py
@@ -3,9 +3,7 @@ from typing import Union
 import demisto_client
 from wcmatch.pathlib import Path
 
-from demisto_sdk.commands.common.constants import (PLAYBOOK,
-                                                   TEST_PLAYBOOKS_DIR,
-                                                   FileType)
+from demisto_sdk.commands.common.constants import PLAYBOOK, TEST_PLAYBOOKS_DIR, FileType
 from demisto_sdk.commands.common.content.objects.pack_objects.abstract_pack_objects.yaml_content_object import \
     YAMLContentObject
 

--- a/demisto_sdk/commands/common/content/objects/pack_objects/readme/readme.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/readme/readme.py
@@ -4,10 +4,8 @@ from typing import List, Optional, Union
 
 from wcmatch.pathlib import Path
 
-from demisto_sdk.commands.common.constants import (
-    CONTRIBUTORS_README_TEMPLATE, FileType)
-from demisto_sdk.commands.common.content.objects.abstract_objects import \
-    TextObject
+from demisto_sdk.commands.common.constants import CONTRIBUTORS_README_TEMPLATE, FileType
+from demisto_sdk.commands.common.content.objects.abstract_objects import TextObject
 from demisto_sdk.commands.common.tools import get_mp_tag_parser
 
 

--- a/demisto_sdk/commands/common/content/objects/pack_objects/release_note/release_note.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/release_note/release_note.py
@@ -3,8 +3,7 @@ from typing import Union
 from wcmatch.pathlib import Path
 
 from demisto_sdk.commands.common.constants import FileType
-from demisto_sdk.commands.common.content.objects.abstract_objects import \
-    TextObject
+from demisto_sdk.commands.common.content.objects.abstract_objects import TextObject
 
 
 class ReleaseNote(TextObject):

--- a/demisto_sdk/commands/common/content/objects/pack_objects/release_note_config/release_note_config.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/release_note_config/release_note_config.py
@@ -3,8 +3,7 @@ from typing import Union
 from wcmatch.pathlib import Path
 
 from demisto_sdk.commands.common.constants import FileType
-from demisto_sdk.commands.common.content.objects.abstract_objects import \
-    JSONObject
+from demisto_sdk.commands.common.content.objects.abstract_objects import JSONObject
 
 
 class ReleaseNoteConfig(JSONObject):

--- a/demisto_sdk/commands/common/content/objects/pack_objects/script/script.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/script/script.py
@@ -5,8 +5,7 @@ import demisto_client
 from packaging.version import parse
 from wcmatch.pathlib import Path
 
-from demisto_sdk.commands.common.constants import (SCRIPT, TEST_PLAYBOOKS_DIR,
-                                                   FileType)
+from demisto_sdk.commands.common.constants import SCRIPT, TEST_PLAYBOOKS_DIR, FileType
 from demisto_sdk.commands.common.content.objects.pack_objects.abstract_pack_objects.yaml_unify_content_object import \
     YAMLContentUnifiedObject
 from demisto_sdk.commands.common.tools import get_demisto_version

--- a/demisto_sdk/commands/common/content/objects/pack_objects/secret_ignore/secret_ignore.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/secret_ignore/secret_ignore.py
@@ -2,8 +2,7 @@ from typing import Union
 
 from wcmatch.pathlib import Path
 
-from demisto_sdk.commands.common.content.objects.abstract_objects import \
-    TextObject
+from demisto_sdk.commands.common.content.objects.abstract_objects import TextObject
 
 
 class SecretIgnore(TextObject):

--- a/demisto_sdk/commands/common/content/objects/pack_objects/tool/agent_tool.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/tool/agent_tool.py
@@ -7,8 +7,7 @@ from wcmatch.pathlib import Path
 
 import demisto_sdk.commands.common.content.errors as exc
 from demisto_sdk.commands.common.constants import TOOL
-from demisto_sdk.commands.common.content.objects.abstract_objects import \
-    GeneralObject
+from demisto_sdk.commands.common.content.objects.abstract_objects import GeneralObject
 
 
 class AgentTool(GeneralObject):

--- a/demisto_sdk/commands/common/content/objects/pack_objects/xdrc_template/xdrc_template.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/xdrc_template/xdrc_template.py
@@ -4,13 +4,11 @@ import demisto_client
 from wcmatch.pathlib import Path
 
 import demisto_sdk.commands.common.content.errors as exc
-from demisto_sdk.commands.common.constants import (ENTITY_TYPE_TO_DIR,
-                                                   XDRC_TEMPLATE, FileType)
+from demisto_sdk.commands.common.constants import ENTITY_TYPE_TO_DIR, XDRC_TEMPLATE, FileType
 from demisto_sdk.commands.common.content.objects.pack_objects.abstract_pack_objects.json_content_object import \
     JSONContentObject
 from demisto_sdk.commands.common.tools import generate_xsiam_normalized_name
-from demisto_sdk.commands.unify.xdrc_template_unifier import \
-    XDRCTemplateUnifier
+from demisto_sdk.commands.unify.xdrc_template_unifier import XDRCTemplateUnifier
 
 
 class XDRCTemplate(JSONContentObject):

--- a/demisto_sdk/commands/common/content/objects/pack_objects/xsiam_dashboard_image/xsiam_dashboard_image.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/xsiam_dashboard_image/xsiam_dashboard_image.py
@@ -3,8 +3,7 @@ from typing import Union
 from wcmatch.pathlib import Path
 
 import demisto_sdk.commands.common.content.errors as exc
-from demisto_sdk.commands.common.content.objects.abstract_objects import \
-    GeneralObject
+from demisto_sdk.commands.common.content.objects.abstract_objects import GeneralObject
 
 
 class XSIAMDashboardImage(GeneralObject):

--- a/demisto_sdk/commands/common/content/objects/pack_objects/xsiam_report_image/xsiam_report_image.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/xsiam_report_image/xsiam_report_image.py
@@ -3,8 +3,7 @@ from typing import Union
 from wcmatch.pathlib import Path
 
 import demisto_sdk.commands.common.content.errors as exc
-from demisto_sdk.commands.common.content.objects.abstract_objects import \
-    GeneralObject
+from demisto_sdk.commands.common.content.objects.abstract_objects import GeneralObject
 
 
 class XSIAMReportImage(GeneralObject):

--- a/demisto_sdk/commands/common/content/objects/root_objects/content_descriptor/content_descriptor.py
+++ b/demisto_sdk/commands/common/content/objects/root_objects/content_descriptor/content_descriptor.py
@@ -2,8 +2,7 @@ from typing import Union
 
 from wcmatch.pathlib import Path
 
-from demisto_sdk.commands.common.content.objects.abstract_objects.json_object import \
-    JSONObject
+from demisto_sdk.commands.common.content.objects.abstract_objects.json_object import JSONObject
 
 
 class ContentDescriptor(JSONObject):

--- a/demisto_sdk/commands/common/content/objects/root_objects/documentation/documentation.py
+++ b/demisto_sdk/commands/common/content/objects/root_objects/documentation/documentation.py
@@ -3,8 +3,7 @@ from typing import Union
 from wcmatch.pathlib import Path
 
 from demisto_sdk.commands.common.constants import DOCUMENTATION
-from demisto_sdk.commands.common.content.objects.abstract_objects.json_object import \
-    JSONObject
+from demisto_sdk.commands.common.content.objects.abstract_objects.json_object import JSONObject
 
 
 class Documentation(JSONObject):

--- a/demisto_sdk/commands/common/content/objects_factory.py
+++ b/demisto_sdk/commands/common/content/objects_factory.py
@@ -3,19 +3,21 @@ from typing import Union
 from wcmatch.pathlib import Path
 
 from demisto_sdk.commands.common.constants import OLD_INDICATOR_TYPE, FileType
-from demisto_sdk.commands.common.content.objects.abstract_objects.general_object import \
-    GeneralObject
-from demisto_sdk.commands.common.content.objects.pack_objects import (
-    AgentTool, AuthorImage, ChangeLog, Classifier, ClassifierMapper,
-    Connection, Contributors, CorrelationRule, Dashboard, DocFile,
-    GenericDefinition, GenericField, GenericModule, GenericType, IncidentField,
-    IncidentType, IndicatorField, IndicatorType, Integration, Job, Layout,
-    LayoutsContainer, Lists, ModelingRule, OldClassifier, OldIndicatorType,
-    PackIgnore, PackMetaData, ParsingRule, Playbook, PreProcessRule, Readme,
-    ReleaseNote, ReleaseNoteConfig, Report, Script, SecretIgnore, Trigger,
-    Widget, Wizard, XDRCTemplate, XSIAMDashboard, XSIAMReport)
-from demisto_sdk.commands.common.content.objects.root_objects import \
-    Documentation
+from demisto_sdk.commands.common.content.objects.abstract_objects.general_object import GeneralObject
+from demisto_sdk.commands.common.content.objects.pack_objects import (AgentTool, AuthorImage, ChangeLog, Classifier,
+                                                                      ClassifierMapper, Connection, Contributors,
+                                                                      CorrelationRule, Dashboard, DocFile,
+                                                                      GenericDefinition, GenericField, GenericModule,
+                                                                      GenericType, IncidentField, IncidentType,
+                                                                      IndicatorField, IndicatorType, Integration, Job,
+                                                                      Layout, LayoutsContainer, Lists, ModelingRule,
+                                                                      OldClassifier, OldIndicatorType, PackIgnore,
+                                                                      PackMetaData, ParsingRule, Playbook,
+                                                                      PreProcessRule, Readme, ReleaseNote,
+                                                                      ReleaseNoteConfig, Report, Script, SecretIgnore,
+                                                                      Trigger, Widget, Wizard, XDRCTemplate,
+                                                                      XSIAMDashboard, XSIAMReport)
+from demisto_sdk.commands.common.content.objects.root_objects import Documentation
 from demisto_sdk.commands.common.tools import find_type
 
 from .errors import ContentFactoryError

--- a/demisto_sdk/commands/common/content/tests/content_test.py
+++ b/demisto_sdk/commands/common/content/tests/content_test.py
@@ -1,10 +1,8 @@
 import pytest
 
 from demisto_sdk.commands.common.content import Content
-from demisto_sdk.commands.common.content.objects.pack_objects import (Playbook,
-                                                                      Script)
-from demisto_sdk.commands.common.content.objects.root_objects import (
-    ContentDescriptor, Documentation)
+from demisto_sdk.commands.common.content.objects.pack_objects import Playbook, Script
+from demisto_sdk.commands.common.content.objects.root_objects import ContentDescriptor, Documentation
 from demisto_sdk.commands.common.tools import src_root
 
 TEST_DATA = src_root() / 'tests' / 'test_files'

--- a/demisto_sdk/commands/common/content/tests/objects/abstract_objects/json_object_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/abstract_objects/json_object_test.py
@@ -1,11 +1,8 @@
 import pytest
 
-from demisto_sdk.commands.common.constants import (INDICATOR_TYPES_DIR,
-                                                   PACKS_DIR)
-from demisto_sdk.commands.common.content.errors import (ContentInitializeError,
-                                                        ContentSerializeError)
-from demisto_sdk.commands.common.content.objects.abstract_objects import \
-    JSONObject
+from demisto_sdk.commands.common.constants import INDICATOR_TYPES_DIR, PACKS_DIR
+from demisto_sdk.commands.common.content.errors import ContentInitializeError, ContentSerializeError
+from demisto_sdk.commands.common.content.objects.abstract_objects import JSONObject
 from demisto_sdk.commands.common.tools import src_root
 
 TEST_DATA = src_root() / 'tests' / 'test_files'

--- a/demisto_sdk/commands/common/content/tests/objects/abstract_objects/text_object_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/abstract_objects/text_object_test.py
@@ -3,8 +3,7 @@ from pathlib import Path
 import pytest
 
 from demisto_sdk.commands.common.content.errors import ContentInitializeError
-from demisto_sdk.commands.common.content.objects.abstract_objects import \
-    TextObject
+from demisto_sdk.commands.common.content.objects.abstract_objects import TextObject
 from demisto_sdk.commands.common.tools import src_root
 
 TEST_DATA = src_root() / 'tests' / 'test_files'

--- a/demisto_sdk/commands/common/content/tests/objects/abstract_objects/yaml_object_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/abstract_objects/yaml_object_test.py
@@ -1,10 +1,8 @@
 import pytest
 
 from demisto_sdk.commands.common.constants import PACKS_DIR, PLAYBOOKS_DIR
-from demisto_sdk.commands.common.content.errors import (ContentInitializeError,
-                                                        ContentSerializeError)
-from demisto_sdk.commands.common.content.objects.abstract_objects import \
-    YAMLObject
+from demisto_sdk.commands.common.content.errors import ContentInitializeError, ContentSerializeError
+from demisto_sdk.commands.common.content.objects.abstract_objects import YAMLObject
 from demisto_sdk.commands.common.handlers import YAML_Handler
 from demisto_sdk.commands.common.tools import src_root
 

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/abstract_pack_objects/json_content_object_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/abstract_pack_objects/json_content_object_test.py
@@ -3,8 +3,7 @@ from typing import Union
 import pytest
 from wcmatch.pathlib import Path
 
-from demisto_sdk.commands.common.constants import (
-    CLASSIFIERS_DIR, DEFAULT_CONTENT_ITEM_FROM_VERSION, PACKS_DIR)
+from demisto_sdk.commands.common.constants import CLASSIFIERS_DIR, DEFAULT_CONTENT_ITEM_FROM_VERSION, PACKS_DIR
 from demisto_sdk.commands.common.content.objects.pack_objects.abstract_pack_objects.json_content_object import \
     JSONContentObject
 from demisto_sdk.commands.common.tools import src_root

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/abstract_pack_objects/yaml_content_object_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/abstract_pack_objects/yaml_content_object_test.py
@@ -1,6 +1,5 @@
-from demisto_sdk.commands.common.constants import (
-    DEFAULT_CONTENT_ITEM_FROM_VERSION, DEFAULT_CONTENT_ITEM_TO_VERSION,
-    PACKS_DIR, SCRIPTS_DIR)
+from demisto_sdk.commands.common.constants import (DEFAULT_CONTENT_ITEM_FROM_VERSION, DEFAULT_CONTENT_ITEM_TO_VERSION,
+                                                   PACKS_DIR, SCRIPTS_DIR)
 from demisto_sdk.commands.common.content.objects.pack_objects.abstract_pack_objects.yaml_content_object import \
     YAMLContentObject
 from demisto_sdk.commands.common.tools import src_root

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/author_image/author_image_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/author_image/author_image_test.py
@@ -1,8 +1,6 @@
 from demisto_sdk.commands.common.constants import PACKS_DIR
-from demisto_sdk.commands.common.content.objects.pack_objects import \
-    AuthorImage
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects.pack_objects import AuthorImage
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 from demisto_sdk.commands.common.tools import src_root
 
 TEST_DATA = src_root() / 'tests' / 'test_files'

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/change_log/change_log_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/change_log/change_log_test.py
@@ -1,7 +1,6 @@
 from demisto_sdk.commands.common.constants import CLASSIFIERS_DIR, PACKS_DIR
 from demisto_sdk.commands.common.content.objects.pack_objects import ChangeLog
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 from demisto_sdk.commands.common.tools import src_root
 
 TEST_DATA = src_root() / 'tests' / 'test_files'

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/classifier/classifier_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/classifier/classifier_test.py
@@ -1,8 +1,6 @@
 from demisto_sdk.commands.common.constants import CLASSIFIERS_DIR, PACKS_DIR
-from demisto_sdk.commands.common.content.objects.pack_objects import (
-    Classifier, ClassifierMapper, OldClassifier)
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects.pack_objects import Classifier, ClassifierMapper, OldClassifier
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 from demisto_sdk.commands.common.tools import src_root
 
 TEST_DATA = src_root() / 'tests' / 'test_files'

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/connection/connection_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/connection/connection_test.py
@@ -1,7 +1,6 @@
 from demisto_sdk.commands.common.constants import CONNECTIONS_DIR, PACKS_DIR
 from demisto_sdk.commands.common.content.objects.pack_objects import Connection
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 from demisto_sdk.commands.common.tools import src_root
 
 TEST_DATA = src_root() / 'tests' / 'test_files'

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/correlation_rule/correlation_rule_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/correlation_rule/correlation_rule_test.py
@@ -1,7 +1,5 @@
-from demisto_sdk.commands.common.content.objects.pack_objects import \
-    CorrelationRule
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects.pack_objects import CorrelationRule
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 
 
 def get_correlation_rule(pack, name):

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/dashboard/dashboard_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/dashboard/dashboard_test.py
@@ -1,7 +1,6 @@
 from demisto_sdk.commands.common.constants import DASHBOARDS_DIR, PACKS_DIR
 from demisto_sdk.commands.common.content.objects.pack_objects import Dashboard
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 from demisto_sdk.commands.common.tools import src_root
 
 TEST_DATA = src_root() / 'tests' / 'test_files'

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/doc_file/doc_file_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/doc_file/doc_file_test.py
@@ -1,7 +1,6 @@
 from demisto_sdk.commands.common.constants import DOC_FILES_DIR, PACKS_DIR
 from demisto_sdk.commands.common.content.objects.pack_objects import DocFile
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 from demisto_sdk.commands.common.tools import src_root
 
 TEST_DATA = src_root() / 'tests' / 'test_files'

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/incident_field/incident_field_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/incident_field/incident_field_test.py
@@ -1,9 +1,6 @@
-from demisto_sdk.commands.common.constants import (INCIDENT_FIELDS_DIR,
-                                                   PACKS_DIR)
-from demisto_sdk.commands.common.content.objects.pack_objects import \
-    IncidentField
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.constants import INCIDENT_FIELDS_DIR, PACKS_DIR
+from demisto_sdk.commands.common.content.objects.pack_objects import IncidentField
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 from demisto_sdk.commands.common.tools import src_root
 
 TEST_DATA = src_root() / 'tests' / 'test_files'

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/incident_type/incident_type_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/incident_type/incident_type_test.py
@@ -1,8 +1,6 @@
 from demisto_sdk.commands.common.constants import INCIDENT_TYPES_DIR, PACKS_DIR
-from demisto_sdk.commands.common.content.objects.pack_objects import \
-    IncidentType
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects.pack_objects import IncidentType
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 from demisto_sdk.commands.common.tools import src_root
 
 TEST_DATA = src_root() / 'tests' / 'test_files'

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/indicator_field/indicator_field_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/indicator_field/indicator_field_test.py
@@ -1,7 +1,5 @@
-from demisto_sdk.commands.common.constants import (INDICATOR_FIELDS_DIR,
-                                                   PACKS_DIR)
-from demisto_sdk.commands.common.content.objects.pack_objects import \
-    IndicatorField
+from demisto_sdk.commands.common.constants import INDICATOR_FIELDS_DIR, PACKS_DIR
+from demisto_sdk.commands.common.content.objects.pack_objects import IndicatorField
 from demisto_sdk.commands.common.tools import src_root
 
 TEST_DATA = src_root() / 'tests' / 'test_files'

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/indicator_type/indicator_type_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/indicator_type/indicator_type_test.py
@@ -1,11 +1,8 @@
 import pytest
 
-from demisto_sdk.commands.common.constants import (INDICATOR_TYPES_DIR,
-                                                   PACKS_DIR)
-from demisto_sdk.commands.common.content.objects.pack_objects import (
-    IndicatorType, OldIndicatorType)
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.constants import INDICATOR_TYPES_DIR, PACKS_DIR
+from demisto_sdk.commands.common.content.objects.pack_objects import IndicatorType, OldIndicatorType
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 from demisto_sdk.commands.common.tools import src_root
 
 TEST_DATA = src_root() / 'tests' / 'test_files'

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/integration/integration_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/integration/integration_test.py
@@ -1,9 +1,7 @@
 from pathlib import Path
 
-from demisto_sdk.commands.common.content.objects.pack_objects import \
-    Integration
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects.pack_objects import Integration
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 
 
 class TestNotUnifiedIntegration:

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/job/job_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/job/job_test.py
@@ -1,7 +1,5 @@
-from demisto_sdk.commands.common.content.objects.pack_objects.job.job import \
-    Job
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects.pack_objects.job.job import Job
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 
 sample_job_name = "sample-job"
 sample_file_path = f"Jobs/{sample_job_name}.json"

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/layout/layout_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/layout/layout_test.py
@@ -1,9 +1,7 @@
 import pytest
 
-from demisto_sdk.commands.common.content.objects.pack_objects import \
-    LayoutsContainer
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects.pack_objects import LayoutsContainer
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 from demisto_sdk.commands.common.tools import src_root
 
 TEST_DATA = src_root() / 'tests' / 'test_files'

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/lists/lists_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/lists/lists_test.py
@@ -1,7 +1,6 @@
 from demisto_sdk.commands.common.constants import LISTS_DIR, PACKS_DIR
 from demisto_sdk.commands.common.content.objects.pack_objects import Lists
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 from demisto_sdk.commands.common.tools import src_root
 
 TEST_DATA = src_root() / 'tests' / 'test_files'

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/modeling_rule/modeling_rule_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/modeling_rule/modeling_rule_test.py
@@ -1,7 +1,5 @@
-from demisto_sdk.commands.common.content.objects.pack_objects import \
-    ModelingRule
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects.pack_objects import ModelingRule
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 from demisto_sdk.commands.common.tools import get_yaml
 
 

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/pack_ignore/pack_ignore_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/pack_ignore/pack_ignore_test.py
@@ -1,7 +1,6 @@
 from demisto_sdk.commands.common.constants import PACKS_DIR
 from demisto_sdk.commands.common.content.objects.pack_objects import PackIgnore
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 from demisto_sdk.commands.common.tools import src_root
 
 TEST_DATA = src_root() / 'tests' / 'test_files'

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/pack_metadata/pack_metadata_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/pack_metadata/pack_metadata_test.py
@@ -6,14 +6,10 @@ from shutil import rmtree
 import pytest
 from packaging.version import parse
 
-from demisto_sdk.commands.common.constants import (PACKS_DIR, XSOAR_AUTHOR,
-                                                   XSOAR_SUPPORT,
-                                                   XSOAR_SUPPORT_URL)
-from demisto_sdk.commands.common.content.objects.pack_objects import \
-    PackMetaData
+from demisto_sdk.commands.common.constants import PACKS_DIR, XSOAR_AUTHOR, XSOAR_SUPPORT, XSOAR_SUPPORT_URL
+from demisto_sdk.commands.common.content.objects.pack_objects import PackMetaData
 from demisto_sdk.commands.common.content.objects.pack_objects.pack import Pack
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 from demisto_sdk.commands.common.logger import logging_setup
 from demisto_sdk.commands.common.tools import src_root
 from TestSuite.test_tools import ChangeCWD
@@ -179,8 +175,7 @@ def test_load_user_metadata_basic(repo):
         - Verify that pack's metadata information was loaded successfully.
 
     """
-    from demisto_sdk.commands.create_artifacts.content_artifacts_creator import \
-        ArtifactsManager
+    from demisto_sdk.commands.create_artifacts.content_artifacts_creator import ArtifactsManager
 
     pack_1 = repo.setup_one_pack('Pack1')
     pack_1.pack_metadata.write_json(
@@ -238,8 +233,7 @@ def test_load_user_metadata_advanced(repo):
         - Verify that pack's metadata information was loaded successfully.
 
     """
-    from demisto_sdk.commands.create_artifacts.content_artifacts_creator import \
-        ArtifactsManager
+    from demisto_sdk.commands.create_artifacts.content_artifacts_creator import ArtifactsManager
 
     pack_1 = repo.setup_one_pack('Pack1')
     pack_1.pack_metadata.write_json(

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/pack_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/pack_test.py
@@ -7,11 +7,12 @@ import pytest
 
 from demisto_sdk.commands.common.constants import PACKS_DIR
 from demisto_sdk.commands.common.content import Pack
-from demisto_sdk.commands.common.content.objects.pack_objects import (
-    AgentTool, Classifier, Connection, Contributors, Dashboard, DocFile,
-    IncidentField, IncidentType, IndicatorField, IndicatorType, Integration,
-    LayoutsContainer, PackIgnore, PackMetaData, Playbook, Readme, ReleaseNote,
-    Report, Script, SecretIgnore, Widget)
+from demisto_sdk.commands.common.content.objects.pack_objects import (AgentTool, Classifier, Connection, Contributors,
+                                                                      Dashboard, DocFile, IncidentField, IncidentType,
+                                                                      IndicatorField, IndicatorType, Integration,
+                                                                      LayoutsContainer, PackIgnore, PackMetaData,
+                                                                      Playbook, Readme, ReleaseNote, Report, Script,
+                                                                      SecretIgnore, Widget)
 from demisto_sdk.commands.common.logger import logging_setup
 from demisto_sdk.commands.common.tools import src_root
 
@@ -98,8 +99,7 @@ def test_sign_pack_exception_thrown(repo, capsys, mocker):
     import subprocess
 
     import demisto_sdk.commands.common.content.objects.pack_objects.pack as pack_class
-    from demisto_sdk.commands.common.content.objects.pack_objects.pack import \
-        Pack
+    from demisto_sdk.commands.common.content.objects.pack_objects.pack import Pack
 
     mocker.patch.object(subprocess, 'Popen', autospec=True)
 
@@ -128,8 +128,7 @@ def test_sign_pack_error_from_subprocess(repo, capsys, fake_process):
 
     """
     import demisto_sdk.commands.common.content.objects.pack_objects.pack as pack_class
-    from demisto_sdk.commands.common.content.objects.pack_objects.pack import \
-        Pack
+    from demisto_sdk.commands.common.content.objects.pack_objects.pack import Pack
 
     pack_class.logger = logging_setup(3)
 
@@ -160,8 +159,7 @@ def test_sign_pack_success(repo, capsys, fake_process):
 
     """
     import demisto_sdk.commands.common.content.objects.pack_objects.pack as pack_class
-    from demisto_sdk.commands.common.content.objects.pack_objects.pack import \
-        Pack
+    from demisto_sdk.commands.common.content.objects.pack_objects.pack import Pack
 
     pack_class.logger = logging_setup(3)
 

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/parsing_rule/parsing_rule_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/parsing_rule/parsing_rule_test.py
@@ -1,7 +1,5 @@
-from demisto_sdk.commands.common.content.objects.pack_objects import \
-    ParsingRule
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects.pack_objects import ParsingRule
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 
 
 def get_parsing_rule(pack, name):

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/playbook/playbook_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/playbook/playbook_test.py
@@ -1,7 +1,6 @@
 from demisto_sdk.commands.common.constants import PACKS_DIR, PLAYBOOKS_DIR
 from demisto_sdk.commands.common.content.objects.pack_objects import Playbook
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 from demisto_sdk.commands.common.tools import src_root
 
 TEST_DATA = src_root() / 'tests' / 'test_files'

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/pre_process_rule/pre_process_rule_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/pre_process_rule/pre_process_rule_test.py
@@ -1,9 +1,6 @@
-from demisto_sdk.commands.common.constants import (PACKS_DIR,
-                                                   PRE_PROCESS_RULES_DIR)
-from demisto_sdk.commands.common.content.objects.pack_objects import \
-    PreProcessRule
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.constants import PACKS_DIR, PRE_PROCESS_RULES_DIR
+from demisto_sdk.commands.common.content.objects.pack_objects import PreProcessRule
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 from demisto_sdk.commands.common.tools import src_root
 
 TEST_DATA = src_root() / 'tests' / 'test_files'

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/readme/readme_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/readme/readme_test.py
@@ -1,13 +1,10 @@
 import pytest
 from wcmatch.pathlib import Path
 
-from demisto_sdk.commands.common.constants import (
-    CONTRIBUTORS_README_TEMPLATE, PACKS_DIR, PLAYBOOKS_DIR)
+from demisto_sdk.commands.common.constants import CONTRIBUTORS_README_TEMPLATE, PACKS_DIR, PLAYBOOKS_DIR
 from demisto_sdk.commands.common.content.objects.pack_objects import Readme
-from demisto_sdk.commands.common.content.objects.pack_objects.contributors.contributors import \
-    Contributors
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects.pack_objects.contributors.contributors import Contributors
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 from demisto_sdk.commands.common.tools import src_root
 
 TEST_DATA = src_root() / 'tests' / 'test_files'

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/release_note/release_note_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/release_note/release_note_test.py
@@ -1,8 +1,6 @@
 from demisto_sdk.commands.common.constants import PACKS_DIR, RELEASE_NOTES_DIR
-from demisto_sdk.commands.common.content.objects.pack_objects import \
-    ReleaseNote
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects.pack_objects import ReleaseNote
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 from demisto_sdk.commands.common.tools import src_root
 
 TEST_DATA = src_root() / 'tests' / 'test_files'

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/release_note_config/release_note_config_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/release_note_config/release_note_config_test.py
@@ -1,7 +1,5 @@
-from demisto_sdk.commands.common.content.objects.pack_objects import \
-    ReleaseNoteConfig
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects.pack_objects import ReleaseNoteConfig
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 
 
 class TestReleaseNoteConfig:

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/report/report_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/report/report_test.py
@@ -1,7 +1,6 @@
 from demisto_sdk.commands.common.constants import PACKS_DIR, REPORTS_DIR
 from demisto_sdk.commands.common.content.objects.pack_objects import Report
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 from demisto_sdk.commands.common.tools import src_root
 
 TEST_DATA = src_root() / 'tests' / 'test_files'

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/script/script_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/script/script_test.py
@@ -1,8 +1,7 @@
 from pathlib import Path
 
 from demisto_sdk.commands.common.content.objects.pack_objects import Script
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 
 
 class TestNotUnifiedScript:

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/secret_ignore/secret_ignore_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/secret_ignore/secret_ignore_test.py
@@ -1,8 +1,6 @@
 from demisto_sdk.commands.common.constants import PACKS_DIR
-from demisto_sdk.commands.common.content.objects.pack_objects import \
-    SecretIgnore
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects.pack_objects import SecretIgnore
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 from demisto_sdk.commands.common.tools import src_root
 
 TEST_DATA = src_root() / 'tests' / 'test_files'

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/trigger/trigger_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/trigger/trigger_test.py
@@ -1,6 +1,5 @@
 from demisto_sdk.commands.common.content.objects.pack_objects import Trigger
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 
 
 def get_trigger(pack, name):

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/widget/widget_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/widget/widget_test.py
@@ -1,7 +1,6 @@
 from demisto_sdk.commands.common.constants import PACKS_DIR, WIDGETS_DIR
 from demisto_sdk.commands.common.content.objects.pack_objects import Widget
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 from demisto_sdk.commands.common.tools import src_root
 
 TEST_DATA = src_root() / 'tests' / 'test_files'

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/wizard/wizard_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/wizard/wizard_test.py
@@ -1,7 +1,5 @@
-from demisto_sdk.commands.common.content.objects.pack_objects.wizard.wizard import \
-    Wizard
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects.pack_objects.wizard.wizard import Wizard
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 
 sample_wizard_name = "sample-wizard"
 sample_file_path = f"Wizards/{sample_wizard_name}.json"

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/xdrctemplate/xdrc_template_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/xdrctemplate/xdrc_template_test.py
@@ -1,7 +1,5 @@
-from demisto_sdk.commands.common.content.objects.pack_objects import \
-    XDRCTemplate
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects.pack_objects import XDRCTemplate
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 
 
 class TestXDRCTemplate:

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/xsiam_dashboard/xsiam_dashboard_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/xsiam_dashboard/xsiam_dashboard_test.py
@@ -1,7 +1,5 @@
-from demisto_sdk.commands.common.content.objects.pack_objects import \
-    XSIAMDashboard
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects.pack_objects import XSIAMDashboard
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 
 
 def get_xsiam_dashboard(pack, name):

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/xsiam_report/xsiam_report_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/xsiam_report/xsiam_report_test.py
@@ -1,7 +1,5 @@
-from demisto_sdk.commands.common.content.objects.pack_objects import \
-    XSIAMReport
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects.pack_objects import XSIAMReport
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 
 
 def get_xsiam_report(pack, name):

--- a/demisto_sdk/commands/common/content/tests/objects/root_objects/content_descriptor/content_descriptor_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/root_objects/content_descriptor/content_descriptor_test.py
@@ -1,5 +1,4 @@
-from demisto_sdk.commands.common.content.objects.root_objects import \
-    ContentDescriptor
+from demisto_sdk.commands.common.content.objects.root_objects import ContentDescriptor
 from demisto_sdk.commands.common.tools import src_root
 
 TEST_DATA = src_root() / 'tests' / 'test_files'

--- a/demisto_sdk/commands/common/content/tests/objects/root_objects/documentation/documentation_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/root_objects/documentation/documentation_test.py
@@ -1,6 +1,5 @@
 from demisto_sdk.commands.common.constants import DOCUMENTATION_DIR
-from demisto_sdk.commands.common.content.objects.root_objects import \
-    Documentation
+from demisto_sdk.commands.common.content.objects.root_objects import Documentation
 from demisto_sdk.commands.common.tools import src_root
 
 TEST_DATA = src_root() / 'tests' / 'test_files'

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -5,10 +5,9 @@ from typing import Any, Dict, List, Optional, Union
 import decorator
 from requests import Response
 
-from demisto_sdk.commands.common.constants import (
-    BETA_INTEGRATION_DISCLAIMER, FILETYPE_TO_DEFAULT_FROMVERSION,
-    INTEGRATION_CATEGORIES, PACK_METADATA_DESC, PACK_METADATA_NAME, FileType,
-    MarketplaceVersions)
+from demisto_sdk.commands.common.constants import (BETA_INTEGRATION_DISCLAIMER, FILETYPE_TO_DEFAULT_FROMVERSION,
+                                                   INTEGRATION_CATEGORIES, PACK_METADATA_DESC, PACK_METADATA_NAME,
+                                                   FileType, MarketplaceVersions)
 from demisto_sdk.commands.common.content_constant_paths import CONF_PATH
 
 FOUND_FILES_AND_ERRORS: list = []

--- a/demisto_sdk/commands/common/hook_validations/author_image.py
+++ b/demisto_sdk/commands/common/hook_validations/author_image.py
@@ -1,12 +1,9 @@
 from typing import Optional
 
-from demisto_sdk.commands.common.constants import (PACK_METADATA_SUPPORT,
-                                                   PACKS_DIR,
-                                                   PACKS_PACK_META_FILE_NAME)
+from demisto_sdk.commands.common.constants import PACK_METADATA_SUPPORT, PACKS_DIR, PACKS_PACK_META_FILE_NAME
 from demisto_sdk.commands.common.errors import Errors
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.common.hook_validations.base_validator import \
-    error_codes
+from demisto_sdk.commands.common.hook_validations.base_validator import error_codes
 from demisto_sdk.commands.common.hook_validations.image import ImageValidator
 from demisto_sdk.commands.common.tools import get_pack_name, os
 

--- a/demisto_sdk/commands/common/hook_validations/base_validator.py
+++ b/demisto_sdk/commands/common/hook_validations/base_validator.py
@@ -4,21 +4,13 @@ from typing import Optional
 
 import click
 
-from demisto_sdk.commands.common.constants import (PACK_METADATA_SUPPORT,
-                                                   PACKS_DIR,
-                                                   PACKS_PACK_META_FILE_NAME,
-                                                   FileType)
-from demisto_sdk.commands.common.errors import (ALLOWED_IGNORE_ERRORS,
-                                                FOUND_FILES_AND_ERRORS,
-                                                FOUND_FILES_AND_IGNORED_ERRORS,
-                                                PRESET_ERROR_TO_CHECK,
-                                                PRESET_ERROR_TO_IGNORE,
-                                                get_all_error_codes,
-                                                get_error_object)
+from demisto_sdk.commands.common.constants import PACK_METADATA_SUPPORT, PACKS_DIR, PACKS_PACK_META_FILE_NAME, FileType
+from demisto_sdk.commands.common.errors import (ALLOWED_IGNORE_ERRORS, FOUND_FILES_AND_ERRORS,
+                                                FOUND_FILES_AND_IGNORED_ERRORS, PRESET_ERROR_TO_CHECK,
+                                                PRESET_ERROR_TO_IGNORE, get_all_error_codes, get_error_object)
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.common.tools import (
-    find_type, get_file_displayed_name, get_json, get_pack_name,
-    get_relative_path_from_packs_dir, get_yaml, print_warning)
+from demisto_sdk.commands.common.tools import (find_type, get_file_displayed_name, get_json, get_pack_name,
+                                               get_relative_path_from_packs_dir, get_yaml, print_warning)
 
 json = JSON_Handler()
 

--- a/demisto_sdk/commands/common/hook_validations/classifier.py
+++ b/demisto_sdk/commands/common/hook_validations/classifier.py
@@ -2,15 +2,11 @@ from distutils.version import LooseVersion
 
 import click
 
-from demisto_sdk.commands.common.constants import \
-    LAYOUT_AND_MAPPER_BUILT_IN_FIELDS
+from demisto_sdk.commands.common.constants import LAYOUT_AND_MAPPER_BUILT_IN_FIELDS
 from demisto_sdk.commands.common.errors import Errors
-from demisto_sdk.commands.common.hook_validations.base_validator import \
-    error_codes
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
-from demisto_sdk.commands.common.tools import \
-    get_all_incident_and_indicator_fields_from_id_set
+from demisto_sdk.commands.common.hook_validations.base_validator import error_codes
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
+from demisto_sdk.commands.common.tools import get_all_incident_and_indicator_fields_from_id_set
 from demisto_sdk.commands.common.update_id_set import BUILT_IN_FIELDS
 
 FROM_VERSION_FOR_NEW_CLASSIFIER = '6.0.0'

--- a/demisto_sdk/commands/common/hook_validations/conf_json.py
+++ b/demisto_sdk/commands/common/hook_validations/conf_json.py
@@ -4,8 +4,7 @@ from demisto_sdk.commands.common.constants import API_MODULES_PACK, FileType
 from demisto_sdk.commands.common.content_constant_paths import CONF_PATH
 from demisto_sdk.commands.common.errors import Errors
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.common.hook_validations.base_validator import (
-    BaseValidator, error_codes)
+from demisto_sdk.commands.common.hook_validations.base_validator import BaseValidator, error_codes
 from demisto_sdk.commands.common.tools import _get_file_id, get_pack_name
 
 json = JSON_Handler()

--- a/demisto_sdk/commands/common/hook_validations/content_entity_validator.py
+++ b/demisto_sdk/commands/common/hook_validations/content_entity_validator.py
@@ -8,26 +8,21 @@ from typing import Optional
 import click
 from packaging import version
 
-from demisto_sdk.commands.common.constants import (
-    API_MODULES_PACK, DEFAULT_CONTENT_ITEM_FROM_VERSION,
-    ENTITY_NAME_SEPARATORS, EXCLUDED_DISPLAY_NAME_WORDS, FEATURE_BRANCHES,
-    FROM_TO_VERSION_REGEX, GENERIC_OBJECTS_OLDEST_SUPPORTED_VERSION,
-    OLDEST_SUPPORTED_VERSION, FileType)
+from demisto_sdk.commands.common.constants import (API_MODULES_PACK, DEFAULT_CONTENT_ITEM_FROM_VERSION,
+                                                   ENTITY_NAME_SEPARATORS, EXCLUDED_DISPLAY_NAME_WORDS,
+                                                   FEATURE_BRANCHES, FROM_TO_VERSION_REGEX,
+                                                   GENERIC_OBJECTS_OLDEST_SUPPORTED_VERSION, OLDEST_SUPPORTED_VERSION,
+                                                   FileType)
 from demisto_sdk.commands.common.content import Content
 from demisto_sdk.commands.common.content_constant_paths import CONF_PATH
 from demisto_sdk.commands.common.errors import Errors
 from demisto_sdk.commands.common.git_util import GitUtil
 from demisto_sdk.commands.common.handlers import JSON_Handler, YAML_Handler
-from demisto_sdk.commands.common.hook_validations.base_validator import (
-    BaseValidator, error_codes)
-from demisto_sdk.commands.common.hook_validations.structure import \
-    StructureValidator
-from demisto_sdk.commands.common.tools import (_get_file_id, find_type,
-                                               get_file_displayed_name,
-                                               is_test_config_match,
+from demisto_sdk.commands.common.hook_validations.base_validator import BaseValidator, error_codes
+from demisto_sdk.commands.common.hook_validations.structure import StructureValidator
+from demisto_sdk.commands.common.tools import (_get_file_id, find_type, get_file_displayed_name, is_test_config_match,
                                                run_command)
-from demisto_sdk.commands.format.format_constants import \
-    OLD_FILE_DEFAULT_1_FROMVERSION
+from demisto_sdk.commands.format.format_constants import OLD_FILE_DEFAULT_1_FROMVERSION
 
 json = JSON_Handler()
 yaml = YAML_Handler()

--- a/demisto_sdk/commands/common/hook_validations/correlation_rule.py
+++ b/demisto_sdk/commands/common/hook_validations/correlation_rule.py
@@ -3,8 +3,7 @@ This module is designed to validate the correctness of generic definition entiti
 """
 import logging
 
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
 
 
 class CorrelationRuleValidator(ContentEntityValidator):

--- a/demisto_sdk/commands/common/hook_validations/dashboard.py
+++ b/demisto_sdk/commands/common/hook_validations/dashboard.py
@@ -1,8 +1,6 @@
 from demisto_sdk.commands.common.errors import Errors
-from demisto_sdk.commands.common.hook_validations.base_validator import \
-    error_codes
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
+from demisto_sdk.commands.common.hook_validations.base_validator import error_codes
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
 from demisto_sdk.commands.common.tools import print_error
 
 

--- a/demisto_sdk/commands/common/hook_validations/description.py
+++ b/demisto_sdk/commands/common/hook_validations/description.py
@@ -1,14 +1,10 @@
 import glob
 from typing import List, Optional
 
-from demisto_sdk.commands.common.constants import (BETA_INTEGRATION_DISCLAIMER,
-                                                   PACKS_INTEGRATION_YML_REGEX,
-                                                   FileType)
+from demisto_sdk.commands.common.constants import BETA_INTEGRATION_DISCLAIMER, PACKS_INTEGRATION_YML_REGEX, FileType
 from demisto_sdk.commands.common.errors import FOUND_FILES_AND_ERRORS, Errors
-from demisto_sdk.commands.common.hook_validations.base_validator import (
-    BaseValidator, error_codes)
-from demisto_sdk.commands.common.hook_validations.structure import \
-    StructureValidator
+from demisto_sdk.commands.common.hook_validations.base_validator import BaseValidator, error_codes
+from demisto_sdk.commands.common.hook_validations.structure import StructureValidator
 from demisto_sdk.commands.common.tools import find_type, get_yaml, os, re
 
 CONTRIBUTOR_DETAILED_DESC = 'Contributed Integration'

--- a/demisto_sdk/commands/common/hook_validations/docker.py
+++ b/demisto_sdk/commands/common/hook_validations/docker.py
@@ -8,8 +8,7 @@ from pkg_resources import parse_version
 
 from demisto_sdk.commands.common.constants import IronBankDockers
 from demisto_sdk.commands.common.errors import Errors
-from demisto_sdk.commands.common.hook_validations.base_validator import (
-    BaseValidator, error_codes)
+from demisto_sdk.commands.common.hook_validations.base_validator import BaseValidator, error_codes
 from demisto_sdk.commands.common.tools import get_yaml
 
 # disable insecure warnings

--- a/demisto_sdk/commands/common/hook_validations/field_base_validator.py
+++ b/demisto_sdk/commands/common/hook_validations/field_base_validator.py
@@ -6,16 +6,11 @@ from distutils.version import LooseVersion
 from enum import IntEnum
 from typing import List, Set
 
-from demisto_sdk.commands.common.constants import (
-    DEFAULT_CONTENT_ITEM_FROM_VERSION, MarketplaceVersions)
+from demisto_sdk.commands.common.constants import DEFAULT_CONTENT_ITEM_FROM_VERSION, MarketplaceVersions
 from demisto_sdk.commands.common.errors import Errors
-from demisto_sdk.commands.common.hook_validations.base_validator import \
-    error_codes
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
-from demisto_sdk.commands.common.tools import (get_core_pack_list,
-                                               get_pack_metadata,
-                                               get_pack_name, print_warning)
+from demisto_sdk.commands.common.hook_validations.base_validator import error_codes
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
+from demisto_sdk.commands.common.tools import get_core_pack_list, get_pack_metadata, get_pack_name, print_warning
 
 # Cortex XSOAR is using a Bleve DB, those keys cannot be the cliName
 BleveMapping = {

--- a/demisto_sdk/commands/common/hook_validations/generic_definition.py
+++ b/demisto_sdk/commands/common/hook_validations/generic_definition.py
@@ -2,8 +2,7 @@
 This module is designed to validate the correctness of generic definition entities in content.
 """
 
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
 
 
 class GenericDefinitionValidator(ContentEntityValidator):

--- a/demisto_sdk/commands/common/hook_validations/generic_field.py
+++ b/demisto_sdk/commands/common/hook_validations/generic_field.py
@@ -2,10 +2,8 @@
 This module is designed to validate the correctness of generic field entities in content.
 """
 from demisto_sdk.commands.common.errors import Errors
-from demisto_sdk.commands.common.hook_validations.base_validator import \
-    error_codes
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
+from demisto_sdk.commands.common.hook_validations.base_validator import error_codes
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
 
 GENERIC_FIELD_GROUP = 4
 GENERIC_FIELD_ID_PREFIX = 'generic_'

--- a/demisto_sdk/commands/common/hook_validations/generic_module.py
+++ b/demisto_sdk/commands/common/hook_validations/generic_module.py
@@ -2,8 +2,7 @@
 This module is designed to validate the correctness of generic module entities in content.
 """
 
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
 
 
 class GenericModuleValidator(ContentEntityValidator):

--- a/demisto_sdk/commands/common/hook_validations/generic_type.py
+++ b/demisto_sdk/commands/common/hook_validations/generic_type.py
@@ -2,8 +2,7 @@
 This module is designed to validate the correctness of generic type entities in content.
 """
 
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
 
 
 class GenericTypeValidator(ContentEntityValidator):

--- a/demisto_sdk/commands/common/hook_validations/id.py
+++ b/demisto_sdk/commands/common/hook_validations/id.py
@@ -11,17 +11,14 @@ import demisto_sdk.commands.common.constants as constants
 from demisto_sdk.commands.common.configuration import Configuration
 from demisto_sdk.commands.common.constants import GENERIC_COMMANDS_NAMES
 from demisto_sdk.commands.common.errors import Errors
-from demisto_sdk.commands.common.hook_validations.base_validator import (
-    BaseValidator, error_codes)
-from demisto_sdk.commands.common.tools import (
-    get_script_or_sub_playbook_tasks_from_playbook, get_yaml)
-from demisto_sdk.commands.common.update_id_set import (
-    get_classifier_data, get_incident_field_data, get_incident_type_data,
-    get_integration_data, get_layout_data, get_layouts_scripts_ids,
-    get_layoutscontainer_data, get_mapper_data, get_pack_metadata_data,
-    get_playbook_data, get_script_data)
-from demisto_sdk.commands.unify.integration_script_unifier import \
-    IntegrationScriptUnifier
+from demisto_sdk.commands.common.hook_validations.base_validator import BaseValidator, error_codes
+from demisto_sdk.commands.common.tools import get_script_or_sub_playbook_tasks_from_playbook, get_yaml
+from demisto_sdk.commands.common.update_id_set import (get_classifier_data, get_incident_field_data,
+                                                       get_incident_type_data, get_integration_data, get_layout_data,
+                                                       get_layouts_scripts_ids, get_layoutscontainer_data,
+                                                       get_mapper_data, get_pack_metadata_data, get_playbook_data,
+                                                       get_script_data)
+from demisto_sdk.commands.unify.integration_script_unifier import IntegrationScriptUnifier
 
 
 class IDSetValidations(BaseValidator):

--- a/demisto_sdk/commands/common/hook_validations/image.py
+++ b/demisto_sdk/commands/common/hook_validations/image.py
@@ -3,12 +3,10 @@ import glob
 
 import imagesize
 
-from demisto_sdk.commands.common.constants import (
-    DEFAULT_DBOT_IMAGE_BASE64, DEFAULT_IMAGE_BASE64, IMAGE_REGEX,
-    PACKS_INTEGRATION_NON_SPLIT_YML_REGEX)
+from demisto_sdk.commands.common.constants import (DEFAULT_DBOT_IMAGE_BASE64, DEFAULT_IMAGE_BASE64, IMAGE_REGEX,
+                                                   PACKS_INTEGRATION_NON_SPLIT_YML_REGEX)
 from demisto_sdk.commands.common.errors import Errors
-from demisto_sdk.commands.common.hook_validations.base_validator import (
-    BaseValidator, error_codes)
+from demisto_sdk.commands.common.hook_validations.base_validator import BaseValidator, error_codes
 from demisto_sdk.commands.common.tools import get_yaml, os, re
 
 

--- a/demisto_sdk/commands/common/hook_validations/incident_field.py
+++ b/demisto_sdk/commands/common/hook_validations/incident_field.py
@@ -4,8 +4,7 @@ This module is designed to validate the correctness of incident field entities i
 
 from typing import Set
 
-from demisto_sdk.commands.common.hook_validations.field_base_validator import \
-    FieldBaseValidator
+from demisto_sdk.commands.common.hook_validations.field_base_validator import FieldBaseValidator
 
 
 class IncidentFieldValidator(FieldBaseValidator):

--- a/demisto_sdk/commands/common/hook_validations/incident_type.py
+++ b/demisto_sdk/commands/common/hook_validations/incident_type.py
@@ -1,13 +1,10 @@
 import re
 from distutils.version import LooseVersion
 
-from demisto_sdk.commands.common.constants import \
-    DEFAULT_CONTENT_ITEM_FROM_VERSION
+from demisto_sdk.commands.common.constants import DEFAULT_CONTENT_ITEM_FROM_VERSION
 from demisto_sdk.commands.common.errors import Errors
-from demisto_sdk.commands.common.hook_validations.base_validator import \
-    error_codes
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
+from demisto_sdk.commands.common.hook_validations.base_validator import error_codes
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
 
 # Checks if playbookID is a UUID format
 INVALID_PLAYBOOK_ID = r'[\w\d]{8}-[\w\d]{4}-[\w\d]{4}-[\w\d]{4}-[\w\d]{12}'

--- a/demisto_sdk/commands/common/hook_validations/indicator_field.py
+++ b/demisto_sdk/commands/common/hook_validations/indicator_field.py
@@ -4,10 +4,8 @@ This module is designed to validate the correctness of incident field entities i
 from distutils.version import LooseVersion
 from typing import Optional
 
-from demisto_sdk.commands.common.constants import \
-    INDICATOR_FIELD_TYPE_TO_MIN_VERSION
-from demisto_sdk.commands.common.hook_validations.field_base_validator import \
-    FieldBaseValidator
+from demisto_sdk.commands.common.constants import INDICATOR_FIELD_TYPE_TO_MIN_VERSION
+from demisto_sdk.commands.common.hook_validations.field_base_validator import FieldBaseValidator
 
 
 class IndicatorFieldValidator(FieldBaseValidator):

--- a/demisto_sdk/commands/common/hook_validations/integration.py
+++ b/demisto_sdk/commands/common/hook_validations/integration.py
@@ -4,37 +4,29 @@ from pathlib import Path
 from typing import Dict, Optional
 
 from demisto_sdk.commands.common import tools
-from demisto_sdk.commands.common.constants import (
-    ALERT_FETCH_REQUIRED_PARAMS, BANG_COMMAND_ARGS_MAPPING_DICT,
-    BANG_COMMAND_NAMES, DBOT_SCORES_DICT, DEFAULT_CONTENT_ITEM_FROM_VERSION,
-    DEPRECATED_REGEXES, ENDPOINT_COMMAND_NAME, ENDPOINT_FLEXIBLE_REQUIRED_ARGS,
-    FEED_REQUIRED_PARAMS, FIRST_FETCH, FIRST_FETCH_PARAM,
-    INCIDENT_FETCH_REQUIRED_PARAMS, IOC_OUTPUTS_DICT, MAX_FETCH,
-    MAX_FETCH_PARAM, PACKS_DIR, PACKS_PACK_META_FILE_NAME, PYTHON_SUBTYPES,
-    REPUTATION_COMMAND_NAMES, TYPE_PWSH, XSOAR_CONTEXT_STANDARD_URL,
-    XSOAR_SUPPORT, MarketplaceVersions)
-from demisto_sdk.commands.common.default_additional_info_loader import \
-    load_default_additional_info_dict
-from demisto_sdk.commands.common.errors import (FOUND_FILES_AND_ERRORS,
-                                                FOUND_FILES_AND_IGNORED_ERRORS,
-                                                Errors)
+from demisto_sdk.commands.common.constants import (ALERT_FETCH_REQUIRED_PARAMS, BANG_COMMAND_ARGS_MAPPING_DICT,
+                                                   BANG_COMMAND_NAMES, DBOT_SCORES_DICT,
+                                                   DEFAULT_CONTENT_ITEM_FROM_VERSION, DEPRECATED_REGEXES,
+                                                   ENDPOINT_COMMAND_NAME, ENDPOINT_FLEXIBLE_REQUIRED_ARGS,
+                                                   FEED_REQUIRED_PARAMS, FIRST_FETCH, FIRST_FETCH_PARAM,
+                                                   INCIDENT_FETCH_REQUIRED_PARAMS, IOC_OUTPUTS_DICT, MAX_FETCH,
+                                                   MAX_FETCH_PARAM, PACKS_DIR, PACKS_PACK_META_FILE_NAME,
+                                                   PYTHON_SUBTYPES, REPUTATION_COMMAND_NAMES, TYPE_PWSH,
+                                                   XSOAR_CONTEXT_STANDARD_URL, XSOAR_SUPPORT, MarketplaceVersions)
+from demisto_sdk.commands.common.default_additional_info_loader import load_default_additional_info_dict
+from demisto_sdk.commands.common.errors import FOUND_FILES_AND_ERRORS, FOUND_FILES_AND_IGNORED_ERRORS, Errors
 from demisto_sdk.commands.common.handlers import JSON_Handler, YAML_Handler
-from demisto_sdk.commands.common.hook_validations.base_validator import \
-    error_codes
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
-from demisto_sdk.commands.common.hook_validations.description import \
-    DescriptionValidator
-from demisto_sdk.commands.common.hook_validations.docker import \
-    DockerImageValidator
+from demisto_sdk.commands.common.hook_validations.base_validator import error_codes
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
+from demisto_sdk.commands.common.hook_validations.description import DescriptionValidator
+from demisto_sdk.commands.common.hook_validations.docker import DockerImageValidator
 from demisto_sdk.commands.common.hook_validations.image import ImageValidator
-from demisto_sdk.commands.common.tools import (
-    _get_file_id, compare_context_path_in_yml_and_readme,
-    extract_deprecated_command_names_from_yml,
-    extract_none_deprecated_command_names_from_yml, get_core_pack_list,
-    get_file_version_suffix_if_exists, get_files_in_dir, get_item_marketplaces,
-    get_pack_name, is_iron_bank_pack, print_error, server_version_compare,
-    string_to_bool)
+from demisto_sdk.commands.common.tools import (_get_file_id, compare_context_path_in_yml_and_readme,
+                                               extract_deprecated_command_names_from_yml,
+                                               extract_none_deprecated_command_names_from_yml, get_core_pack_list,
+                                               get_file_version_suffix_if_exists, get_files_in_dir,
+                                               get_item_marketplaces, get_pack_name, is_iron_bank_pack, print_error,
+                                               server_version_compare, string_to_bool)
 
 json = JSON_Handler()
 yaml = YAML_Handler()

--- a/demisto_sdk/commands/common/hook_validations/job.py
+++ b/demisto_sdk/commands/common/hook_validations/job.py
@@ -1,12 +1,9 @@
 from distutils.version import LooseVersion
 
-from demisto_sdk.commands.common.constants import (
-    FILETYPE_TO_DEFAULT_FROMVERSION, JOB, FileType)
+from demisto_sdk.commands.common.constants import FILETYPE_TO_DEFAULT_FROMVERSION, JOB, FileType
 from demisto_sdk.commands.common.errors import Errors
-from demisto_sdk.commands.common.hook_validations.base_validator import \
-    error_codes
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
+from demisto_sdk.commands.common.hook_validations.base_validator import error_codes
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
 
 
 class JobValidator(ContentEntityValidator):

--- a/demisto_sdk/commands/common/hook_validations/layout.py
+++ b/demisto_sdk/commands/common/hook_validations/layout.py
@@ -5,18 +5,15 @@ from typing import Dict, List
 
 import click
 
-from demisto_sdk.commands.common.constants import (
-    DEFAULT_CONTENT_ITEM_FROM_VERSION, DEFAULT_CONTENT_ITEM_TO_VERSION,
-    LAYOUT_AND_MAPPER_BUILT_IN_FIELDS,
-    LAYOUTS_CONTAINERS_OLDEST_SUPPORTED_VERSION)
+from demisto_sdk.commands.common.constants import (DEFAULT_CONTENT_ITEM_FROM_VERSION, DEFAULT_CONTENT_ITEM_TO_VERSION,
+                                                   LAYOUT_AND_MAPPER_BUILT_IN_FIELDS,
+                                                   LAYOUTS_CONTAINERS_OLDEST_SUPPORTED_VERSION)
 from demisto_sdk.commands.common.errors import Errors
-from demisto_sdk.commands.common.hook_validations.base_validator import \
-    error_codes
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
-from demisto_sdk.commands.common.tools import (
-    LAYOUT_CONTAINER_FIELDS, get_all_incident_and_indicator_fields_from_id_set,
-    get_invalid_incident_fields_from_layout)
+from demisto_sdk.commands.common.hook_validations.base_validator import error_codes
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
+from demisto_sdk.commands.common.tools import (LAYOUT_CONTAINER_FIELDS,
+                                               get_all_incident_and_indicator_fields_from_id_set,
+                                               get_invalid_incident_fields_from_layout)
 from demisto_sdk.commands.common.update_id_set import BUILT_IN_FIELDS
 
 FROM_VERSION_LAYOUTS_CONTAINER = '6.0.0'

--- a/demisto_sdk/commands/common/hook_validations/lists.py
+++ b/demisto_sdk/commands/common/hook_validations/lists.py
@@ -2,10 +2,8 @@ from distutils.version import LooseVersion
 from typing import List
 
 from demisto_sdk.commands.common.errors import Errors
-from demisto_sdk.commands.common.hook_validations.base_validator import \
-    error_codes
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
+from demisto_sdk.commands.common.hook_validations.base_validator import error_codes
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
 
 FROM_VERSION_LISTS = '6.5.0'
 DEFAULT_VERSION = -1

--- a/demisto_sdk/commands/common/hook_validations/mapper.py
+++ b/demisto_sdk/commands/common/hook_validations/mapper.py
@@ -3,16 +3,12 @@ from typing import Dict, List
 
 import click
 
-from demisto_sdk.commands.common.constants import \
-    LAYOUT_AND_MAPPER_BUILT_IN_FIELDS
+from demisto_sdk.commands.common.constants import LAYOUT_AND_MAPPER_BUILT_IN_FIELDS
 from demisto_sdk.commands.common.errors import Errors
-from demisto_sdk.commands.common.hook_validations.base_validator import \
-    error_codes
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
-from demisto_sdk.commands.common.tools import (
-    get_all_incident_and_indicator_fields_from_id_set,
-    get_invalid_incident_fields_from_mapper)
+from demisto_sdk.commands.common.hook_validations.base_validator import error_codes
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
+from demisto_sdk.commands.common.tools import (get_all_incident_and_indicator_fields_from_id_set,
+                                               get_invalid_incident_fields_from_mapper)
 from demisto_sdk.commands.common.update_id_set import BUILT_IN_FIELDS
 
 FROM_VERSION = '6.0.0'

--- a/demisto_sdk/commands/common/hook_validations/modeling_rule.py
+++ b/demisto_sdk/commands/common/hook_validations/modeling_rule.py
@@ -5,8 +5,7 @@ import os
 
 from demisto_sdk.commands.common.errors import Errors
 from demisto_sdk.commands.common.handlers import YAML_Handler
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
 from demisto_sdk.commands.common.tools import get_files_in_dir
 
 yaml = YAML_Handler()

--- a/demisto_sdk/commands/common/hook_validations/old_release_notes.py
+++ b/demisto_sdk/commands/common/hook_validations/old_release_notes.py
@@ -4,11 +4,9 @@ import os
 import re
 
 from demisto_sdk.commands.common.errors import Errors
-from demisto_sdk.commands.common.hook_validations.base_validator import (
-    BaseValidator, error_codes)
-from demisto_sdk.commands.common.tools import (
-    old_get_latest_release_notes_text, old_get_release_notes_file_path,
-    run_command)
+from demisto_sdk.commands.common.hook_validations.base_validator import BaseValidator, error_codes
+from demisto_sdk.commands.common.tools import (old_get_latest_release_notes_text, old_get_release_notes_file_path,
+                                               run_command)
 
 
 class OldReleaseNotesValidator(BaseValidator):

--- a/demisto_sdk/commands/common/hook_validations/pack_unique_files.py
+++ b/demisto_sdk/commands/common/hook_validations/pack_unique_files.py
@@ -16,30 +16,26 @@ from git import GitCommandError, Repo
 from packaging.version import parse
 
 from demisto_sdk.commands.common import tools
-from demisto_sdk.commands.common.constants import (  # PACK_METADATA_PRICE,
-    API_MODULES_PACK, EXCLUDED_DISPLAY_NAME_WORDS, INTEGRATIONS_DIR,
-    PACK_METADATA_CATEGORIES, PACK_METADATA_CERTIFICATION,
-    PACK_METADATA_CREATED, PACK_METADATA_CURR_VERSION,
-    PACK_METADATA_DEPENDENCIES, PACK_METADATA_DESC, PACK_METADATA_EMAIL,
-    PACK_METADATA_FIELDS, PACK_METADATA_KEYWORDS, PACK_METADATA_NAME,
-    PACK_METADATA_SUPPORT, PACK_METADATA_TAGS, PACK_METADATA_URL,
-    PACK_METADATA_USE_CASES, PACKS_PACK_IGNORE_FILE_NAME,
-    PACKS_PACK_META_FILE_NAME, PACKS_README_FILE_NAME,
-    PACKS_WHITELIST_FILE_NAME, VERSION_REGEX, MarketplaceVersions)
+from demisto_sdk.commands.common.constants import API_MODULES_PACK  # PACK_METADATA_PRICE,
+from demisto_sdk.commands.common.constants import (EXCLUDED_DISPLAY_NAME_WORDS, INTEGRATIONS_DIR,
+                                                   PACK_METADATA_CATEGORIES, PACK_METADATA_CERTIFICATION,
+                                                   PACK_METADATA_CREATED, PACK_METADATA_CURR_VERSION,
+                                                   PACK_METADATA_DEPENDENCIES, PACK_METADATA_DESC, PACK_METADATA_EMAIL,
+                                                   PACK_METADATA_FIELDS, PACK_METADATA_KEYWORDS, PACK_METADATA_NAME,
+                                                   PACK_METADATA_SUPPORT, PACK_METADATA_TAGS, PACK_METADATA_URL,
+                                                   PACK_METADATA_USE_CASES, PACKS_PACK_IGNORE_FILE_NAME,
+                                                   PACKS_PACK_META_FILE_NAME, PACKS_README_FILE_NAME,
+                                                   PACKS_WHITELIST_FILE_NAME, VERSION_REGEX, MarketplaceVersions)
 from demisto_sdk.commands.common.content import Content
 from demisto_sdk.commands.common.content.objects.pack_objects.pack import Pack
 from demisto_sdk.commands.common.errors import Errors
 from demisto_sdk.commands.common.git_util import GitUtil
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.common.hook_validations.base_validator import (
-    BaseValidator, error_codes)
+from demisto_sdk.commands.common.hook_validations.base_validator import BaseValidator, error_codes
 from demisto_sdk.commands.common.hook_validations.readme import ReadMeValidator
-from demisto_sdk.commands.common.tools import (get_core_pack_list, get_json,
-                                               get_remote_file,
-                                               pack_name_to_path,
+from demisto_sdk.commands.common.tools import (get_core_pack_list, get_json, get_remote_file, pack_name_to_path,
                                                print_warning)
-from demisto_sdk.commands.find_dependencies.find_dependencies import \
-    PackDependencies
+from demisto_sdk.commands.find_dependencies.find_dependencies import PackDependencies
 
 json = JSON_Handler()
 

--- a/demisto_sdk/commands/common/hook_validations/parsing_rule.py
+++ b/demisto_sdk/commands/common/hook_validations/parsing_rule.py
@@ -3,8 +3,7 @@ This module is designed to validate the correctness of generic definition entiti
 """
 import logging
 
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
 
 
 class ParsingRuleValidator(ContentEntityValidator):

--- a/demisto_sdk/commands/common/hook_validations/playbook.py
+++ b/demisto_sdk/commands/common/hook_validations/playbook.py
@@ -5,10 +5,8 @@ import click
 
 from demisto_sdk.commands.common.constants import DEPRECATED_REGEXES
 from demisto_sdk.commands.common.errors import Errors
-from demisto_sdk.commands.common.hook_validations.base_validator import \
-    error_codes
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
+from demisto_sdk.commands.common.hook_validations.base_validator import error_codes
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
 from demisto_sdk.commands.common.tools import LOG_COLORS, is_string_uuid
 
 

--- a/demisto_sdk/commands/common/hook_validations/pre_process_rule.py
+++ b/demisto_sdk/commands/common/hook_validations/pre_process_rule.py
@@ -4,10 +4,8 @@ from typing import List
 import click
 
 from demisto_sdk.commands.common.errors import Errors
-from demisto_sdk.commands.common.hook_validations.base_validator import \
-    error_codes
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
+from demisto_sdk.commands.common.hook_validations.base_validator import error_codes
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
 
 FROM_VERSION_PRE_PROCESS_RULES = '6.5.0'
 

--- a/demisto_sdk/commands/common/hook_validations/python_file.py
+++ b/demisto_sdk/commands/common/hook_validations/python_file.py
@@ -1,8 +1,7 @@
 from pathlib import Path
 
 from demisto_sdk.commands.common.errors import Errors
-from demisto_sdk.commands.common.hook_validations.base_validator import (
-    BaseValidator, error_codes)
+from demisto_sdk.commands.common.hook_validations.base_validator import BaseValidator, error_codes
 
 
 class PythonFileValidator(BaseValidator):

--- a/demisto_sdk/commands/common/hook_validations/readme.py
+++ b/demisto_sdk/commands/common/hook_validations/readme.py
@@ -16,22 +16,16 @@ from requests.adapters import HTTPAdapter
 from requests.exceptions import HTTPError
 from urllib3.util import Retry
 
-from demisto_sdk.commands.common.constants import (RELATIVE_HREF_URL_REGEX,
-                                                   RELATIVE_MARKDOWN_URL_REGEX)
+from demisto_sdk.commands.common.constants import RELATIVE_HREF_URL_REGEX, RELATIVE_MARKDOWN_URL_REGEX
 from demisto_sdk.commands.common.docker_helper import init_global_docker_client
-from demisto_sdk.commands.common.errors import (FOUND_FILES_AND_ERRORS,
-                                                FOUND_FILES_AND_IGNORED_ERRORS,
-                                                Errors)
+from demisto_sdk.commands.common.errors import FOUND_FILES_AND_ERRORS, FOUND_FILES_AND_IGNORED_ERRORS, Errors
 from demisto_sdk.commands.common.git_util import GitUtil
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.common.hook_validations.base_validator import (
-    BaseValidator, error_codes)
-from demisto_sdk.commands.common.MDXServer import (start_docker_MDX_server,
-                                                   start_local_MDX_server)
-from demisto_sdk.commands.common.tools import (
-    compare_context_path_in_yml_and_readme, get_content_path,
-    get_url_with_retries, get_yaml, get_yml_paths_in_dir, print_warning,
-    run_command_os)
+from demisto_sdk.commands.common.hook_validations.base_validator import BaseValidator, error_codes
+from demisto_sdk.commands.common.MDXServer import start_docker_MDX_server, start_local_MDX_server
+from demisto_sdk.commands.common.tools import (compare_context_path_in_yml_and_readme, get_content_path,
+                                               get_url_with_retries, get_yaml, get_yml_paths_in_dir, print_warning,
+                                               run_command_os)
 
 json = JSON_Handler()
 

--- a/demisto_sdk/commands/common/hook_validations/release_notes.py
+++ b/demisto_sdk/commands/common/hook_validations/release_notes.py
@@ -4,17 +4,12 @@ import itertools
 import os
 import re
 
-from demisto_sdk.commands.common.constants import (
-    PACKS_DIR, RN_HEADER_BY_FILE_TYPE, SKIP_RELEASE_NOTES_FOR_TYPES)
+from demisto_sdk.commands.common.constants import PACKS_DIR, RN_HEADER_BY_FILE_TYPE, SKIP_RELEASE_NOTES_FOR_TYPES
 from demisto_sdk.commands.common.errors import Errors
-from demisto_sdk.commands.common.hook_validations.base_validator import (
-    BaseValidator, error_codes)
-from demisto_sdk.commands.common.tools import (extract_docker_image_from_text,
-                                               find_type, get_dict_from_file,
-                                               get_latest_release_notes_text,
-                                               get_pack_name,
-                                               get_release_notes_file_path,
-                                               get_yaml)
+from demisto_sdk.commands.common.hook_validations.base_validator import BaseValidator, error_codes
+from demisto_sdk.commands.common.tools import (extract_docker_image_from_text, find_type, get_dict_from_file,
+                                               get_latest_release_notes_text, get_pack_name,
+                                               get_release_notes_file_path, get_yaml)
 from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
 
 

--- a/demisto_sdk/commands/common/hook_validations/release_notes_config.py
+++ b/demisto_sdk/commands/common/hook_validations/release_notes_config.py
@@ -3,8 +3,7 @@ from __future__ import print_function
 import os
 
 from demisto_sdk.commands.common.errors import Errors
-from demisto_sdk.commands.common.hook_validations.base_validator import (
-    BaseValidator, error_codes)
+from demisto_sdk.commands.common.hook_validations.base_validator import BaseValidator, error_codes
 
 
 class ReleaseNotesConfigValidator(BaseValidator):

--- a/demisto_sdk/commands/common/hook_validations/report.py
+++ b/demisto_sdk/commands/common/hook_validations/report.py
@@ -1,5 +1,4 @@
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
 
 
 class ReportValidator(ContentEntityValidator):

--- a/demisto_sdk/commands/common/hook_validations/reputation.py
+++ b/demisto_sdk/commands/common/hook_validations/reputation.py
@@ -1,13 +1,10 @@
 import re
 from distutils.version import LooseVersion
 
-from demisto_sdk.commands.common.constants import \
-    DEFAULT_CONTENT_ITEM_FROM_VERSION
+from demisto_sdk.commands.common.constants import DEFAULT_CONTENT_ITEM_FROM_VERSION
 from demisto_sdk.commands.common.errors import Errors
-from demisto_sdk.commands.common.hook_validations.base_validator import \
-    error_codes
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
+from demisto_sdk.commands.common.hook_validations.base_validator import error_codes
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
 
 # Valid indicator type can include letters, numbers whitespaces, ampersands and underscores.
 VALID_INDICATOR_TYPE = '^[A-Za-z0-9_& ]*$'

--- a/demisto_sdk/commands/common/hook_validations/script.py
+++ b/demisto_sdk/commands/common/hook_validations/script.py
@@ -2,19 +2,14 @@ import os
 import re
 from typing import Optional
 
-from demisto_sdk.commands.common.constants import (
-    API_MODULES_PACK, DEFAULT_CONTENT_ITEM_FROM_VERSION, DEPRECATED_REGEXES,
-    PYTHON_SUBTYPES, TYPE_PWSH)
+from demisto_sdk.commands.common.constants import (API_MODULES_PACK, DEFAULT_CONTENT_ITEM_FROM_VERSION,
+                                                   DEPRECATED_REGEXES, PYTHON_SUBTYPES, TYPE_PWSH)
 from demisto_sdk.commands.common.errors import Errors
-from demisto_sdk.commands.common.hook_validations.base_validator import \
-    error_codes
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
-from demisto_sdk.commands.common.hook_validations.docker import \
-    DockerImageValidator
-from demisto_sdk.commands.common.tools import (
-    get_core_pack_list, get_file_version_suffix_if_exists, get_files_in_dir,
-    get_pack_name, server_version_compare)
+from demisto_sdk.commands.common.hook_validations.base_validator import error_codes
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
+from demisto_sdk.commands.common.hook_validations.docker import DockerImageValidator
+from demisto_sdk.commands.common.tools import (get_core_pack_list, get_file_version_suffix_if_exists, get_files_in_dir,
+                                               get_pack_name, server_version_compare)
 
 
 class ScriptValidator(ContentEntityValidator):

--- a/demisto_sdk/commands/common/hook_validations/structure.py
+++ b/demisto_sdk/commands/common/hook_validations/structure.py
@@ -12,15 +12,13 @@ import click
 from pykwalify.core import Core
 
 from demisto_sdk.commands.common.configuration import Configuration
-from demisto_sdk.commands.common.constants import (
-    ACCEPTED_FILE_EXTENSIONS, CHECKED_TYPES_REGEXES,
-    FILE_TYPES_PATHS_TO_VALIDATE, OLD_REPUTATION, SCHEMA_TO_REGEX, FileType)
+from demisto_sdk.commands.common.constants import (ACCEPTED_FILE_EXTENSIONS, CHECKED_TYPES_REGEXES,
+                                                   FILE_TYPES_PATHS_TO_VALIDATE, OLD_REPUTATION, SCHEMA_TO_REGEX,
+                                                   FileType)
 from demisto_sdk.commands.common.errors import Errors
 from demisto_sdk.commands.common.handlers import JSON_Handler, YAML_Handler
-from demisto_sdk.commands.common.hook_validations.base_validator import (
-    BaseValidator, error_codes)
-from demisto_sdk.commands.common.tools import (get_remote_file,
-                                               is_file_path_in_pack)
+from demisto_sdk.commands.common.hook_validations.base_validator import BaseValidator, error_codes
+from demisto_sdk.commands.common.tools import get_remote_file, is_file_path_in_pack
 
 json = JSON_Handler()
 yaml = YAML_Handler()

--- a/demisto_sdk/commands/common/hook_validations/test_playbook.py
+++ b/demisto_sdk/commands/common/hook_validations/test_playbook.py
@@ -1,8 +1,6 @@
 from demisto_sdk.commands.common.errors import Errors
-from demisto_sdk.commands.common.hook_validations.base_validator import \
-    error_codes
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
+from demisto_sdk.commands.common.hook_validations.base_validator import error_codes
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
 from demisto_sdk.commands.common.tools import is_string_uuid
 
 

--- a/demisto_sdk/commands/common/hook_validations/triggers.py
+++ b/demisto_sdk/commands/common/hook_validations/triggers.py
@@ -3,8 +3,7 @@ This module is designed to validate the correctness of generic definition entiti
 """
 import logging
 
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
 
 
 class TriggersValidator(ContentEntityValidator):

--- a/demisto_sdk/commands/common/hook_validations/widget.py
+++ b/demisto_sdk/commands/common/hook_validations/widget.py
@@ -1,10 +1,8 @@
 from distutils.version import LooseVersion
 
 from demisto_sdk.commands.common.errors import Errors
-from demisto_sdk.commands.common.hook_validations.base_validator import \
-    error_codes
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
+from demisto_sdk.commands.common.hook_validations.base_validator import error_codes
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
 
 
 class WidgetValidator(ContentEntityValidator):

--- a/demisto_sdk/commands/common/hook_validations/wizard.py
+++ b/demisto_sdk/commands/common/hook_validations/wizard.py
@@ -2,13 +2,10 @@ from typing import Optional
 
 import click
 
-from demisto_sdk.commands.common.constants import (
-    FILETYPE_TO_DEFAULT_FROMVERSION, WIZARD, FileType)
+from demisto_sdk.commands.common.constants import FILETYPE_TO_DEFAULT_FROMVERSION, WIZARD, FileType
 from demisto_sdk.commands.common.errors import Errors
-from demisto_sdk.commands.common.hook_validations.base_validator import \
-    error_codes
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
+from demisto_sdk.commands.common.hook_validations.base_validator import error_codes
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
 from demisto_sdk.commands.common.tools import get_pack_name
 
 

--- a/demisto_sdk/commands/common/hook_validations/xsiam_dashboard.py
+++ b/demisto_sdk/commands/common/hook_validations/xsiam_dashboard.py
@@ -3,8 +3,7 @@ This module is designed to validate the correctness of generic definition entiti
 """
 import logging
 
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
 
 
 class XSIAMDashboardValidator(ContentEntityValidator):

--- a/demisto_sdk/commands/common/hook_validations/xsiam_report.py
+++ b/demisto_sdk/commands/common/hook_validations/xsiam_report.py
@@ -3,8 +3,7 @@ This module is designed to validate the correctness of generic definition entiti
 """
 import logging
 
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
 
 
 class XSIAMReportValidator(ContentEntityValidator):

--- a/demisto_sdk/commands/common/hook_validations/xsoar_config_json.py
+++ b/demisto_sdk/commands/common/hook_validations/xsoar_config_json.py
@@ -6,8 +6,7 @@ from prettytable import PrettyTable
 
 from demisto_sdk.commands.common.errors import Errors
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.common.hook_validations.base_validator import (
-    BaseValidator, error_codes)
+from demisto_sdk.commands.common.hook_validations.base_validator import BaseValidator, error_codes
 from demisto_sdk.commands.common.tools import get_dict_from_file
 
 json = JSON_Handler()

--- a/demisto_sdk/commands/common/legacy_git_tools.py
+++ b/demisto_sdk/commands/common/legacy_git_tools.py
@@ -5,18 +5,12 @@ from typing import Callable, List
 
 import click
 
-from demisto_sdk.commands.common.constants import (KNOWN_FILE_STATUSES,
-                                                   PACKS_PACK_META_FILE_NAME,
-                                                   TESTS_AND_DOC_DIRECTORIES,
-                                                   FileType)
+from demisto_sdk.commands.common.constants import (KNOWN_FILE_STATUSES, PACKS_PACK_META_FILE_NAME,
+                                                   TESTS_AND_DOC_DIRECTORIES, FileType)
 from demisto_sdk.commands.common.errors import Errors
-from demisto_sdk.commands.common.hook_validations.base_validator import \
-    BaseValidator
-from demisto_sdk.commands.common.tools import (filter_packagify_changes,
-                                               find_type, get_pack_name,
-                                               has_remote_configured,
-                                               is_origin_content_repo,
-                                               run_command)
+from demisto_sdk.commands.common.hook_validations.base_validator import BaseValidator
+from demisto_sdk.commands.common.tools import (filter_packagify_changes, find_type, get_pack_name,
+                                               has_remote_configured, is_origin_content_repo, run_command)
 from demisto_sdk.commands.validate.validate_manager import ValidateManager
 
 

--- a/demisto_sdk/commands/common/tests/author_image_validator_test.py
+++ b/demisto_sdk/commands/common/tests/author_image_validator_test.py
@@ -2,8 +2,7 @@ import os
 
 import pytest
 
-from demisto_sdk.commands.common.hook_validations.author_image import \
-    AuthorImageValidator
+from demisto_sdk.commands.common.hook_validations.author_image import AuthorImageValidator
 from demisto_sdk.commands.common.legacy_git_tools import git_path
 
 

--- a/demisto_sdk/commands/common/tests/base_validator_test.py
+++ b/demisto_sdk/commands/common/tests/base_validator_test.py
@@ -4,13 +4,10 @@ from os.path import join
 import pytest
 
 from demisto_sdk.commands.common.constants import PACK_METADATA_SUPPORT
-from demisto_sdk.commands.common.errors import (FOUND_FILES_AND_ERRORS,
-                                                FOUND_FILES_AND_IGNORED_ERRORS,
-                                                PRESET_ERROR_TO_CHECK,
-                                                PRESET_ERROR_TO_IGNORE, Errors)
+from demisto_sdk.commands.common.errors import (FOUND_FILES_AND_ERRORS, FOUND_FILES_AND_IGNORED_ERRORS,
+                                                PRESET_ERROR_TO_CHECK, PRESET_ERROR_TO_IGNORE, Errors)
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.common.hook_validations.base_validator import \
-    BaseValidator
+from demisto_sdk.commands.common.hook_validations.base_validator import BaseValidator
 from demisto_sdk.commands.common.legacy_git_tools import git_path
 from demisto_sdk.commands.common.tools import get_yaml
 from TestSuite.test_tools import ChangeCWD

--- a/demisto_sdk/commands/common/tests/classifier_test.py
+++ b/demisto_sdk/commands/common/tests/classifier_test.py
@@ -1,11 +1,9 @@
 import pytest
 from mock import patch
 
-from demisto_sdk.commands.common.hook_validations.classifier import \
-    ClassifierValidator
+from demisto_sdk.commands.common.hook_validations.classifier import ClassifierValidator
 from demisto_sdk.commands.common.hook_validations.mapper import MapperValidator
-from demisto_sdk.commands.common.hook_validations.structure import \
-    StructureValidator
+from demisto_sdk.commands.common.hook_validations.structure import StructureValidator
 
 
 def mock_structure(file_path=None, current_file=None, old_file=None):

--- a/demisto_sdk/commands/common/tests/conf_test.py
+++ b/demisto_sdk/commands/common/tests/conf_test.py
@@ -1,8 +1,7 @@
 import pytest
 
 from demisto_sdk.commands.common.constants import FileType
-from demisto_sdk.commands.common.hook_validations.conf_json import \
-    ConfJsonValidator
+from demisto_sdk.commands.common.hook_validations.conf_json import ConfJsonValidator
 
 WITH_DESCRIPTION = {
     "test": "description"

--- a/demisto_sdk/commands/common/tests/content_entity_validator_test.py
+++ b/demisto_sdk/commands/common/tests/content_entity_validator_test.py
@@ -2,19 +2,14 @@ import os
 
 import pytest
 
-from demisto_sdk.commands.common.constants import (API_MODULES_PACK,
-                                                   EXCLUDED_DISPLAY_NAME_WORDS)
+from demisto_sdk.commands.common.constants import API_MODULES_PACK, EXCLUDED_DISPLAY_NAME_WORDS
 from demisto_sdk.commands.common.handlers import YAML_Handler
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
-from demisto_sdk.commands.common.hook_validations.structure import \
-    StructureValidator
-from demisto_sdk.commands.common.tools import (get_not_registered_tests,
-                                               is_test_config_match)
-from demisto_sdk.tests.constants_test import (
-    INVALID_INTEGRATION_WITH_NO_TEST_PLAYBOOK, INVALID_PLAYBOOK_PATH,
-    VALID_INTEGRATION_TEST_PATH, VALID_PLAYBOOK_ID_PATH,
-    VALID_TEST_PLAYBOOK_PATH)
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
+from demisto_sdk.commands.common.hook_validations.structure import StructureValidator
+from demisto_sdk.commands.common.tools import get_not_registered_tests, is_test_config_match
+from demisto_sdk.tests.constants_test import (INVALID_INTEGRATION_WITH_NO_TEST_PLAYBOOK, INVALID_PLAYBOOK_PATH,
+                                              VALID_INTEGRATION_TEST_PATH, VALID_PLAYBOOK_ID_PATH,
+                                              VALID_TEST_PLAYBOOK_PATH)
 
 HAS_TESTS_KEY_UNPUTS = [
     (VALID_INTEGRATION_TEST_PATH, 'integration', True),

--- a/demisto_sdk/commands/common/tests/dashboard_test.py
+++ b/demisto_sdk/commands/common/tests/dashboard_test.py
@@ -3,10 +3,8 @@ from typing import Optional
 import pytest
 from mock import patch
 
-from demisto_sdk.commands.common.hook_validations.dashboard import \
-    DashboardValidator
-from demisto_sdk.commands.common.hook_validations.structure import \
-    StructureValidator
+from demisto_sdk.commands.common.hook_validations.dashboard import DashboardValidator
+from demisto_sdk.commands.common.hook_validations.structure import StructureValidator
 
 
 def mock_structure(file_path=None, current_file=None, old_file=None):

--- a/demisto_sdk/commands/common/tests/dependencies_test.py
+++ b/demisto_sdk/commands/common/tests/dependencies_test.py
@@ -6,8 +6,7 @@ from typing import List
 import pytest
 
 from demisto_sdk.commands.create_id_set.create_id_set import IDSetCreator
-from demisto_sdk.commands.find_dependencies.find_dependencies import \
-    PackDependencies
+from demisto_sdk.commands.find_dependencies.find_dependencies import PackDependencies
 from TestSuite.integration import Integration
 from TestSuite.json_based import JSONBased
 from TestSuite.playbook import Playbook

--- a/demisto_sdk/commands/common/tests/deprecation_test.py
+++ b/demisto_sdk/commands/common/tests/deprecation_test.py
@@ -1,11 +1,8 @@
 import pytest
 
-from demisto_sdk.commands.common.hook_validations.deprecation import \
-    DeprecationValidator
-from demisto_sdk.commands.common.hook_validations.integration import \
-    IntegrationValidator
-from demisto_sdk.commands.common.hook_validations.playbook import \
-    PlaybookValidator
+from demisto_sdk.commands.common.hook_validations.deprecation import DeprecationValidator
+from demisto_sdk.commands.common.hook_validations.integration import IntegrationValidator
+from demisto_sdk.commands.common.hook_validations.playbook import PlaybookValidator
 from demisto_sdk.commands.common.hook_validations.script import ScriptValidator
 from demisto_sdk.commands.common.tests.integration_test import mock_structure
 

--- a/demisto_sdk/commands/common/tests/description_test.py
+++ b/demisto_sdk/commands/common/tests/description_test.py
@@ -4,8 +4,7 @@ import os
 import pytest
 
 from demisto_sdk.commands.common.handlers import YAML_Handler
-from demisto_sdk.commands.common.hook_validations.description import \
-    DescriptionValidator
+from demisto_sdk.commands.common.hook_validations.description import DescriptionValidator
 from TestSuite.test_tools import ChangeCWD
 
 yaml = YAML_Handler()

--- a/demisto_sdk/commands/common/tests/docker_test.py
+++ b/demisto_sdk/commands/common/tests/docker_test.py
@@ -4,8 +4,7 @@ import mock
 import pytest
 
 from demisto_sdk.commands.common.errors import Errors
-from demisto_sdk.commands.common.hook_validations.docker import \
-    DockerImageValidator
+from demisto_sdk.commands.common.hook_validations.docker import DockerImageValidator
 from demisto_sdk.commands.common.legacy_git_tools import git_path
 from demisto_sdk.commands.common.tools import get_yaml
 from TestSuite.test_tools import ChangeCWD

--- a/demisto_sdk/commands/common/tests/field_validator_test.py
+++ b/demisto_sdk/commands/common/tests/field_validator_test.py
@@ -4,10 +4,8 @@ from typing import List
 import pytest
 from mock import patch
 
-from demisto_sdk.commands.common.hook_validations.field_base_validator import (
-    FieldBaseValidator, GroupFieldTypes)
-from demisto_sdk.commands.common.hook_validations.structure import \
-    StructureValidator
+from demisto_sdk.commands.common.hook_validations.field_base_validator import FieldBaseValidator, GroupFieldTypes
+from demisto_sdk.commands.common.hook_validations.structure import StructureValidator
 
 INDICATOR_GROUP_NUMBER = 2
 INCIDENT_GROUP_NUMBER = 0
@@ -429,8 +427,7 @@ class TestFieldValidator:
             Then
             - Ensure validate fails when the field name does not start with the pack name prefix.
         """
-        from demisto_sdk.commands.common.hook_validations import \
-            field_base_validator
+        from demisto_sdk.commands.common.hook_validations import field_base_validator
         with patch.object(StructureValidator, '__init__', lambda a, b: None):
             structure = StructureValidator("")
             structure.current_file = current_file

--- a/demisto_sdk/commands/common/tests/generic_field_test.py
+++ b/demisto_sdk/commands/common/tests/generic_field_test.py
@@ -3,10 +3,8 @@ from collections import namedtuple
 
 from mock import patch
 
-from demisto_sdk.commands.common.hook_validations.structure import \
-    StructureValidator
-from demisto_sdk.tests.test_files.validate_integration_test_valid_types import \
-    GENERIC_FIELD
+from demisto_sdk.commands.common.hook_validations.structure import StructureValidator
+from demisto_sdk.tests.test_files.validate_integration_test_valid_types import GENERIC_FIELD
 
 
 def mock_structure(file_path=None, current_file=None, old_file=None):

--- a/demisto_sdk/commands/common/tests/git_config_test.py
+++ b/demisto_sdk/commands/common/tests/git_config_test.py
@@ -5,9 +5,7 @@ import click
 import pytest
 from git import Repo
 
-from demisto_sdk.commands.common.git_content_config import (GitContentConfig,
-                                                            GitCredentials,
-                                                            GitProvider)
+from demisto_sdk.commands.common.git_content_config import GitContentConfig, GitCredentials, GitProvider
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.legacy_git_tools import git_path
 

--- a/demisto_sdk/commands/common/tests/image_test.py
+++ b/demisto_sdk/commands/common/tests/image_test.py
@@ -4,8 +4,7 @@ import pytest
 
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.hook_validations import image
-from demisto_sdk.commands.common.hook_validations.integration import \
-    IntegrationValidator
+from demisto_sdk.commands.common.hook_validations.integration import IntegrationValidator
 from demisto_sdk.commands.common.legacy_git_tools import git_path
 from demisto_sdk.commands.common.tests.integration_test import mock_structure
 from TestSuite.file import File

--- a/demisto_sdk/commands/common/tests/incident_field_test.py
+++ b/demisto_sdk/commands/common/tests/incident_field_test.py
@@ -1,9 +1,7 @@
 import pytest
 
-from demisto_sdk.commands.common.hook_validations.incident_field import \
-    IncidentFieldValidator
-from demisto_sdk.commands.common.hook_validations.structure import \
-    StructureValidator
+from demisto_sdk.commands.common.hook_validations.incident_field import IncidentFieldValidator
+from demisto_sdk.commands.common.hook_validations.structure import StructureValidator
 
 INCIDENT_GROUP_NUMBER = 0
 

--- a/demisto_sdk/commands/common/tests/incident_type_test.py
+++ b/demisto_sdk/commands/common/tests/incident_type_test.py
@@ -3,10 +3,8 @@ from typing import Optional
 import pytest
 from mock import patch
 
-from demisto_sdk.commands.common.hook_validations.incident_type import \
-    IncidentTypeValidator
-from demisto_sdk.commands.common.hook_validations.structure import \
-    StructureValidator
+from demisto_sdk.commands.common.hook_validations.incident_type import IncidentTypeValidator
+from demisto_sdk.commands.common.hook_validations.structure import StructureValidator
 
 
 def mock_structure(file_path=None, current_file=None, old_file=None):

--- a/demisto_sdk/commands/common/tests/indicator_field_test.py
+++ b/demisto_sdk/commands/common/tests/indicator_field_test.py
@@ -1,9 +1,7 @@
 import pytest
 
-from demisto_sdk.commands.common.hook_validations.indicator_field import \
-    IndicatorFieldValidator
-from demisto_sdk.commands.common.hook_validations.structure import \
-    StructureValidator
+from demisto_sdk.commands.common.hook_validations.indicator_field import IndicatorFieldValidator
+from demisto_sdk.commands.common.hook_validations.structure import StructureValidator
 
 INDICATOR_GROUP_NUMBER = 2
 

--- a/demisto_sdk/commands/common/tests/integration_test.py
+++ b/demisto_sdk/commands/common/tests/integration_test.py
@@ -5,15 +5,11 @@ from typing import Any, Dict, List, Optional
 import pytest
 from mock import mock_open, patch
 
-from demisto_sdk.commands.common.constants import (
-    ALERT_FETCH_REQUIRED_PARAMS, FEED_REQUIRED_PARAMS, FIRST_FETCH_PARAM,
-    INCIDENT_FETCH_REQUIRED_PARAMS, MAX_FETCH_PARAM, MarketplaceVersions)
-from demisto_sdk.commands.common.default_additional_info_loader import \
-    load_default_additional_info_dict
-from demisto_sdk.commands.common.hook_validations.integration import \
-    IntegrationValidator
-from demisto_sdk.commands.common.hook_validations.structure import \
-    StructureValidator
+from demisto_sdk.commands.common.constants import (ALERT_FETCH_REQUIRED_PARAMS, FEED_REQUIRED_PARAMS, FIRST_FETCH_PARAM,
+                                                   INCIDENT_FETCH_REQUIRED_PARAMS, MAX_FETCH_PARAM, MarketplaceVersions)
+from demisto_sdk.commands.common.default_additional_info_loader import load_default_additional_info_dict
+from demisto_sdk.commands.common.hook_validations.integration import IntegrationValidator
+from demisto_sdk.commands.common.hook_validations.structure import StructureValidator
 from demisto_sdk.commands.common.legacy_git_tools import git_path
 from TestSuite.integration import Integration
 from TestSuite.test_tools import ChangeCWD

--- a/demisto_sdk/commands/common/tests/layout_test.py
+++ b/demisto_sdk/commands/common/tests/layout_test.py
@@ -1,10 +1,8 @@
 import pytest
 from mock import patch
 
-from demisto_sdk.commands.common.hook_validations.layout import (
-    LayoutsContainerValidator, LayoutValidator)
-from demisto_sdk.commands.common.hook_validations.structure import \
-    StructureValidator
+from demisto_sdk.commands.common.hook_validations.layout import LayoutsContainerValidator, LayoutValidator
+from demisto_sdk.commands.common.hook_validations.structure import StructureValidator
 
 
 def mock_structure(file_path=None, current_file=None, old_file=None):

--- a/demisto_sdk/commands/common/tests/legacy_git_tools_test.py
+++ b/demisto_sdk/commands/common/tests/legacy_git_tools_test.py
@@ -1,8 +1,8 @@
 import os
 
 from demisto_sdk.commands.common.constants import FileType
-from demisto_sdk.commands.common.legacy_git_tools import (
-    filter_changed_files, get_changed_files, get_modified_and_added_files)
+from demisto_sdk.commands.common.legacy_git_tools import (filter_changed_files, get_changed_files,
+                                                          get_modified_and_added_files)
 from demisto_sdk.tests.constants_test import *
 
 

--- a/demisto_sdk/commands/common/tests/lists_test.py
+++ b/demisto_sdk/commands/common/tests/lists_test.py
@@ -4,8 +4,7 @@ from mock import patch
 from demisto_sdk.commands.common.constants import LISTS_DIR, PACKS_DIR
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.hook_validations.lists import ListsValidator
-from demisto_sdk.commands.common.hook_validations.structure import \
-    StructureValidator
+from demisto_sdk.commands.common.hook_validations.structure import StructureValidator
 from demisto_sdk.commands.common.tools import src_root
 
 json = JSON_Handler()

--- a/demisto_sdk/commands/common/tests/mapper_test.py
+++ b/demisto_sdk/commands/common/tests/mapper_test.py
@@ -2,8 +2,7 @@ import pytest
 from mock import patch
 
 from demisto_sdk.commands.common.hook_validations.mapper import MapperValidator
-from demisto_sdk.commands.common.hook_validations.structure import \
-    StructureValidator
+from demisto_sdk.commands.common.hook_validations.structure import StructureValidator
 
 
 def mock_structure(file_path=None, current_file=None, old_file=None):

--- a/demisto_sdk/commands/common/tests/modeling_rules_test.py
+++ b/demisto_sdk/commands/common/tests/modeling_rules_test.py
@@ -1,10 +1,8 @@
 import os
 
 from demisto_sdk.commands.common.handlers import YAML_Handler
-from demisto_sdk.commands.common.hook_validations.modeling_rule import \
-    ModelingRuleValidator
-from demisto_sdk.commands.common.hook_validations.structure import \
-    StructureValidator
+from demisto_sdk.commands.common.hook_validations.modeling_rule import ModelingRuleValidator
+from demisto_sdk.commands.common.hook_validations.structure import StructureValidator
 from TestSuite.test_tools import ChangeCWD
 
 yaml = YAML_Handler()

--- a/demisto_sdk/commands/common/tests/old_release_notes_test.py
+++ b/demisto_sdk/commands/common/tests/old_release_notes_test.py
@@ -1,7 +1,6 @@
 import pytest
 
-from demisto_sdk.commands.common.hook_validations.old_release_notes import \
-    OldReleaseNotesValidator
+from demisto_sdk.commands.common.hook_validations.old_release_notes import OldReleaseNotesValidator
 
 
 def get_validator(file_path='', diff=''):

--- a/demisto_sdk/commands/common/tests/pack_metadata_validator_test.py
+++ b/demisto_sdk/commands/common/tests/pack_metadata_validator_test.py
@@ -6,11 +6,10 @@ import pytest
 
 from demisto_sdk.commands.common import tools
 from demisto_sdk.commands.common.constants import EXCLUDED_DISPLAY_NAME_WORDS
-from demisto_sdk.commands.common.hook_validations.base_validator import \
-    BaseValidator
-from demisto_sdk.commands.common.hook_validations.pack_unique_files import (
-    PACK_METADATA_NAME, PACK_METADATA_SUPPORT,
-    BlockingValidationFailureException, PackUniqueFilesValidator)
+from demisto_sdk.commands.common.hook_validations.base_validator import BaseValidator
+from demisto_sdk.commands.common.hook_validations.pack_unique_files import (PACK_METADATA_NAME, PACK_METADATA_SUPPORT,
+                                                                            BlockingValidationFailureException,
+                                                                            PackUniqueFilesValidator)
 from demisto_sdk.commands.common.legacy_git_tools import git_path
 
 

--- a/demisto_sdk/commands/common/tests/pack_unique_files_test.py
+++ b/demisto_sdk/commands/common/tests/pack_unique_files_test.py
@@ -8,19 +8,13 @@ from git import GitCommandError
 
 from demisto_sdk.__main__ import main
 from demisto_sdk.commands.common import tools
-from demisto_sdk.commands.common.constants import (PACK_METADATA_DESC,
-                                                   PACK_METADATA_SUPPORT,
-                                                   PACK_METADATA_TAGS,
-                                                   PACK_METADATA_USE_CASES,
-                                                   PACKS_PACK_META_FILE_NAME,
-                                                   PACKS_README_FILE_NAME,
-                                                   XSOAR_SUPPORT)
+from demisto_sdk.commands.common.constants import (PACK_METADATA_DESC, PACK_METADATA_SUPPORT, PACK_METADATA_TAGS,
+                                                   PACK_METADATA_USE_CASES, PACKS_PACK_META_FILE_NAME,
+                                                   PACKS_README_FILE_NAME, XSOAR_SUPPORT)
 from demisto_sdk.commands.common.errors import Errors
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.common.hook_validations.base_validator import \
-    BaseValidator
-from demisto_sdk.commands.common.hook_validations.pack_unique_files import \
-    PackUniqueFilesValidator
+from demisto_sdk.commands.common.hook_validations.base_validator import BaseValidator
+from demisto_sdk.commands.common.hook_validations.pack_unique_files import PackUniqueFilesValidator
 from demisto_sdk.commands.common.legacy_git_tools import git_path
 from TestSuite.test_tools import ChangeCWD
 
@@ -650,8 +644,7 @@ class TestPackUniqueFilesValidator:
                     - Validation succeed
                     - Valid absolute image paths were not caught
         """
-        from demisto_sdk.commands.common.hook_validations.readme import \
-            ReadMeValidator
+        from demisto_sdk.commands.common.hook_validations.readme import ReadMeValidator
 
         self.validator = PackUniqueFilesValidator(os.path.join(self.FILES_PATH, 'DummyPack2'))
         mocker.patch.object(ReadMeValidator, 'check_readme_relative_image_paths',

--- a/demisto_sdk/commands/common/tests/playbook_test.py
+++ b/demisto_sdk/commands/common/tests/playbook_test.py
@@ -4,15 +4,12 @@ from typing import Optional
 import pytest
 from mock import patch
 
-from demisto_sdk.commands.common.hook_validations.playbook import \
-    PlaybookValidator
-from demisto_sdk.commands.common.hook_validations.structure import \
-    StructureValidator
-from demisto_sdk.tests.constants_test import (
-    CONTENT_REPO_EXAMPLE_ROOT, CORRECT_PLAYBOOK_REFERENCE_USE,
-    INCORRECT_PLAYBOOK_REFERENCE_USE, INVALID_PLAYBOOK_INPUTS_USE,
-    INVALID_PLAYBOOK_UNHANDLED_CONDITION,
-    INVALID_TEST_PLAYBOOK_UNHANDLED_CONDITION, VALID_PLAYBOOK_INPUTS_USE)
+from demisto_sdk.commands.common.hook_validations.playbook import PlaybookValidator
+from demisto_sdk.commands.common.hook_validations.structure import StructureValidator
+from demisto_sdk.tests.constants_test import (CONTENT_REPO_EXAMPLE_ROOT, CORRECT_PLAYBOOK_REFERENCE_USE,
+                                              INCORRECT_PLAYBOOK_REFERENCE_USE, INVALID_PLAYBOOK_INPUTS_USE,
+                                              INVALID_PLAYBOOK_UNHANDLED_CONDITION,
+                                              INVALID_TEST_PLAYBOOK_UNHANDLED_CONDITION, VALID_PLAYBOOK_INPUTS_USE)
 from TestSuite.test_tools import ChangeCWD
 
 

--- a/demisto_sdk/commands/common/tests/pre_process_rule_test.py
+++ b/demisto_sdk/commands/common/tests/pre_process_rule_test.py
@@ -1,5 +1,4 @@
-from demisto_sdk.commands.common.hook_validations.pre_process_rule import \
-    PreProcessRuleValidator
+from demisto_sdk.commands.common.hook_validations.pre_process_rule import PreProcessRuleValidator
 
 
 class TestPreProcessRuleValidator:

--- a/demisto_sdk/commands/common/tests/python_file_test.py
+++ b/demisto_sdk/commands/common/tests/python_file_test.py
@@ -1,7 +1,6 @@
 import pytest
 
-from demisto_sdk.commands.common.hook_validations.python_file import \
-    PythonFileValidator
+from demisto_sdk.commands.common.hook_validations.python_file import PythonFileValidator
 
 
 @pytest.mark.parametrize("file_input",

--- a/demisto_sdk/commands/common/tests/release_notes_config_test.py
+++ b/demisto_sdk/commands/common/tests/release_notes_config_test.py
@@ -2,8 +2,7 @@ from typing import Optional
 
 import pytest
 
-from demisto_sdk.commands.common.hook_validations.release_notes_config import \
-    ReleaseNotesConfigValidator
+from demisto_sdk.commands.common.hook_validations.release_notes_config import ReleaseNotesConfigValidator
 
 
 class TestReleaseNotesConfigValidator:

--- a/demisto_sdk/commands/common/tests/release_notes_test.py
+++ b/demisto_sdk/commands/common/tests/release_notes_test.py
@@ -3,10 +3,8 @@ import os
 import pytest
 
 from demisto_sdk.commands.common.constants import FileType
-from demisto_sdk.commands.common.hook_validations.release_notes import \
-    ReleaseNotesValidator
-from demisto_sdk.commands.common.hook_validations.structure import \
-    StructureValidator
+from demisto_sdk.commands.common.hook_validations.release_notes import ReleaseNotesValidator
+from demisto_sdk.commands.common.hook_validations.structure import StructureValidator
 from demisto_sdk.commands.common.legacy_git_tools import git_path
 from demisto_sdk.commands.common.tools import get_dict_from_file
 from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN

--- a/demisto_sdk/commands/common/tests/reputation_test.py
+++ b/demisto_sdk/commands/common/tests/reputation_test.py
@@ -1,9 +1,7 @@
 import pytest
 
-from demisto_sdk.commands.common.hook_validations.reputation import \
-    ReputationValidator
-from demisto_sdk.commands.common.hook_validations.structure import \
-    StructureValidator
+from demisto_sdk.commands.common.hook_validations.reputation import ReputationValidator
+from demisto_sdk.commands.common.hook_validations.structure import StructureValidator
 
 data_is_valid_version = [
     (-1, True),

--- a/demisto_sdk/commands/common/tests/script_test.py
+++ b/demisto_sdk/commands/common/tests/script_test.py
@@ -4,8 +4,7 @@ import pytest
 from mock import patch
 
 from demisto_sdk.commands.common.hook_validations.script import ScriptValidator
-from demisto_sdk.commands.common.hook_validations.structure import \
-    StructureValidator
+from demisto_sdk.commands.common.hook_validations.structure import StructureValidator
 from TestSuite.test_tools import ChangeCWD
 
 

--- a/demisto_sdk/commands/common/tests/structure_test.py
+++ b/demisto_sdk/commands/common/tests/structure_test.py
@@ -5,38 +5,34 @@ from typing import List, Tuple
 
 import pytest
 
-from demisto_sdk.commands.common.constants import (
-    CODE_FILES_REGEX, PACKAGE_YML_FILE_REGEX,
-    PACKS_CLASSIFIER_JSON_5_9_9_REGEX, PACKS_CLASSIFIER_JSON_REGEX,
-    PACKS_DASHBOARD_JSON_REGEX, PACKS_INCIDENT_FIELD_JSON_REGEX,
-    PACKS_INCIDENT_TYPE_JSON_REGEX, PACKS_INTEGRATION_NON_SPLIT_YML_REGEX,
-    PACKS_INTEGRATION_PY_REGEX, PACKS_INTEGRATION_TEST_PY_REGEX,
-    PACKS_INTEGRATION_YML_REGEX, PACKS_LAYOUT_JSON_REGEX,
-    PACKS_LAYOUTS_CONTAINER_JSON_REGEX, PACKS_MAPPER_JSON_REGEX,
-    PACKS_SCRIPT_PY_REGEX, PACKS_SCRIPT_TEST_PLAYBOOK,
-    PACKS_SCRIPT_TEST_PY_REGEX, PACKS_SCRIPT_YML_REGEX,
-    PACKS_WIDGET_JSON_REGEX, PLAYBOOK_README_REGEX, PLAYBOOK_YML_REGEX,
-    TEST_PLAYBOOK_YML_REGEX)
+from demisto_sdk.commands.common.constants import (CODE_FILES_REGEX, PACKAGE_YML_FILE_REGEX,
+                                                   PACKS_CLASSIFIER_JSON_5_9_9_REGEX, PACKS_CLASSIFIER_JSON_REGEX,
+                                                   PACKS_DASHBOARD_JSON_REGEX, PACKS_INCIDENT_FIELD_JSON_REGEX,
+                                                   PACKS_INCIDENT_TYPE_JSON_REGEX,
+                                                   PACKS_INTEGRATION_NON_SPLIT_YML_REGEX, PACKS_INTEGRATION_PY_REGEX,
+                                                   PACKS_INTEGRATION_TEST_PY_REGEX, PACKS_INTEGRATION_YML_REGEX,
+                                                   PACKS_LAYOUT_JSON_REGEX, PACKS_LAYOUTS_CONTAINER_JSON_REGEX,
+                                                   PACKS_MAPPER_JSON_REGEX, PACKS_SCRIPT_PY_REGEX,
+                                                   PACKS_SCRIPT_TEST_PLAYBOOK, PACKS_SCRIPT_TEST_PY_REGEX,
+                                                   PACKS_SCRIPT_YML_REGEX, PACKS_WIDGET_JSON_REGEX,
+                                                   PLAYBOOK_README_REGEX, PLAYBOOK_YML_REGEX, TEST_PLAYBOOK_YML_REGEX)
 from demisto_sdk.commands.common.handlers import JSON_Handler, YAML_Handler
-from demisto_sdk.commands.common.hook_validations.base_validator import \
-    BaseValidator
-from demisto_sdk.commands.common.hook_validations.structure import (
-    StructureValidator, checked_type_by_reg)
-from demisto_sdk.tests.constants_test import (
-    DASHBOARD_TARGET, DIR_LIST, INCIDENT_FIELD_TARGET,
-    INDICATORFIELD_EXACT_SCHEME, INDICATORFIELD_EXTRA_FIELDS,
-    INDICATORFIELD_MISSING_AND_EXTRA_FIELDS, INDICATORFIELD_MISSING_FIELD,
-    INTEGRATION_TARGET, INVALID_DASHBOARD_PATH, INVALID_INTEGRATION_ID_PATH,
-    INVALID_INTEGRATION_YML_1, INVALID_INTEGRATION_YML_2,
-    INVALID_INTEGRATION_YML_3, INVALID_INTEGRATION_YML_4,
-    INVALID_LAYOUT_CONTAINER_PATH, INVALID_LAYOUT_PATH, INVALID_PLAYBOOK_PATH,
-    INVALID_REPUTATION_FILE, INVALID_WIDGET_PATH, LAYOUT_TARGET,
-    LAYOUTS_CONTAINER_TARGET, PLAYBOOK_PACK_TARGET, PLAYBOOK_TARGET,
-    VALID_DASHBOARD_PATH, VALID_INTEGRATION_ID_PATH,
-    VALID_INTEGRATION_TEST_PATH, VALID_LAYOUT_CONTAINER_PATH,
-    VALID_LAYOUT_PATH, VALID_PLAYBOOK_ARCSIGHT_ADD_DOMAIN_PATH,
-    VALID_PLAYBOOK_ID_PATH, VALID_REPUTATION_FILE, VALID_TEST_PLAYBOOK_PATH,
-    VALID_WIDGET_PATH, WIDGET_TARGET)
+from demisto_sdk.commands.common.hook_validations.base_validator import BaseValidator
+from demisto_sdk.commands.common.hook_validations.structure import StructureValidator, checked_type_by_reg
+from demisto_sdk.tests.constants_test import (DASHBOARD_TARGET, DIR_LIST, INCIDENT_FIELD_TARGET,
+                                              INDICATORFIELD_EXACT_SCHEME, INDICATORFIELD_EXTRA_FIELDS,
+                                              INDICATORFIELD_MISSING_AND_EXTRA_FIELDS, INDICATORFIELD_MISSING_FIELD,
+                                              INTEGRATION_TARGET, INVALID_DASHBOARD_PATH, INVALID_INTEGRATION_ID_PATH,
+                                              INVALID_INTEGRATION_YML_1, INVALID_INTEGRATION_YML_2,
+                                              INVALID_INTEGRATION_YML_3, INVALID_INTEGRATION_YML_4,
+                                              INVALID_LAYOUT_CONTAINER_PATH, INVALID_LAYOUT_PATH, INVALID_PLAYBOOK_PATH,
+                                              INVALID_REPUTATION_FILE, INVALID_WIDGET_PATH, LAYOUT_TARGET,
+                                              LAYOUTS_CONTAINER_TARGET, PLAYBOOK_PACK_TARGET, PLAYBOOK_TARGET,
+                                              VALID_DASHBOARD_PATH, VALID_INTEGRATION_ID_PATH,
+                                              VALID_INTEGRATION_TEST_PATH, VALID_LAYOUT_CONTAINER_PATH,
+                                              VALID_LAYOUT_PATH, VALID_PLAYBOOK_ARCSIGHT_ADD_DOMAIN_PATH,
+                                              VALID_PLAYBOOK_ID_PATH, VALID_REPUTATION_FILE, VALID_TEST_PLAYBOOK_PATH,
+                                              VALID_WIDGET_PATH, WIDGET_TARGET)
 from TestSuite.json_based import JSONBased
 from TestSuite.pack import Pack
 from TestSuite.test_tools import ChangeCWD

--- a/demisto_sdk/commands/common/tests/timers_test.py
+++ b/demisto_sdk/commands/common/tests/timers_test.py
@@ -2,10 +2,7 @@ import logging
 import tempfile
 from pathlib import Path
 
-from demisto_sdk.commands.common.timers import (MEASURE_TYPE_TO_HEADERS,
-                                                MeasureType,
-                                                report_time_measurements,
-                                                timer)
+from demisto_sdk.commands.common.timers import MEASURE_TYPE_TO_HEADERS, MeasureType, report_time_measurements, timer
 
 logger = logging.getLogger('demisto-sdk')
 

--- a/demisto_sdk/commands/common/tests/tools_test.py
+++ b/demisto_sdk/commands/common/tests/tools_test.py
@@ -10,48 +10,44 @@ import pytest
 import requests
 
 from demisto_sdk.commands.common import tools
-from demisto_sdk.commands.common.constants import (
-    DEFAULT_CONTENT_ITEM_TO_VERSION, DOC_FILES_DIR, INDICATOR_TYPES_DIR,
-    INTEGRATIONS_DIR, LAYOUTS_DIR, METADATA_FILE_NAME, PACKS_DIR,
-    PACKS_PACK_IGNORE_FILE_NAME, PLAYBOOKS_DIR, SCRIPTS_DIR,
-    TEST_PLAYBOOKS_DIR, TRIGGER_DIR, XSIAM_DASHBOARDS_DIR, XSIAM_REPORTS_DIR,
-    XSOAR_CONFIG_FILE, FileType, MarketplaceVersions)
+from demisto_sdk.commands.common.constants import (DEFAULT_CONTENT_ITEM_TO_VERSION, DOC_FILES_DIR, INDICATOR_TYPES_DIR,
+                                                   INTEGRATIONS_DIR, LAYOUTS_DIR, METADATA_FILE_NAME, PACKS_DIR,
+                                                   PACKS_PACK_IGNORE_FILE_NAME, PLAYBOOKS_DIR, SCRIPTS_DIR,
+                                                   TEST_PLAYBOOKS_DIR, TRIGGER_DIR, XSIAM_DASHBOARDS_DIR,
+                                                   XSIAM_REPORTS_DIR, XSOAR_CONFIG_FILE, FileType, MarketplaceVersions)
 from demisto_sdk.commands.common.content import Content
-from demisto_sdk.commands.common.content.tests.objects.pack_objects.pack_ignore.pack_ignore_test import \
-    PACK_IGNORE
-from demisto_sdk.commands.common.git_content_config import (GitContentConfig,
-                                                            GitCredentials)
+from demisto_sdk.commands.common.content.tests.objects.pack_objects.pack_ignore.pack_ignore_test import PACK_IGNORE
+from demisto_sdk.commands.common.git_content_config import GitContentConfig, GitCredentials
 from demisto_sdk.commands.common.git_util import GitUtil
 from demisto_sdk.commands.common.legacy_git_tools import git_path
-from demisto_sdk.commands.common.tools import (
-    LOG_COLORS, MarketplaceTagParser, TagParser, arg_to_list,
-    compare_context_path_in_yml_and_readme, field_to_cli_name,
-    filter_files_by_type, filter_files_on_pack, filter_packagify_changes,
-    find_type, find_type_by_path, generate_xsiam_normalized_name,
-    get_code_lang, get_current_repo, get_dict_from_file, get_display_name,
-    get_entity_id_by_entity_type, get_entity_name_by_entity_type,
-    get_file_displayed_name, get_file_version_suffix_if_exists,
-    get_files_in_dir, get_ignore_pack_skipped_tests, get_item_marketplaces,
-    get_last_release_version, get_last_remote_release_version,
-    get_latest_release_notes_text, get_pack_metadata,
-    get_relative_path_from_packs_dir, get_release_note_entries,
-    get_release_notes_file_path, get_scripts_and_commands_from_yml_data,
-    get_test_playbook_id, get_to_version, get_yaml, has_remote_configured,
-    is_object_in_id_set, is_origin_content_repo, is_pack_path, is_uuid,
-    retrieve_file_ending, run_command_os, server_version_compare,
-    string_to_bool, to_kebab_case)
-from demisto_sdk.tests.constants_test import (
-    DUMMY_SCRIPT_PATH, IGNORED_PNG, INDICATORFIELD_EXTRA_FIELDS,
-    SOURCE_FORMAT_INTEGRATION_COPY, TEST_PLAYBOOK, VALID_BETA_INTEGRATION_PATH,
-    VALID_DASHBOARD_PATH, VALID_GENERIC_DEFINITION_PATH,
-    VALID_GENERIC_FIELD_PATH, VALID_GENERIC_MODULE_PATH,
-    VALID_GENERIC_TYPE_PATH, VALID_INCIDENT_FIELD_PATH,
-    VALID_INCIDENT_TYPE_FILE, VALID_INCIDENT_TYPE_FILE__RAW_DOWNLOADED,
-    VALID_INCIDENT_TYPE_PATH, VALID_INTEGRATION_TEST_PATH, VALID_LAYOUT_PATH,
-    VALID_MD, VALID_PLAYBOOK_ID_PATH, VALID_REPUTATION_FILE, VALID_SCRIPT_PATH,
-    VALID_WIDGET_PATH)
-from demisto_sdk.tests.test_files.validate_integration_test_valid_types import (
-    LAYOUT, MAPPER, OLD_CLASSIFIER, REPUTATION)
+from demisto_sdk.commands.common.tools import (LOG_COLORS, MarketplaceTagParser, TagParser, arg_to_list,
+                                               compare_context_path_in_yml_and_readme, field_to_cli_name,
+                                               filter_files_by_type, filter_files_on_pack, filter_packagify_changes,
+                                               find_type, find_type_by_path, generate_xsiam_normalized_name,
+                                               get_code_lang, get_current_repo, get_dict_from_file, get_display_name,
+                                               get_entity_id_by_entity_type, get_entity_name_by_entity_type,
+                                               get_file_displayed_name, get_file_version_suffix_if_exists,
+                                               get_files_in_dir, get_ignore_pack_skipped_tests, get_item_marketplaces,
+                                               get_last_release_version, get_last_remote_release_version,
+                                               get_latest_release_notes_text, get_pack_metadata,
+                                               get_relative_path_from_packs_dir, get_release_note_entries,
+                                               get_release_notes_file_path, get_scripts_and_commands_from_yml_data,
+                                               get_test_playbook_id, get_to_version, get_yaml, has_remote_configured,
+                                               is_object_in_id_set, is_origin_content_repo, is_pack_path, is_uuid,
+                                               retrieve_file_ending, run_command_os, server_version_compare,
+                                               string_to_bool, to_kebab_case)
+from demisto_sdk.tests.constants_test import (DUMMY_SCRIPT_PATH, IGNORED_PNG, INDICATORFIELD_EXTRA_FIELDS,
+                                              SOURCE_FORMAT_INTEGRATION_COPY, TEST_PLAYBOOK,
+                                              VALID_BETA_INTEGRATION_PATH, VALID_DASHBOARD_PATH,
+                                              VALID_GENERIC_DEFINITION_PATH, VALID_GENERIC_FIELD_PATH,
+                                              VALID_GENERIC_MODULE_PATH, VALID_GENERIC_TYPE_PATH,
+                                              VALID_INCIDENT_FIELD_PATH, VALID_INCIDENT_TYPE_FILE,
+                                              VALID_INCIDENT_TYPE_FILE__RAW_DOWNLOADED, VALID_INCIDENT_TYPE_PATH,
+                                              VALID_INTEGRATION_TEST_PATH, VALID_LAYOUT_PATH, VALID_MD,
+                                              VALID_PLAYBOOK_ID_PATH, VALID_REPUTATION_FILE, VALID_SCRIPT_PATH,
+                                              VALID_WIDGET_PATH)
+from demisto_sdk.tests.test_files.validate_integration_test_valid_types import (LAYOUT, MAPPER, OLD_CLASSIFIER,
+                                                                                REPUTATION)
 from TestSuite.file import File
 from TestSuite.pack import Pack
 from TestSuite.playbook import Playbook

--- a/demisto_sdk/commands/common/tests/update_id_set_test.py
+++ b/demisto_sdk/commands/common/tests/update_id_set_test.py
@@ -9,27 +9,28 @@ import pytest
 
 import demisto_sdk.commands.common.tools as tools
 import demisto_sdk.commands.common.update_id_set as uis
-from demisto_sdk.commands.common.constants import (
-    FILETYPE_TO_DEFAULT_FROMVERSION, JOBS_DIR, WIZARDS_DIR, FileType,
-    MarketplaceVersions)
+from demisto_sdk.commands.common.constants import (FILETYPE_TO_DEFAULT_FROMVERSION, JOBS_DIR, WIZARDS_DIR, FileType,
+                                                   MarketplaceVersions)
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.legacy_git_tools import git_path
-from demisto_sdk.commands.common.update_id_set import (
-    add_item_to_exclusion_dict, does_dict_have_alternative_key,
-    find_duplicates, get_classifier_data, get_correlation_rule_data,
-    get_dashboard_data, get_fields_by_script_argument,
-    get_filters_and_transformers_from_complex_value,
-    get_filters_and_transformers_from_playbook, get_general_data,
-    get_generic_field_data, get_generic_module_data, get_generic_type_data,
-    get_incident_fields_by_playbook_input, get_incident_type_data,
-    get_indicator_type_data, get_layout_data, get_mapper_data,
-    get_modeling_rule_data, get_pack_metadata_data, get_parsing_rule_data,
-    get_playbook_data, get_report_data, get_script_data, get_trigger_data,
-    get_values_for_keys_recursively, get_widget_data, get_xdrc_template_data,
-    get_xsiam_dashboard_data, get_xsiam_report_data, has_duplicate,
-    merge_id_sets, process_general_items, process_incident_fields,
-    process_integration, process_jobs, process_layoutscontainers,
-    process_script, process_wizards, re_create_id_set, should_skip_item_by_mp)
+from demisto_sdk.commands.common.update_id_set import (add_item_to_exclusion_dict, does_dict_have_alternative_key,
+                                                       find_duplicates, get_classifier_data, get_correlation_rule_data,
+                                                       get_dashboard_data, get_fields_by_script_argument,
+                                                       get_filters_and_transformers_from_complex_value,
+                                                       get_filters_and_transformers_from_playbook, get_general_data,
+                                                       get_generic_field_data, get_generic_module_data,
+                                                       get_generic_type_data, get_incident_fields_by_playbook_input,
+                                                       get_incident_type_data, get_indicator_type_data, get_layout_data,
+                                                       get_mapper_data, get_modeling_rule_data, get_pack_metadata_data,
+                                                       get_parsing_rule_data, get_playbook_data, get_report_data,
+                                                       get_script_data, get_trigger_data,
+                                                       get_values_for_keys_recursively, get_widget_data,
+                                                       get_xdrc_template_data, get_xsiam_dashboard_data,
+                                                       get_xsiam_report_data, has_duplicate, merge_id_sets,
+                                                       process_general_items, process_incident_fields,
+                                                       process_integration, process_jobs, process_layoutscontainers,
+                                                       process_script, process_wizards, re_create_id_set,
+                                                       should_skip_item_by_mp)
 from TestSuite.utils import IsEqualFunctions
 
 json = JSON_Handler()

--- a/demisto_sdk/commands/common/tests/widget_test.py
+++ b/demisto_sdk/commands/common/tests/widget_test.py
@@ -1,8 +1,7 @@
 import pytest
 from mock import patch
 
-from demisto_sdk.commands.common.hook_validations.structure import \
-    StructureValidator
+from demisto_sdk.commands.common.hook_validations.structure import StructureValidator
 from demisto_sdk.commands.common.hook_validations.widget import WidgetValidator
 
 

--- a/demisto_sdk/commands/common/tests/wizards_test.py
+++ b/demisto_sdk/commands/common/tests/wizards_test.py
@@ -2,8 +2,7 @@ import pytest
 from mock import patch
 
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.common.hook_validations.structure import \
-    StructureValidator
+from demisto_sdk.commands.common.hook_validations.structure import StructureValidator
 from demisto_sdk.commands.common.hook_validations.wizard import WizardValidator
 
 json = JSON_Handler()

--- a/demisto_sdk/commands/common/tests/xsoar_config_file_test.py
+++ b/demisto_sdk/commands/common/tests/xsoar_config_file_test.py
@@ -3,8 +3,7 @@ from typing import Iterator, List
 import pytest
 from jsonschema import ValidationError
 
-from demisto_sdk.commands.common.hook_validations.xsoar_config_json import \
-    XSOARConfigJsonValidator
+from demisto_sdk.commands.common.hook_validations.xsoar_config_json import XSOARConfigJsonValidator
 
 
 def test_schema_file_correct_path():

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -31,26 +31,26 @@ from packaging.version import LegacyVersion, Version, parse
 from pebble import ProcessFuture, ProcessPool
 from requests.exceptions import HTTPError
 
-from demisto_sdk.commands.common.constants import (
-    ALL_FILES_VALIDATION_IGNORE_WHITELIST, API_MODULES_PACK, CLASSIFIERS_DIR,
-    DASHBOARDS_DIR, DEF_DOCKER, DEF_DOCKER_PWSH,
-    DEFAULT_CONTENT_ITEM_FROM_VERSION, DEFAULT_CONTENT_ITEM_TO_VERSION,
-    DOC_FILES_DIR, ENV_DEMISTO_SDK_MARKETPLACE, ID_IN_COMMONFIELDS, ID_IN_ROOT,
-    INCIDENT_FIELDS_DIR, INCIDENT_TYPES_DIR, INDICATOR_FIELDS_DIR,
-    INDICATOR_TYPES_DIR, INTEGRATIONS_DIR, JOBS_DIR, LAYOUTS_DIR, LISTS_DIR,
-    MARKETPLACE_KEY_PACK_METADATA, METADATA_FILE_NAME, MODELING_RULES_DIR,
-    NON_LETTERS_OR_NUMBERS_PATTERN, OFFICIAL_CONTENT_ID_SET_PATH,
-    PACK_METADATA_IRON_BANK_TAG, PACKAGE_SUPPORTING_DIRECTORIES,
-    PACKAGE_YML_FILE_REGEX, PACKS_DIR, PACKS_DIR_REGEX,
-    PACKS_PACK_IGNORE_FILE_NAME, PACKS_PACK_META_FILE_NAME,
-    PACKS_README_FILE_NAME, PARSING_RULES_DIR, PLAYBOOKS_DIR,
-    PRE_PROCESS_RULES_DIR, RELEASE_NOTES_DIR, RELEASE_NOTES_REGEX, REPORTS_DIR,
-    SCRIPTS_DIR, SIEM_ONLY_ENTITIES, TEST_PLAYBOOKS_DIR, TRIGGER_DIR,
-    TYPE_PWSH, UNRELEASE_HEADER, UUID_REGEX, WIDGETS_DIR, XDRC_TEMPLATE_DIR,
-    XSIAM_DASHBOARDS_DIR, XSIAM_REPORTS_DIR, XSOAR_CONFIG_FILE, FileType,
-    FileTypeToIDSetKeys, IdSetKeys, MarketplaceVersions, urljoin)
-from demisto_sdk.commands.common.git_content_config import (GitContentConfig,
-                                                            GitProvider)
+from demisto_sdk.commands.common.constants import (ALL_FILES_VALIDATION_IGNORE_WHITELIST, API_MODULES_PACK,
+                                                   CLASSIFIERS_DIR, DASHBOARDS_DIR, DEF_DOCKER, DEF_DOCKER_PWSH,
+                                                   DEFAULT_CONTENT_ITEM_FROM_VERSION, DEFAULT_CONTENT_ITEM_TO_VERSION,
+                                                   DOC_FILES_DIR, ENV_DEMISTO_SDK_MARKETPLACE, ID_IN_COMMONFIELDS,
+                                                   ID_IN_ROOT, INCIDENT_FIELDS_DIR, INCIDENT_TYPES_DIR,
+                                                   INDICATOR_FIELDS_DIR, INDICATOR_TYPES_DIR, INTEGRATIONS_DIR,
+                                                   JOBS_DIR, LAYOUTS_DIR, LISTS_DIR, MARKETPLACE_KEY_PACK_METADATA,
+                                                   METADATA_FILE_NAME, MODELING_RULES_DIR,
+                                                   NON_LETTERS_OR_NUMBERS_PATTERN, OFFICIAL_CONTENT_ID_SET_PATH,
+                                                   PACK_METADATA_IRON_BANK_TAG, PACKAGE_SUPPORTING_DIRECTORIES,
+                                                   PACKAGE_YML_FILE_REGEX, PACKS_DIR, PACKS_DIR_REGEX,
+                                                   PACKS_PACK_IGNORE_FILE_NAME, PACKS_PACK_META_FILE_NAME,
+                                                   PACKS_README_FILE_NAME, PARSING_RULES_DIR, PLAYBOOKS_DIR,
+                                                   PRE_PROCESS_RULES_DIR, RELEASE_NOTES_DIR, RELEASE_NOTES_REGEX,
+                                                   REPORTS_DIR, SCRIPTS_DIR, SIEM_ONLY_ENTITIES, TEST_PLAYBOOKS_DIR,
+                                                   TRIGGER_DIR, TYPE_PWSH, UNRELEASE_HEADER, UUID_REGEX, WIDGETS_DIR,
+                                                   XDRC_TEMPLATE_DIR, XSIAM_DASHBOARDS_DIR, XSIAM_REPORTS_DIR,
+                                                   XSOAR_CONFIG_FILE, FileType, FileTypeToIDSetKeys, IdSetKeys,
+                                                   MarketplaceVersions, urljoin)
+from demisto_sdk.commands.common.git_content_config import GitContentConfig, GitProvider
 from demisto_sdk.commands.common.git_util import GitUtil
 from demisto_sdk.commands.common.handlers import JSON_Handler, YAML_Handler
 

--- a/demisto_sdk/commands/common/update_id_set.py
+++ b/demisto_sdk/commands/common/update_id_set.py
@@ -16,28 +16,23 @@ from typing import Callable, Dict, List, Optional, Tuple
 import click
 import networkx
 
-from demisto_sdk.commands.common.constants import (
-    CLASSIFIERS_DIR, COMMON_TYPES_PACK, CORRELATION_RULES_DIR, DASHBOARDS_DIR,
-    DEFAULT_CONTENT_ITEM_FROM_VERSION, DEFAULT_CONTENT_ITEM_TO_VERSION,
-    GENERIC_DEFINITIONS_DIR, GENERIC_FIELDS_DIR, GENERIC_MODULES_DIR,
-    GENERIC_TYPES_DIR, INCIDENT_FIELDS_DIR, INCIDENT_TYPES_DIR,
-    INDICATOR_FIELDS_DIR, INDICATOR_TYPES_DIR, JOBS_DIR, LAYOUTS_DIR,
-    LISTS_DIR, MAPPERS_DIR, MODELING_RULES_DIR, PARSING_RULES_DIR, REPORTS_DIR,
-    SCRIPTS_DIR, TEST_PLAYBOOKS_DIR, TRIGGER_DIR, WIDGETS_DIR, WIZARDS_DIR,
-    XDRC_TEMPLATE_DIR, XSIAM_DASHBOARDS_DIR, XSIAM_REPORTS_DIR, FileType,
-    MarketplaceVersions)
-from demisto_sdk.commands.common.content_constant_paths import (
-    DEFAULT_ID_SET_PATH, MP_V2_ID_SET_PATH, XPANSE_ID_SET_PATH)
+from demisto_sdk.commands.common.constants import (CLASSIFIERS_DIR, COMMON_TYPES_PACK, CORRELATION_RULES_DIR,
+                                                   DASHBOARDS_DIR, DEFAULT_CONTENT_ITEM_FROM_VERSION,
+                                                   DEFAULT_CONTENT_ITEM_TO_VERSION, GENERIC_DEFINITIONS_DIR,
+                                                   GENERIC_FIELDS_DIR, GENERIC_MODULES_DIR, GENERIC_TYPES_DIR,
+                                                   INCIDENT_FIELDS_DIR, INCIDENT_TYPES_DIR, INDICATOR_FIELDS_DIR,
+                                                   INDICATOR_TYPES_DIR, JOBS_DIR, LAYOUTS_DIR, LISTS_DIR, MAPPERS_DIR,
+                                                   MODELING_RULES_DIR, PARSING_RULES_DIR, REPORTS_DIR, SCRIPTS_DIR,
+                                                   TEST_PLAYBOOKS_DIR, TRIGGER_DIR, WIDGETS_DIR, WIZARDS_DIR,
+                                                   XDRC_TEMPLATE_DIR, XSIAM_DASHBOARDS_DIR, XSIAM_REPORTS_DIR, FileType,
+                                                   MarketplaceVersions)
+from demisto_sdk.commands.common.content_constant_paths import (DEFAULT_ID_SET_PATH, MP_V2_ID_SET_PATH,
+                                                                XPANSE_ID_SET_PATH)
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.common.tools import (LOG_COLORS, find_type,
-                                               get_current_repo,
-                                               get_display_name, get_file,
-                                               get_item_marketplaces, get_json,
-                                               get_pack_name, get_yaml,
-                                               print_color, print_error,
-                                               print_warning)
-from demisto_sdk.commands.unify.integration_script_unifier import \
-    IntegrationScriptUnifier
+from demisto_sdk.commands.common.tools import (LOG_COLORS, find_type, get_current_repo, get_display_name, get_file,
+                                               get_item_marketplaces, get_json, get_pack_name, get_yaml, print_color,
+                                               print_error, print_warning)
+from demisto_sdk.commands.unify.integration_script_unifier import IntegrationScriptUnifier
 
 json = JSON_Handler()
 

--- a/demisto_sdk/commands/content_graph/content_graph_builder.py
+++ b/demisto_sdk/commands/content_graph/content_graph_builder.py
@@ -5,11 +5,9 @@ from typing import List
 
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.content_graph.common import Nodes, Relationships
-from demisto_sdk.commands.content_graph.interface.graph import \
-    ContentGraphInterface
+from demisto_sdk.commands.content_graph.interface.graph import ContentGraphInterface
 from demisto_sdk.commands.content_graph.objects.repository import ContentDTO
-from demisto_sdk.commands.content_graph.parsers.repository import \
-    RepositoryParser
+from demisto_sdk.commands.content_graph.parsers.repository import RepositoryParser
 
 json = JSON_Handler()
 

--- a/demisto_sdk/commands/content_graph/content_graph_commands.py
+++ b/demisto_sdk/commands/content_graph/content_graph_commands.py
@@ -2,10 +2,8 @@ import logging
 
 import demisto_sdk.commands.content_graph.neo4j_service as neo4j_service
 from demisto_sdk.commands.content_graph.common import REPO_PATH
-from demisto_sdk.commands.content_graph.content_graph_builder import \
-    ContentGraphBuilder
-from demisto_sdk.commands.content_graph.interface.graph import \
-    ContentGraphInterface
+from demisto_sdk.commands.content_graph.content_graph_builder import ContentGraphBuilder
+from demisto_sdk.commands.content_graph.interface.graph import ContentGraphInterface
 
 logger = logging.getLogger("demisto-sdk")
 

--- a/demisto_sdk/commands/content_graph/interface/graph.py
+++ b/demisto_sdk/commands/content_graph/interface/graph.py
@@ -2,8 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, Iterable, List, Optional
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
-from demisto_sdk.commands.content_graph.common import (ContentType,
-                                                       RelationshipType)
+from demisto_sdk.commands.content_graph.common import ContentType, RelationshipType
 from demisto_sdk.commands.content_graph.objects.base_content import BaseContent
 from demisto_sdk.commands.content_graph.objects.repository import ContentDTO
 

--- a/demisto_sdk/commands/content_graph/interface/neo4j/neo4j_graph.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/neo4j_graph.py
@@ -6,30 +6,20 @@ from neo4j import GraphDatabase, Neo4jDriver, Session, graph
 
 import demisto_sdk.commands.content_graph.neo4j_service as neo4j_service
 from demisto_sdk.commands.common.constants import MarketplaceVersions
-from demisto_sdk.commands.content_graph.common import (NEO4J_DATABASE_URL,
-                                                       NEO4J_PASSWORD,
-                                                       NEO4J_USERNAME,
-                                                       ContentType,
-                                                       Neo4jResult,
-                                                       RelationshipType)
-from demisto_sdk.commands.content_graph.interface.graph import \
-    ContentGraphInterface
-from demisto_sdk.commands.content_graph.interface.neo4j.queries.constraints import \
-    create_constraints
-from demisto_sdk.commands.content_graph.interface.neo4j.queries.dependencies import (
-    create_pack_dependencies, get_all_level_packs_dependencies)
-from demisto_sdk.commands.content_graph.interface.neo4j.queries.indexes import \
-    create_indexes
-from demisto_sdk.commands.content_graph.interface.neo4j.queries.nodes import (
-    _match, create_nodes, delete_all_graph_nodes, duplicates_exist)
-from demisto_sdk.commands.content_graph.interface.neo4j.queries.relationships import \
-    create_relationships
-from demisto_sdk.commands.content_graph.objects.base_content import (
-    BaseContent, ServerContent, content_type_to_model)
+from demisto_sdk.commands.content_graph.common import (NEO4J_DATABASE_URL, NEO4J_PASSWORD, NEO4J_USERNAME, ContentType,
+                                                       Neo4jResult, RelationshipType)
+from demisto_sdk.commands.content_graph.interface.graph import ContentGraphInterface
+from demisto_sdk.commands.content_graph.interface.neo4j.queries.constraints import create_constraints
+from demisto_sdk.commands.content_graph.interface.neo4j.queries.dependencies import (create_pack_dependencies,
+                                                                                     get_all_level_packs_dependencies)
+from demisto_sdk.commands.content_graph.interface.neo4j.queries.indexes import create_indexes
+from demisto_sdk.commands.content_graph.interface.neo4j.queries.nodes import (_match, create_nodes,
+                                                                              delete_all_graph_nodes, duplicates_exist)
+from demisto_sdk.commands.content_graph.interface.neo4j.queries.relationships import create_relationships
+from demisto_sdk.commands.content_graph.objects.base_content import BaseContent, ServerContent, content_type_to_model
 from demisto_sdk.commands.content_graph.objects.integration import Integration
 from demisto_sdk.commands.content_graph.objects.pack import Pack
-from demisto_sdk.commands.content_graph.objects.relationship import \
-    RelationshipData
+from demisto_sdk.commands.content_graph.objects.relationship import RelationshipData
 
 logger = logging.getLogger("demisto-sdk")
 

--- a/demisto_sdk/commands/content_graph/interface/neo4j/queries/constraints.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/queries/constraints.py
@@ -1,9 +1,7 @@
 from neo4j import Transaction
 
-from demisto_sdk.commands.content_graph.common import (ContentType,
-                                                       RelationshipType)
-from demisto_sdk.commands.content_graph.interface.neo4j.queries.common import \
-    run_query
+from demisto_sdk.commands.content_graph.common import ContentType, RelationshipType
+from demisto_sdk.commands.content_graph.interface.neo4j.queries.common import run_query
 
 NODE_PROPERTY_UNIQUENESS_TEMPLATE = (
     "CREATE CONSTRAINT IF NOT EXISTS FOR (n:{label}) REQUIRE n.{prop} IS UNIQUE"

--- a/demisto_sdk/commands/content_graph/interface/neo4j/queries/dependencies.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/queries/dependencies.py
@@ -3,14 +3,9 @@ from typing import Dict, List, Set
 
 from neo4j import Transaction
 
-from demisto_sdk.commands.common.constants import (GENERIC_COMMANDS_NAMES,
-                                                   REPUTATION_COMMAND_NAMES,
-                                                   MarketplaceVersions)
-from demisto_sdk.commands.content_graph.common import (ContentType,
-                                                       Neo4jResult,
-                                                       RelationshipType)
-from demisto_sdk.commands.content_graph.interface.neo4j.queries.common import (
-    run_query, to_neo4j_map)
+from demisto_sdk.commands.common.constants import GENERIC_COMMANDS_NAMES, REPUTATION_COMMAND_NAMES, MarketplaceVersions
+from demisto_sdk.commands.content_graph.common import ContentType, Neo4jResult, RelationshipType
+from demisto_sdk.commands.content_graph.interface.neo4j.queries.common import run_query, to_neo4j_map
 
 REPUTATION_COMMANDS_NODE_IDS = [
     f"{ContentType.COMMAND}:{cmd}" for cmd in REPUTATION_COMMAND_NAMES

--- a/demisto_sdk/commands/content_graph/interface/neo4j/queries/indexes.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/queries/indexes.py
@@ -2,10 +2,8 @@ from typing import List
 
 from neo4j import Transaction
 
-from demisto_sdk.commands.content_graph.common import (ContentType,
-                                                       RelationshipType)
-from demisto_sdk.commands.content_graph.interface.neo4j.queries.common import \
-    run_query
+from demisto_sdk.commands.content_graph.common import ContentType, RelationshipType
+from demisto_sdk.commands.content_graph.interface.neo4j.queries.common import run_query
 
 CREATE_NODE_INDEX_TEMPLATE = "CREATE INDEX IF NOT EXISTS FOR (n:{label}) ON ({props})"
 NODE_INDEX_OPTIONS = [

--- a/demisto_sdk/commands/content_graph/interface/neo4j/queries/nodes.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/queries/nodes.py
@@ -4,11 +4,9 @@ from typing import Any, Dict, Iterable, List, Optional
 from neo4j import Transaction
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
-from demisto_sdk.commands.content_graph.common import (SERVER_CONTENT_ITEMS,
-                                                       ContentType,
-                                                       Neo4jResult)
-from demisto_sdk.commands.content_graph.interface.neo4j.queries.common import (
-    intersects, run_query, to_neo4j_map, versioned)
+from demisto_sdk.commands.content_graph.common import SERVER_CONTENT_ITEMS, ContentType, Neo4jResult
+from demisto_sdk.commands.content_graph.interface.neo4j.queries.common import (intersects, run_query, to_neo4j_map,
+                                                                               versioned)
 
 logger = logging.getLogger("demisto-sdk")
 

--- a/demisto_sdk/commands/content_graph/interface/neo4j/queries/relationships.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/queries/relationships.py
@@ -3,10 +3,8 @@ from typing import Any, Dict, List
 
 from neo4j import Transaction
 
-from demisto_sdk.commands.content_graph.common import (ContentType,
-                                                       RelationshipType)
-from demisto_sdk.commands.content_graph.interface.neo4j.queries.common import (
-    labels_of, node_map, run_query)
+from demisto_sdk.commands.content_graph.common import ContentType, RelationshipType
+from demisto_sdk.commands.content_graph.interface.neo4j.queries.common import labels_of, node_map, run_query
 
 
 def build_source_properties() -> str:

--- a/demisto_sdk/commands/content_graph/neo4j_service.py
+++ b/demisto_sdk/commands/content_graph/neo4j_service.py
@@ -7,9 +7,7 @@ import requests
 from requests.adapters import HTTPAdapter, Retry
 
 from demisto_sdk.commands.common.tools import run_command
-from demisto_sdk.commands.content_graph.common import (NEO4J_DATABASE_HTTP,
-                                                       NEO4J_PASSWORD,
-                                                       REPO_PATH)
+from demisto_sdk.commands.content_graph.common import NEO4J_DATABASE_HTTP, NEO4J_PASSWORD, REPO_PATH
 
 NEO4J_SERVICE_IMAGE = "neo4j:4.4.12"
 NEO4J_ADMIN_IMAGE = "neo4j/neo4j-admin:4.4.12"

--- a/demisto_sdk/commands/content_graph/objects/__init__.py
+++ b/demisto_sdk/commands/content_graph/objects/__init__.py
@@ -33,45 +33,32 @@ __all__ = [
 ]
 
 from demisto_sdk.commands.content_graph.objects.classifier import Classifier
-from demisto_sdk.commands.content_graph.objects.correlation_rule import \
-    CorrelationRule
+from demisto_sdk.commands.content_graph.objects.correlation_rule import CorrelationRule
 from demisto_sdk.commands.content_graph.objects.dashboard import Dashboard
-from demisto_sdk.commands.content_graph.objects.generic_definition import \
-    GenericDefinition
-from demisto_sdk.commands.content_graph.objects.generic_field import \
-    GenericField
-from demisto_sdk.commands.content_graph.objects.generic_module import \
-    GenericModule
+from demisto_sdk.commands.content_graph.objects.generic_definition import GenericDefinition
+from demisto_sdk.commands.content_graph.objects.generic_field import GenericField
+from demisto_sdk.commands.content_graph.objects.generic_module import GenericModule
 from demisto_sdk.commands.content_graph.objects.generic_type import GenericType
-from demisto_sdk.commands.content_graph.objects.incident_field import \
-    IncidentField
-from demisto_sdk.commands.content_graph.objects.incident_type import \
-    IncidentType
-from demisto_sdk.commands.content_graph.objects.indicator_field import \
-    IndicatorField
-from demisto_sdk.commands.content_graph.objects.indicator_type import \
-    IndicatorType
+from demisto_sdk.commands.content_graph.objects.incident_field import IncidentField
+from demisto_sdk.commands.content_graph.objects.incident_type import IncidentType
+from demisto_sdk.commands.content_graph.objects.indicator_field import IndicatorField
+from demisto_sdk.commands.content_graph.objects.indicator_type import IndicatorType
 from demisto_sdk.commands.content_graph.objects.integration import Integration
 from demisto_sdk.commands.content_graph.objects.job import Job
 from demisto_sdk.commands.content_graph.objects.layout import Layout
 from demisto_sdk.commands.content_graph.objects.list import List
 from demisto_sdk.commands.content_graph.objects.mapper import Mapper
-from demisto_sdk.commands.content_graph.objects.modeling_rule import \
-    ModelingRule
+from demisto_sdk.commands.content_graph.objects.modeling_rule import ModelingRule
 from demisto_sdk.commands.content_graph.objects.pack import Pack
 from demisto_sdk.commands.content_graph.objects.parsing_rule import ParsingRule
 from demisto_sdk.commands.content_graph.objects.playbook import Playbook
-from demisto_sdk.commands.content_graph.objects.relationship import \
-    RelationshipData
+from demisto_sdk.commands.content_graph.objects.relationship import RelationshipData
 from demisto_sdk.commands.content_graph.objects.report import Report
 from demisto_sdk.commands.content_graph.objects.script import Script
-from demisto_sdk.commands.content_graph.objects.test_playbook import \
-    TestPlaybook
+from demisto_sdk.commands.content_graph.objects.test_playbook import TestPlaybook
 from demisto_sdk.commands.content_graph.objects.trigger import Trigger
 from demisto_sdk.commands.content_graph.objects.widget import Widget
 from demisto_sdk.commands.content_graph.objects.wizard import Wizard
-from demisto_sdk.commands.content_graph.objects.xdrc_template import \
-    XDRCTemplate
-from demisto_sdk.commands.content_graph.objects.xsiam_dashboard import \
-    XSIAMDashboard
+from demisto_sdk.commands.content_graph.objects.xdrc_template import XDRCTemplate
+from demisto_sdk.commands.content_graph.objects.xsiam_dashboard import XSIAMDashboard
 from demisto_sdk.commands.content_graph.objects.xsiam_report import XSIAMReport

--- a/demisto_sdk/commands/content_graph/objects/base_content.py
+++ b/demisto_sdk/commands/content_graph/objects/base_content.py
@@ -7,12 +7,10 @@ from pydantic import BaseModel, DirectoryPath, Field
 from pydantic.main import ModelMetaclass
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
-from demisto_sdk.commands.content_graph.common import (ContentType,
-                                                       RelationshipType)
+from demisto_sdk.commands.content_graph.common import ContentType, RelationshipType
 
 if TYPE_CHECKING:
-    from demisto_sdk.commands.content_graph.objects.relationship import \
-        RelationshipData
+    from demisto_sdk.commands.content_graph.objects.relationship import RelationshipData
 
 content_type_to_model: Dict[ContentType, Type["BaseContent"]] = {}
 

--- a/demisto_sdk/commands/content_graph/objects/content_item.py
+++ b/demisto_sdk/commands/content_graph/objects/content_item.py
@@ -10,8 +10,7 @@ if TYPE_CHECKING:
 from pydantic import DirectoryPath
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
-from demisto_sdk.commands.content_graph.common import (ContentType,
-                                                       RelationshipType)
+from demisto_sdk.commands.content_graph.common import ContentType, RelationshipType
 from demisto_sdk.commands.content_graph.objects.base_content import BaseContent
 
 

--- a/demisto_sdk/commands/content_graph/objects/integration.py
+++ b/demisto_sdk/commands/content_graph/objects/integration.py
@@ -8,10 +8,8 @@ if TYPE_CHECKING:
 
 from pydantic import Field
 
-from demisto_sdk.commands.content_graph.common import (ContentType,
-                                                       RelationshipType)
-from demisto_sdk.commands.content_graph.objects.integration_script import \
-    IntegrationScript
+from demisto_sdk.commands.content_graph.common import ContentType, RelationshipType
+from demisto_sdk.commands.content_graph.objects.integration_script import IntegrationScript
 
 
 class Command(BaseContent, content_type=ContentType.COMMAND):  # type: ignore[call-arg]

--- a/demisto_sdk/commands/content_graph/objects/integration_script.py
+++ b/demisto_sdk/commands/content_graph/objects/integration_script.py
@@ -7,8 +7,7 @@ from pydantic import Field
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.common.handlers import YAML_Handler
 from demisto_sdk.commands.content_graph.objects.content_item import ContentItem
-from demisto_sdk.commands.unify.integration_script_unifier import \
-    IntegrationScriptUnifier
+from demisto_sdk.commands.unify.integration_script_unifier import IntegrationScriptUnifier
 
 yaml = YAML_Handler()
 

--- a/demisto_sdk/commands/content_graph/objects/pack.py
+++ b/demisto_sdk/commands/content_graph/objects/pack.py
@@ -7,60 +7,44 @@ from typing import TYPE_CHECKING, Any, Generator, List, Optional
 from packaging.version import parse
 from pydantic import BaseModel, Field
 
-from demisto_sdk.commands.common.constants import (
-    CONTRIBUTORS_README_TEMPLATE, MarketplaceVersions)
+from demisto_sdk.commands.common.constants import CONTRIBUTORS_README_TEMPLATE, MarketplaceVersions
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.tools import MarketplaceTagParser
-from demisto_sdk.commands.content_graph.common import (PACK_METADATA_FILENAME,
-                                                       ContentType, Nodes,
-                                                       Relationships,
+from demisto_sdk.commands.content_graph.common import (PACK_METADATA_FILENAME, ContentType, Nodes, Relationships,
                                                        RelationshipType)
 from demisto_sdk.commands.content_graph.objects.base_content import BaseContent
 from demisto_sdk.commands.content_graph.objects.classifier import Classifier
 from demisto_sdk.commands.content_graph.objects.content_item import ContentItem
-from demisto_sdk.commands.content_graph.objects.correlation_rule import \
-    CorrelationRule
+from demisto_sdk.commands.content_graph.objects.correlation_rule import CorrelationRule
 from demisto_sdk.commands.content_graph.objects.dashboard import Dashboard
-from demisto_sdk.commands.content_graph.objects.generic_definition import \
-    GenericDefinition
-from demisto_sdk.commands.content_graph.objects.generic_field import \
-    GenericField
-from demisto_sdk.commands.content_graph.objects.generic_module import \
-    GenericModule
+from demisto_sdk.commands.content_graph.objects.generic_definition import GenericDefinition
+from demisto_sdk.commands.content_graph.objects.generic_field import GenericField
+from demisto_sdk.commands.content_graph.objects.generic_module import GenericModule
 from demisto_sdk.commands.content_graph.objects.generic_type import GenericType
-from demisto_sdk.commands.content_graph.objects.incident_field import \
-    IncidentField
-from demisto_sdk.commands.content_graph.objects.incident_type import \
-    IncidentType
-from demisto_sdk.commands.content_graph.objects.indicator_field import \
-    IndicatorField
-from demisto_sdk.commands.content_graph.objects.indicator_type import \
-    IndicatorType
+from demisto_sdk.commands.content_graph.objects.incident_field import IncidentField
+from demisto_sdk.commands.content_graph.objects.incident_type import IncidentType
+from demisto_sdk.commands.content_graph.objects.indicator_field import IndicatorField
+from demisto_sdk.commands.content_graph.objects.indicator_type import IndicatorType
 from demisto_sdk.commands.content_graph.objects.integration import Integration
 from demisto_sdk.commands.content_graph.objects.job import Job
 from demisto_sdk.commands.content_graph.objects.layout import Layout
 from demisto_sdk.commands.content_graph.objects.list import List as ListObject
 from demisto_sdk.commands.content_graph.objects.mapper import Mapper
-from demisto_sdk.commands.content_graph.objects.modeling_rule import \
-    ModelingRule
+from demisto_sdk.commands.content_graph.objects.modeling_rule import ModelingRule
 from demisto_sdk.commands.content_graph.objects.parsing_rule import ParsingRule
 from demisto_sdk.commands.content_graph.objects.playbook import Playbook
 from demisto_sdk.commands.content_graph.objects.report import Report
 from demisto_sdk.commands.content_graph.objects.script import Script
-from demisto_sdk.commands.content_graph.objects.test_playbook import \
-    TestPlaybook
+from demisto_sdk.commands.content_graph.objects.test_playbook import TestPlaybook
 from demisto_sdk.commands.content_graph.objects.trigger import Trigger
 from demisto_sdk.commands.content_graph.objects.widget import Widget
 from demisto_sdk.commands.content_graph.objects.wizard import Wizard
-from demisto_sdk.commands.content_graph.objects.xdrc_template import \
-    XDRCTemplate
-from demisto_sdk.commands.content_graph.objects.xsiam_dashboard import \
-    XSIAMDashboard
+from demisto_sdk.commands.content_graph.objects.xdrc_template import XDRCTemplate
+from demisto_sdk.commands.content_graph.objects.xsiam_dashboard import XSIAMDashboard
 from demisto_sdk.commands.content_graph.objects.xsiam_report import XSIAMReport
 
 if TYPE_CHECKING:
-    from demisto_sdk.commands.content_graph.objects.relationship import \
-        RelationshipData
+    from demisto_sdk.commands.content_graph.objects.relationship import RelationshipData
 
 logger = logging.getLogger("demisto-sdk")
 json = JSON_Handler()

--- a/demisto_sdk/commands/content_graph/objects/script.py
+++ b/demisto_sdk/commands/content_graph/objects/script.py
@@ -3,8 +3,7 @@ from typing import List, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.objects.integration_script import \
-    IntegrationScript
+from demisto_sdk.commands.content_graph.objects.integration_script import IntegrationScript
 
 
 class Script(IntegrationScript, content_type=ContentType.SCRIPT):  # type: ignore[call-arg]

--- a/demisto_sdk/commands/content_graph/objects/xdrc_template.py
+++ b/demisto_sdk/commands/content_graph/objects/xdrc_template.py
@@ -5,8 +5,7 @@ from pydantic.types import DirectoryPath
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
 from demisto_sdk.commands.content_graph.objects.content_item import ContentItem
-from demisto_sdk.commands.unify.xdrc_template_unifier import \
-    XDRCTemplateUnifier
+from demisto_sdk.commands.unify.xdrc_template_unifier import XDRCTemplateUnifier
 
 
 class XDRCTemplate(ContentItem, content_type=ContentType.XDRC_TEMPLATE):

--- a/demisto_sdk/commands/content_graph/parsers/__init__.py
+++ b/demisto_sdk/commands/content_graph/parsers/__init__.py
@@ -30,49 +30,31 @@ __all__ = [
     "XDRCTemplateParser"
 ]
 
-from demisto_sdk.commands.content_graph.parsers.classifier import \
-    ClassifierParser
-from demisto_sdk.commands.content_graph.parsers.correlation_rule import \
-    CorrelationRuleParser
-from demisto_sdk.commands.content_graph.parsers.dashboard import \
-    DashboardParser
-from demisto_sdk.commands.content_graph.parsers.generic_definition import \
-    GenericDefinitionParser
-from demisto_sdk.commands.content_graph.parsers.generic_field import \
-    GenericFieldParser
-from demisto_sdk.commands.content_graph.parsers.generic_module import \
-    GenericModuleParser
-from demisto_sdk.commands.content_graph.parsers.generic_type import \
-    GenericTypeParser
-from demisto_sdk.commands.content_graph.parsers.incident_field import \
-    IncidentFieldParser
-from demisto_sdk.commands.content_graph.parsers.incident_type import \
-    IncidentTypeParser
-from demisto_sdk.commands.content_graph.parsers.indicator_field import \
-    IndicatorFieldParser
-from demisto_sdk.commands.content_graph.parsers.indicator_type import \
-    IndicatorTypeParser
-from demisto_sdk.commands.content_graph.parsers.integration import \
-    IntegrationParser
+from demisto_sdk.commands.content_graph.parsers.classifier import ClassifierParser
+from demisto_sdk.commands.content_graph.parsers.correlation_rule import CorrelationRuleParser
+from demisto_sdk.commands.content_graph.parsers.dashboard import DashboardParser
+from demisto_sdk.commands.content_graph.parsers.generic_definition import GenericDefinitionParser
+from demisto_sdk.commands.content_graph.parsers.generic_field import GenericFieldParser
+from demisto_sdk.commands.content_graph.parsers.generic_module import GenericModuleParser
+from demisto_sdk.commands.content_graph.parsers.generic_type import GenericTypeParser
+from demisto_sdk.commands.content_graph.parsers.incident_field import IncidentFieldParser
+from demisto_sdk.commands.content_graph.parsers.incident_type import IncidentTypeParser
+from demisto_sdk.commands.content_graph.parsers.indicator_field import IndicatorFieldParser
+from demisto_sdk.commands.content_graph.parsers.indicator_type import IndicatorTypeParser
+from demisto_sdk.commands.content_graph.parsers.integration import IntegrationParser
 from demisto_sdk.commands.content_graph.parsers.job import JobParser
 from demisto_sdk.commands.content_graph.parsers.layout import LayoutParser
 from demisto_sdk.commands.content_graph.parsers.list import ListParser
 from demisto_sdk.commands.content_graph.parsers.mapper import MapperParser
-from demisto_sdk.commands.content_graph.parsers.modeling_rule import \
-    ModelingRuleParser
-from demisto_sdk.commands.content_graph.parsers.parsing_rule import \
-    ParsingRuleParser
+from demisto_sdk.commands.content_graph.parsers.modeling_rule import ModelingRuleParser
+from demisto_sdk.commands.content_graph.parsers.parsing_rule import ParsingRuleParser
 from demisto_sdk.commands.content_graph.parsers.playbook import PlaybookParser
 from demisto_sdk.commands.content_graph.parsers.report import ReportParser
 from demisto_sdk.commands.content_graph.parsers.script import ScriptParser
-from demisto_sdk.commands.content_graph.parsers.test_playbook import \
-    TestPlaybookParser
+from demisto_sdk.commands.content_graph.parsers.test_playbook import TestPlaybookParser
 from demisto_sdk.commands.content_graph.parsers.trigger import TriggerParser
 from demisto_sdk.commands.content_graph.parsers.widget import WidgetParser
 from demisto_sdk.commands.content_graph.parsers.wizard import WizardParser
-from demisto_sdk.commands.content_graph.parsers.xdrc_template import \
-    XDRCTemplateParser
-from demisto_sdk.commands.content_graph.parsers.xsiam_dashboard import \
-    XSIAMDashboardParser
-from demisto_sdk.commands.content_graph.parsers.xsiam_report import \
-    XSIAMReportParser
+from demisto_sdk.commands.content_graph.parsers.xdrc_template import XDRCTemplateParser
+from demisto_sdk.commands.content_graph.parsers.xsiam_dashboard import XSIAMDashboardParser
+from demisto_sdk.commands.content_graph.parsers.xsiam_report import XSIAMReportParser

--- a/demisto_sdk/commands/content_graph/parsers/classifier.py
+++ b/demisto_sdk/commands/content_graph/parsers/classifier.py
@@ -3,10 +3,8 @@ from typing import List, Optional, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.parsers.content_item import \
-    IncorrectParserException
-from demisto_sdk.commands.content_graph.parsers.json_content_item import \
-    JSONContentItemParser
+from demisto_sdk.commands.content_graph.parsers.content_item import IncorrectParserException
+from demisto_sdk.commands.content_graph.parsers.json_content_item import JSONContentItemParser
 from demisto_sdk.commands.content_graph.parsers.mapper import MapperParser
 
 

--- a/demisto_sdk/commands/content_graph/parsers/content_item.py
+++ b/demisto_sdk/commands/content_graph/parsers/content_item.py
@@ -5,14 +5,10 @@ from typing import Dict, List, Optional, Set, Type, cast
 
 from packaging.version import Version
 
-from demisto_sdk.commands.common.constants import (MARKETPLACE_MIN_VERSION,
-                                                   MarketplaceVersions)
-from demisto_sdk.commands.content_graph.common import (UNIFIED_FILES_SUFFIXES,
-                                                       ContentType,
-                                                       Relationships,
+from demisto_sdk.commands.common.constants import MARKETPLACE_MIN_VERSION, MarketplaceVersions
+from demisto_sdk.commands.content_graph.common import (UNIFIED_FILES_SUFFIXES, ContentType, Relationships,
                                                        RelationshipType)
-from demisto_sdk.commands.content_graph.parsers.base_content import \
-    BaseContentParser
+from demisto_sdk.commands.content_graph.parsers.base_content import BaseContentParser
 
 logger = logging.getLogger("demisto-sdk")
 

--- a/demisto_sdk/commands/content_graph/parsers/content_items_list.py
+++ b/demisto_sdk/commands/content_graph/parsers/content_items_list.py
@@ -1,8 +1,7 @@
 import logging
 
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.parsers.content_item import \
-    ContentItemParser
+from demisto_sdk.commands.content_graph.parsers.content_item import ContentItemParser
 
 logger = logging.getLogger("demisto-sdk")
 

--- a/demisto_sdk/commands/content_graph/parsers/correlation_rule.py
+++ b/demisto_sdk/commands/content_graph/parsers/correlation_rule.py
@@ -3,8 +3,7 @@ from typing import List, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.parsers.yaml_content_item import \
-    YAMLContentItemParser
+from demisto_sdk.commands.content_graph.parsers.yaml_content_item import YAMLContentItemParser
 
 
 class CorrelationRuleParser(

--- a/demisto_sdk/commands/content_graph/parsers/dashboard.py
+++ b/demisto_sdk/commands/content_graph/parsers/dashboard.py
@@ -3,8 +3,7 @@ from typing import List, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.parsers.json_content_item import \
-    JSONContentItemParser
+from demisto_sdk.commands.content_graph.parsers.json_content_item import JSONContentItemParser
 
 
 class DashboardParser(JSONContentItemParser, content_type=ContentType.DASHBOARD):

--- a/demisto_sdk/commands/content_graph/parsers/generic_definition.py
+++ b/demisto_sdk/commands/content_graph/parsers/generic_definition.py
@@ -3,8 +3,7 @@ from typing import List, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.parsers.json_content_item import \
-    JSONContentItemParser
+from demisto_sdk.commands.content_graph.parsers.json_content_item import JSONContentItemParser
 
 
 class GenericDefinitionParser(

--- a/demisto_sdk/commands/content_graph/parsers/generic_field.py
+++ b/demisto_sdk/commands/content_graph/parsers/generic_field.py
@@ -3,8 +3,7 @@ from typing import List, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.parsers.json_content_item import \
-    JSONContentItemParser
+from demisto_sdk.commands.content_graph.parsers.json_content_item import JSONContentItemParser
 
 
 class GenericFieldParser(JSONContentItemParser, content_type=ContentType.GENERIC_FIELD):

--- a/demisto_sdk/commands/content_graph/parsers/generic_module.py
+++ b/demisto_sdk/commands/content_graph/parsers/generic_module.py
@@ -3,8 +3,7 @@ from typing import List, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.parsers.json_content_item import \
-    JSONContentItemParser
+from demisto_sdk.commands.content_graph.parsers.json_content_item import JSONContentItemParser
 
 
 class GenericModuleParser(

--- a/demisto_sdk/commands/content_graph/parsers/generic_type.py
+++ b/demisto_sdk/commands/content_graph/parsers/generic_type.py
@@ -3,8 +3,7 @@ from typing import List, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.parsers.json_content_item import \
-    JSONContentItemParser
+from demisto_sdk.commands.content_graph.parsers.json_content_item import JSONContentItemParser
 
 
 class GenericTypeParser(JSONContentItemParser, content_type=ContentType.GENERIC_TYPE):

--- a/demisto_sdk/commands/content_graph/parsers/incident_field.py
+++ b/demisto_sdk/commands/content_graph/parsers/incident_field.py
@@ -3,8 +3,7 @@ from typing import List, Optional, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.parsers.json_content_item import \
-    JSONContentItemParser
+from demisto_sdk.commands.content_graph.parsers.json_content_item import JSONContentItemParser
 
 
 class IncidentFieldParser(

--- a/demisto_sdk/commands/content_graph/parsers/incident_type.py
+++ b/demisto_sdk/commands/content_graph/parsers/incident_type.py
@@ -3,8 +3,7 @@ from typing import List, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.parsers.json_content_item import \
-    JSONContentItemParser
+from demisto_sdk.commands.content_graph.parsers.json_content_item import JSONContentItemParser
 
 
 class IncidentTypeParser(JSONContentItemParser, content_type=ContentType.INCIDENT_TYPE):

--- a/demisto_sdk/commands/content_graph/parsers/indicator_field.py
+++ b/demisto_sdk/commands/content_graph/parsers/indicator_field.py
@@ -3,8 +3,7 @@ from typing import List, Optional, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.parsers.json_content_item import \
-    JSONContentItemParser
+from demisto_sdk.commands.content_graph.parsers.json_content_item import JSONContentItemParser
 
 
 class IndicatorFieldParser(

--- a/demisto_sdk/commands/content_graph/parsers/indicator_type.py
+++ b/demisto_sdk/commands/content_graph/parsers/indicator_type.py
@@ -3,8 +3,7 @@ from typing import List, Optional, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.parsers.json_content_item import \
-    JSONContentItemParser
+from demisto_sdk.commands.content_graph.parsers.json_content_item import JSONContentItemParser
 
 
 class IndicatorTypeParser(

--- a/demisto_sdk/commands/content_graph/parsers/integration.py
+++ b/demisto_sdk/commands/content_graph/parsers/integration.py
@@ -2,10 +2,9 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
-from demisto_sdk.commands.content_graph.common import (ContentType,
-                                                       RelationshipType)
-from demisto_sdk.commands.content_graph.parsers.integration_script import (
-    IntegrationScriptParser, IntegrationScriptUnifier)
+from demisto_sdk.commands.content_graph.common import ContentType, RelationshipType
+from demisto_sdk.commands.content_graph.parsers.integration_script import (IntegrationScriptParser,
+                                                                           IntegrationScriptUnifier)
 
 
 class IntegrationParser(IntegrationScriptParser, content_type=ContentType.INTEGRATION):

--- a/demisto_sdk/commands/content_graph/parsers/integration_script.py
+++ b/demisto_sdk/commands/content_graph/parsers/integration_script.py
@@ -3,10 +3,8 @@ from pathlib import Path
 from typing import List, Optional, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
-from demisto_sdk.commands.content_graph.parsers.yaml_content_item import \
-    YAMLContentItemParser
-from demisto_sdk.commands.unify.integration_script_unifier import \
-    IntegrationScriptUnifier
+from demisto_sdk.commands.content_graph.parsers.yaml_content_item import YAMLContentItemParser
+from demisto_sdk.commands.unify.integration_script_unifier import IntegrationScriptUnifier
 
 
 class IntegrationScriptParser(YAMLContentItemParser):

--- a/demisto_sdk/commands/content_graph/parsers/job.py
+++ b/demisto_sdk/commands/content_graph/parsers/job.py
@@ -3,8 +3,7 @@ from typing import List, Optional, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.parsers.json_content_item import \
-    JSONContentItemParser
+from demisto_sdk.commands.content_graph.parsers.json_content_item import JSONContentItemParser
 
 
 class JobParser(JSONContentItemParser, content_type=ContentType.JOB):

--- a/demisto_sdk/commands/content_graph/parsers/json_content_item.py
+++ b/demisto_sdk/commands/content_graph/parsers/json_content_item.py
@@ -2,12 +2,10 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from demisto_sdk.commands.common.constants import (
-    DEFAULT_CONTENT_ITEM_FROM_VERSION, DEFAULT_CONTENT_ITEM_TO_VERSION,
-    MarketplaceVersions)
+from demisto_sdk.commands.common.constants import (DEFAULT_CONTENT_ITEM_FROM_VERSION, DEFAULT_CONTENT_ITEM_TO_VERSION,
+                                                   MarketplaceVersions)
 from demisto_sdk.commands.common.tools import get_files_in_dir, get_json
-from demisto_sdk.commands.content_graph.parsers.content_item import (
-    ContentItemParser, NotAContentItemException)
+from demisto_sdk.commands.content_graph.parsers.content_item import ContentItemParser, NotAContentItemException
 
 logger = logging.getLogger("demisto-sdk")
 

--- a/demisto_sdk/commands/content_graph/parsers/layout.py
+++ b/demisto_sdk/commands/content_graph/parsers/layout.py
@@ -3,10 +3,8 @@ from typing import List, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.parsers.content_item import \
-    NotAContentItemException
-from demisto_sdk.commands.content_graph.parsers.json_content_item import \
-    JSONContentItemParser
+from demisto_sdk.commands.content_graph.parsers.content_item import NotAContentItemException
+from demisto_sdk.commands.content_graph.parsers.json_content_item import JSONContentItemParser
 
 
 class LayoutParser(JSONContentItemParser, content_type=ContentType.LAYOUT):

--- a/demisto_sdk/commands/content_graph/parsers/list.py
+++ b/demisto_sdk/commands/content_graph/parsers/list.py
@@ -3,8 +3,7 @@ from typing import List, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.parsers.json_content_item import \
-    JSONContentItemParser
+from demisto_sdk.commands.content_graph.parsers.json_content_item import JSONContentItemParser
 
 
 class ListParser(JSONContentItemParser, content_type=ContentType.LIST):

--- a/demisto_sdk/commands/content_graph/parsers/mapper.py
+++ b/demisto_sdk/commands/content_graph/parsers/mapper.py
@@ -3,8 +3,7 @@ from typing import Any, Dict, List, Optional, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.parsers.json_content_item import \
-    JSONContentItemParser
+from demisto_sdk.commands.content_graph.parsers.json_content_item import JSONContentItemParser
 
 IGNORED_INCIDENT_TYPES = ["dbot_classification_incident_type_all"]
 

--- a/demisto_sdk/commands/content_graph/parsers/modeling_rule.py
+++ b/demisto_sdk/commands/content_graph/parsers/modeling_rule.py
@@ -3,8 +3,7 @@ from typing import List, Optional, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.parsers.yaml_content_item import \
-    YAMLContentItemParser
+from demisto_sdk.commands.content_graph.parsers.yaml_content_item import YAMLContentItemParser
 
 
 class ModelingRuleParser(YAMLContentItemParser, content_type=ContentType.MODELING_RULE):

--- a/demisto_sdk/commands/content_graph/parsers/pack.py
+++ b/demisto_sdk/commands/content_graph/parsers/pack.py
@@ -4,15 +4,11 @@ from typing import Any, Dict, Iterator, List, Optional
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.common.tools import get_json
-from demisto_sdk.commands.content_graph.common import (
-    PACK_CONTRIBUTORS_FILENAME, PACK_METADATA_FILENAME, ContentType,
-    Relationships)
-from demisto_sdk.commands.content_graph.parsers.base_content import \
-    BaseContentParser
-from demisto_sdk.commands.content_graph.parsers.content_item import (
-    ContentItemParser, NotAContentItemException)
-from demisto_sdk.commands.content_graph.parsers.content_items_list import \
-    ContentItemsList
+from demisto_sdk.commands.content_graph.common import (PACK_CONTRIBUTORS_FILENAME, PACK_METADATA_FILENAME, ContentType,
+                                                       Relationships)
+from demisto_sdk.commands.content_graph.parsers.base_content import BaseContentParser
+from demisto_sdk.commands.content_graph.parsers.content_item import ContentItemParser, NotAContentItemException
+from demisto_sdk.commands.content_graph.parsers.content_items_list import ContentItemsList
 
 logger = logging.getLogger("demisto-sdk")
 

--- a/demisto_sdk/commands/content_graph/parsers/parsing_rule.py
+++ b/demisto_sdk/commands/content_graph/parsers/parsing_rule.py
@@ -3,8 +3,7 @@ from typing import List, Optional, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.parsers.yaml_content_item import \
-    YAMLContentItemParser
+from demisto_sdk.commands.content_graph.parsers.yaml_content_item import YAMLContentItemParser
 
 
 class ParsingRuleParser(YAMLContentItemParser, content_type=ContentType.PARSING_RULE):

--- a/demisto_sdk/commands/content_graph/parsers/playbook.py
+++ b/demisto_sdk/commands/content_graph/parsers/playbook.py
@@ -4,12 +4,9 @@ from typing import Any, Dict, List, Optional, Set
 import networkx
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
-from demisto_sdk.commands.common.update_id_set import (
-    BUILT_IN_FIELDS, build_tasks_graph, get_fields_by_script_argument)
-from demisto_sdk.commands.content_graph.common import (ContentType,
-                                                       RelationshipType)
-from demisto_sdk.commands.content_graph.parsers.yaml_content_item import \
-    YAMLContentItemParser
+from demisto_sdk.commands.common.update_id_set import BUILT_IN_FIELDS, build_tasks_graph, get_fields_by_script_argument
+from demisto_sdk.commands.content_graph.common import ContentType, RelationshipType
+from demisto_sdk.commands.content_graph.parsers.yaml_content_item import YAMLContentItemParser
 
 LIST_COMMANDS = ["Builtin|||setList", "Builtin|||getList"]
 

--- a/demisto_sdk/commands/content_graph/parsers/report.py
+++ b/demisto_sdk/commands/content_graph/parsers/report.py
@@ -3,8 +3,7 @@ from typing import List, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.parsers.json_content_item import \
-    JSONContentItemParser
+from demisto_sdk.commands.content_graph.parsers.json_content_item import JSONContentItemParser
 
 
 class ReportParser(JSONContentItemParser, content_type=ContentType.REPORT):

--- a/demisto_sdk/commands/content_graph/parsers/script.py
+++ b/demisto_sdk/commands/content_graph/parsers/script.py
@@ -4,8 +4,7 @@ from typing import List, Optional, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.parsers.integration_script import \
-    IntegrationScriptParser
+from demisto_sdk.commands.content_graph.parsers.integration_script import IntegrationScriptParser
 
 EXECUTE_CMD_PATTERN = re.compile(
     r"execute_?command\(['\"]([a-zA-Z-_]+)['\"].*", re.IGNORECASE

--- a/demisto_sdk/commands/content_graph/parsers/test_playbook.py
+++ b/demisto_sdk/commands/content_graph/parsers/test_playbook.py
@@ -3,8 +3,7 @@ from typing import List, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.parsers.content_item import (
-    IncorrectParserException, NotAContentItemException)
+from demisto_sdk.commands.content_graph.parsers.content_item import IncorrectParserException, NotAContentItemException
 from demisto_sdk.commands.content_graph.parsers.playbook import PlaybookParser
 from demisto_sdk.commands.content_graph.parsers.script import ScriptParser
 

--- a/demisto_sdk/commands/content_graph/parsers/trigger.py
+++ b/demisto_sdk/commands/content_graph/parsers/trigger.py
@@ -3,8 +3,7 @@ from typing import List, Optional, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.parsers.json_content_item import \
-    JSONContentItemParser
+from demisto_sdk.commands.content_graph.parsers.json_content_item import JSONContentItemParser
 
 
 class TriggerParser(JSONContentItemParser, content_type=ContentType.TRIGGER):

--- a/demisto_sdk/commands/content_graph/parsers/widget.py
+++ b/demisto_sdk/commands/content_graph/parsers/widget.py
@@ -3,8 +3,7 @@ from typing import List, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.parsers.json_content_item import \
-    JSONContentItemParser
+from demisto_sdk.commands.content_graph.parsers.json_content_item import JSONContentItemParser
 
 
 class WidgetParser(JSONContentItemParser, content_type=ContentType.WIDGET):

--- a/demisto_sdk/commands/content_graph/parsers/wizard.py
+++ b/demisto_sdk/commands/content_graph/parsers/wizard.py
@@ -3,8 +3,7 @@ from typing import List, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.parsers.json_content_item import \
-    JSONContentItemParser
+from demisto_sdk.commands.content_graph.parsers.json_content_item import JSONContentItemParser
 
 
 class WizardParser(JSONContentItemParser, content_type=ContentType.WIZARD):

--- a/demisto_sdk/commands/content_graph/parsers/xdrc_template.py
+++ b/demisto_sdk/commands/content_graph/parsers/xdrc_template.py
@@ -3,8 +3,7 @@ from typing import List, Optional, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.parsers.json_content_item import \
-    JSONContentItemParser
+from demisto_sdk.commands.content_graph.parsers.json_content_item import JSONContentItemParser
 
 
 class XDRCTemplateParser(JSONContentItemParser, content_type=ContentType.XDRC_TEMPLATE):

--- a/demisto_sdk/commands/content_graph/parsers/xsiam_dashboard.py
+++ b/demisto_sdk/commands/content_graph/parsers/xsiam_dashboard.py
@@ -3,8 +3,7 @@ from typing import Any, Dict, List, Optional, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.parsers.json_content_item import \
-    JSONContentItemParser
+from demisto_sdk.commands.content_graph.parsers.json_content_item import JSONContentItemParser
 
 
 class XSIAMDashboardParser(

--- a/demisto_sdk/commands/content_graph/parsers/xsiam_report.py
+++ b/demisto_sdk/commands/content_graph/parsers/xsiam_report.py
@@ -3,8 +3,7 @@ from typing import Any, Dict, List, Optional, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.parsers.json_content_item import \
-    JSONContentItemParser
+from demisto_sdk.commands.content_graph.parsers.json_content_item import JSONContentItemParser
 
 
 class XSIAMReportParser(JSONContentItemParser, content_type=ContentType.XSIAM_REPORT):

--- a/demisto_sdk/commands/content_graph/parsers/yaml_content_item.py
+++ b/demisto_sdk/commands/content_graph/parsers/yaml_content_item.py
@@ -2,14 +2,11 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
-from demisto_sdk.commands.common.constants import (
-    DEFAULT_CONTENT_ITEM_FROM_VERSION, DEFAULT_CONTENT_ITEM_TO_VERSION,
-    MarketplaceVersions)
+from demisto_sdk.commands.common.constants import (DEFAULT_CONTENT_ITEM_FROM_VERSION, DEFAULT_CONTENT_ITEM_TO_VERSION,
+                                                   MarketplaceVersions)
 from demisto_sdk.commands.common.tools import get_yaml, get_yml_paths_in_dir
-from demisto_sdk.commands.content_graph.common import (ContentType,
-                                                       RelationshipType)
-from demisto_sdk.commands.content_graph.parsers.content_item import (
-    ContentItemParser, NotAContentItemException)
+from demisto_sdk.commands.content_graph.common import ContentType, RelationshipType
+from demisto_sdk.commands.content_graph.parsers.content_item import ContentItemParser, NotAContentItemException
 
 logger = logging.getLogger("demisto-sdk")
 

--- a/demisto_sdk/commands/content_graph/tests/create_content_graph_test.py
+++ b/demisto_sdk/commands/content_graph/tests/create_content_graph_test.py
@@ -6,21 +6,17 @@ import pytest
 import demisto_sdk.commands.content_graph.content_graph_commands as content_graph_commands
 import demisto_sdk.commands.content_graph.neo4j_service as neo4j_service
 from demisto_sdk.commands.common.constants import MarketplaceVersions
-from demisto_sdk.commands.content_graph.common import (ContentType,
-                                                       RelationshipType)
-from demisto_sdk.commands.content_graph.content_graph_commands import (
-    create_content_graph, stop_content_graph)
+from demisto_sdk.commands.content_graph.common import ContentType, RelationshipType
+from demisto_sdk.commands.content_graph.content_graph_commands import create_content_graph, stop_content_graph
 from demisto_sdk.commands.content_graph.interface.neo4j.neo4j_graph import \
     Neo4jContentGraphInterface as ContentGraphInterface
 from demisto_sdk.commands.content_graph.objects.classifier import Classifier
-from demisto_sdk.commands.content_graph.objects.integration import (
-    Command, Integration)
+from demisto_sdk.commands.content_graph.objects.integration import Command, Integration
 from demisto_sdk.commands.content_graph.objects.pack import Pack
 from demisto_sdk.commands.content_graph.objects.playbook import Playbook
 from demisto_sdk.commands.content_graph.objects.repository import ContentDTO
 from demisto_sdk.commands.content_graph.objects.script import Script
-from demisto_sdk.commands.content_graph.objects.test_playbook import \
-    TestPlaybook
+from demisto_sdk.commands.content_graph.objects.test_playbook import TestPlaybook
 from demisto_sdk.commands.content_graph.tests.test_tools import load_json
 from TestSuite.repo import Repo
 

--- a/demisto_sdk/commands/content_graph/tests/neo4j_interface_test.py
+++ b/demisto_sdk/commands/content_graph/tests/neo4j_interface_test.py
@@ -42,8 +42,7 @@ class TestNeo4jQueries:
         Then:
             - Make sure the output string has the expected content type labels.
         """
-        from demisto_sdk.commands.content_graph.interface.neo4j.queries.common import \
-            labels_of
+        from demisto_sdk.commands.content_graph.interface.neo4j.queries.common import labels_of
 
         integration_labels = labels_of(content_type)
         for content_type in expected_labels:
@@ -58,8 +57,7 @@ class TestNeo4jQueries:
         Then:
             - Make sure the output is a string representation of a map in neo4j format.
         """
-        from demisto_sdk.commands.content_graph.interface.neo4j.queries.common import \
-            node_map
+        from demisto_sdk.commands.content_graph.interface.neo4j.queries.common import node_map
 
         assert (
             node_map(

--- a/demisto_sdk/commands/content_graph/tests/parsers_and_models_test.py
+++ b/demisto_sdk/commands/content_graph/tests/parsers_and_models_test.py
@@ -3,18 +3,13 @@ from typing import Dict, List, Optional, Set
 
 import pytest
 
-from demisto_sdk.commands.common.constants import (
-    DEFAULT_CONTENT_ITEM_FROM_VERSION, DEFAULT_CONTENT_ITEM_TO_VERSION,
-    MarketplaceVersions)
-from demisto_sdk.commands.content_graph.common import (ContentType,
-                                                       Relationships,
-                                                       RelationshipType)
+from demisto_sdk.commands.common.constants import (DEFAULT_CONTENT_ITEM_FROM_VERSION, DEFAULT_CONTENT_ITEM_TO_VERSION,
+                                                   MarketplaceVersions)
+from demisto_sdk.commands.content_graph.common import ContentType, Relationships, RelationshipType
 from demisto_sdk.commands.content_graph.objects.content_item import ContentItem
 from demisto_sdk.commands.content_graph.objects.pack import Pack as PackModel
-from demisto_sdk.commands.content_graph.parsers.content_item import \
-    NotAContentItemException
-from demisto_sdk.commands.content_graph.tests.test_tools import (load_json,
-                                                                 load_yaml)
+from demisto_sdk.commands.content_graph.parsers.content_item import NotAContentItemException
+from demisto_sdk.commands.content_graph.tests.test_tools import load_json, load_yaml
 from TestSuite.pack import Pack
 from TestSuite.repo import Repo
 
@@ -260,8 +255,7 @@ class TestParsersAndModels:
         Then:
             - Verify NotAContentItemException is raised, meaning we skip parsing the classifier.
         """
-        from demisto_sdk.commands.content_graph.parsers.classifier import \
-            ClassifierParser
+        from demisto_sdk.commands.content_graph.parsers.classifier import ClassifierParser
 
         classifier = pack.create_classifier(
             "TestClassifier", load_json("classifier.json")
@@ -282,10 +276,8 @@ class TestParsersAndModels:
             - Verify the generic content item properties are parsed correctly.
             - Verify the specific properties of the content item are parsed correctly.
         """
-        from demisto_sdk.commands.content_graph.objects.classifier import \
-            Classifier
-        from demisto_sdk.commands.content_graph.parsers.classifier import \
-            ClassifierParser
+        from demisto_sdk.commands.content_graph.objects.classifier import Classifier
+        from demisto_sdk.commands.content_graph.parsers.classifier import ClassifierParser
 
         classifier = pack.create_classifier(
             "TestClassifier", load_json("classifier.json")
@@ -326,10 +318,8 @@ class TestParsersAndModels:
             - Verify the generic content item properties are parsed correctly.
             - Verify the specific properties of the content item are parsed correctly.
         """
-        from demisto_sdk.commands.content_graph.objects.correlation_rule import \
-            CorrelationRule
-        from demisto_sdk.commands.content_graph.parsers.correlation_rule import \
-            CorrelationRuleParser
+        from demisto_sdk.commands.content_graph.objects.correlation_rule import CorrelationRule
+        from demisto_sdk.commands.content_graph.parsers.correlation_rule import CorrelationRuleParser
 
         colrrelation_rule = pack.create_correlation_rule(
             "TestCorrelationRule", load_yaml("correlation_rule.yml")
@@ -361,10 +351,8 @@ class TestParsersAndModels:
             - Verify the generic content item properties are parsed correctly.
             - Verify the specific properties of the content item are parsed correctly.
         """
-        from demisto_sdk.commands.content_graph.objects.dashboard import \
-            Dashboard
-        from demisto_sdk.commands.content_graph.parsers.dashboard import \
-            DashboardParser
+        from demisto_sdk.commands.content_graph.objects.dashboard import Dashboard
+        from demisto_sdk.commands.content_graph.parsers.dashboard import DashboardParser
 
         dashboard = pack.create_dashboard("TestDashboard", load_json("dashboard.json"))
         dashboard_path = Path(dashboard.path)
@@ -398,10 +386,8 @@ class TestParsersAndModels:
             - Verify the generic content item properties are parsed correctly.
             - Verify the specific properties of the content item are parsed correctly.
         """
-        from demisto_sdk.commands.content_graph.objects.generic_definition import \
-            GenericDefinition
-        from demisto_sdk.commands.content_graph.parsers.generic_definition import \
-            GenericDefinitionParser
+        from demisto_sdk.commands.content_graph.objects.generic_definition import GenericDefinition
+        from demisto_sdk.commands.content_graph.parsers.generic_definition import GenericDefinitionParser
 
         generic_definition = pack.create_generic_definition(
             "TestGenericDefinition", load_json("generic_definition.json")
@@ -433,10 +419,8 @@ class TestParsersAndModels:
             - Verify the generic content item properties are parsed correctly.
             - Verify the specific properties of the content item are parsed correctly.
         """
-        from demisto_sdk.commands.content_graph.objects.generic_module import \
-            GenericModule
-        from demisto_sdk.commands.content_graph.parsers.generic_module import \
-            GenericModuleParser
+        from demisto_sdk.commands.content_graph.objects.generic_module import GenericModule
+        from demisto_sdk.commands.content_graph.parsers.generic_module import GenericModuleParser
 
         generic_module = pack.create_generic_module(
             "TestGenericModule", load_json("generic_module.json")
@@ -467,10 +451,8 @@ class TestParsersAndModels:
             - Verify the generic content item properties are parsed correctly.
             - Verify the specific properties of the content item are parsed correctly.
         """
-        from demisto_sdk.commands.content_graph.objects.generic_type import \
-            GenericType
-        from demisto_sdk.commands.content_graph.parsers.generic_type import \
-            GenericTypeParser
+        from demisto_sdk.commands.content_graph.objects.generic_type import GenericType
+        from demisto_sdk.commands.content_graph.parsers.generic_type import GenericTypeParser
 
         generic_type = pack.create_generic_module(
             "TestGenericType", load_json("generic_type.json")
@@ -504,10 +486,8 @@ class TestParsersAndModels:
             - Verify the generic content item properties are parsed correctly.
             - Verify the specific properties of the content item are parsed correctly.
         """
-        from demisto_sdk.commands.content_graph.objects.incident_field import \
-            IncidentField
-        from demisto_sdk.commands.content_graph.parsers.incident_field import \
-            IncidentFieldParser
+        from demisto_sdk.commands.content_graph.objects.incident_field import IncidentField
+        from demisto_sdk.commands.content_graph.parsers.incident_field import IncidentFieldParser
 
         incident_field = pack.create_incident_field(
             "TestIncidentField", load_json("incident_field.json")
@@ -546,10 +526,8 @@ class TestParsersAndModels:
             - Verify the generic content item properties are parsed correctly.
             - Verify the specific properties of the content item are parsed correctly.
         """
-        from demisto_sdk.commands.content_graph.objects.incident_type import \
-            IncidentType
-        from demisto_sdk.commands.content_graph.parsers.incident_type import \
-            IncidentTypeParser
+        from demisto_sdk.commands.content_graph.objects.incident_type import IncidentType
+        from demisto_sdk.commands.content_graph.parsers.incident_type import IncidentTypeParser
 
         incident_type = pack.create_incident_field(
             "TestIncidentType", load_json("incident_type.json")
@@ -590,10 +568,8 @@ class TestParsersAndModels:
             - Verify the generic content item properties are parsed correctly.
             - Verify the specific properties of the content item are parsed correctly.
         """
-        from demisto_sdk.commands.content_graph.objects.indicator_field import \
-            IndicatorField
-        from demisto_sdk.commands.content_graph.parsers.indicator_field import \
-            IndicatorFieldParser
+        from demisto_sdk.commands.content_graph.objects.indicator_field import IndicatorField
+        from demisto_sdk.commands.content_graph.parsers.indicator_field import IndicatorFieldParser
 
         indicator_field = pack.create_incident_field(
             "TestIndicatorField", load_json("indicator_field.json")
@@ -631,10 +607,8 @@ class TestParsersAndModels:
             - Verify the generic content item properties are parsed correctly.
             - Verify the specific properties of the content item are parsed correctly.
         """
-        from demisto_sdk.commands.content_graph.objects.indicator_type import \
-            IndicatorType
-        from demisto_sdk.commands.content_graph.parsers.indicator_type import \
-            IndicatorTypeParser
+        from demisto_sdk.commands.content_graph.objects.indicator_type import IndicatorType
+        from demisto_sdk.commands.content_graph.parsers.indicator_type import IndicatorTypeParser
 
         indicator_type = pack.create_indicator_type(
             "TestIndicatorType", load_json("indicator_type.json")
@@ -674,10 +648,8 @@ class TestParsersAndModels:
             - Verify the generic content item properties are parsed correctly.
             - Verify the specific properties of the content item are parsed correctly.
         """
-        from demisto_sdk.commands.content_graph.objects.integration import \
-            Integration
-        from demisto_sdk.commands.content_graph.parsers.integration import \
-            IntegrationParser
+        from demisto_sdk.commands.content_graph.objects.integration import Integration
+        from demisto_sdk.commands.content_graph.parsers.integration import IntegrationParser
 
         integration = pack.create_integration()
         integration.create_default_integration("TestIntegration")
@@ -712,10 +684,8 @@ class TestParsersAndModels:
             - Verify the generic content item properties are parsed correctly.
             - Verify the specific properties of the content item are parsed correctly.
         """
-        from demisto_sdk.commands.content_graph.objects.integration import \
-            Integration
-        from demisto_sdk.commands.content_graph.parsers.integration import \
-            IntegrationParser
+        from demisto_sdk.commands.content_graph.objects.integration import Integration
+        from demisto_sdk.commands.content_graph.parsers.integration import IntegrationParser
 
         integration = pack.create_integration(yml=load_yaml("unified_integration.yml"))
         integration_path = Path(integration.path)
@@ -790,8 +760,7 @@ class TestParsersAndModels:
             - Verify the generic content item properties are parsed correctly.
             - Verify the specific properties of the content item are parsed correctly.
         """
-        from demisto_sdk.commands.content_graph.parsers.layout import \
-            LayoutParser
+        from demisto_sdk.commands.content_graph.parsers.layout import LayoutParser
 
         layout = pack.create_layout("TestLayout")
         layout_path = Path(layout.path)
@@ -810,8 +779,7 @@ class TestParsersAndModels:
             - Verify the specific properties of the content item are parsed correctly.
         """
         from demisto_sdk.commands.content_graph.objects.layout import Layout
-        from demisto_sdk.commands.content_graph.parsers.layout import \
-            LayoutParser
+        from demisto_sdk.commands.content_graph.parsers.layout import LayoutParser
 
         layout = pack.create_layoutcontainer(
             "TestLayoutscontainer", load_json("layoutscontainer.json")
@@ -853,8 +821,7 @@ class TestParsersAndModels:
             - Verify the generic content item properties are parsed correctly.
             - Verify the specific properties of the content item are parsed correctly.
         """
-        from demisto_sdk.commands.content_graph.objects.list import \
-            List as ListObject
+        from demisto_sdk.commands.content_graph.objects.list import List as ListObject
         from demisto_sdk.commands.content_graph.parsers.list import ListParser
 
         list_ = pack.create_list("TestList", load_json("list.json"))
@@ -886,8 +853,7 @@ class TestParsersAndModels:
             - Verify the specific properties of the content item are parsed correctly.
         """
         from demisto_sdk.commands.content_graph.objects.mapper import Mapper
-        from demisto_sdk.commands.content_graph.parsers.mapper import \
-            MapperParser
+        from demisto_sdk.commands.content_graph.parsers.mapper import MapperParser
 
         mapper = pack.create_mapper(
             "TestIncomingMapper", load_json("incoming_mapper.json")
@@ -930,8 +896,7 @@ class TestParsersAndModels:
             - Verify the specific properties of the content item are parsed correctly.
         """
         from demisto_sdk.commands.content_graph.objects.mapper import Mapper
-        from demisto_sdk.commands.content_graph.parsers.mapper import \
-            MapperParser
+        from demisto_sdk.commands.content_graph.parsers.mapper import MapperParser
 
         mapper = pack.create_mapper(
             "TestOutgoingMapper", load_json("outgoing_mapper.json")
@@ -973,10 +938,8 @@ class TestParsersAndModels:
             - Verify the generic content item properties are parsed correctly.
             - Verify the specific properties of the content item are parsed correctly.
         """
-        from demisto_sdk.commands.content_graph.objects.modeling_rule import \
-            ModelingRule
-        from demisto_sdk.commands.content_graph.parsers.modeling_rule import \
-            ModelingRuleParser
+        from demisto_sdk.commands.content_graph.objects.modeling_rule import ModelingRule
+        from demisto_sdk.commands.content_graph.parsers.modeling_rule import ModelingRuleParser
 
         modeling_rule = pack.create_modeling_rule(
             "TestModelingRule", load_yaml("modeling_rule.yml")
@@ -1005,10 +968,8 @@ class TestParsersAndModels:
             - Verify the generic content item properties are parsed correctly.
             - Verify the specific properties of the content item are parsed correctly.
         """
-        from demisto_sdk.commands.content_graph.objects.parsing_rule import \
-            ParsingRule
-        from demisto_sdk.commands.content_graph.parsers.parsing_rule import \
-            ParsingRuleParser
+        from demisto_sdk.commands.content_graph.objects.parsing_rule import ParsingRule
+        from demisto_sdk.commands.content_graph.parsers.parsing_rule import ParsingRuleParser
 
         parsing_rule = pack.create_parsing_rule(
             "TestParsingRule", load_yaml("parsing_rule.yml")
@@ -1038,10 +999,8 @@ class TestParsersAndModels:
               In particular, make sure redundant backslashes are removed from the playbook's description.
             - Verify the specific properties of the content item are parsed correctly.
         """
-        from demisto_sdk.commands.content_graph.objects.playbook import \
-            Playbook
-        from demisto_sdk.commands.content_graph.parsers.playbook import \
-            PlaybookParser
+        from demisto_sdk.commands.content_graph.objects.playbook import Playbook
+        from demisto_sdk.commands.content_graph.parsers.playbook import PlaybookParser
 
         playbook = pack.create_playbook()
         playbook.create_default_playbook(name="sample")
@@ -1078,8 +1037,7 @@ class TestParsersAndModels:
             - Verify the specific properties of the content item are parsed correctly.
         """
         from demisto_sdk.commands.content_graph.objects.report import Report
-        from demisto_sdk.commands.content_graph.parsers.report import \
-            ReportParser
+        from demisto_sdk.commands.content_graph.parsers.report import ReportParser
 
         report = pack.create_report("TestReport", load_json("report.json"))
         report_path = Path(report.path)
@@ -1114,8 +1072,7 @@ class TestParsersAndModels:
             - Verify the specific properties of the content item are parsed correctly.
         """
         from demisto_sdk.commands.content_graph.objects.script import Script
-        from demisto_sdk.commands.content_graph.parsers.script import \
-            ScriptParser
+        from demisto_sdk.commands.content_graph.parsers.script import ScriptParser
 
         script = pack.create_script()
         script.create_default_script()
@@ -1151,10 +1108,8 @@ class TestParsersAndModels:
             - Verify the generic content item properties are parsed correctly.
             - Verify the specific properties of the content item are parsed correctly.
         """
-        from demisto_sdk.commands.content_graph.objects.test_playbook import \
-            TestPlaybook
-        from demisto_sdk.commands.content_graph.parsers.test_playbook import \
-            TestPlaybookParser
+        from demisto_sdk.commands.content_graph.objects.test_playbook import TestPlaybook
+        from demisto_sdk.commands.content_graph.parsers.test_playbook import TestPlaybookParser
 
         test_playbook = pack.create_test_playbook()
         test_playbook.create_default_test_playbook(name="sample")
@@ -1189,8 +1144,7 @@ class TestParsersAndModels:
             - Verify the specific properties of the content item are parsed correctly.
         """
         from demisto_sdk.commands.content_graph.objects.trigger import Trigger
-        from demisto_sdk.commands.content_graph.parsers.trigger import \
-            TriggerParser
+        from demisto_sdk.commands.content_graph.parsers.trigger import TriggerParser
 
         trigger = pack.create_trigger("TestTrigger", load_json("trigger.json"))
         trigger_path = Path(trigger.path)
@@ -1224,8 +1178,7 @@ class TestParsersAndModels:
             - Verify the specific properties of the content item are parsed correctly.
         """
         from demisto_sdk.commands.content_graph.objects.widget import Widget
-        from demisto_sdk.commands.content_graph.parsers.widget import \
-            WidgetParser
+        from demisto_sdk.commands.content_graph.parsers.widget import WidgetParser
 
         widget = pack.create_widget("TestWidget", load_json("widget.json"))
         widget_path = Path(widget.path)
@@ -1259,8 +1212,7 @@ class TestParsersAndModels:
             - Verify the specific properties of the content item are parsed correctly.
         """
         from demisto_sdk.commands.content_graph.objects.wizard import Wizard
-        from demisto_sdk.commands.content_graph.parsers.wizard import \
-            WizardParser
+        from demisto_sdk.commands.content_graph.parsers.wizard import WizardParser
 
         wizard_json = load_json("wizard.json")
         wizard = pack.create_wizard(
@@ -1313,10 +1265,8 @@ class TestParsersAndModels:
             - Verify the generic content item properties are parsed correctly.
             - Verify the specific properties of the content item are parsed correctly.
         """
-        from demisto_sdk.commands.content_graph.objects.xsiam_dashboard import \
-            XSIAMDashboard
-        from demisto_sdk.commands.content_graph.parsers.xsiam_dashboard import \
-            XSIAMDashboardParser
+        from demisto_sdk.commands.content_graph.objects.xsiam_dashboard import XSIAMDashboard
+        from demisto_sdk.commands.content_graph.parsers.xsiam_dashboard import XSIAMDashboardParser
 
         xsiam_dashboard = pack.create_xsiam_dashboard(
             "TestXSIAMDashboard", load_json("xsiam_dashboard.json")
@@ -1346,10 +1296,8 @@ class TestParsersAndModels:
             - Verify the generic content item properties are parsed correctly.
             - Verify the specific properties of the content item are parsed correctly.
         """
-        from demisto_sdk.commands.content_graph.objects.xsiam_report import \
-            XSIAMReport
-        from demisto_sdk.commands.content_graph.parsers.xsiam_report import \
-            XSIAMReportParser
+        from demisto_sdk.commands.content_graph.objects.xsiam_report import XSIAMReport
+        from demisto_sdk.commands.content_graph.parsers.xsiam_report import XSIAMReportParser
 
         xsiam_report = pack.create_xsiam_report(
             "TestXSIAMReport", load_json("xsiam_report.json")
@@ -1379,8 +1327,7 @@ class TestParsersAndModels:
             - Verify the content items are modeled correctly.
             - Verify the pack is modeled correctly.
         """
-        from demisto_sdk.commands.content_graph.objects.pack import \
-            Pack as PackModel
+        from demisto_sdk.commands.content_graph.objects.pack import Pack as PackModel
         from demisto_sdk.commands.content_graph.parsers.pack import PackParser
 
         pack = repo.create_pack("HelloWorld")
@@ -1437,10 +1384,8 @@ class TestParsersAndModels:
         Then:
             - Verify the repository is modeled correctly.
         """
-        from demisto_sdk.commands.content_graph.objects.repository import \
-            ContentDTO
-        from demisto_sdk.commands.content_graph.parsers.repository import \
-            RepositoryParser
+        from demisto_sdk.commands.content_graph.objects.repository import ContentDTO
+        from demisto_sdk.commands.content_graph.parsers.repository import RepositoryParser
 
         pack1 = repo.create_pack("sample1")
         pack1.pack_metadata.write_json(load_json("pack_metadata.json"))

--- a/demisto_sdk/commands/convert/converters/base_converter.py
+++ b/demisto_sdk/commands/convert/converters/base_converter.py
@@ -2,12 +2,9 @@ import re
 from abc import abstractmethod
 from typing import Dict, Iterator, List, Union
 
-from demisto_sdk.commands.common.constants import (ENTITY_NAME_SEPARATORS,
-                                                   FileType)
-from demisto_sdk.commands.common.content.objects.pack_objects.classifier.classifier import \
-    Classifier
-from demisto_sdk.commands.common.content.objects.pack_objects.layout.layout import \
-    LayoutObject
+from demisto_sdk.commands.common.constants import ENTITY_NAME_SEPARATORS, FileType
+from demisto_sdk.commands.common.content.objects.pack_objects.classifier.classifier import Classifier
+from demisto_sdk.commands.common.content.objects.pack_objects.layout.layout import LayoutObject
 from demisto_sdk.commands.common.handlers import JSON_Handler
 
 json = JSON_Handler()

--- a/demisto_sdk/commands/convert/converters/classifier/classifier_6_0_0_converter.py
+++ b/demisto_sdk/commands/convert/converters/classifier/classifier_6_0_0_converter.py
@@ -1,11 +1,9 @@
 from typing import List, Set
 
 from demisto_sdk.commands.common.constants import FileType
-from demisto_sdk.commands.common.content.objects.pack_objects.classifier.classifier import \
-    Classifier
+from demisto_sdk.commands.common.content.objects.pack_objects.classifier.classifier import Classifier
 from demisto_sdk.commands.common.content.objects.pack_objects.pack import Pack
-from demisto_sdk.commands.convert.converters.classifier.classifier_base_converter import \
-    ClassifierBaseConverter
+from demisto_sdk.commands.convert.converters.classifier.classifier_base_converter import ClassifierBaseConverter
 
 
 class ClassifierSixConverter(ClassifierBaseConverter):

--- a/demisto_sdk/commands/convert/converters/classifier/classifier_base_converter.py
+++ b/demisto_sdk/commands/convert/converters/classifier/classifier_base_converter.py
@@ -3,12 +3,10 @@ from abc import abstractmethod
 from typing import Optional, Set
 
 from demisto_sdk.commands.common.constants import FileType
-from demisto_sdk.commands.common.content.objects.pack_objects.classifier.classifier import \
-    Classifier
+from demisto_sdk.commands.common.content.objects.pack_objects.classifier.classifier import Classifier
 from demisto_sdk.commands.common.content.objects.pack_objects.pack import Pack
 from demisto_sdk.commands.common.tools import get_yaml
-from demisto_sdk.commands.convert.converters.base_converter import \
-    BaseConverter
+from demisto_sdk.commands.convert.converters.base_converter import BaseConverter
 
 
 class ClassifierBaseConverter(BaseConverter):

--- a/demisto_sdk/commands/convert/converters/classifier/tests/classifier_6_0_0_converter_test.py
+++ b/demisto_sdk/commands/convert/converters/classifier/tests/classifier_6_0_0_converter_test.py
@@ -4,13 +4,11 @@ from pathlib import Path
 
 import pytest
 
-from demisto_sdk.commands.common.content.objects.pack_objects.classifier.classifier import \
-    Classifier
+from demisto_sdk.commands.common.content.objects.pack_objects.classifier.classifier import Classifier
 from demisto_sdk.commands.common.content.objects.pack_objects.pack import Pack
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.legacy_git_tools import git_path
-from demisto_sdk.commands.convert.converters.classifier.classifier_6_0_0_converter import \
-    ClassifierSixConverter
+from demisto_sdk.commands.convert.converters.classifier.classifier_6_0_0_converter import ClassifierSixConverter
 from TestSuite.pack import Pack as MockPack
 from TestSuite.repo import Repo
 

--- a/demisto_sdk/commands/convert/converters/classifier/tests/classifier_base_converter_test.py
+++ b/demisto_sdk/commands/convert/converters/classifier/tests/classifier_base_converter_test.py
@@ -3,11 +3,9 @@ from typing import Optional
 
 import pytest
 
-from demisto_sdk.commands.common.content.objects.pack_objects.classifier.classifier import \
-    Classifier
+from demisto_sdk.commands.common.content.objects.pack_objects.classifier.classifier import Classifier
 from demisto_sdk.commands.common.legacy_git_tools import git_path
-from demisto_sdk.commands.convert.converters.classifier.classifier_base_converter import \
-    ClassifierBaseConverter
+from demisto_sdk.commands.convert.converters.classifier.classifier_base_converter import ClassifierBaseConverter
 
 
 class TestLayoutBaseConverter:

--- a/demisto_sdk/commands/convert/converters/layout/layout_6_0_0_converter.py
+++ b/demisto_sdk/commands/convert/converters/layout/layout_6_0_0_converter.py
@@ -2,11 +2,9 @@ import shutil
 from typing import Dict, List, Set
 
 from demisto_sdk.commands.common.constants import FileType
-from demisto_sdk.commands.common.content.objects.pack_objects.layout.layout import \
-    LayoutObject
+from demisto_sdk.commands.common.content.objects.pack_objects.layout.layout import LayoutObject
 from demisto_sdk.commands.common.content.objects.pack_objects.pack import Pack
-from demisto_sdk.commands.convert.converters.layout.layout_base_converter import \
-    LayoutBaseConverter
+from demisto_sdk.commands.convert.converters.layout.layout_base_converter import LayoutBaseConverter
 
 
 class LayoutSixConverter(LayoutBaseConverter):

--- a/demisto_sdk/commands/convert/converters/layout/layout_base_converter.py
+++ b/demisto_sdk/commands/convert/converters/layout/layout_base_converter.py
@@ -5,8 +5,7 @@ from typing import Any, Dict, Optional
 from demisto_sdk.commands.common.constants import FileType
 from demisto_sdk.commands.common.content.objects.pack_objects.pack import Pack
 from demisto_sdk.commands.common.tools import get_yaml
-from demisto_sdk.commands.convert.converters.base_converter import \
-    BaseConverter
+from demisto_sdk.commands.convert.converters.base_converter import BaseConverter
 
 
 class LayoutBaseConverter(BaseConverter):

--- a/demisto_sdk/commands/convert/converters/layout/layout_up_to_5_9_9_converter.py
+++ b/demisto_sdk/commands/convert/converters/layout/layout_up_to_5_9_9_converter.py
@@ -1,15 +1,11 @@
 from typing import Any, Dict, Iterator, List, Union
 
 from demisto_sdk.commands.common.constants import FileType
-from demisto_sdk.commands.common.content.objects.pack_objects.incident_type.incident_type import \
-    IncidentType
-from demisto_sdk.commands.common.content.objects.pack_objects.indicator_type.indicator_type import \
-    IndicatorType
-from demisto_sdk.commands.common.content.objects.pack_objects.layout.layout import \
-    LayoutObject
+from demisto_sdk.commands.common.content.objects.pack_objects.incident_type.incident_type import IncidentType
+from demisto_sdk.commands.common.content.objects.pack_objects.indicator_type.indicator_type import IndicatorType
+from demisto_sdk.commands.common.content.objects.pack_objects.layout.layout import LayoutObject
 from demisto_sdk.commands.common.content.objects.pack_objects.pack import Pack
-from demisto_sdk.commands.convert.converters.layout.layout_base_converter import \
-    LayoutBaseConverter
+from demisto_sdk.commands.convert.converters.layout.layout_base_converter import LayoutBaseConverter
 
 
 class LayoutBelowSixConverter(LayoutBaseConverter):

--- a/demisto_sdk/commands/convert/converters/layout/tests/layout_6_0_0_converter_test.py
+++ b/demisto_sdk/commands/convert/converters/layout/tests/layout_6_0_0_converter_test.py
@@ -7,8 +7,7 @@ import pytest
 from demisto_sdk.commands.common.content.objects.pack_objects.pack import Pack
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.legacy_git_tools import git_path
-from demisto_sdk.commands.convert.converters.layout.layout_6_0_0_converter import \
-    LayoutSixConverter
+from demisto_sdk.commands.convert.converters.layout.layout_6_0_0_converter import LayoutSixConverter
 from TestSuite.pack import Pack as MockPack
 from TestSuite.repo import Repo
 

--- a/demisto_sdk/commands/convert/converters/layout/tests/layout_base_converter_test.py
+++ b/demisto_sdk/commands/convert/converters/layout/tests/layout_base_converter_test.py
@@ -3,8 +3,7 @@ from typing import Dict
 import pytest
 
 from demisto_sdk.commands.common.content.objects.pack_objects.pack import Pack
-from demisto_sdk.commands.convert.converters.layout.layout_base_converter import \
-    LayoutBaseConverter
+from demisto_sdk.commands.convert.converters.layout.layout_base_converter import LayoutBaseConverter
 
 
 class TestLayoutBaseConverter:

--- a/demisto_sdk/commands/convert/converters/layout/tests/layout_up_to_5_9_9_test.py
+++ b/demisto_sdk/commands/convert/converters/layout/tests/layout_up_to_5_9_9_test.py
@@ -5,13 +5,11 @@ from typing import Dict
 
 import pytest
 
-from demisto_sdk.commands.common.content.objects.pack_objects.layout.layout import \
-    Layout
+from demisto_sdk.commands.common.content.objects.pack_objects.layout.layout import Layout
 from demisto_sdk.commands.common.content.objects.pack_objects.pack import Pack
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.legacy_git_tools import git_path
-from demisto_sdk.commands.convert.converters.layout.layout_up_to_5_9_9_converter import \
-    LayoutBelowSixConverter
+from demisto_sdk.commands.convert.converters.layout.layout_up_to_5_9_9_converter import LayoutBelowSixConverter
 from TestSuite.pack import Pack as MockPack
 from TestSuite.repo import Repo
 

--- a/demisto_sdk/commands/convert/converters/tests/base_converter_test.py
+++ b/demisto_sdk/commands/convert/converters/tests/base_converter_test.py
@@ -4,15 +4,12 @@ from pathlib import Path
 
 import pytest
 
-from demisto_sdk.commands.common.constants import (ENTITY_NAME_SEPARATORS,
-                                                   FileType)
+from demisto_sdk.commands.common.constants import ENTITY_NAME_SEPARATORS, FileType
 from demisto_sdk.commands.common.content.objects.pack_objects.pack import Pack
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.legacy_git_tools import git_path
-from demisto_sdk.commands.convert.converters.base_converter import \
-    BaseConverter
-from demisto_sdk.commands.convert.converters.layout.layout_6_0_0_converter import \
-    LayoutSixConverter
+from demisto_sdk.commands.convert.converters.base_converter import BaseConverter
+from demisto_sdk.commands.convert.converters.layout.layout_6_0_0_converter import LayoutSixConverter
 from TestSuite.pack import Pack as MockPack
 from TestSuite.repo import Repo
 

--- a/demisto_sdk/commands/convert/dir_convert_managers.py
+++ b/demisto_sdk/commands/convert/dir_convert_managers.py
@@ -6,16 +6,11 @@ from packaging.version import Version
 
 from demisto_sdk.commands.common.content.objects.pack_objects.pack import Pack
 from demisto_sdk.commands.common.tools import is_pack_path
-from demisto_sdk.commands.convert.converters.classifier.classifier_6_0_0_converter import \
-    ClassifierSixConverter
-from demisto_sdk.commands.convert.converters.classifier.classifier_base_converter import \
-    ClassifierBaseConverter
-from demisto_sdk.commands.convert.converters.layout.layout_6_0_0_converter import \
-    LayoutSixConverter
-from demisto_sdk.commands.convert.converters.layout.layout_base_converter import \
-    LayoutBaseConverter
-from demisto_sdk.commands.convert.converters.layout.layout_up_to_5_9_9_converter import \
-    LayoutBelowSixConverter
+from demisto_sdk.commands.convert.converters.classifier.classifier_6_0_0_converter import ClassifierSixConverter
+from demisto_sdk.commands.convert.converters.classifier.classifier_base_converter import ClassifierBaseConverter
+from demisto_sdk.commands.convert.converters.layout.layout_6_0_0_converter import LayoutSixConverter
+from demisto_sdk.commands.convert.converters.layout.layout_base_converter import LayoutBaseConverter
+from demisto_sdk.commands.convert.converters.layout.layout_up_to_5_9_9_converter import LayoutBelowSixConverter
 
 
 class AbstractDirConvertManager:

--- a/demisto_sdk/commands/coverage_analyze/coverage_report.py
+++ b/demisto_sdk/commands/coverage_analyze/coverage_report.py
@@ -4,12 +4,8 @@ from typing import Dict, Optional, Union
 
 import coverage
 
-from demisto_sdk.commands.coverage_analyze.helpers import (CoverageSummary,
-                                                           export_report,
-                                                           get_coverage_obj,
-                                                           get_report_str,
-                                                           parse_report_type,
-                                                           percent_to_float)
+from demisto_sdk.commands.coverage_analyze.helpers import (CoverageSummary, export_report, get_coverage_obj,
+                                                           get_report_str, parse_report_type, percent_to_float)
 
 logger = logging.getLogger('demisto-sdk')
 

--- a/demisto_sdk/commands/coverage_analyze/tests/coverage_report_test.py
+++ b/demisto_sdk/commands/coverage_analyze/tests/coverage_report_test.py
@@ -7,13 +7,11 @@ import pytest
 
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.logger import logging_setup
-from demisto_sdk.commands.coverage_analyze.coverage_report import \
-    CoverageReport
-from demisto_sdk.commands.coverage_analyze.helpers import (fix_file_path,
-                                                           get_coverage_obj)
-from demisto_sdk.commands.coverage_analyze.tests.helpers_test import (
-    COVERAGE_FILES_DIR, JSON_MIN_DATA_FILE, PYTHON_FILE_PATH, TEST_DATA_DIR,
-    TestCoverageSummary, copy_file, read_file)
+from demisto_sdk.commands.coverage_analyze.coverage_report import CoverageReport
+from demisto_sdk.commands.coverage_analyze.helpers import fix_file_path, get_coverage_obj
+from demisto_sdk.commands.coverage_analyze.tests.helpers_test import (COVERAGE_FILES_DIR, JSON_MIN_DATA_FILE,
+                                                                      PYTHON_FILE_PATH, TEST_DATA_DIR,
+                                                                      TestCoverageSummary, copy_file, read_file)
 
 json = JSON_Handler()
 

--- a/demisto_sdk/commands/coverage_analyze/tests/helpers_test.py
+++ b/demisto_sdk/commands/coverage_analyze/tests/helpers_test.py
@@ -12,15 +12,9 @@ from freezegun import freeze_time
 
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.logger import logging_setup
-from demisto_sdk.commands.coverage_analyze.helpers import (CoverageSummary,
-                                                           InvalidReportType,
-                                                           coverage_files,
-                                                           export_report,
-                                                           fix_file_path,
-                                                           get_coverage_obj,
-                                                           get_report_str,
-                                                           parse_report_type,
-                                                           percent_to_float)
+from demisto_sdk.commands.coverage_analyze.helpers import (CoverageSummary, InvalidReportType, coverage_files,
+                                                           export_report, fix_file_path, get_coverage_obj,
+                                                           get_report_str, parse_report_type, percent_to_float)
 
 json = JSON_Handler()
 

--- a/demisto_sdk/commands/coverage_analyze/tests/tools_test.py
+++ b/demisto_sdk/commands/coverage_analyze/tests/tools_test.py
@@ -3,11 +3,8 @@ from datetime import datetime
 
 import pytest
 
-from demisto_sdk.commands.coverage_analyze.tests.helpers_test import (
-    JSON_MIN_DATA_FILE, TEST_DATA_DIR, read_file)
-from demisto_sdk.commands.coverage_analyze.tools import (HISTORY_URL,
-                                                         LATEST_URL,
-                                                         get_total_coverage)
+from demisto_sdk.commands.coverage_analyze.tests.helpers_test import JSON_MIN_DATA_FILE, TEST_DATA_DIR, read_file
+from demisto_sdk.commands.coverage_analyze.tools import HISTORY_URL, LATEST_URL, get_total_coverage
 
 
 class TestGetTotalCoverage:

--- a/demisto_sdk/commands/create_artifacts/artifacts_report.py
+++ b/demisto_sdk/commands/create_artifacts/artifacts_report.py
@@ -4,10 +4,9 @@ from typing import List, Union
 from tabulate import tabulate
 from wcmatch.pathlib import Path
 
-from demisto_sdk.commands.common.content.objects.abstract_objects.text_object import \
-    TextObject
-from demisto_sdk.commands.common.content.objects.pack_objects import (
-    JSONContentObject, YAMLContentObject, YAMLContentUnifiedObject)
+from demisto_sdk.commands.common.content.objects.abstract_objects.text_object import TextObject
+from demisto_sdk.commands.common.content.objects.pack_objects import (JSONContentObject, YAMLContentObject,
+                                                                      YAMLContentUnifiedObject)
 from demisto_sdk.commands.common.logger import Colors
 
 ContentObject = Union[YAMLContentUnifiedObject, YAMLContentObject, JSONContentObject, TextObject]

--- a/demisto_sdk/commands/create_artifacts/content_artifacts_creator.py
+++ b/demisto_sdk/commands/create_artifacts/content_artifacts_creator.py
@@ -13,25 +13,22 @@ from packaging.version import parse
 from pebble import ProcessFuture, ProcessPool
 from wcmatch.pathlib import BRACE, EXTMATCH, NEGATE, NODIR, SPLIT, Path
 
-from demisto_sdk.commands.common.constants import (
-    BASE_PACK, CLASSIFIERS_DIR, CONTENT_ITEMS_DISPLAY_FOLDERS,
-    CORRELATION_RULES_DIR, DASHBOARDS_DIR, DOCUMENTATION_DIR,
-    GENERIC_DEFINITIONS_DIR, GENERIC_FIELDS_DIR, GENERIC_MODULES_DIR,
-    GENERIC_TYPES_DIR, INCIDENT_FIELDS_DIR, INCIDENT_TYPES_DIR,
-    INDICATOR_FIELDS_DIR, INDICATOR_TYPES_DIR, INTEGRATIONS_DIR, JOBS_DIR,
-    LAYOUTS_DIR, LISTS_DIR, MODELING_RULES_DIR, PACKS_DIR, PARSING_RULES_DIR,
-    PLAYBOOKS_DIR, PRE_PROCESS_RULES_DIR, RELEASE_NOTES_DIR, REPORTS_DIR,
-    SCRIPTS_DIR, TEST_PLAYBOOKS_DIR, TOOLS_DIR, TRIGGER_DIR, WIDGETS_DIR,
-    WIZARDS_DIR, XDRC_TEMPLATE_DIR, XSIAM_DASHBOARDS_DIR, XSIAM_REPORTS_DIR,
-    ContentItems, FileType, MarketplaceVersions)
-from demisto_sdk.commands.common.content import (Content, ContentError,
-                                                 ContentFactoryError, Pack)
-from demisto_sdk.commands.common.content.objects.abstract_objects.text_object import \
-    TextObject
-from demisto_sdk.commands.common.content.objects.pack_objects import (
-    JSONContentObject, Script, YAMLContentObject, YAMLContentUnifiedObject)
-from demisto_sdk.commands.common.tools import (alternate_item_fields,
-                                               arg_to_list, open_id_set_file,
+from demisto_sdk.commands.common.constants import (BASE_PACK, CLASSIFIERS_DIR, CONTENT_ITEMS_DISPLAY_FOLDERS,
+                                                   CORRELATION_RULES_DIR, DASHBOARDS_DIR, DOCUMENTATION_DIR,
+                                                   GENERIC_DEFINITIONS_DIR, GENERIC_FIELDS_DIR, GENERIC_MODULES_DIR,
+                                                   GENERIC_TYPES_DIR, INCIDENT_FIELDS_DIR, INCIDENT_TYPES_DIR,
+                                                   INDICATOR_FIELDS_DIR, INDICATOR_TYPES_DIR, INTEGRATIONS_DIR,
+                                                   JOBS_DIR, LAYOUTS_DIR, LISTS_DIR, MODELING_RULES_DIR, PACKS_DIR,
+                                                   PARSING_RULES_DIR, PLAYBOOKS_DIR, PRE_PROCESS_RULES_DIR,
+                                                   RELEASE_NOTES_DIR, REPORTS_DIR, SCRIPTS_DIR, TEST_PLAYBOOKS_DIR,
+                                                   TOOLS_DIR, TRIGGER_DIR, WIDGETS_DIR, WIZARDS_DIR, XDRC_TEMPLATE_DIR,
+                                                   XSIAM_DASHBOARDS_DIR, XSIAM_REPORTS_DIR, ContentItems, FileType,
+                                                   MarketplaceVersions)
+from demisto_sdk.commands.common.content import Content, ContentError, ContentFactoryError, Pack
+from demisto_sdk.commands.common.content.objects.abstract_objects.text_object import TextObject
+from demisto_sdk.commands.common.content.objects.pack_objects import (JSONContentObject, Script, YAMLContentObject,
+                                                                      YAMLContentUnifiedObject)
+from demisto_sdk.commands.common.tools import (alternate_item_fields, arg_to_list, open_id_set_file,
                                                should_alternate_field_by_item)
 
 from .artifacts_report import ArtifactsReport, ObjectReport

--- a/demisto_sdk/commands/create_artifacts/tests/content_artifacts_creator_test.py
+++ b/demisto_sdk/commands/create_artifacts/tests/content_artifacts_creator_test.py
@@ -147,8 +147,7 @@ def test_modify_common_server_constants():
     Notes:
         - After test clean up changes.
     """
-    from demisto_sdk.commands.create_artifacts.content_artifacts_creator import \
-        modify_common_server_constants
+    from demisto_sdk.commands.create_artifacts.content_artifacts_creator import modify_common_server_constants
     path_before = COMMON_SERVER / 'CommonServerPython.py'
     path_excepted = COMMON_SERVER / 'CommonServerPython_modified.py'
     old_data = path_before.read_text()
@@ -161,8 +160,8 @@ def test_modify_common_server_constants():
 
 def test_dump_pack(mock_git):
     import demisto_sdk.commands.create_artifacts.content_artifacts_creator as cca
-    from demisto_sdk.commands.create_artifacts.content_artifacts_creator import (
-        ArtifactsManager, Pack, create_dirs, dump_pack)
+    from demisto_sdk.commands.create_artifacts.content_artifacts_creator import (ArtifactsManager, Pack, create_dirs,
+                                                                                 dump_pack)
 
     cca.logger = logging_setup(0)
 
@@ -214,8 +213,7 @@ def test_contains_indicator_type():
 
 
 def test_create_content_artifacts(mock_git):
-    from demisto_sdk.commands.create_artifacts.content_artifacts_creator import \
-        ArtifactsManager
+    from demisto_sdk.commands.create_artifacts.content_artifacts_creator import ArtifactsManager
     with temp_dir() as temp:
         config = ArtifactsManager(artifacts_path=temp,
                                   content_version='6.0.0',
@@ -238,8 +236,7 @@ def test_create_content_artifacts_by_id_set(mock_git):
     2. An item of a pack does not exist under the pack's section in the id set - the item will not exist as an artifact.
 
     """
-    from demisto_sdk.commands.create_artifacts.content_artifacts_creator import \
-        ArtifactsManager
+    from demisto_sdk.commands.create_artifacts.content_artifacts_creator import ArtifactsManager
     with temp_dir() as temp:
         config = ArtifactsManager(artifacts_path=temp,
                                   content_version='6.0.0',
@@ -257,8 +254,7 @@ def test_create_content_artifacts_by_id_set(mock_git):
 
 def test_create_private_content_artifacts(private_repo):
     from demisto_sdk.commands.common.content import Content
-    from demisto_sdk.commands.create_artifacts.content_artifacts_creator import \
-        ArtifactsManager
+    from demisto_sdk.commands.create_artifacts.content_artifacts_creator import ArtifactsManager
 
     with temp_dir() as temp:
         config = ArtifactsManager(artifacts_path=temp,
@@ -277,8 +273,7 @@ def test_create_private_content_artifacts(private_repo):
 
 @pytest.mark.parametrize(argnames="suffix", argvalues=["yml", "json"])
 def test_malformed_file_failure(suffix: str, mock_git):
-    from demisto_sdk.commands.create_artifacts.content_artifacts_creator import \
-        ArtifactsManager
+    from demisto_sdk.commands.create_artifacts.content_artifacts_creator import ArtifactsManager
     with temp_dir() as temp:
         config = ArtifactsManager(artifacts_path=temp,
                                   content_version='6.0.0',
@@ -294,8 +289,7 @@ def test_malformed_file_failure(suffix: str, mock_git):
 
 
 def test_duplicate_file_failure(mock_git):
-    from demisto_sdk.commands.create_artifacts.content_artifacts_creator import \
-        ArtifactsManager
+    from demisto_sdk.commands.create_artifacts.content_artifacts_creator import ArtifactsManager
     with temp_dir() as temp:
         config = ArtifactsManager(artifacts_path=temp,
                                   content_version='6.0.0',
@@ -325,8 +319,7 @@ def test_sign_packs_failure(repo, capsys, key, tool):
 
     """
     import demisto_sdk.commands.create_artifacts.content_artifacts_creator as cca
-    from demisto_sdk.commands.create_artifacts.content_artifacts_creator import (
-        ArtifactsManager, sign_packs)
+    from demisto_sdk.commands.create_artifacts.content_artifacts_creator import ArtifactsManager, sign_packs
 
     cca.logger = logging_setup(2)
 
@@ -365,8 +358,7 @@ def mock_single_pack_git(mocker):
 
 
 def test_use_alternative_fields(mock_single_pack_git):
-    from demisto_sdk.commands.create_artifacts.content_artifacts_creator import \
-        ArtifactsManager
+    from demisto_sdk.commands.create_artifacts.content_artifacts_creator import ArtifactsManager
 
     with temp_dir() as temp:
         config = ArtifactsManager(artifacts_path=temp,

--- a/demisto_sdk/commands/create_id_set/create_id_set.py
+++ b/demisto_sdk/commands/create_id_set/create_id_set.py
@@ -5,10 +5,8 @@ from typing import Optional
 
 from genericpath import exists
 
-from demisto_sdk.commands.common.constants import (GENERIC_COMMANDS_NAMES,
-                                                   MarketplaceVersions)
-from demisto_sdk.commands.common.content_constant_paths import (
-    DEFAULT_ID_SET_PATH, MP_V2_ID_SET_PATH)
+from demisto_sdk.commands.common.constants import GENERIC_COMMANDS_NAMES, MarketplaceVersions
+from demisto_sdk.commands.common.content_constant_paths import DEFAULT_ID_SET_PATH, MP_V2_ID_SET_PATH
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.tools import open_id_set_file
 from demisto_sdk.commands.common.update_id_set import re_create_id_set

--- a/demisto_sdk/commands/create_id_set/tests/create_id_set_test.py
+++ b/demisto_sdk/commands/create_id_set/tests/create_id_set_test.py
@@ -6,8 +6,7 @@ from tempfile import mkdtemp
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.legacy_git_tools import git_path
-from demisto_sdk.commands.common.update_id_set import (ID_SET_ENTITIES,
-                                                       ID_SET_XPANSE_ENTITIES)
+from demisto_sdk.commands.common.update_id_set import ID_SET_ENTITIES, ID_SET_XPANSE_ENTITIES
 from demisto_sdk.commands.create_id_set.create_id_set import IDSetCreator
 from TestSuite.test_tools import ChangeCWD
 from TestSuite.utils import IsEqualFunctions

--- a/demisto_sdk/commands/doc_reviewer/doc_reviewer.py
+++ b/demisto_sdk/commands/doc_reviewer/doc_reviewer.py
@@ -12,18 +12,13 @@ import nltk
 from nltk.corpus import brown, webtext
 from spellchecker import SpellChecker
 
-from demisto_sdk.commands.common.constants import (PACKS_PACK_IGNORE_FILE_NAME,
-                                                   FileType)
-from demisto_sdk.commands.common.content import (Content, Integration,
-                                                 Playbook, ReleaseNote, Script,
-                                                 path_to_pack_object)
-from demisto_sdk.commands.common.content.objects.abstract_objects import \
-    TextObject
+from demisto_sdk.commands.common.constants import PACKS_PACK_IGNORE_FILE_NAME, FileType
+from demisto_sdk.commands.common.content import Content, Integration, Playbook, ReleaseNote, Script, path_to_pack_object
+from demisto_sdk.commands.common.content.objects.abstract_objects import TextObject
 from demisto_sdk.commands.common.content.objects.pack_objects.abstract_pack_objects.yaml_content_object import \
     YAMLContentObject
 from demisto_sdk.commands.common.git_util import GitUtil
-from demisto_sdk.commands.common.tools import (add_default_pack_known_words,
-                                               find_type)
+from demisto_sdk.commands.common.tools import add_default_pack_known_words, find_type
 from demisto_sdk.commands.doc_reviewer.known_words import KNOWN_WORDS
 from demisto_sdk.commands.doc_reviewer.rn_checker import ReleaseNotesChecker
 

--- a/demisto_sdk/commands/doc_reviewer/tests/doc_reviewer_test.py
+++ b/demisto_sdk/commands/doc_reviewer/tests/doc_reviewer_test.py
@@ -8,8 +8,7 @@ import pytest
 from demisto_sdk.commands.common.constants import FileType
 from demisto_sdk.commands.common.tools import find_type, get_yaml
 from demisto_sdk.commands.doc_reviewer.doc_reviewer import DocReviewer
-from demisto_sdk.tests.integration_tests.validate_integration_test import \
-    AZURE_FEED_PACK_PATH
+from demisto_sdk.tests.integration_tests.validate_integration_test import AZURE_FEED_PACK_PATH
 from TestSuite.json_based import JSONBased
 from TestSuite.test_tools import ChangeCWD
 

--- a/demisto_sdk/commands/download/downloader.py
+++ b/demisto_sdk/commands/download/downloader.py
@@ -16,23 +16,16 @@ from mergedeep import merge
 from tabulate import tabulate
 from urllib3.exceptions import MaxRetryError
 
-from demisto_sdk.commands.common.constants import (
-    CONTENT_ENTITIES_DIRS, CONTENT_FILE_ENDINGS,
-    DELETED_JSON_FIELDS_BY_DEMISTO, DELETED_YML_FIELDS_BY_DEMISTO,
-    ENTITY_NAME_SEPARATORS, ENTITY_TYPE_TO_DIR, FILE_EXIST_REASON,
-    FILE_NOT_IN_CC_REASON, INTEGRATIONS_DIR, PLAYBOOKS_DIR, SCRIPTS_DIR,
-    TEST_PLAYBOOKS_DIR)
+from demisto_sdk.commands.common.constants import (CONTENT_ENTITIES_DIRS, CONTENT_FILE_ENDINGS,
+                                                   DELETED_JSON_FIELDS_BY_DEMISTO, DELETED_YML_FIELDS_BY_DEMISTO,
+                                                   ENTITY_NAME_SEPARATORS, ENTITY_TYPE_TO_DIR, FILE_EXIST_REASON,
+                                                   FILE_NOT_IN_CC_REASON, INTEGRATIONS_DIR, PLAYBOOKS_DIR, SCRIPTS_DIR,
+                                                   TEST_PLAYBOOKS_DIR)
 from demisto_sdk.commands.common.handlers import JSON_Handler, YAML_Handler
-from demisto_sdk.commands.common.tools import (LOG_COLORS, find_type,
-                                               get_child_directories,
-                                               get_child_files, get_code_lang,
-                                               get_dict_from_file,
-                                               get_entity_id_by_entity_type,
-                                               get_entity_name_by_entity_type,
-                                               get_files_in_dir, get_json,
-                                               get_yaml, get_yml_paths_in_dir,
-                                               print_color,
-                                               retrieve_file_ending)
+from demisto_sdk.commands.common.tools import (LOG_COLORS, find_type, get_child_directories, get_child_files,
+                                               get_code_lang, get_dict_from_file, get_entity_id_by_entity_type,
+                                               get_entity_name_by_entity_type, get_files_in_dir, get_json, get_yaml,
+                                               get_yml_paths_in_dir, print_color, retrieve_file_ending)
 from demisto_sdk.commands.format.format_module import format_manager
 from demisto_sdk.commands.split.ymlsplitter import YmlSplitter
 

--- a/demisto_sdk/commands/download/tests/downloader_test.py
+++ b/demisto_sdk/commands/download/tests/downloader_test.py
@@ -5,18 +5,17 @@ from pathlib import Path
 import pytest
 from mock import patch
 
-from demisto_sdk.commands.common.constants import (
-    CLASSIFIERS_DIR, CONNECTIONS_DIR, CONTENT_ENTITIES_DIRS, DASHBOARDS_DIR,
-    DELETED_JSON_FIELDS_BY_DEMISTO, DELETED_YML_FIELDS_BY_DEMISTO,
-    GENERIC_DEFINITIONS_DIR, GENERIC_FIELDS_DIR, GENERIC_MODULES_DIR,
-    GENERIC_TYPES_DIR, INCIDENT_FIELDS_DIR, INCIDENT_TYPES_DIR,
-    INDICATOR_FIELDS_DIR, INDICATOR_TYPES_DIR, INTEGRATIONS_DIR, JOBS_DIR,
-    LAYOUTS_DIR, LISTS_DIR, MODELING_RULES_DIR, PLAYBOOKS_DIR,
-    PRE_PROCESS_RULES_DIR, REPORTS_DIR, SCRIPTS_DIR, TEST_PLAYBOOKS_DIR,
-    WIDGETS_DIR, WIZARDS_DIR, XDRC_TEMPLATE_DIR)
+from demisto_sdk.commands.common.constants import (CLASSIFIERS_DIR, CONNECTIONS_DIR, CONTENT_ENTITIES_DIRS,
+                                                   DASHBOARDS_DIR, DELETED_JSON_FIELDS_BY_DEMISTO,
+                                                   DELETED_YML_FIELDS_BY_DEMISTO, GENERIC_DEFINITIONS_DIR,
+                                                   GENERIC_FIELDS_DIR, GENERIC_MODULES_DIR, GENERIC_TYPES_DIR,
+                                                   INCIDENT_FIELDS_DIR, INCIDENT_TYPES_DIR, INDICATOR_FIELDS_DIR,
+                                                   INDICATOR_TYPES_DIR, INTEGRATIONS_DIR, JOBS_DIR, LAYOUTS_DIR,
+                                                   LISTS_DIR, MODELING_RULES_DIR, PLAYBOOKS_DIR, PRE_PROCESS_RULES_DIR,
+                                                   REPORTS_DIR, SCRIPTS_DIR, TEST_PLAYBOOKS_DIR, WIDGETS_DIR,
+                                                   WIZARDS_DIR, XDRC_TEMPLATE_DIR)
 from demisto_sdk.commands.common.handlers import YAML_Handler
-from demisto_sdk.commands.common.tools import (get_child_files, get_json,
-                                               get_yaml)
+from demisto_sdk.commands.common.tools import get_child_files, get_json, get_yaml
 from demisto_sdk.commands.download.downloader import Downloader
 
 yaml = YAML_Handler()

--- a/demisto_sdk/commands/find_dependencies/find_dependencies.py
+++ b/demisto_sdk/commands/find_dependencies/find_dependencies.py
@@ -12,18 +12,14 @@ from packaging.version import Version
 from requests import RequestException
 
 from demisto_sdk.commands.common import constants
-from demisto_sdk.commands.common.constants import (
-    DEFAULT_CONTENT_ITEM_TO_VERSION, GENERIC_COMMANDS_NAMES,
-    IGNORED_PACKS_IN_DEPENDENCY_CALC, PACKS_DIR)
+from demisto_sdk.commands.common.constants import (DEFAULT_CONTENT_ITEM_TO_VERSION, GENERIC_COMMANDS_NAMES,
+                                                   IGNORED_PACKS_IN_DEPENDENCY_CALC, PACKS_DIR)
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.common.tools import (
-    ProcessPoolHandler, get_content_id_set, get_content_path, get_pack_name,
-    is_external_repository, item_type_to_content_items_header, print_error,
-    print_success, print_warning, wait_futures_complete)
-from demisto_sdk.commands.common.update_id_set import (
-    merge_id_sets, update_excluded_items_dict)
-from demisto_sdk.commands.create_id_set.create_id_set import (IDSetCreator,
-                                                              get_id_set)
+from demisto_sdk.commands.common.tools import (ProcessPoolHandler, get_content_id_set, get_content_path, get_pack_name,
+                                               is_external_repository, item_type_to_content_items_header, print_error,
+                                               print_success, print_warning, wait_futures_complete)
+from demisto_sdk.commands.common.update_id_set import merge_id_sets, update_excluded_items_dict
+from demisto_sdk.commands.create_id_set.create_id_set import IDSetCreator, get_id_set
 
 json = JSON_Handler()
 

--- a/demisto_sdk/commands/find_dependencies/tests/find_dependencies_test.py
+++ b/demisto_sdk/commands/find_dependencies/tests/find_dependencies_test.py
@@ -5,13 +5,13 @@ import networkx as nx
 import pytest
 
 import demisto_sdk.commands.create_id_set.create_id_set as cis
-from demisto_sdk.commands.common.constants import (
-    FILETYPE_TO_DEFAULT_FROMVERSION, FileType, MarketplaceVersions)
-from demisto_sdk.commands.find_dependencies.find_dependencies import (
-    PackDependencies, calculate_single_pack_dependencies,
-    find_dependencies_between_two_packs, get_packs_dependent_on_given_packs,
-    remove_items_from_content_entities_sections,
-    remove_items_from_packs_section)
+from demisto_sdk.commands.common.constants import FILETYPE_TO_DEFAULT_FROMVERSION, FileType, MarketplaceVersions
+from demisto_sdk.commands.find_dependencies.find_dependencies import (PackDependencies,
+                                                                      calculate_single_pack_dependencies,
+                                                                      find_dependencies_between_two_packs,
+                                                                      get_packs_dependent_on_given_packs,
+                                                                      remove_items_from_content_entities_sections,
+                                                                      remove_items_from_packs_section)
 from TestSuite.test_tools import ChangeCWD
 from TestSuite.utils import IsEqualFunctions
 

--- a/demisto_sdk/commands/format/format_module.py
+++ b/demisto_sdk/commands/format/format_module.py
@@ -4,46 +4,30 @@ from typing import Dict, List, Tuple
 
 import click
 
-from demisto_sdk.commands.common.constants import (JOB,
-                                                   TESTS_AND_DOC_DIRECTORIES,
-                                                   FileType)
+from demisto_sdk.commands.common.constants import JOB, TESTS_AND_DOC_DIRECTORIES, FileType
 from demisto_sdk.commands.common.git_util import GitUtil
-from demisto_sdk.commands.common.tools import (find_type, get_files_in_dir,
-                                               print_error, print_success,
-                                               print_warning)
+from demisto_sdk.commands.common.tools import find_type, get_files_in_dir, print_error, print_success, print_warning
 from demisto_sdk.commands.format.format_constants import SCHEMAS_PATH
-from demisto_sdk.commands.format.update_classifier import (
-    ClassifierJSONFormat, OldClassifierJSONFormat)
+from demisto_sdk.commands.format.update_classifier import ClassifierJSONFormat, OldClassifierJSONFormat
 from demisto_sdk.commands.format.update_connection import ConnectionJSONFormat
 from demisto_sdk.commands.format.update_dashboard import DashboardJSONFormat
 from demisto_sdk.commands.format.update_description import DescriptionFormat
-from demisto_sdk.commands.format.update_genericdefinition import \
-    GenericDefinitionJSONFormat
-from demisto_sdk.commands.format.update_genericfield import \
-    GenericFieldJSONFormat
-from demisto_sdk.commands.format.update_genericmodule import \
-    GenericModuleJSONFormat
-from demisto_sdk.commands.format.update_generictype import \
-    GenericTypeJSONFormat
-from demisto_sdk.commands.format.update_incidentfields import \
-    IncidentFieldJSONFormat
-from demisto_sdk.commands.format.update_incidenttype import \
-    IncidentTypesJSONFormat
-from demisto_sdk.commands.format.update_indicatorfields import \
-    IndicatorFieldJSONFormat
-from demisto_sdk.commands.format.update_indicatortype import \
-    IndicatorTypeJSONFormat
+from demisto_sdk.commands.format.update_genericdefinition import GenericDefinitionJSONFormat
+from demisto_sdk.commands.format.update_genericfield import GenericFieldJSONFormat
+from demisto_sdk.commands.format.update_genericmodule import GenericModuleJSONFormat
+from demisto_sdk.commands.format.update_generictype import GenericTypeJSONFormat
+from demisto_sdk.commands.format.update_incidentfields import IncidentFieldJSONFormat
+from demisto_sdk.commands.format.update_incidenttype import IncidentTypesJSONFormat
+from demisto_sdk.commands.format.update_indicatorfields import IndicatorFieldJSONFormat
+from demisto_sdk.commands.format.update_indicatortype import IndicatorTypeJSONFormat
 from demisto_sdk.commands.format.update_integration import IntegrationYMLFormat
 from demisto_sdk.commands.format.update_job import JobJSONFormat
 from demisto_sdk.commands.format.update_layout import LayoutBaseFormat
 from demisto_sdk.commands.format.update_lists import ListsFormat
 from demisto_sdk.commands.format.update_mapper import MapperJSONFormat
-from demisto_sdk.commands.format.update_pack_metadata import \
-    PackMetadataJsonFormat
-from demisto_sdk.commands.format.update_playbook import (PlaybookYMLFormat,
-                                                         TestPlaybookYMLFormat)
-from demisto_sdk.commands.format.update_pre_process_rules import \
-    PreProcessRulesFormat
+from demisto_sdk.commands.format.update_pack_metadata import PackMetadataJsonFormat
+from demisto_sdk.commands.format.update_playbook import PlaybookYMLFormat, TestPlaybookYMLFormat
+from demisto_sdk.commands.format.update_pre_process_rules import PreProcessRulesFormat
 from demisto_sdk.commands.format.update_pythonfile import PythonFileFormat
 from demisto_sdk.commands.format.update_readme import ReadmeFormat
 from demisto_sdk.commands.format.update_report import ReportJSONFormat

--- a/demisto_sdk/commands/format/tests/test_formatting_generic_test.py
+++ b/demisto_sdk/commands/format/tests/test_formatting_generic_test.py
@@ -1,7 +1,6 @@
 import pytest
 
-from demisto_sdk.commands.common.constants import (
-    FILETYPE_TO_DEFAULT_FROMVERSION, GENERAL_DEFAULT_FROMVERSION, FileType)
+from demisto_sdk.commands.common.constants import FILETYPE_TO_DEFAULT_FROMVERSION, GENERAL_DEFAULT_FROMVERSION, FileType
 from demisto_sdk.commands.format.format_constants import VERSION_6_0_0
 from demisto_sdk.commands.format.update_generic import BaseUpdate
 from demisto_sdk.commands.validate.validate_manager import ValidateManager

--- a/demisto_sdk/commands/format/tests/test_formatting_job_test.py
+++ b/demisto_sdk/commands/format/tests/test_formatting_job_test.py
@@ -1,7 +1,6 @@
 import pytest
 
-from demisto_sdk.commands.common.constants import (
-    FILETYPE_TO_DEFAULT_FROMVERSION, JOB, FileType)
+from demisto_sdk.commands.common.constants import FILETYPE_TO_DEFAULT_FROMVERSION, JOB, FileType
 from demisto_sdk.commands.format.format_module import run_format_on_file
 
 

--- a/demisto_sdk/commands/format/tests/test_formatting_json_test.py
+++ b/demisto_sdk/commands/format/tests/test_formatting_json_test.py
@@ -7,60 +7,51 @@ from mock import patch
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.format import (update_dashboard, update_incidenttype,
-                                         update_indicatortype)
+from demisto_sdk.commands.format import update_dashboard, update_incidenttype, update_indicatortype
 from demisto_sdk.commands.format.format_module import format_manager
-from demisto_sdk.commands.format.update_classifier import (
-    ClassifierJSONFormat, OldClassifierJSONFormat)
+from demisto_sdk.commands.format.update_classifier import ClassifierJSONFormat, OldClassifierJSONFormat
 from demisto_sdk.commands.format.update_connection import ConnectionJSONFormat
 from demisto_sdk.commands.format.update_dashboard import DashboardJSONFormat
 from demisto_sdk.commands.format.update_generic import BaseUpdate
 from demisto_sdk.commands.format.update_generic_json import BaseUpdateJSON
-from demisto_sdk.commands.format.update_genericfield import \
-    GenericFieldJSONFormat
-from demisto_sdk.commands.format.update_incidentfields import \
-    IncidentFieldJSONFormat
-from demisto_sdk.commands.format.update_incidenttype import \
-    IncidentTypesJSONFormat
-from demisto_sdk.commands.format.update_indicatorfields import \
-    IndicatorFieldJSONFormat
-from demisto_sdk.commands.format.update_indicatortype import \
-    IndicatorTypeJSONFormat
+from demisto_sdk.commands.format.update_genericfield import GenericFieldJSONFormat
+from demisto_sdk.commands.format.update_incidentfields import IncidentFieldJSONFormat
+from demisto_sdk.commands.format.update_incidenttype import IncidentTypesJSONFormat
+from demisto_sdk.commands.format.update_indicatorfields import IndicatorFieldJSONFormat
+from demisto_sdk.commands.format.update_indicatortype import IndicatorTypeJSONFormat
 from demisto_sdk.commands.format.update_layout import LayoutBaseFormat
 from demisto_sdk.commands.format.update_lists import ListsFormat
 from demisto_sdk.commands.format.update_mapper import MapperJSONFormat
-from demisto_sdk.commands.format.update_pack_metadata import \
-    PackMetadataJsonFormat
-from demisto_sdk.commands.format.update_pre_process_rules import \
-    PreProcessRulesFormat
+from demisto_sdk.commands.format.update_pack_metadata import PackMetadataJsonFormat
+from demisto_sdk.commands.format.update_pre_process_rules import PreProcessRulesFormat
 from demisto_sdk.commands.format.update_report import ReportJSONFormat
 from demisto_sdk.commands.format.update_widget import WidgetJSONFormat
-from demisto_sdk.tests.constants_test import (
-    CLASSIFIER_5_9_9_SCHEMA_PATH, CLASSIFIER_PATH, CLASSIFIER_SCHEMA_PATH,
-    CONNECTION_SCHEMA_PATH, DASHBOARD_PATH, DESTINATION_FORMAT_CLASSIFIER,
-    DESTINATION_FORMAT_CLASSIFIER_5_9_9, DESTINATION_FORMAT_DASHBOARD_COPY,
-    DESTINATION_FORMAT_INCIDENTFIELD_COPY,
-    DESTINATION_FORMAT_INCIDENTTYPE_COPY,
-    DESTINATION_FORMAT_INDICATORFIELD_COPY,
-    DESTINATION_FORMAT_INDICATORTYPE_COPY, DESTINATION_FORMAT_LAYOUT_COPY,
-    DESTINATION_FORMAT_LAYOUT_INVALID_NAME_COPY,
-    DESTINATION_FORMAT_LAYOUTS_CONTAINER_COPY, DESTINATION_FORMAT_LISTS_COPY,
-    DESTINATION_FORMAT_MAPPER, DESTINATION_FORMAT_PRE_PROCESS_RULES_COPY,
-    DESTINATION_FORMAT_PRE_PROCESS_RULES_INVALID_NAME_COPY,
-    DESTINATION_FORMAT_REPORT, DESTINATION_FORMAT_WIDGET,
-    GENERICFIELD_SCHEMA_PATH, INCIDENTFIELD_PATH, INCIDENTFIELD_SCHEMA_PATH,
-    INCIDENTTYPE_PATH, INDICATORFIELD_PATH, INDICATORFIELD_SCHEMA_PATH,
-    INDICATORTYPE_PATH, INVALID_OUTPUT_PATH, LAYOUT_PATH, LAYOUT_SCHEMA_PATH,
-    LAYOUTS_CONTAINER_PATH, LAYOUTS_CONTAINER_SCHEMA_PATH, LISTS_PATH,
-    LISTS_SCHEMA_PATH, MAPPER_PATH, MAPPER_SCHEMA_PATH, PRE_PROCESS_RULES_PATH,
-    PRE_PROCESS_RULES_SCHEMA_PATH, REPORT_PATH, SOURCE_FORMAT_CLASSIFIER,
-    SOURCE_FORMAT_CLASSIFIER_5_9_9, SOURCE_FORMAT_DASHBOARD_COPY,
-    SOURCE_FORMAT_INCIDENTFIELD_COPY, SOURCE_FORMAT_INCIDENTTYPE_COPY,
-    SOURCE_FORMAT_INDICATORFIELD_COPY, SOURCE_FORMAT_INDICATORTYPE_COPY,
-    SOURCE_FORMAT_LAYOUT_COPY, SOURCE_FORMAT_LAYOUTS_CONTAINER,
-    SOURCE_FORMAT_LAYOUTS_CONTAINER_COPY, SOURCE_FORMAT_LISTS_COPY,
-    SOURCE_FORMAT_MAPPER, SOURCE_FORMAT_PRE_PROCESS_RULES_COPY,
-    SOURCE_FORMAT_REPORT, SOURCE_FORMAT_WIDGET, WIDGET_PATH)
+from demisto_sdk.tests.constants_test import (CLASSIFIER_5_9_9_SCHEMA_PATH, CLASSIFIER_PATH, CLASSIFIER_SCHEMA_PATH,
+                                              CONNECTION_SCHEMA_PATH, DASHBOARD_PATH, DESTINATION_FORMAT_CLASSIFIER,
+                                              DESTINATION_FORMAT_CLASSIFIER_5_9_9, DESTINATION_FORMAT_DASHBOARD_COPY,
+                                              DESTINATION_FORMAT_INCIDENTFIELD_COPY,
+                                              DESTINATION_FORMAT_INCIDENTTYPE_COPY,
+                                              DESTINATION_FORMAT_INDICATORFIELD_COPY,
+                                              DESTINATION_FORMAT_INDICATORTYPE_COPY, DESTINATION_FORMAT_LAYOUT_COPY,
+                                              DESTINATION_FORMAT_LAYOUT_INVALID_NAME_COPY,
+                                              DESTINATION_FORMAT_LAYOUTS_CONTAINER_COPY, DESTINATION_FORMAT_LISTS_COPY,
+                                              DESTINATION_FORMAT_MAPPER, DESTINATION_FORMAT_PRE_PROCESS_RULES_COPY,
+                                              DESTINATION_FORMAT_PRE_PROCESS_RULES_INVALID_NAME_COPY,
+                                              DESTINATION_FORMAT_REPORT, DESTINATION_FORMAT_WIDGET,
+                                              GENERICFIELD_SCHEMA_PATH, INCIDENTFIELD_PATH, INCIDENTFIELD_SCHEMA_PATH,
+                                              INCIDENTTYPE_PATH, INDICATORFIELD_PATH, INDICATORFIELD_SCHEMA_PATH,
+                                              INDICATORTYPE_PATH, INVALID_OUTPUT_PATH, LAYOUT_PATH, LAYOUT_SCHEMA_PATH,
+                                              LAYOUTS_CONTAINER_PATH, LAYOUTS_CONTAINER_SCHEMA_PATH, LISTS_PATH,
+                                              LISTS_SCHEMA_PATH, MAPPER_PATH, MAPPER_SCHEMA_PATH,
+                                              PRE_PROCESS_RULES_PATH, PRE_PROCESS_RULES_SCHEMA_PATH, REPORT_PATH,
+                                              SOURCE_FORMAT_CLASSIFIER, SOURCE_FORMAT_CLASSIFIER_5_9_9,
+                                              SOURCE_FORMAT_DASHBOARD_COPY, SOURCE_FORMAT_INCIDENTFIELD_COPY,
+                                              SOURCE_FORMAT_INCIDENTTYPE_COPY, SOURCE_FORMAT_INDICATORFIELD_COPY,
+                                              SOURCE_FORMAT_INDICATORTYPE_COPY, SOURCE_FORMAT_LAYOUT_COPY,
+                                              SOURCE_FORMAT_LAYOUTS_CONTAINER, SOURCE_FORMAT_LAYOUTS_CONTAINER_COPY,
+                                              SOURCE_FORMAT_LISTS_COPY, SOURCE_FORMAT_MAPPER,
+                                              SOURCE_FORMAT_PRE_PROCESS_RULES_COPY, SOURCE_FORMAT_REPORT,
+                                              SOURCE_FORMAT_WIDGET, WIDGET_PATH)
 from TestSuite.json_based import JSONBased
 
 json = JSON_Handler()
@@ -767,8 +758,7 @@ class TestFormattingLayoutscontainer:
         Then
             - Ensure that fromVersion field was updated successfully with GENERAL_DEFAULT_FROMVERSION value
         """
-        from demisto_sdk.commands.common.constants import \
-            GENERAL_DEFAULT_FROMVERSION
+        from demisto_sdk.commands.common.constants import GENERAL_DEFAULT_FROMVERSION
 
         layoutscontainer_formatter.from_version = GENERAL_DEFAULT_FROMVERSION
         layoutscontainer_formatter.set_fromVersion()
@@ -1083,8 +1073,7 @@ class TestFormattingClassifier:
         Then
             - Ensure that fromVersion field was updated successfully with '6.0.0' value
         """
-        from demisto_sdk.commands.common.constants import \
-            GENERAL_DEFAULT_FROMVERSION
+        from demisto_sdk.commands.common.constants import GENERAL_DEFAULT_FROMVERSION
 
         classifier_formatter.from_version = GENERAL_DEFAULT_FROMVERSION
         classifier_formatter.set_fromVersion()
@@ -1276,8 +1265,7 @@ class TestFormattingMapper:
         Then
             - Ensure that fromVersion field was updated successfully with GENERAL_DEFAULT_FROMVERSION value
         """
-        from demisto_sdk.commands.common.constants import \
-            GENERAL_DEFAULT_FROMVERSION
+        from demisto_sdk.commands.common.constants import GENERAL_DEFAULT_FROMVERSION
 
         mapper_formatter.from_version = GENERAL_DEFAULT_FROMVERSION
         mapper_formatter.set_fromVersion()
@@ -1471,8 +1459,7 @@ class TestFormattingReport:
         Then
             - Ensure that the integration fromversion is set to GENERAL_DEFAULT_FROMVERSION
         """
-        from demisto_sdk.commands.common.constants import \
-            GENERAL_DEFAULT_FROMVERSION
+        from demisto_sdk.commands.common.constants import GENERAL_DEFAULT_FROMVERSION
 
         pack.pack_metadata.update({'support': 'partner', 'currentVersion': '1.0.0'})
         incident_type = pack.create_incident_type(name='TestType', content={})
@@ -1490,8 +1477,7 @@ class TestFormattingReport:
         Then
             - Ensure that the integration fromversion is set to GENERAL_DEFAULT_FROMVERSION
         """
-        from demisto_sdk.commands.common.constants import \
-            GENERAL_DEFAULT_FROMVERSION
+        from demisto_sdk.commands.common.constants import GENERAL_DEFAULT_FROMVERSION
 
         pack.pack_metadata.update({'support': 'partner', 'currentVersion': '1.0.0'})
         incident_type = pack.create_incident_type(name='TestType')

--- a/demisto_sdk/commands/format/tests/test_formatting_md_test.py
+++ b/demisto_sdk/commands/format/tests/test_formatting_md_test.py
@@ -1,9 +1,8 @@
 from demisto_sdk.commands.format.update_description import DescriptionFormat
-from demisto_sdk.tests.constants_test import (
-    SOURCE_DESCRIPTION_FORMATTED_CONTRIB_DETAILS,
-    SOURCE_DESCRIPTION_FORMATTED_WITH_BETA_DESCRIPTION,
-    SOURCE_DESCRIPTION_WITH_CONTRIB_DETAILS,
-    SOURCE_DESCRIPTION_WITHOUT_BETA_DESCRIPTION)
+from demisto_sdk.tests.constants_test import (SOURCE_DESCRIPTION_FORMATTED_CONTRIB_DETAILS,
+                                              SOURCE_DESCRIPTION_FORMATTED_WITH_BETA_DESCRIPTION,
+                                              SOURCE_DESCRIPTION_WITH_CONTRIB_DETAILS,
+                                              SOURCE_DESCRIPTION_WITHOUT_BETA_DESCRIPTION)
 
 
 class TestDescriptionFormat:

--- a/demisto_sdk/commands/format/tests/test_formatting_readme_test.py
+++ b/demisto_sdk/commands/format/tests/test_formatting_readme_test.py
@@ -16,8 +16,7 @@ def test_format_wit_update_docker_flag(mocker):
     (but has a node), that the run ends without any exception.
     """
     from demisto_sdk.commands.common.git_util import GitUtil
-    from demisto_sdk.commands.common.hook_validations.readme import \
-        ReadMeValidator
+    from demisto_sdk.commands.common.hook_validations.readme import ReadMeValidator
     from demisto_sdk.commands.format.format_module import format_manager
     from demisto_sdk.commands.validate.validate_manager import ValidateManager
     mocker.patch.object(ReadMeValidator, 'are_modules_installed_for_verify', return_value=False)

--- a/demisto_sdk/commands/format/tests/test_formatting_yml_test.py
+++ b/demisto_sdk/commands/format/tests/test_formatting_yml_test.py
@@ -9,35 +9,31 @@ import click
 import pytest
 from mock import Mock, patch
 
-from demisto_sdk.commands.common.constants import (
-    ALERT_FETCH_REQUIRED_PARAMS, FEED_REQUIRED_PARAMS,
-    GENERAL_DEFAULT_FROMVERSION, INCIDENT_FETCH_REQUIRED_PARAMS,
-    NO_TESTS_DEPRECATED, MarketplaceVersions)
+from demisto_sdk.commands.common.constants import (ALERT_FETCH_REQUIRED_PARAMS, FEED_REQUIRED_PARAMS,
+                                                   GENERAL_DEFAULT_FROMVERSION, INCIDENT_FETCH_REQUIRED_PARAMS,
+                                                   NO_TESTS_DEPRECATED, MarketplaceVersions)
 from demisto_sdk.commands.common.handlers import YAML_Handler
-from demisto_sdk.commands.common.hook_validations.docker import \
-    DockerImageValidator
-from demisto_sdk.commands.common.hook_validations.integration import \
-    IntegrationValidator
+from demisto_sdk.commands.common.hook_validations.docker import DockerImageValidator
+from demisto_sdk.commands.common.hook_validations.integration import IntegrationValidator
 from demisto_sdk.commands.common.legacy_git_tools import git_path
 from demisto_sdk.commands.common.tools import LOG_COLORS, is_string_uuid
 from demisto_sdk.commands.format.format_module import format_manager
 from demisto_sdk.commands.format.update_generic import BaseUpdate
 from demisto_sdk.commands.format.update_generic_yml import BaseUpdateYML
 from demisto_sdk.commands.format.update_integration import IntegrationYMLFormat
-from demisto_sdk.commands.format.update_playbook import (PlaybookYMLFormat,
-                                                         TestPlaybookYMLFormat)
+from demisto_sdk.commands.format.update_playbook import PlaybookYMLFormat, TestPlaybookYMLFormat
 from demisto_sdk.commands.format.update_script import ScriptYMLFormat
-from demisto_sdk.tests.constants_test import (
-    DESTINATION_FORMAT_INTEGRATION, DESTINATION_FORMAT_INTEGRATION_COPY,
-    DESTINATION_FORMAT_PLAYBOOK, DESTINATION_FORMAT_PLAYBOOK_COPY,
-    DESTINATION_FORMAT_SCRIPT_COPY, DESTINATION_FORMAT_TEST_PLAYBOOK,
-    FEED_INTEGRATION_EMPTY_VALID, FEED_INTEGRATION_INVALID,
-    FEED_INTEGRATION_VALID, GIT_ROOT, INTEGRATION_PATH, PLAYBOOK_PATH,
-    PLAYBOOK_WITH_INCIDENT_INDICATOR_SCRIPTS, SOURCE_BETA_INTEGRATION_FILE,
-    SOURCE_FORMAT_INTEGRATION_COPY, SOURCE_FORMAT_INTEGRATION_DEFAULT_VALUE,
-    SOURCE_FORMAT_INTEGRATION_INVALID, SOURCE_FORMAT_INTEGRATION_VALID,
-    SOURCE_FORMAT_PLAYBOOK, SOURCE_FORMAT_PLAYBOOK_COPY,
-    SOURCE_FORMAT_SCRIPT_COPY, SOURCE_FORMAT_TEST_PLAYBOOK, TEST_PLAYBOOK_PATH)
+from demisto_sdk.tests.constants_test import (DESTINATION_FORMAT_INTEGRATION, DESTINATION_FORMAT_INTEGRATION_COPY,
+                                              DESTINATION_FORMAT_PLAYBOOK, DESTINATION_FORMAT_PLAYBOOK_COPY,
+                                              DESTINATION_FORMAT_SCRIPT_COPY, DESTINATION_FORMAT_TEST_PLAYBOOK,
+                                              FEED_INTEGRATION_EMPTY_VALID, FEED_INTEGRATION_INVALID,
+                                              FEED_INTEGRATION_VALID, GIT_ROOT, INTEGRATION_PATH, PLAYBOOK_PATH,
+                                              PLAYBOOK_WITH_INCIDENT_INDICATOR_SCRIPTS, SOURCE_BETA_INTEGRATION_FILE,
+                                              SOURCE_FORMAT_INTEGRATION_COPY, SOURCE_FORMAT_INTEGRATION_DEFAULT_VALUE,
+                                              SOURCE_FORMAT_INTEGRATION_INVALID, SOURCE_FORMAT_INTEGRATION_VALID,
+                                              SOURCE_FORMAT_PLAYBOOK, SOURCE_FORMAT_PLAYBOOK_COPY,
+                                              SOURCE_FORMAT_SCRIPT_COPY, SOURCE_FORMAT_TEST_PLAYBOOK,
+                                              TEST_PLAYBOOK_PATH)
 from TestSuite.test_tools import ChangeCWD
 
 yaml = YAML_Handler()
@@ -91,8 +87,7 @@ class TestFormatting:
         base_yml = IntegrationYMLFormat(source_path, path=schema_path)
         base_yml.set_params_default_additional_info()
 
-        from demisto_sdk.commands.common.default_additional_info_loader import \
-            load_default_additional_info_dict
+        from demisto_sdk.commands.common.default_additional_info_loader import load_default_additional_info_dict
         default_additional_info = load_default_additional_info_dict()
 
         api_key_param = base_yml.data['configuration'][4]
@@ -1058,8 +1053,7 @@ class TestFormatting:
         Then
             - Ensure that the integration fromversion is set to GENERAL_DEFAULT_FROMVERSION
         """
-        from demisto_sdk.commands.common.constants import \
-            GENERAL_DEFAULT_FROMVERSION
+        from demisto_sdk.commands.common.constants import GENERAL_DEFAULT_FROMVERSION
 
         pack.pack_metadata.update({'support': 'partner', 'currentVersion': '1.0.0'})
         integration = pack.create_integration()
@@ -1076,8 +1070,7 @@ class TestFormatting:
         Then
             - Ensure that the integration fromversion is set to GENERAL_DEFAULT_FROMVERSION
         """
-        from demisto_sdk.commands.common.constants import \
-            GENERAL_DEFAULT_FROMVERSION
+        from demisto_sdk.commands.common.constants import GENERAL_DEFAULT_FROMVERSION
 
         pack.pack_metadata.update({'support': 'partner', 'currentVersion': '1.0.0'})
         script = pack.create_script()

--- a/demisto_sdk/commands/format/update_classifier.py
+++ b/demisto_sdk/commands/format/update_classifier.py
@@ -4,9 +4,7 @@ from typing import Tuple
 import click
 
 from demisto_sdk.commands.common.constants import FileType
-from demisto_sdk.commands.format.format_constants import (ERROR_RETURN_CODE,
-                                                          SKIP_RETURN_CODE,
-                                                          SUCCESS_RETURN_CODE,
+from demisto_sdk.commands.format.format_constants import (ERROR_RETURN_CODE, SKIP_RETURN_CODE, SUCCESS_RETURN_CODE,
                                                           VERSION_6_0_0)
 from demisto_sdk.commands.format.update_generic_json import BaseUpdateJSON
 

--- a/demisto_sdk/commands/format/update_connection.py
+++ b/demisto_sdk/commands/format/update_connection.py
@@ -2,9 +2,7 @@ from typing import Tuple
 
 import click
 
-from demisto_sdk.commands.format.format_constants import (ERROR_RETURN_CODE,
-                                                          SKIP_RETURN_CODE,
-                                                          SUCCESS_RETURN_CODE)
+from demisto_sdk.commands.format.format_constants import ERROR_RETURN_CODE, SKIP_RETURN_CODE, SUCCESS_RETURN_CODE
 from demisto_sdk.commands.format.update_generic_json import BaseUpdateJSON
 
 

--- a/demisto_sdk/commands/format/update_dashboard.py
+++ b/demisto_sdk/commands/format/update_dashboard.py
@@ -2,9 +2,7 @@ from typing import Tuple
 
 import click
 
-from demisto_sdk.commands.format.format_constants import (ERROR_RETURN_CODE,
-                                                          SKIP_RETURN_CODE,
-                                                          SUCCESS_RETURN_CODE)
+from demisto_sdk.commands.format.format_constants import ERROR_RETURN_CODE, SKIP_RETURN_CODE, SUCCESS_RETURN_CODE
 from demisto_sdk.commands.format.update_generic_json import BaseUpdateJSON
 
 

--- a/demisto_sdk/commands/format/update_description.py
+++ b/demisto_sdk/commands/format/update_description.py
@@ -5,9 +5,7 @@ import click
 
 from demisto_sdk.commands.common.constants import BETA_INTEGRATION_DISCLAIMER
 from demisto_sdk.commands.common.tools import find_type
-from demisto_sdk.commands.format.format_constants import (ERROR_RETURN_CODE,
-                                                          SKIP_RETURN_CODE,
-                                                          SUCCESS_RETURN_CODE)
+from demisto_sdk.commands.format.format_constants import ERROR_RETURN_CODE, SKIP_RETURN_CODE, SUCCESS_RETURN_CODE
 from demisto_sdk.commands.format.update_generic import BaseUpdate
 
 CONTRIBUTOR_DETAILED_DESC = 'Contributed Integration'

--- a/demisto_sdk/commands/format/update_generic.py
+++ b/demisto_sdk/commands/format/update_generic.py
@@ -6,16 +6,13 @@ from typing import Any, Dict, Set, Union
 import click
 import dictdiffer
 
-from demisto_sdk.commands.common.constants import (GENERAL_DEFAULT_FROMVERSION,
-                                                   VERSION_5_5_0)
+from demisto_sdk.commands.common.constants import GENERAL_DEFAULT_FROMVERSION, VERSION_5_5_0
 from demisto_sdk.commands.common.handlers import YAML_Handler
-from demisto_sdk.commands.common.tools import (LOG_COLORS, get_dict_from_file,
-                                               get_max_version,
-                                               get_remote_file,
+from demisto_sdk.commands.common.tools import (LOG_COLORS, get_dict_from_file, get_max_version, get_remote_file,
                                                is_file_from_content_repo)
-from demisto_sdk.commands.format.format_constants import (
-    DEFAULT_VERSION, ERROR_RETURN_CODE, JSON_FROM_SERVER_VERSION_KEY,
-    OLD_FILE_TYPES, SKIP_RETURN_CODE, SUCCESS_RETURN_CODE)
+from demisto_sdk.commands.format.format_constants import (DEFAULT_VERSION, ERROR_RETURN_CODE,
+                                                          JSON_FROM_SERVER_VERSION_KEY, OLD_FILE_TYPES,
+                                                          SKIP_RETURN_CODE, SUCCESS_RETURN_CODE)
 from demisto_sdk.commands.validate.validate_manager import ValidateManager
 
 yaml = YAML_Handler(allow_duplicate_keys=True)

--- a/demisto_sdk/commands/format/update_generic_json.py
+++ b/demisto_sdk/commands/format/update_generic_json.py
@@ -3,12 +3,10 @@ from typing import Optional
 
 import click
 
-from demisto_sdk.commands.common.constants import \
-    DEFAULT_CONTENT_ITEM_TO_VERSION
+from demisto_sdk.commands.common.constants import DEFAULT_CONTENT_ITEM_TO_VERSION
 from demisto_sdk.commands.common.handlers import JSON_Handler, YAML_Handler
 from demisto_sdk.commands.common.tools import is_uuid, print_error
-from demisto_sdk.commands.format.format_constants import (
-    ARGUMENTS_DEFAULT_VALUES, TO_VERSION_5_9_9)
+from demisto_sdk.commands.format.format_constants import ARGUMENTS_DEFAULT_VALUES, TO_VERSION_5_9_9
 from demisto_sdk.commands.format.update_generic import BaseUpdate
 
 yaml = YAML_Handler()

--- a/demisto_sdk/commands/format/update_generic_yml.py
+++ b/demisto_sdk/commands/format/update_generic_yml.py
@@ -3,18 +3,13 @@ from typing import Dict, List, Optional
 
 import click
 
-from demisto_sdk.commands.common.constants import (ENTITY_TYPE_TO_DIR,
-                                                   INTEGRATION,
-                                                   NO_TESTS_DEPRECATED,
-                                                   PLAYBOOK,
-                                                   TEST_PLAYBOOKS_DIR,
-                                                   FileType)
+from demisto_sdk.commands.common.constants import (ENTITY_TYPE_TO_DIR, INTEGRATION, NO_TESTS_DEPRECATED, PLAYBOOK,
+                                                   TEST_PLAYBOOKS_DIR, FileType)
 from demisto_sdk.commands.common.content_constant_paths import CONF_PATH
 from demisto_sdk.commands.common.handlers import JSON_Handler, YAML_Handler
-from demisto_sdk.commands.common.tools import (
-    _get_file_id, find_type, get_entity_id_by_entity_type,
-    get_not_registered_tests, get_scripts_and_commands_from_yml_data, get_yaml,
-    is_uuid, listdir_fullpath)
+from demisto_sdk.commands.common.tools import (_get_file_id, find_type, get_entity_id_by_entity_type,
+                                               get_not_registered_tests, get_scripts_and_commands_from_yml_data,
+                                               get_yaml, is_uuid, listdir_fullpath)
 from demisto_sdk.commands.format.update_generic import BaseUpdate
 
 json = JSON_Handler()

--- a/demisto_sdk/commands/format/update_genericdefinition.py
+++ b/demisto_sdk/commands/format/update_genericdefinition.py
@@ -2,11 +2,8 @@ from typing import Tuple
 
 import click
 
-from demisto_sdk.commands.common.constants import (
-    FILETYPE_TO_DEFAULT_FROMVERSION, FileType)
-from demisto_sdk.commands.format.format_constants import (ERROR_RETURN_CODE,
-                                                          SKIP_RETURN_CODE,
-                                                          SUCCESS_RETURN_CODE)
+from demisto_sdk.commands.common.constants import FILETYPE_TO_DEFAULT_FROMVERSION, FileType
+from demisto_sdk.commands.format.format_constants import ERROR_RETURN_CODE, SKIP_RETURN_CODE, SUCCESS_RETURN_CODE
 from demisto_sdk.commands.format.update_generic_json import BaseUpdateJSON
 
 

--- a/demisto_sdk/commands/format/update_genericfield.py
+++ b/demisto_sdk/commands/format/update_genericfield.py
@@ -2,11 +2,10 @@ from typing import Tuple
 
 import click
 
-from demisto_sdk.commands.common.constants import (
-    FILETYPE_TO_DEFAULT_FROMVERSION, FileType)
-from demisto_sdk.commands.format.format_constants import (
-    ERROR_RETURN_CODE, GENERIC_FIELD_DEFAULT_GROUP,
-    GENERIC_FIELD_DEFAULT_ID_PREFIX, SKIP_RETURN_CODE, SUCCESS_RETURN_CODE)
+from demisto_sdk.commands.common.constants import FILETYPE_TO_DEFAULT_FROMVERSION, FileType
+from demisto_sdk.commands.format.format_constants import (ERROR_RETURN_CODE, GENERIC_FIELD_DEFAULT_GROUP,
+                                                          GENERIC_FIELD_DEFAULT_ID_PREFIX, SKIP_RETURN_CODE,
+                                                          SUCCESS_RETURN_CODE)
 from demisto_sdk.commands.format.update_generic_json import BaseUpdateJSON
 
 

--- a/demisto_sdk/commands/format/update_genericmodule.py
+++ b/demisto_sdk/commands/format/update_genericmodule.py
@@ -2,11 +2,8 @@ from typing import Tuple
 
 import click
 
-from demisto_sdk.commands.common.constants import (
-    FILETYPE_TO_DEFAULT_FROMVERSION, FileType)
-from demisto_sdk.commands.format.format_constants import (ERROR_RETURN_CODE,
-                                                          SKIP_RETURN_CODE,
-                                                          SUCCESS_RETURN_CODE)
+from demisto_sdk.commands.common.constants import FILETYPE_TO_DEFAULT_FROMVERSION, FileType
+from demisto_sdk.commands.format.format_constants import ERROR_RETURN_CODE, SKIP_RETURN_CODE, SUCCESS_RETURN_CODE
 from demisto_sdk.commands.format.update_generic_json import BaseUpdateJSON
 
 

--- a/demisto_sdk/commands/format/update_generictype.py
+++ b/demisto_sdk/commands/format/update_generictype.py
@@ -2,11 +2,8 @@ from typing import Tuple
 
 import click
 
-from demisto_sdk.commands.common.constants import (
-    FILETYPE_TO_DEFAULT_FROMVERSION, FileType)
-from demisto_sdk.commands.format.format_constants import (ERROR_RETURN_CODE,
-                                                          SKIP_RETURN_CODE,
-                                                          SUCCESS_RETURN_CODE)
+from demisto_sdk.commands.common.constants import FILETYPE_TO_DEFAULT_FROMVERSION, FileType
+from demisto_sdk.commands.format.format_constants import ERROR_RETURN_CODE, SKIP_RETURN_CODE, SUCCESS_RETURN_CODE
 from demisto_sdk.commands.format.update_generic_json import BaseUpdateJSON
 
 

--- a/demisto_sdk/commands/format/update_incidentfields.py
+++ b/demisto_sdk/commands/format/update_incidentfields.py
@@ -3,12 +3,8 @@ from typing import List, Tuple
 import click
 
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.common.tools import (get_dict_from_file,
-                                               get_item_marketplaces,
-                                               open_id_set_file)
-from demisto_sdk.commands.format.format_constants import (ERROR_RETURN_CODE,
-                                                          SKIP_RETURN_CODE,
-                                                          SUCCESS_RETURN_CODE)
+from demisto_sdk.commands.common.tools import get_dict_from_file, get_item_marketplaces, open_id_set_file
+from demisto_sdk.commands.format.format_constants import ERROR_RETURN_CODE, SKIP_RETURN_CODE, SUCCESS_RETURN_CODE
 from demisto_sdk.commands.format.update_generic_json import BaseUpdateJSON
 
 json = JSON_Handler()

--- a/demisto_sdk/commands/format/update_incidenttype.py
+++ b/demisto_sdk/commands/format/update_incidenttype.py
@@ -2,9 +2,7 @@ from typing import Tuple
 
 import click
 
-from demisto_sdk.commands.format.format_constants import (ERROR_RETURN_CODE,
-                                                          SKIP_RETURN_CODE,
-                                                          SUCCESS_RETURN_CODE)
+from demisto_sdk.commands.format.format_constants import ERROR_RETURN_CODE, SKIP_RETURN_CODE, SUCCESS_RETURN_CODE
 from demisto_sdk.commands.format.update_generic_json import BaseUpdateJSON
 
 

--- a/demisto_sdk/commands/format/update_indicatorfields.py
+++ b/demisto_sdk/commands/format/update_indicatorfields.py
@@ -2,11 +2,8 @@ from typing import Tuple
 
 import click
 
-from demisto_sdk.commands.common.constants import \
-    INDICATOR_FIELD_TYPE_TO_MIN_VERSION
-from demisto_sdk.commands.format.format_constants import (ERROR_RETURN_CODE,
-                                                          SKIP_RETURN_CODE,
-                                                          SUCCESS_RETURN_CODE)
+from demisto_sdk.commands.common.constants import INDICATOR_FIELD_TYPE_TO_MIN_VERSION
+from demisto_sdk.commands.format.format_constants import ERROR_RETURN_CODE, SKIP_RETURN_CODE, SUCCESS_RETURN_CODE
 from demisto_sdk.commands.format.update_generic_json import BaseUpdateJSON
 
 

--- a/demisto_sdk/commands/format/update_indicatortype.py
+++ b/demisto_sdk/commands/format/update_indicatortype.py
@@ -2,9 +2,7 @@ from typing import Tuple
 
 import click
 
-from demisto_sdk.commands.format.format_constants import (ERROR_RETURN_CODE,
-                                                          SKIP_RETURN_CODE,
-                                                          SUCCESS_RETURN_CODE)
+from demisto_sdk.commands.format.format_constants import ERROR_RETURN_CODE, SKIP_RETURN_CODE, SUCCESS_RETURN_CODE
 from demisto_sdk.commands.format.update_generic_json import BaseUpdateJSON
 
 

--- a/demisto_sdk/commands/format/update_integration.py
+++ b/demisto_sdk/commands/format/update_integration.py
@@ -3,16 +3,12 @@ from typing import Tuple
 
 import click
 
-from demisto_sdk.commands.common.constants import (
-    ALERT_FETCH_REQUIRED_PARAMS, BANG_COMMAND_NAMES, BETA_INTEGRATION,
-    FEED_REQUIRED_PARAMS, INCIDENT_FETCH_REQUIRED_PARAMS, INTEGRATION,
-    TYPE_PWSH, MarketplaceVersions, ParameterType)
+from demisto_sdk.commands.common.constants import (ALERT_FETCH_REQUIRED_PARAMS, BANG_COMMAND_NAMES, BETA_INTEGRATION,
+                                                   FEED_REQUIRED_PARAMS, INCIDENT_FETCH_REQUIRED_PARAMS, INTEGRATION,
+                                                   TYPE_PWSH, MarketplaceVersions, ParameterType)
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.common.tools import (find_type,
-                                               get_item_marketplaces, get_json)
-from demisto_sdk.commands.format.format_constants import (ERROR_RETURN_CODE,
-                                                          SKIP_RETURN_CODE,
-                                                          SUCCESS_RETURN_CODE)
+from demisto_sdk.commands.common.tools import find_type, get_item_marketplaces, get_json
+from demisto_sdk.commands.format.format_constants import ERROR_RETURN_CODE, SKIP_RETURN_CODE, SUCCESS_RETURN_CODE
 from demisto_sdk.commands.format.update_generic_yml import BaseUpdateYML
 from demisto_sdk.commands.format.update_script import ScriptYMLFormat
 
@@ -68,8 +64,7 @@ class IntegrationYMLFormat(BaseUpdateYML):
                 integration_argument['type'] = 8
 
     def set_params_default_additional_info(self):
-        from demisto_sdk.commands.common.default_additional_info_loader import \
-            load_default_additional_info_dict
+        from demisto_sdk.commands.common.default_additional_info_loader import load_default_additional_info_dict
 
         default_additional_info = load_default_additional_info_dict()
 

--- a/demisto_sdk/commands/format/update_job.py
+++ b/demisto_sdk/commands/format/update_job.py
@@ -2,11 +2,8 @@ import traceback
 
 import click
 
-from demisto_sdk.commands.common.constants import (
-    FILETYPE_TO_DEFAULT_FROMVERSION, FileType)
-from demisto_sdk.commands.format.format_constants import (ERROR_RETURN_CODE,
-                                                          SKIP_RETURN_CODE,
-                                                          SUCCESS_RETURN_CODE)
+from demisto_sdk.commands.common.constants import FILETYPE_TO_DEFAULT_FROMVERSION, FileType
+from demisto_sdk.commands.format.format_constants import ERROR_RETURN_CODE, SKIP_RETURN_CODE, SUCCESS_RETURN_CODE
 from demisto_sdk.commands.format.update_generic_json import BaseUpdateJSON
 
 SELECTED_FEEDS = 'selectedFeeds'

--- a/demisto_sdk/commands/format/update_layout.py
+++ b/demisto_sdk/commands/format/update_layout.py
@@ -6,18 +6,16 @@ from typing import Dict, List, Tuple
 
 import click
 
-from demisto_sdk.commands.common.constants import (
-    LAYOUT_AND_MAPPER_BUILT_IN_FIELDS, FileType)
+from demisto_sdk.commands.common.constants import LAYOUT_AND_MAPPER_BUILT_IN_FIELDS, FileType
 from demisto_sdk.commands.common.handlers import YAML_Handler
-from demisto_sdk.commands.common.tools import (
-    LAYOUT_CONTAINER_FIELDS, LOG_COLORS,
-    get_all_incident_and_indicator_fields_from_id_set,
-    get_invalid_incident_fields_from_layout, normalize_field_name, print_color,
-    print_error, remove_copy_and_dev_suffixes_from_str)
+from demisto_sdk.commands.common.tools import (LAYOUT_CONTAINER_FIELDS, LOG_COLORS,
+                                               get_all_incident_and_indicator_fields_from_id_set,
+                                               get_invalid_incident_fields_from_layout, normalize_field_name,
+                                               print_color, print_error, remove_copy_and_dev_suffixes_from_str)
 from demisto_sdk.commands.common.update_id_set import BUILT_IN_FIELDS
-from demisto_sdk.commands.format.format_constants import (
-    DEFAULT_VERSION, ERROR_RETURN_CODE, NEW_FILE_DEFAULT_5_FROMVERSION,
-    SKIP_RETURN_CODE, SUCCESS_RETURN_CODE, VERSION_6_0_0)
+from demisto_sdk.commands.format.format_constants import (DEFAULT_VERSION, ERROR_RETURN_CODE,
+                                                          NEW_FILE_DEFAULT_5_FROMVERSION, SKIP_RETURN_CODE,
+                                                          SUCCESS_RETURN_CODE, VERSION_6_0_0)
 from demisto_sdk.commands.format.update_generic_json import BaseUpdateJSON
 
 yaml = YAML_Handler()

--- a/demisto_sdk/commands/format/update_lists.py
+++ b/demisto_sdk/commands/format/update_lists.py
@@ -3,11 +3,8 @@ from typing import Tuple
 
 import click
 
-from demisto_sdk.commands.common.constants import (
-    FILETYPE_TO_DEFAULT_FROMVERSION, FileType)
-from demisto_sdk.commands.format.format_constants import (ERROR_RETURN_CODE,
-                                                          SKIP_RETURN_CODE,
-                                                          SUCCESS_RETURN_CODE)
+from demisto_sdk.commands.common.constants import FILETYPE_TO_DEFAULT_FROMVERSION, FileType
+from demisto_sdk.commands.format.format_constants import ERROR_RETURN_CODE, SKIP_RETURN_CODE, SUCCESS_RETURN_CODE
 from demisto_sdk.commands.format.update_generic_json import BaseUpdateJSON
 
 MIN_FROM_VERSION_LISTS = '6.5.0'

--- a/demisto_sdk/commands/format/update_mapper.py
+++ b/demisto_sdk/commands/format/update_mapper.py
@@ -3,15 +3,11 @@ from typing import Tuple
 
 import click
 
-from demisto_sdk.commands.common.constants import \
-    LAYOUT_AND_MAPPER_BUILT_IN_FIELDS
-from demisto_sdk.commands.common.tools import (
-    get_all_incident_and_indicator_fields_from_id_set,
-    get_invalid_incident_fields_from_mapper)
+from demisto_sdk.commands.common.constants import LAYOUT_AND_MAPPER_BUILT_IN_FIELDS
+from demisto_sdk.commands.common.tools import (get_all_incident_and_indicator_fields_from_id_set,
+                                               get_invalid_incident_fields_from_mapper)
 from demisto_sdk.commands.common.update_id_set import BUILT_IN_FIELDS
-from demisto_sdk.commands.format.format_constants import (ERROR_RETURN_CODE,
-                                                          SKIP_RETURN_CODE,
-                                                          SUCCESS_RETURN_CODE)
+from demisto_sdk.commands.format.format_constants import ERROR_RETURN_CODE, SKIP_RETURN_CODE, SUCCESS_RETURN_CODE
 from demisto_sdk.commands.format.update_generic_json import BaseUpdateJSON
 
 logger = logging.getLogger('demisto-sdk')

--- a/demisto_sdk/commands/format/update_pack_metadata.py
+++ b/demisto_sdk/commands/format/update_pack_metadata.py
@@ -4,9 +4,7 @@ import os
 import click
 
 from demisto_sdk.commands.common.content.objects.pack_objects.pack import Pack
-from demisto_sdk.commands.format.format_constants import (ERROR_RETURN_CODE,
-                                                          SKIP_RETURN_CODE,
-                                                          SUCCESS_RETURN_CODE)
+from demisto_sdk.commands.format.format_constants import ERROR_RETURN_CODE, SKIP_RETURN_CODE, SUCCESS_RETURN_CODE
 from demisto_sdk.commands.format.update_generic_json import BaseUpdateJSON
 
 logger = logging.getLogger('demisto-sdk')

--- a/demisto_sdk/commands/format/update_playbook.py
+++ b/demisto_sdk/commands/format/update_playbook.py
@@ -7,12 +7,9 @@ from git import InvalidGitRepositoryError
 
 from demisto_sdk.commands.common.constants import PLAYBOOK, FileType
 from demisto_sdk.commands.common.git_util import GitUtil
-from demisto_sdk.commands.common.tools import (
-    find_type, get_yaml, is_string_uuid, remove_copy_and_dev_suffixes_from_str,
-    write_yml)
-from demisto_sdk.commands.format.format_constants import (ERROR_RETURN_CODE,
-                                                          SCHEMAS_PATH,
-                                                          SKIP_RETURN_CODE,
+from demisto_sdk.commands.common.tools import (find_type, get_yaml, is_string_uuid,
+                                               remove_copy_and_dev_suffixes_from_str, write_yml)
+from demisto_sdk.commands.format.format_constants import (ERROR_RETURN_CODE, SCHEMAS_PATH, SKIP_RETURN_CODE,
                                                           SUCCESS_RETURN_CODE)
 from demisto_sdk.commands.format.update_generic_yml import BaseUpdateYML
 

--- a/demisto_sdk/commands/format/update_pre_process_rules.py
+++ b/demisto_sdk/commands/format/update_pre_process_rules.py
@@ -3,11 +3,8 @@ from typing import Tuple
 
 import click
 
-from demisto_sdk.commands.common.constants import (
-    FILETYPE_TO_DEFAULT_FROMVERSION, FileType)
-from demisto_sdk.commands.format.format_constants import (ERROR_RETURN_CODE,
-                                                          SKIP_RETURN_CODE,
-                                                          SUCCESS_RETURN_CODE)
+from demisto_sdk.commands.common.constants import FILETYPE_TO_DEFAULT_FROMVERSION, FileType
+from demisto_sdk.commands.format.format_constants import ERROR_RETURN_CODE, SKIP_RETURN_CODE, SUCCESS_RETURN_CODE
 from demisto_sdk.commands.format.update_generic_json import BaseUpdateJSON
 
 

--- a/demisto_sdk/commands/format/update_pythonfile.py
+++ b/demisto_sdk/commands/format/update_pythonfile.py
@@ -5,8 +5,8 @@ from typing import Tuple
 import click
 
 from demisto_sdk.commands.common.tools import LOG_COLORS, print_color
-from demisto_sdk.commands.format.format_constants import (
-    ERROR_RETURN_CODE, SKIP_VALIDATE_PY_RETURN_CODE, SUCCESS_RETURN_CODE)
+from demisto_sdk.commands.format.format_constants import (ERROR_RETURN_CODE, SKIP_VALIDATE_PY_RETURN_CODE,
+                                                          SUCCESS_RETURN_CODE)
 from demisto_sdk.commands.format.update_generic_yml import BaseUpdate
 
 AUTOPEP_LINE_LENGTH = '130'

--- a/demisto_sdk/commands/format/update_readme.py
+++ b/demisto_sdk/commands/format/update_readme.py
@@ -2,12 +2,9 @@ from typing import Optional, Tuple
 
 import click
 
-from demisto_sdk.commands.common.hook_validations.readme import (
-    ReadmeUrl, get_relative_urls)
+from demisto_sdk.commands.common.hook_validations.readme import ReadmeUrl, get_relative_urls
 from demisto_sdk.commands.common.tools import print_error
-from demisto_sdk.commands.format.format_constants import (ERROR_RETURN_CODE,
-                                                          SKIP_RETURN_CODE,
-                                                          SUCCESS_RETURN_CODE)
+from demisto_sdk.commands.format.format_constants import ERROR_RETURN_CODE, SKIP_RETURN_CODE, SUCCESS_RETURN_CODE
 from demisto_sdk.commands.format.update_generic import BaseUpdate
 
 

--- a/demisto_sdk/commands/format/update_report.py
+++ b/demisto_sdk/commands/format/update_report.py
@@ -2,11 +2,8 @@ from typing import Tuple
 
 import click
 
-from demisto_sdk.commands.common.tools import (LOG_COLORS, print_color,
-                                               print_error)
-from demisto_sdk.commands.format.format_constants import (ERROR_RETURN_CODE,
-                                                          SKIP_RETURN_CODE,
-                                                          SUCCESS_RETURN_CODE)
+from demisto_sdk.commands.common.tools import LOG_COLORS, print_color, print_error
+from demisto_sdk.commands.format.format_constants import ERROR_RETURN_CODE, SKIP_RETURN_CODE, SUCCESS_RETURN_CODE
 from demisto_sdk.commands.format.update_generic_json import BaseUpdateJSON
 
 

--- a/demisto_sdk/commands/format/update_script.py
+++ b/demisto_sdk/commands/format/update_script.py
@@ -3,14 +3,9 @@ from typing import Optional, Tuple
 import click
 
 from demisto_sdk.commands.common.constants import TYPE_JS, TYPE_PWSH
-from demisto_sdk.commands.common.hook_validations.docker import \
-    DockerImageValidator
-from demisto_sdk.commands.common.tools import (LOG_COLORS, is_iron_bank_pack,
-                                               print_color,
-                                               server_version_compare)
-from demisto_sdk.commands.format.format_constants import (ERROR_RETURN_CODE,
-                                                          SKIP_RETURN_CODE,
-                                                          SUCCESS_RETURN_CODE)
+from demisto_sdk.commands.common.hook_validations.docker import DockerImageValidator
+from demisto_sdk.commands.common.tools import LOG_COLORS, is_iron_bank_pack, print_color, server_version_compare
+from demisto_sdk.commands.format.format_constants import ERROR_RETURN_CODE, SKIP_RETURN_CODE, SUCCESS_RETURN_CODE
 from demisto_sdk.commands.format.update_generic_yml import BaseUpdateYML
 
 

--- a/demisto_sdk/commands/format/update_widget.py
+++ b/demisto_sdk/commands/format/update_widget.py
@@ -3,9 +3,7 @@ from typing import Tuple
 
 import click
 
-from demisto_sdk.commands.format.format_constants import (ERROR_RETURN_CODE,
-                                                          SKIP_RETURN_CODE,
-                                                          SUCCESS_RETURN_CODE)
+from demisto_sdk.commands.format.format_constants import ERROR_RETURN_CODE, SKIP_RETURN_CODE, SUCCESS_RETURN_CODE
 from demisto_sdk.commands.format.update_generic_json import BaseUpdateJSON
 
 

--- a/demisto_sdk/commands/generate_docs/common.py
+++ b/demisto_sdk/commands/generate_docs/common.py
@@ -4,8 +4,7 @@ import re
 from typing import Dict, List, Tuple
 
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.common.tools import (LOG_COLORS, print_color,
-                                               print_warning, run_command)
+from demisto_sdk.commands.common.tools import LOG_COLORS, print_color, print_warning, run_command
 from demisto_sdk.commands.run_cmd.runner import Runner
 
 json = JSON_Handler()

--- a/demisto_sdk/commands/generate_docs/generate_integration_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_integration_doc.py
@@ -5,19 +5,14 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from requests.structures import CaseInsensitiveDict
 
-from demisto_sdk.commands.common.constants import (
-    CONTEXT_OUTPUT_README_TABLE_HEADER, DOCS_COMMAND_SECTION_REGEX)
-from demisto_sdk.commands.common.default_additional_info_loader import \
-    load_default_additional_info_dict
+from demisto_sdk.commands.common.constants import CONTEXT_OUTPUT_README_TABLE_HEADER, DOCS_COMMAND_SECTION_REGEX
+from demisto_sdk.commands.common.default_additional_info_loader import load_default_additional_info_dict
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.common.tools import (LOG_COLORS, get_yaml,
-                                               print_color, print_error,
-                                               print_warning)
-from demisto_sdk.commands.generate_docs.common import (
-    add_lines, build_example_dict, generate_numbered_section, generate_section,
-    generate_table_section, save_output, string_escape_md)
-from demisto_sdk.commands.integration_diff.integration_diff_detector import \
-    IntegrationDiffDetector
+from demisto_sdk.commands.common.tools import LOG_COLORS, get_yaml, print_color, print_error, print_warning
+from demisto_sdk.commands.generate_docs.common import (add_lines, build_example_dict, generate_numbered_section,
+                                                       generate_section, generate_table_section, save_output,
+                                                       string_escape_md)
+from demisto_sdk.commands.integration_diff.integration_diff_detector import IntegrationDiffDetector
 
 json = JSON_Handler()
 

--- a/demisto_sdk/commands/generate_docs/generate_playbook_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_playbook_doc.py
@@ -1,11 +1,10 @@
 import os
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from demisto_sdk.commands.common.tools import (get_yaml, print_error,
-                                               print_warning)
-from demisto_sdk.commands.generate_docs.common import (
-    HEADER_TYPE, generate_list_section, generate_numbered_section,
-    generate_section, generate_table_section, save_output, string_escape_md)
+from demisto_sdk.commands.common.tools import get_yaml, print_error, print_warning
+from demisto_sdk.commands.generate_docs.common import (HEADER_TYPE, generate_list_section, generate_numbered_section,
+                                                       generate_section, generate_table_section, save_output,
+                                                       string_escape_md)
 
 
 def generate_playbook_doc(input_path: str, output: str = None, permissions: str = None, limitations: str = None,

--- a/demisto_sdk/commands/generate_docs/generate_script_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_script_doc.py
@@ -1,16 +1,13 @@
 import os
 import random
 
-from demisto_sdk.commands.common.content_constant_paths import \
-    DEFAULT_ID_SET_PATH
-from demisto_sdk.commands.common.tools import (get_from_version, get_yaml,
-                                               open_id_set_file, print_error,
-                                               print_warning)
+from demisto_sdk.commands.common.content_constant_paths import DEFAULT_ID_SET_PATH
+from demisto_sdk.commands.common.tools import get_from_version, get_yaml, open_id_set_file, print_error, print_warning
 from demisto_sdk.commands.common.update_id_set import get_depends_on
 from demisto_sdk.commands.create_id_set.create_id_set import IDSetCreator
-from demisto_sdk.commands.generate_docs.common import (
-    build_example_dict, generate_list_section, generate_numbered_section,
-    generate_section, generate_table_section, save_output, string_escape_md)
+from demisto_sdk.commands.generate_docs.common import (build_example_dict, generate_list_section,
+                                                       generate_numbered_section, generate_section,
+                                                       generate_table_section, save_output, string_escape_md)
 
 
 def generate_script_doc(input_path, examples, output: str = None, permissions: str = None,

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -8,13 +8,15 @@ from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.legacy_git_tools import git_path
 from demisto_sdk.commands.common.tools import get_json, get_yaml
 from demisto_sdk.commands.create_id_set.create_id_set import IDSetCreator
-from demisto_sdk.commands.generate_docs.generate_integration_doc import (
-    append_or_replace_command_in_docs, disable_md_autolinks,
-    generate_commands_section, generate_integration_doc,
-    generate_mirroring_section, generate_setup_section,
-    generate_single_command_section, get_command_examples)
-from demisto_sdk.commands.generate_docs.generate_script_doc import \
-    generate_script_doc
+from demisto_sdk.commands.generate_docs.generate_integration_doc import (append_or_replace_command_in_docs,
+                                                                         disable_md_autolinks,
+                                                                         generate_commands_section,
+                                                                         generate_integration_doc,
+                                                                         generate_mirroring_section,
+                                                                         generate_setup_section,
+                                                                         generate_single_command_section,
+                                                                         get_command_examples)
+from demisto_sdk.commands.generate_docs.generate_script_doc import generate_script_doc
 from TestSuite.pack import Pack
 
 json = JSON_Handler()
@@ -110,8 +112,7 @@ def test_generate_list_section_empty():
 
 
 def test_generate_numbered_section():
-    from demisto_sdk.commands.generate_docs.common import \
-        generate_numbered_section
+    from demisto_sdk.commands.generate_docs.common import generate_numbered_section
 
     section = generate_numbered_section('Use Cases', '* Drink coffee. * Write code.')
 
@@ -168,8 +169,7 @@ def test_generate_table_section_empty(data, title, empty_message, text, expected
     - Case 2: No section is created.
     - Case 3: No section is created.
     """
-    from demisto_sdk.commands.generate_docs.common import \
-        generate_table_section
+    from demisto_sdk.commands.generate_docs.common import generate_table_section
 
     section = generate_table_section(data, title, empty_message, text)
 
@@ -186,8 +186,7 @@ def test_generate_table_section():
     Then
     - Validate That the script metadata was created correctly.
     """
-    from demisto_sdk.commands.generate_docs.common import \
-        generate_table_section
+    from demisto_sdk.commands.generate_docs.common import generate_table_section
 
     section = generate_table_section([{'Type': 'python2', 'Docker Image': 'demisto/python2'}],
                                      'Script Data', 'No data found.', 'This is the metadata of the script.')
@@ -209,8 +208,7 @@ def test_generate_table_section_with_newlines():
     Then
     - Validate That the \n is escaped correctly in a markdown format.
     """
-    from demisto_sdk.commands.generate_docs.common import \
-        generate_table_section
+    from demisto_sdk.commands.generate_docs.common import generate_table_section
 
     section = generate_table_section([{
         'Name': 'RsaDecryptKeyEntryID',
@@ -265,8 +263,7 @@ def test_generate_table_section_with_newlines():
 
 
 def test_get_inputs():
-    from demisto_sdk.commands.generate_docs.generate_playbook_doc import \
-        get_inputs
+    from demisto_sdk.commands.generate_docs.generate_playbook_doc import get_inputs
     playbook = get_yaml(TEST_PLAYBOOK_PATH)
 
     inputs, errors = get_inputs(playbook)
@@ -297,8 +294,7 @@ def test_get_inputs():
 
 
 def test_get_outputs():
-    from demisto_sdk.commands.generate_docs.generate_playbook_doc import \
-        get_outputs
+    from demisto_sdk.commands.generate_docs.generate_playbook_doc import get_outputs
     playbook = get_yaml(TEST_PLAYBOOK_PATH)
 
     outputs, errors = get_outputs(playbook)
@@ -311,8 +307,7 @@ def test_get_outputs():
 
 
 def test_get_playbook_dependencies():
-    from demisto_sdk.commands.generate_docs.generate_playbook_doc import \
-        get_playbook_dependencies
+    from demisto_sdk.commands.generate_docs.generate_playbook_doc import get_playbook_dependencies
     playbook = get_yaml(TEST_PLAYBOOK_PATH)
 
     playbooks, integrations, scripts, commands = get_playbook_dependencies(playbook, playbook_path=TEST_PLAYBOOK_PATH)
@@ -324,8 +319,7 @@ def test_get_playbook_dependencies():
 
 
 def test_get_input_data_simple():
-    from demisto_sdk.commands.generate_docs.generate_playbook_doc import \
-        get_input_data
+    from demisto_sdk.commands.generate_docs.generate_playbook_doc import get_input_data
     playbook = get_yaml(TEST_PLAYBOOK_PATH)
 
     sample_input = playbook.get('inputs')[1]
@@ -339,8 +333,7 @@ def test_get_input_data_simple():
                          [(0, 'File.Name'),
                           (2, 'No_Accessor')])
 def test_get_input_data_complex(index, expected_result):
-    from demisto_sdk.commands.generate_docs.generate_playbook_doc import \
-        get_input_data
+    from demisto_sdk.commands.generate_docs.generate_playbook_doc import get_input_data
     playbook = get_yaml(TEST_PLAYBOOK_PATH)
 
     sample_input = playbook.get('inputs')[index]
@@ -364,8 +357,7 @@ def test_generate_image_link(playbook_name, custom_image_path, expected_result):
     Then
     - Validate that the output of the command matches the expected result.
     """
-    from demisto_sdk.commands.generate_docs.generate_playbook_doc import \
-        generate_image_path
+    from demisto_sdk.commands.generate_docs.generate_playbook_doc import generate_image_path
 
     output = generate_image_path(playbook_name, custom_image_path)
 
@@ -376,8 +368,7 @@ def test_generate_image_link(playbook_name, custom_image_path, expected_result):
 
 
 def test_get_script_info():
-    from demisto_sdk.commands.generate_docs.generate_script_doc import \
-        get_script_info
+    from demisto_sdk.commands.generate_docs.generate_script_doc import get_script_info
     info = get_script_info(TEST_SCRIPT_PATH)
 
     assert info[0]['Description'] == 'python3'
@@ -386,8 +377,7 @@ def test_get_script_info():
 
 
 def test_get_script_inputs():
-    from demisto_sdk.commands.generate_docs.generate_script_doc import \
-        get_inputs
+    from demisto_sdk.commands.generate_docs.generate_script_doc import get_inputs
     script = get_yaml(TEST_SCRIPT_PATH)
     inputs, errors = get_inputs(script)
 
@@ -399,8 +389,7 @@ def test_get_script_inputs():
 
 
 def test_get_script_outputs():
-    from demisto_sdk.commands.generate_docs.generate_script_doc import \
-        get_outputs
+    from demisto_sdk.commands.generate_docs.generate_script_doc import get_outputs
     script = get_yaml(TEST_SCRIPT_PATH)
     outputs, errors = get_outputs(script)
 
@@ -412,8 +401,7 @@ def test_get_script_outputs():
 
 
 def test_get_used_in():
-    from demisto_sdk.commands.generate_docs.generate_script_doc import \
-        get_used_in
+    from demisto_sdk.commands.generate_docs.generate_script_doc import get_used_in
     script = get_yaml(TEST_SCRIPT_PATH)
     script_id = script.get('commonfields')['id']
     used_in = get_used_in(FAKE_ID_SET, script_id)
@@ -863,8 +851,7 @@ def test_generate_table_section_numbered_section():
             - Validate that the generated table has \t at the beginning of each line.
     """
 
-    from demisto_sdk.commands.generate_docs.common import \
-        generate_table_section
+    from demisto_sdk.commands.generate_docs.common import generate_table_section
 
     expected_section = ['', '    | **Type** | **Docker Image** |', '    | --- | --- |',
                         '    | python2 | demisto/python2 |', '']
@@ -974,8 +961,7 @@ def test_scripts_in_playbook(repo):
         Then
             - Ensure that the scripts we get are from both the script and scriptName fields.
     """
-    from demisto_sdk.commands.generate_docs.generate_playbook_doc import \
-        get_playbook_dependencies
+    from demisto_sdk.commands.generate_docs.generate_playbook_doc import get_playbook_dependencies
     pack = repo.create_pack('pack')
     playbook = pack.create_playbook('LargePlaybook')
     test_task_1 = {
@@ -1086,8 +1072,7 @@ def test_add_access_data_of_type_credentials(access_data: List[Dict], credential
     Case b: 'Password' is added as default for display password name missing.
     Case c: Both display name and display password name are added.
     """
-    from demisto_sdk.commands.generate_docs.generate_integration_doc import \
-        add_access_data_of_type_credentials
+    from demisto_sdk.commands.generate_docs.generate_integration_doc import add_access_data_of_type_credentials
     add_access_data_of_type_credentials(access_data, credentials_conf)
     assert access_data == expected
 
@@ -1102,8 +1087,7 @@ def test_generate_versions_differences_section(monkeypatch):
             - Add a section of differences between versions in README.
     """
 
-    from demisto_sdk.commands.generate_docs.generate_integration_doc import \
-        generate_versions_differences_section
+    from demisto_sdk.commands.generate_docs.generate_integration_doc import generate_versions_differences_section
     monkeypatch.setattr(
         'builtins.input',
         lambda _: ''
@@ -1202,10 +1186,8 @@ def test_missing_data_sections_when_generating_table_section(yml_content, expect
     - Case 3: Empty table section.
     - Case 4: Script data section with a title and a table containing information only about the Cortex XSOAR Version.
     """
-    from demisto_sdk.commands.generate_docs.common import \
-        generate_table_section
-    from demisto_sdk.commands.generate_docs.generate_script_doc import \
-        get_script_info
+    from demisto_sdk.commands.generate_docs.common import generate_table_section
+    from demisto_sdk.commands.generate_docs.generate_script_doc import get_script_info
 
     script_pack = pack.create_script()
     script_pack.yml.write_dict(yml_content)

--- a/demisto_sdk/commands/generate_integration/code_generator.py
+++ b/demisto_sdk/commands/generate_integration/code_generator.py
@@ -10,13 +10,13 @@ import autopep8
 import demisto_sdk.commands.common.tools as tools
 from demisto_sdk.commands.common.constants import ParameterType
 from demisto_sdk.commands.common.handlers import JSON_Handler, YAML_Handler
-from demisto_sdk.commands.generate_integration.base_code import (
-    BASE_ARGUMENT, BASE_BASIC_AUTH, BASE_BEARER_TOKEN, BASE_CLIENT,
-    BASE_CLIENT_API_KEY, BASE_CODE_TEMPLATE, BASE_CREDENTIALS, BASE_FUNCTION,
-    BASE_HEADER, BASE_HEADER_API_KEY, BASE_HEADER_FORMATTED,
-    BASE_LIST_FUNCTIONS, BASE_PARAMS, BASE_REQUEST_FUNCTION)
-from demisto_sdk.commands.generate_integration.XSOARIntegration import \
-    XSOARIntegration
+from demisto_sdk.commands.generate_integration.base_code import (BASE_ARGUMENT, BASE_BASIC_AUTH, BASE_BEARER_TOKEN,
+                                                                 BASE_CLIENT, BASE_CLIENT_API_KEY, BASE_CODE_TEMPLATE,
+                                                                 BASE_CREDENTIALS, BASE_FUNCTION, BASE_HEADER,
+                                                                 BASE_HEADER_API_KEY, BASE_HEADER_FORMATTED,
+                                                                 BASE_LIST_FUNCTIONS, BASE_PARAMS,
+                                                                 BASE_REQUEST_FUNCTION)
+from demisto_sdk.commands.generate_integration.XSOARIntegration import XSOARIntegration
 
 json = JSON_Handler()
 yaml = YAML_Handler(width=50000)

--- a/demisto_sdk/commands/generate_integration/tests/code_generator_test.py
+++ b/demisto_sdk/commands/generate_integration/tests/code_generator_test.py
@@ -3,9 +3,9 @@ from pathlib import Path
 
 from demisto_sdk.commands.common.handlers import JSON_Handler, YAML_Handler
 from demisto_sdk.commands.common.legacy_git_tools import git_path
-from demisto_sdk.commands.generate_integration.code_generator import (
-    IntegrationGeneratorCommand, IntegrationGeneratorConfig,
-    IntegrationGeneratorOutput, json_body_to_code)
+from demisto_sdk.commands.generate_integration.code_generator import (IntegrationGeneratorCommand,
+                                                                      IntegrationGeneratorConfig,
+                                                                      IntegrationGeneratorOutput, json_body_to_code)
 
 json = JSON_Handler()
 yaml = YAML_Handler()
@@ -77,8 +77,7 @@ class TestCodeGenerator:
         - ensure code is generated
         - esnrue the code is identical to what is stored under test_files folder
         """
-        from demisto_sdk.commands.common.hook_validations.docker import \
-            DockerImageValidator
+        from demisto_sdk.commands.common.hook_validations.docker import DockerImageValidator
 
         mocker.patch.object(DockerImageValidator, 'get_docker_image_latest_tag_request', return_value='3.8.6.12176')
 
@@ -115,8 +114,7 @@ class TestCodeGenerator:
         Then
         - ensure it generates the yml successfully and the yml is the exact as expected yml from test_files folder
        """
-        from demisto_sdk.commands.common.hook_validations.docker import \
-            DockerImageValidator
+        from demisto_sdk.commands.common.hook_validations.docker import DockerImageValidator
 
         mocker.patch.object(DockerImageValidator, 'get_docker_image_latest_tag_request', return_value='3.8.6.12176')
 
@@ -144,8 +142,7 @@ class TestCodeGenerator:
         - ensure VirusTotalTest dir contains VirusTotalTest.py
         - ensure VirusTotalTest dir contains VirusTotalTest.yml
         """
-        from demisto_sdk.commands.common.hook_validations.docker import \
-            DockerImageValidator
+        from demisto_sdk.commands.common.hook_validations.docker import DockerImageValidator
 
         mocker.patch.object(DockerImageValidator, 'get_docker_image_latest_tag_request', return_value='3.8.6.12176')
 
@@ -174,8 +171,7 @@ class TestCodeGenerator:
         - ensure integration-VirusTotalTest.yml exists
         - ensure the unified file contains the script
         """
-        from demisto_sdk.commands.common.hook_validations.docker import \
-            DockerImageValidator
+        from demisto_sdk.commands.common.hook_validations.docker import DockerImageValidator
 
         mocker.patch.object(DockerImageValidator, 'get_docker_image_latest_tag_request', return_value='3.8.6.12176')
 

--- a/demisto_sdk/commands/generate_outputs/generate_context/generate_integration_context.py
+++ b/demisto_sdk/commands/generate_outputs/generate_context/generate_integration_context.py
@@ -1,13 +1,9 @@
 from typing import Dict, List, Optional
 
-from demisto_sdk.commands.common.tools import (get_yaml, print_error,
-                                               print_success, print_v,
-                                               write_yml)
+from demisto_sdk.commands.common.tools import get_yaml, print_error, print_success, print_v, write_yml
 from demisto_sdk.commands.generate_docs.common import build_example_dict
-from demisto_sdk.commands.generate_docs.generate_integration_doc import \
-    get_command_examples
-from demisto_sdk.commands.generate_outputs.json_to_outputs.json_to_outputs import \
-    parse_json
+from demisto_sdk.commands.generate_docs.generate_integration_doc import get_command_examples
+from demisto_sdk.commands.generate_outputs.json_to_outputs.json_to_outputs import parse_json
 
 
 def dict_from_outputs_str(command: str, outputs: str, verbose=False):

--- a/demisto_sdk/commands/generate_outputs/generate_context/tests/generate_integration_context_test.py
+++ b/demisto_sdk/commands/generate_outputs/generate_context/tests/generate_integration_context_test.py
@@ -141,8 +141,7 @@ def test_insert_outputs(mocker):
     Then
       - Ensure the outputs are inserted correctly
     """
-    from demisto_sdk.commands.generate_outputs.generate_context import \
-        generate_integration_context
+    from demisto_sdk.commands.generate_outputs.generate_context import generate_integration_context
     command_name = 'zoom-fetch-recording'
     mocker.patch.object(generate_integration_context,
                         'build_example_dict',
@@ -176,8 +175,7 @@ def test_generate_integration_context(mocker, tmpdir):
     Then
       - Ensure the outputs are inserted correctly
     """
-    from demisto_sdk.commands.generate_outputs.generate_context import \
-        generate_integration_context
+    from demisto_sdk.commands.generate_outputs.generate_context import generate_integration_context
 
     command_name = 'zoom-fetch-recording'
     mocker.patch.object(generate_integration_context,

--- a/demisto_sdk/commands/generate_outputs/generate_descriptions/tests/generate_descriptions_test.py
+++ b/demisto_sdk/commands/generate_outputs/generate_descriptions/tests/generate_descriptions_test.py
@@ -29,8 +29,7 @@ def test_ai21_api_request(mocker):
         Then
            - Ensure the descriptions are generated with probability indicators
     """
-    from demisto_sdk.commands.generate_outputs.generate_descriptions import \
-        generate_descriptions
+    from demisto_sdk.commands.generate_outputs.generate_descriptions import generate_descriptions
 
     mocker.patch.dict(os.environ, {'AI21_KEY': '123'})
 
@@ -55,8 +54,7 @@ def test_build_description_with_probabilities():
         Then
           - Ensure the output is wrapped with *'s
     """
-    from demisto_sdk.commands.generate_outputs.generate_descriptions import \
-        generate_descriptions
+    from demisto_sdk.commands.generate_outputs.generate_descriptions import generate_descriptions
 
     assert generate_descriptions.build_description_with_probabilities(
         LOGPROB_INPUT_AI21) == 'The **Unkown**'
@@ -71,8 +69,7 @@ def test_generate_ai_descriptions(mocker, tmp_path):
       Then
          - Ensure the descriptions are generated
     """
-    from demisto_sdk.commands.generate_outputs.generate_descriptions import \
-        generate_descriptions
+    from demisto_sdk.commands.generate_outputs.generate_descriptions import generate_descriptions
 
     mocker.patch.dict(os.environ, {'AI21_KEY': '123'})
 
@@ -105,8 +102,7 @@ def test_generate_ai_descriptions_interactive(mocker, tmp_path, monkeypatch):
       Then
          - Ensure the output uses the user's string
     """
-    from demisto_sdk.commands.generate_outputs.generate_descriptions import \
-        generate_descriptions
+    from demisto_sdk.commands.generate_outputs.generate_descriptions import generate_descriptions
 
     mocker.patch.dict(os.environ, {'AI21_KEY': '123'})
     mocker.patch.object(
@@ -145,8 +141,7 @@ def test_generate_ai_descriptions_interactive_similar_path(mocker, tmp_path):
       Then
          - Ensure the descriptions are according to the user's decisions
     """
-    from demisto_sdk.commands.generate_outputs.generate_descriptions import \
-        generate_descriptions
+    from demisto_sdk.commands.generate_outputs.generate_descriptions import generate_descriptions
 
     mocker.patch.dict(os.environ, {'AI21_KEY': '123'})
     import builtins

--- a/demisto_sdk/commands/generate_outputs/generate_outputs.py
+++ b/demisto_sdk/commands/generate_outputs/generate_outputs.py
@@ -3,10 +3,8 @@ import os
 from demisto_sdk.commands.common.tools import FileType, find_type, print_error
 from demisto_sdk.commands.generate_outputs.generate_context.generate_integration_context import \
     generate_integration_context
-from demisto_sdk.commands.generate_outputs.generate_descriptions.generate_descriptions import \
-    generate_ai_descriptions
-from demisto_sdk.commands.generate_outputs.json_to_outputs.json_to_outputs import \
-    json_to_outputs
+from demisto_sdk.commands.generate_outputs.generate_descriptions.generate_descriptions import generate_ai_descriptions
+from demisto_sdk.commands.generate_outputs.json_to_outputs.json_to_outputs import json_to_outputs
 
 
 def json_to_outputs_flow(kwargs):

--- a/demisto_sdk/commands/generate_outputs/json_to_outputs/json_to_outputs.py
+++ b/demisto_sdk/commands/generate_outputs/json_to_outputs/json_to_outputs.py
@@ -78,8 +78,7 @@ from typing import Dict, Optional
 import dateparser
 
 from demisto_sdk.commands.common.handlers import JSON_Handler, YAML_Handler
-from demisto_sdk.commands.common.tools import (LOG_COLORS, print_color,
-                                               print_error)
+from demisto_sdk.commands.common.tools import LOG_COLORS, print_color, print_error
 
 json = JSON_Handler()
 yaml = YAML_Handler()

--- a/demisto_sdk/commands/generate_outputs/json_to_outputs/tests/json_to_outputs_test.py
+++ b/demisto_sdk/commands/generate_outputs/json_to_outputs/tests/json_to_outputs_test.py
@@ -5,8 +5,8 @@ import pytest
 
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.tools import run_command
-from demisto_sdk.commands.generate_outputs.json_to_outputs.json_to_outputs import (
-    determine_type, json_to_outputs, parse_json)
+from demisto_sdk.commands.generate_outputs.json_to_outputs.json_to_outputs import (determine_type, json_to_outputs,
+                                                                                   parse_json)
 
 json = JSON_Handler()
 

--- a/demisto_sdk/commands/generate_test_playbook/tests/test_playbook_generator_test.py
+++ b/demisto_sdk/commands/generate_test_playbook/tests/test_playbook_generator_test.py
@@ -6,8 +6,8 @@ import pytest
 from demisto_sdk.commands.common.handlers import YAML_Handler
 from demisto_sdk.commands.common.legacy_git_tools import git_path
 from demisto_sdk.commands.common.tools import get_yaml
-from demisto_sdk.commands.generate_test_playbook.test_playbook_generator import (
-    PlaybookTestsGenerator, get_command_examples)
+from demisto_sdk.commands.generate_test_playbook.test_playbook_generator import (PlaybookTestsGenerator,
+                                                                                 get_command_examples)
 
 yaml = YAML_Handler()
 

--- a/demisto_sdk/commands/generate_unit_tests/generate_unit_tests.py
+++ b/demisto_sdk/commands/generate_unit_tests/generate_unit_tests.py
@@ -12,12 +12,9 @@ from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.logger import Colors
 from demisto_sdk.commands.common.tools import print_error, print_success
 from demisto_sdk.commands.generate_docs.common import execute_command
-from demisto_sdk.commands.generate_docs.generate_integration_doc import \
-    get_command_examples
-from demisto_sdk.commands.generate_unit_tests.test_case_builder import (
-    ArgsBuilder, TestCase)
-from demisto_sdk.commands.generate_unit_tests.test_module_builder import \
-    TestModule
+from demisto_sdk.commands.generate_docs.generate_integration_doc import get_command_examples
+from demisto_sdk.commands.generate_unit_tests.test_case_builder import ArgsBuilder, TestCase
+from demisto_sdk.commands.generate_unit_tests.test_module_builder import TestModule
 
 logger = logging.getLogger('demisto-sdk')
 json = JSON_Handler()

--- a/demisto_sdk/commands/generate_unit_tests/test_case_builder.py
+++ b/demisto_sdk/commands/generate_unit_tests/test_case_builder.py
@@ -6,8 +6,7 @@ from typing import Dict, List, Union
 from ordered_set import OrderedSet
 
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.generate_unit_tests.common import (
-    ast_name, extract_outputs_from_command_run)
+from demisto_sdk.commands.generate_unit_tests.common import ast_name, extract_outputs_from_command_run
 
 logger = logging.getLogger('demisto-sdk')
 json = JSON_Handler()

--- a/demisto_sdk/commands/generate_unit_tests/tests/generate_unit_tests_test.py
+++ b/demisto_sdk/commands/generate_unit_tests/tests/generate_unit_tests_test.py
@@ -8,10 +8,8 @@ import pytest
 from klara.contract.solver import MANAGER
 
 from demisto_sdk.commands.common.legacy_git_tools import git_path
-from demisto_sdk.commands.generate_unit_tests.generate_unit_tests import (
-    UnitTestsGenerator, run_generate_unit_tests)
-from demisto_sdk.commands.generate_unit_tests.test_module_builder import \
-    TestModule
+from demisto_sdk.commands.generate_unit_tests.generate_unit_tests import UnitTestsGenerator, run_generate_unit_tests
+from demisto_sdk.commands.generate_unit_tests.test_module_builder import TestModule
 
 ARGS = [({'use_demisto': False}, 'malwarebazaar_all.py'),
         ({'use_demisto': False, 'commands': 'malwarebazaar-comment-add'}, 'malwarebazaar_specific_command.py'),

--- a/demisto_sdk/commands/generate_yml_from_python/generate_yml.py
+++ b/demisto_sdk/commands/generate_yml_from_python/generate_yml.py
@@ -14,9 +14,9 @@ import mock  # type: ignore
 
 from demisto_sdk.commands.common.handlers import YAML_Handler
 from demisto_sdk.commands.common.tools import write_yml
-from demisto_sdk.commands.generate_yml_from_python.yml_metadata_collector import (
-    CommandMetadata, ConfKey, InputArgument, OutputArgument,
-    YMLMetadataCollector)
+from demisto_sdk.commands.generate_yml_from_python.yml_metadata_collector import (CommandMetadata, ConfKey,
+                                                                                  InputArgument, OutputArgument,
+                                                                                  YMLMetadataCollector)
 
 yaml = YAML_Handler()
 

--- a/demisto_sdk/commands/generate_yml_from_python/tests/generate_yml_from_python_test.py
+++ b/demisto_sdk/commands/generate_yml_from_python/tests/generate_yml_from_python_test.py
@@ -8,10 +8,9 @@ from typing import Any, Callable, Optional
 import pytest
 
 from demisto_sdk.commands.common.handlers import YAML_Handler
-from demisto_sdk.commands.generate_yml_from_python.generate_yml import \
-    YMLGenerator
-from demisto_sdk.commands.generate_yml_from_python.yml_metadata_collector import (
-    ConfKey, InputArgument, OutputArgument, YMLMetadataCollector)
+from demisto_sdk.commands.generate_yml_from_python.generate_yml import YMLGenerator
+from demisto_sdk.commands.generate_yml_from_python.yml_metadata_collector import (ConfKey, InputArgument,
+                                                                                  OutputArgument, YMLMetadataCollector)
 from TestSuite.integration import Integration
 
 yaml = YAML_Handler()
@@ -577,8 +576,7 @@ class TestCommandGeneration:
         integration = Integration(tmp_path, "integration_name", repo)
 
         def code_snippet():
-            from demisto_sdk.commands.generate_yml_from_python.yml_metadata_collector import \
-                YMLMetadataCollector
+            from demisto_sdk.commands.generate_yml_from_python.yml_metadata_collector import YMLMetadataCollector
             metadata_collector = YMLMetadataCollector(integration_name="some_name")
 
             @metadata_collector.command(command_name="funky-command", outputs_prefix="funk", execution=False,

--- a/demisto_sdk/commands/init/contribution_converter.py
+++ b/demisto_sdk/commands/init/contribution_converter.py
@@ -12,27 +12,19 @@ from typing import Dict, List, Optional, Union
 import click
 
 from demisto_sdk.commands.common.configuration import Configuration
-from demisto_sdk.commands.common.constants import (
-    AUTOMATION, ENTITY_TYPE_TO_DIR, INTEGRATION, INTEGRATIONS_DIR,
-    MARKETPLACE_LIVE_DISCUSSIONS, MARKETPLACES, PACK_INITIAL_VERSION, SCRIPT,
-    SCRIPTS_DIR, XSOAR_AUTHOR, XSOAR_SUPPORT, XSOAR_SUPPORT_URL, FileType)
+from demisto_sdk.commands.common.constants import (AUTOMATION, ENTITY_TYPE_TO_DIR, INTEGRATION, INTEGRATIONS_DIR,
+                                                   MARKETPLACE_LIVE_DISCUSSIONS, MARKETPLACES, PACK_INITIAL_VERSION,
+                                                   SCRIPT, SCRIPTS_DIR, XSOAR_AUTHOR, XSOAR_SUPPORT, XSOAR_SUPPORT_URL,
+                                                   FileType)
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.common.tools import (LOG_COLORS, capital_case,
-                                               find_type,
-                                               get_child_directories,
-                                               get_child_files,
-                                               get_content_path,
-                                               get_display_name)
+from demisto_sdk.commands.common.tools import (LOG_COLORS, capital_case, find_type, get_child_directories,
+                                               get_child_files, get_content_path, get_display_name)
 from demisto_sdk.commands.format.format_module import format_manager
-from demisto_sdk.commands.generate_docs.generate_integration_doc import \
-    generate_integration_doc
-from demisto_sdk.commands.generate_docs.generate_playbook_doc import \
-    generate_playbook_doc
-from demisto_sdk.commands.generate_docs.generate_script_doc import \
-    generate_script_doc
+from demisto_sdk.commands.generate_docs.generate_integration_doc import generate_integration_doc
+from demisto_sdk.commands.generate_docs.generate_playbook_doc import generate_playbook_doc
+from demisto_sdk.commands.generate_docs.generate_script_doc import generate_script_doc
 from demisto_sdk.commands.split.ymlsplitter import YmlSplitter
-from demisto_sdk.commands.update_release_notes.update_rn_manager import \
-    UpdateReleaseNotesManager
+from demisto_sdk.commands.update_release_notes.update_rn_manager import UpdateReleaseNotesManager
 
 json = JSON_Handler()
 

--- a/demisto_sdk/commands/init/initiator.py
+++ b/demisto_sdk/commands/init/initiator.py
@@ -9,22 +9,20 @@ import click
 
 from demisto_sdk.commands.common import tools
 from demisto_sdk.commands.common.configuration import Configuration
-from demisto_sdk.commands.common.constants import (
-    CLASSIFIERS_DIR, CONNECTIONS_DIR, DASHBOARDS_DIR,
-    DEFAULT_CONTENT_ITEM_FROM_VERSION, DOC_FILES_DIR, GENERIC_DEFINITIONS_DIR,
-    GENERIC_FIELDS_DIR, GENERIC_MODULES_DIR, GENERIC_TYPES_DIR,
-    INCIDENT_FIELDS_DIR, INCIDENT_TYPES_DIR, INDICATOR_FIELDS_DIR,
-    INDICATOR_TYPES_DIR, INTEGRATION_CATEGORIES, INTEGRATIONS_DIR, JOBS_DIR,
-    LAYOUTS_DIR, MARKETPLACE_LIVE_DISCUSSIONS, MARKETPLACES,
-    PACK_INITIAL_VERSION, PACK_SUPPORT_OPTIONS, PLAYBOOKS_DIR, REPORTS_DIR,
-    SCRIPTS_DIR, TEST_PLAYBOOKS_DIR, WIDGETS_DIR, WIZARDS_DIR, XSOAR_AUTHOR,
-    XSOAR_SUPPORT, XSOAR_SUPPORT_URL)
+from demisto_sdk.commands.common.constants import (CLASSIFIERS_DIR, CONNECTIONS_DIR, DASHBOARDS_DIR,
+                                                   DEFAULT_CONTENT_ITEM_FROM_VERSION, DOC_FILES_DIR,
+                                                   GENERIC_DEFINITIONS_DIR, GENERIC_FIELDS_DIR, GENERIC_MODULES_DIR,
+                                                   GENERIC_TYPES_DIR, INCIDENT_FIELDS_DIR, INCIDENT_TYPES_DIR,
+                                                   INDICATOR_FIELDS_DIR, INDICATOR_TYPES_DIR, INTEGRATION_CATEGORIES,
+                                                   INTEGRATIONS_DIR, JOBS_DIR, LAYOUTS_DIR,
+                                                   MARKETPLACE_LIVE_DISCUSSIONS, MARKETPLACES, PACK_INITIAL_VERSION,
+                                                   PACK_SUPPORT_OPTIONS, PLAYBOOKS_DIR, REPORTS_DIR, SCRIPTS_DIR,
+                                                   TEST_PLAYBOOKS_DIR, WIDGETS_DIR, WIZARDS_DIR, XSOAR_AUTHOR,
+                                                   XSOAR_SUPPORT, XSOAR_SUPPORT_URL)
 from demisto_sdk.commands.common.git_content_config import GitContentConfig
 from demisto_sdk.commands.common.handlers import JSON_Handler, YAML_Handler
-from demisto_sdk.commands.common.tools import (LOG_COLORS,
-                                               get_common_server_path,
-                                               get_pack_name, print_error,
-                                               print_v, print_warning)
+from demisto_sdk.commands.common.tools import (LOG_COLORS, get_common_server_path, get_pack_name, print_error, print_v,
+                                               print_warning)
 from demisto_sdk.commands.secrets.secrets import SecretsValidator
 
 json = JSON_Handler()

--- a/demisto_sdk/commands/init/tests/contribution_converter_test.py
+++ b/demisto_sdk/commands/init/tests/contribution_converter_test.py
@@ -15,8 +15,7 @@ from demisto_sdk.commands.common.git_util import GitUtil
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.legacy_git_tools import git_path
 from demisto_sdk.commands.common.tools import get_child_directories
-from demisto_sdk.commands.init.contribution_converter import \
-    ContributionConverter
+from demisto_sdk.commands.init.contribution_converter import ContributionConverter
 from TestSuite.contribution import Contribution
 from TestSuite.repo import Repo
 

--- a/demisto_sdk/commands/init/tests/initiator_test.py
+++ b/demisto_sdk/commands/init/tests/initiator_test.py
@@ -7,10 +7,9 @@ from typing import Callable
 import pytest
 
 from demisto_sdk.commands.common import tools
-from demisto_sdk.commands.common.constants import (
-    INTEGRATION_CATEGORIES, MARKETPLACE_LIVE_DISCUSSIONS, MARKETPLACES,
-    PACK_INITIAL_VERSION, PACK_SUPPORT_OPTIONS, XSOAR_AUTHOR, XSOAR_SUPPORT,
-    XSOAR_SUPPORT_URL)
+from demisto_sdk.commands.common.constants import (INTEGRATION_CATEGORIES, MARKETPLACE_LIVE_DISCUSSIONS, MARKETPLACES,
+                                                   PACK_INITIAL_VERSION, PACK_SUPPORT_OPTIONS, XSOAR_AUTHOR,
+                                                   XSOAR_SUPPORT, XSOAR_SUPPORT_URL)
 from demisto_sdk.commands.common.handlers import JSON_Handler, YAML_Handler
 from demisto_sdk.commands.init.initiator import Initiator
 from TestSuite.test_tools import ChangeCWD

--- a/demisto_sdk/commands/integration_diff/integration_diff_detector.py
+++ b/demisto_sdk/commands/integration_diff/integration_diff_detector.py
@@ -2,8 +2,7 @@ import os
 
 import click
 
-from demisto_sdk.commands.common.constants import (ARGUMENT_FIELDS_TO_CHECK,
-                                                   INTEGRATION_ARGUMENT_TYPES,
+from demisto_sdk.commands.common.constants import (ARGUMENT_FIELDS_TO_CHECK, INTEGRATION_ARGUMENT_TYPES,
                                                    PARAM_FIELDS_TO_CHECK)
 from demisto_sdk.commands.common.tools import get_yaml
 

--- a/demisto_sdk/commands/integration_diff/tests/integration_diff_test.py
+++ b/demisto_sdk/commands/integration_diff/tests/integration_diff_test.py
@@ -1,7 +1,6 @@
 import copy
 
-from demisto_sdk.commands.integration_diff.integration_diff_detector import \
-    IntegrationDiffDetector
+from demisto_sdk.commands.integration_diff.integration_diff_detector import IntegrationDiffDetector
 
 
 class TestIntegrationDiffDetector:

--- a/demisto_sdk/commands/lint/commands_builder.py
+++ b/demisto_sdk/commands/lint/commands_builder.py
@@ -5,16 +5,11 @@ from typing import List, Optional
 
 from packaging.version import parse
 
-from demisto_sdk.commands.lint.resources.pylint_plugins.base_checker import \
-    base_msg
-from demisto_sdk.commands.lint.resources.pylint_plugins.certified_partner_level_checker import \
-    cert_partner_msg
-from demisto_sdk.commands.lint.resources.pylint_plugins.community_level_checker import \
-    community_msg
-from demisto_sdk.commands.lint.resources.pylint_plugins.partner_level_checker import \
-    partner_msg
-from demisto_sdk.commands.lint.resources.pylint_plugins.xsoar_level_checker import \
-    xsoar_msg
+from demisto_sdk.commands.lint.resources.pylint_plugins.base_checker import base_msg
+from demisto_sdk.commands.lint.resources.pylint_plugins.certified_partner_level_checker import cert_partner_msg
+from demisto_sdk.commands.lint.resources.pylint_plugins.community_level_checker import community_msg
+from demisto_sdk.commands.lint.resources.pylint_plugins.partner_level_checker import partner_msg
+from demisto_sdk.commands.lint.resources.pylint_plugins.xsoar_level_checker import xsoar_msg
 
 # Third party packages
 # Local imports

--- a/demisto_sdk/commands/lint/helpers.py
+++ b/demisto_sdk/commands/lint/helpers.py
@@ -23,8 +23,7 @@ from docker.models.containers import Container
 from packaging.version import parse
 
 # Local packages
-from demisto_sdk.commands.common.constants import (TYPE_PWSH, TYPE_PYTHON,
-                                                   DemistoException)
+from demisto_sdk.commands.common.constants import TYPE_PWSH, TYPE_PYTHON, DemistoException
 from demisto_sdk.commands.common.docker_helper import init_global_docker_client
 
 # Python2 requirements

--- a/demisto_sdk/commands/lint/lint_manager.py
+++ b/demisto_sdk/commands/lint/lint_manager.py
@@ -16,27 +16,16 @@ import urllib3.exceptions
 from packaging.version import Version
 from wcmatch.pathlib import Path, PosixPath
 
-from demisto_sdk.commands.common.constants import (PACKS_PACK_META_FILE_NAME,
-                                                   TYPE_PWSH, TYPE_PYTHON,
-                                                   DemistoException)
+from demisto_sdk.commands.common.constants import PACKS_PACK_META_FILE_NAME, TYPE_PWSH, TYPE_PYTHON, DemistoException
 from demisto_sdk.commands.common.docker_helper import init_global_docker_client
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.logger import Colors
 from demisto_sdk.commands.common.timers import report_time_measurements
-from demisto_sdk.commands.common.tools import (find_file, find_type,
-                                               get_api_module_dependencies,
-                                               get_content_path,
-                                               get_file_displayed_name,
-                                               get_json,
-                                               is_external_repository,
-                                               print_error, print_v,
-                                               print_warning,
-                                               retrieve_file_ending)
-from demisto_sdk.commands.lint.helpers import (EXIT_CODES, FAIL, PWSH_CHECKS,
-                                               PY_CHCEKS, SUCCESS,
-                                               build_skipped_exit_code,
-                                               generate_coverage_report,
-                                               get_test_modules)
+from demisto_sdk.commands.common.tools import (find_file, find_type, get_api_module_dependencies, get_content_path,
+                                               get_file_displayed_name, get_json, is_external_repository, print_error,
+                                               print_v, print_warning, retrieve_file_ending)
+from demisto_sdk.commands.lint.helpers import (EXIT_CODES, FAIL, PWSH_CHECKS, PY_CHCEKS, SUCCESS,
+                                               build_skipped_exit_code, generate_coverage_report, get_test_modules)
 from demisto_sdk.commands.lint.linter import Linter
 
 json = JSON_Handler()

--- a/demisto_sdk/commands/lint/linter.py
+++ b/demisto_sdk/commands/lint/linter.py
@@ -16,28 +16,18 @@ import urllib3.exceptions
 from packaging.version import parse
 from wcmatch.pathlib import NEGATE, Path
 
-from demisto_sdk.commands.common.constants import (INTEGRATIONS_DIR,
-                                                   PACKS_PACK_META_FILE_NAME,
-                                                   TYPE_PWSH, TYPE_PYTHON)
-from demisto_sdk.commands.common.docker_helper import (
-    get_docker, init_global_docker_client)
+from demisto_sdk.commands.common.constants import INTEGRATIONS_DIR, PACKS_PACK_META_FILE_NAME, TYPE_PWSH, TYPE_PYTHON
+from demisto_sdk.commands.common.docker_helper import get_docker, init_global_docker_client
 from demisto_sdk.commands.common.handlers import JSON_Handler, YAML_Handler
 from demisto_sdk.commands.common.timers import timer
-from demisto_sdk.commands.common.tools import (get_all_docker_images,
-                                               run_command_os)
-from demisto_sdk.commands.lint.commands_builder import (
-    build_bandit_command, build_flake8_command, build_mypy_command,
-    build_pwsh_analyze_command, build_pwsh_test_command, build_pylint_command,
-    build_pytest_command, build_vulture_command, build_xsoar_linter_command)
-from demisto_sdk.commands.lint.helpers import (EXIT_CODES, FAIL, RERUN, RL,
-                                               SUCCESS, WARNING,
-                                               add_tmp_lint_files,
-                                               add_typing_module,
-                                               coverage_report_editor,
-                                               get_file_from_container,
-                                               get_python_version_from_image,
-                                               pylint_plugin,
-                                               split_warnings_errors,
+from demisto_sdk.commands.common.tools import get_all_docker_images, run_command_os
+from demisto_sdk.commands.lint.commands_builder import (build_bandit_command, build_flake8_command, build_mypy_command,
+                                                        build_pwsh_analyze_command, build_pwsh_test_command,
+                                                        build_pylint_command, build_pytest_command,
+                                                        build_vulture_command, build_xsoar_linter_command)
+from demisto_sdk.commands.lint.helpers import (EXIT_CODES, FAIL, RERUN, RL, SUCCESS, WARNING, add_tmp_lint_files,
+                                               add_typing_module, coverage_report_editor, get_file_from_container,
+                                               get_python_version_from_image, pylint_plugin, split_warnings_errors,
                                                stream_docker_container_output)
 
 json = JSON_Handler()

--- a/demisto_sdk/commands/lint/tests/command_builder_test.py
+++ b/demisto_sdk/commands/lint/tests/command_builder_test.py
@@ -24,8 +24,7 @@ def test_build_flak8_command(files):
 @pytest.mark.parametrize(argnames="files", argvalues=values)
 def test_build_xsoar_linter_py3_command(files):
     """Build xsoar linter command"""
-    from demisto_sdk.commands.lint.commands_builder import \
-        build_xsoar_linter_command
+    from demisto_sdk.commands.lint.commands_builder import build_xsoar_linter_command
     output = build_xsoar_linter_command(files, "base")
     files = [str(file) for file in files]
     expected = f"pylint --ignore=CommonServerPython.py,demistomock.py,CommonServerUserPython.py," \
@@ -38,8 +37,7 @@ def test_build_xsoar_linter_py3_command(files):
 @pytest.mark.parametrize(argnames="files", argvalues=values)
 def test_build_xsoar_linter_py2_command(files):
     """Build xsoar linter command"""
-    from demisto_sdk.commands.lint.commands_builder import \
-        build_xsoar_linter_command
+    from demisto_sdk.commands.lint.commands_builder import build_xsoar_linter_command
     output = build_xsoar_linter_command(files, "base")
     files = [str(file) for file in files]
     expected = f"pylint --ignore=CommonServerPython.py,demistomock.py,CommonServerUserPython.py," \
@@ -52,8 +50,7 @@ def test_build_xsoar_linter_py2_command(files):
 @pytest.mark.parametrize(argnames="files", argvalues=values)
 def test_build_xsoar_linter_no_base_command(files):
     """Build xsoar linter command"""
-    from demisto_sdk.commands.lint.commands_builder import \
-        build_xsoar_linter_command
+    from demisto_sdk.commands.lint.commands_builder import build_xsoar_linter_command
     output = build_xsoar_linter_command(files, "unsupported")
     files = [str(file) for file in files]
     expected = "pylint --ignore=CommonServerPython.py,demistomock.py,CommonServerUserPython.py," \
@@ -93,8 +90,7 @@ def test_build_mypy_command(files, py_num, content_path):
 def test_build_vulture_command(files, mocker):
     """Build bandit command"""
     from demisto_sdk.commands.lint import commands_builder
-    from demisto_sdk.commands.lint.commands_builder import \
-        build_vulture_command
+    from demisto_sdk.commands.lint.commands_builder import build_vulture_command
     mocker.patch.object(commands_builder, 'os')
     commands_builder.os.environ.get.return_value = 20
     output = build_vulture_command(files, Path('~/dev/content/'))
@@ -161,8 +157,7 @@ def test_build_pytest_command_3():
 
 def test_build_pwsh_analyze():
     """Build Pytest command with json"""
-    from demisto_sdk.commands.lint.commands_builder import \
-        build_pwsh_analyze_command
+    from demisto_sdk.commands.lint.commands_builder import build_pwsh_analyze_command
     file = MagicMock()
     command = f"pwsh -Command Invoke-ScriptAnalyzer -EnableExit -Path {file.name}"
     assert command == build_pwsh_analyze_command(file)
@@ -170,7 +165,6 @@ def test_build_pwsh_analyze():
 
 def test_build_pwsh_test():
     """Build Pytest command with json"""
-    from demisto_sdk.commands.lint.commands_builder import \
-        build_pwsh_test_command
+    from demisto_sdk.commands.lint.commands_builder import build_pwsh_test_command
     command = 'pwsh -Command Invoke-Pester -Configuration \'@{Run=@{Exit=$true}; Output=@{Verbosity="Detailed"}}\''
     assert command == build_pwsh_test_command()

--- a/demisto_sdk/commands/lint/tests/helper_test.py
+++ b/demisto_sdk/commands/lint/tests/helper_test.py
@@ -3,8 +3,7 @@ import os
 
 import pytest
 
-from demisto_sdk.commands.lint.helpers import (generate_coverage_report,
-                                               split_warnings_errors)
+from demisto_sdk.commands.lint.helpers import generate_coverage_report, split_warnings_errors
 
 EXIT_CODES = {
     "flake8": 0b1,

--- a/demisto_sdk/commands/lint/tests/linter_manager_test.py
+++ b/demisto_sdk/commands/lint/tests/linter_manager_test.py
@@ -4,8 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from demisto_sdk.commands.common.constants import (TYPE_PWSH, TYPE_PYTHON,
-                                                   FileType)
+from demisto_sdk.commands.common.constants import TYPE_PWSH, TYPE_PYTHON, FileType
 from demisto_sdk.commands.common.legacy_git_tools import git_path
 from demisto_sdk.commands.lint.lint_manager import LintManager
 from TestSuite.test_tools import ChangeCWD

--- a/demisto_sdk/commands/lint/tests/test_pylint_plugin/certified_partner_level_checker_test.py
+++ b/demisto_sdk/commands/lint/tests/test_pylint_plugin/certified_partner_level_checker_test.py
@@ -1,8 +1,7 @@
 import astroid
 import pylint.testutils
 
-from demisto_sdk.commands.lint.resources.pylint_plugins import \
-    certified_partner_level_checker
+from demisto_sdk.commands.lint.resources.pylint_plugins import certified_partner_level_checker
 
 # You can find documentation about adding new test checker here:
 # http://pylint.pycqa.org/en/latest/how_tos/custom_checkers.html#write-a-checker

--- a/demisto_sdk/commands/lint/tests/test_pylint_plugin/partner_level_checker_test.py
+++ b/demisto_sdk/commands/lint/tests/test_pylint_plugin/partner_level_checker_test.py
@@ -1,8 +1,7 @@
 import astroid
 import pylint.testutils
 
-from demisto_sdk.commands.lint.resources.pylint_plugins import \
-    partner_level_checker
+from demisto_sdk.commands.lint.resources.pylint_plugins import partner_level_checker
 
 # You can find documentation about adding new test checker here:
 # http://pylint.pycqa.org/en/latest/how_tos/custom_checkers.html#write-a-checker

--- a/demisto_sdk/commands/lint/tests/test_pylint_plugin/xsoar_level_checker_test.py
+++ b/demisto_sdk/commands/lint/tests/test_pylint_plugin/xsoar_level_checker_test.py
@@ -1,8 +1,7 @@
 import astroid
 import pylint.testutils
 
-from demisto_sdk.commands.lint.resources.pylint_plugins import \
-    xsoar_level_checker
+from demisto_sdk.commands.lint.resources.pylint_plugins import xsoar_level_checker
 
 # You can find documentation about adding new test checker here:
 # http://pylint.pycqa.org/en/latest/how_tos/custom_checkers.html#write-a-checker

--- a/demisto_sdk/commands/openapi_codegen/openapi_codegen.py
+++ b/demisto_sdk/commands/openapi_codegen/openapi_codegen.py
@@ -8,16 +8,14 @@ from typing import Any, List, Optional, Union
 import autopep8
 
 from demisto_sdk.commands.common.handlers import JSON_Handler, YAML_Handler
-from demisto_sdk.commands.common.hook_validations.docker import \
-    DockerImageValidator
+from demisto_sdk.commands.common.hook_validations.docker import DockerImageValidator
 from demisto_sdk.commands.common.tools import camel_to_snake, print_error
-from demisto_sdk.commands.generate_integration.base_code import (
-    BASE_ARGUMENT, BASE_BASIC_AUTH, BASE_CLIENT, BASE_CODE_TEMPLATE,
-    BASE_CREDENTIALS, BASE_DATA, BASE_FUNCTION, BASE_HEADER,
-    BASE_LIST_FUNCTIONS, BASE_PARAMS, BASE_PROPS, BASE_REQUEST_FUNCTION,
-    BASE_TOKEN)
-from demisto_sdk.commands.generate_integration.XSOARIntegration import \
-    XSOARIntegration
+from demisto_sdk.commands.generate_integration.base_code import (BASE_ARGUMENT, BASE_BASIC_AUTH, BASE_CLIENT,
+                                                                 BASE_CODE_TEMPLATE, BASE_CREDENTIALS, BASE_DATA,
+                                                                 BASE_FUNCTION, BASE_HEADER, BASE_LIST_FUNCTIONS,
+                                                                 BASE_PARAMS, BASE_PROPS, BASE_REQUEST_FUNCTION,
+                                                                 BASE_TOKEN)
+from demisto_sdk.commands.generate_integration.XSOARIntegration import XSOARIntegration
 
 json = JSON_Handler()
 

--- a/demisto_sdk/commands/openapi_codegen/tests/openapi_codegen_test.py
+++ b/demisto_sdk/commands/openapi_codegen/tests/openapi_codegen_test.py
@@ -2,8 +2,7 @@ import os
 
 from demisto_sdk.commands.common.handlers import JSON_Handler, YAML_Handler
 from demisto_sdk.commands.common.legacy_git_tools import git_path
-from demisto_sdk.commands.openapi_codegen.openapi_codegen import \
-    OpenAPIIntegration
+from demisto_sdk.commands.openapi_codegen.openapi_codegen import OpenAPIIntegration
 
 json = JSON_Handler()
 
@@ -58,8 +57,7 @@ class TestOpenAPICodeGen:
         Then
             - Ensure the configuration file is generated correctly
         """
-        from demisto_sdk.commands.common.hook_validations.docker import \
-            DockerImageValidator
+        from demisto_sdk.commands.common.hook_validations.docker import DockerImageValidator
 
         mocker.patch.object(DockerImageValidator, 'get_docker_image_latest_tag_request', return_value='3.8.6.12176')
 
@@ -84,8 +82,7 @@ class TestOpenAPICodeGen:
            - Ensure the yaml file is generated correctly
        """
 
-        from demisto_sdk.commands.common.hook_validations.docker import \
-            DockerImageValidator
+        from demisto_sdk.commands.common.hook_validations.docker import DockerImageValidator
 
         mocker.patch.object(DockerImageValidator, 'get_docker_image_latest_tag_request', return_value='3.8.6.12176')
         integration = self.init_integration()
@@ -151,8 +148,7 @@ class TestOpenAPICodeGen:
         Then
            - Ensure the arguments are generated correctly
         """
-        from demisto_sdk.commands.openapi_codegen.openapi_codegen import \
-            BASE_DATA
+        from demisto_sdk.commands.openapi_codegen.openapi_codegen import BASE_DATA
         integration = self.init_integration()
         command = [c for c in integration.configuration['commands'] if c['name'] == 'create-user'][0]
 

--- a/demisto_sdk/commands/postman_codegen/postman_codegen.py
+++ b/demisto_sdk/commands/postman_codegen/postman_codegen.py
@@ -6,14 +6,13 @@ from typing import Any, Dict, List, Union
 import demisto_sdk.commands.common.tools as tools
 from demisto_sdk.commands.common.constants import DemistoException
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.common.hook_validations.docker import \
-    DockerImageValidator
-from demisto_sdk.commands.generate_integration.code_generator import (
-    IntegrationGeneratorArg, IntegrationGeneratorCommand,
-    IntegrationGeneratorConfig, IntegrationGeneratorOutput,
-    IntegrationGeneratorParam, ParameterType)
-from demisto_sdk.commands.generate_outputs.json_to_outputs.json_to_outputs import (
-    determine_type, flatten_json)
+from demisto_sdk.commands.common.hook_validations.docker import DockerImageValidator
+from demisto_sdk.commands.generate_integration.code_generator import (IntegrationGeneratorArg,
+                                                                      IntegrationGeneratorCommand,
+                                                                      IntegrationGeneratorConfig,
+                                                                      IntegrationGeneratorOutput,
+                                                                      IntegrationGeneratorParam, ParameterType)
+from demisto_sdk.commands.generate_outputs.json_to_outputs.json_to_outputs import determine_type, flatten_json
 
 json = JSON_Handler()
 

--- a/demisto_sdk/commands/postman_codegen/tests/postman_codegen_test.py
+++ b/demisto_sdk/commands/postman_codegen/tests/postman_codegen_test.py
@@ -11,13 +11,14 @@ import demisto_sdk.commands.common.tools as tools
 from demisto_sdk.__main__ import main
 from demisto_sdk.commands.common.handlers import JSON_Handler, YAML_Handler
 from demisto_sdk.commands.common.legacy_git_tools import git_path
-from demisto_sdk.commands.generate_integration.code_generator import (
-    IntegrationGeneratorArg, IntegrationGeneratorConfig,
-    IntegrationGeneratorOutput)
-from demisto_sdk.commands.postman_codegen.postman_codegen import (
-    build_commands_names_dict, create_body_format, duplicate_requests_check,
-    find_shared_args_path, flatten_collections, generate_command_outputs,
-    postman_to_autogen_configuration, update_min_unique_path)
+from demisto_sdk.commands.generate_integration.code_generator import (IntegrationGeneratorArg,
+                                                                      IntegrationGeneratorConfig,
+                                                                      IntegrationGeneratorOutput)
+from demisto_sdk.commands.postman_codegen.postman_codegen import (build_commands_names_dict, create_body_format,
+                                                                  duplicate_requests_check, find_shared_args_path,
+                                                                  flatten_collections, generate_command_outputs,
+                                                                  postman_to_autogen_configuration,
+                                                                  update_min_unique_path)
 
 json = JSON_Handler()
 
@@ -429,8 +430,7 @@ class TestPostmanCodeGen:
         - ensure the config file is generated
         - the config file should be identical to the one we have under resources folder
         """
-        from demisto_sdk.commands.common.hook_validations.docker import \
-            DockerImageValidator
+        from demisto_sdk.commands.common.hook_validations.docker import DockerImageValidator
 
         mocker.patch.object(DockerImageValidator, 'get_docker_image_latest_tag_request', return_value='3.8.6.12176')
 

--- a/demisto_sdk/commands/run_cmd/runner.py
+++ b/demisto_sdk/commands/run_cmd/runner.py
@@ -5,11 +5,8 @@ import tempfile
 import demisto_client
 
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.common.tools import (LOG_COLORS, print_color,
-                                               print_error, print_v,
-                                               print_warning)
-from demisto_sdk.commands.generate_outputs.json_to_outputs.json_to_outputs import \
-    json_to_outputs
+from demisto_sdk.commands.common.tools import LOG_COLORS, print_color, print_error, print_v, print_warning
+from demisto_sdk.commands.generate_outputs.json_to_outputs.json_to_outputs import json_to_outputs
 
 json = JSON_Handler()
 

--- a/demisto_sdk/commands/run_playbook/playbook_runner.py
+++ b/demisto_sdk/commands/run_playbook/playbook_runner.py
@@ -4,8 +4,7 @@ import time
 import demisto_client
 from demisto_client.demisto_api.rest import ApiException
 
-from demisto_sdk.commands.common.tools import (LOG_COLORS, print_color,
-                                               print_error)
+from demisto_sdk.commands.common.tools import LOG_COLORS, print_color, print_error
 
 
 class PlaybookRunner:

--- a/demisto_sdk/commands/run_test_playbook/tests/test_playbook_runner_test.py
+++ b/demisto_sdk/commands/run_test_playbook/tests/test_playbook_runner_test.py
@@ -4,10 +4,8 @@ import pytest
 from demisto_client.demisto_api import DefaultApi
 
 from demisto_sdk.__main__ import run_test_playbook
-from demisto_sdk.commands.run_test_playbook.test_playbook_runner import \
-    TestPlaybookRunner
-from demisto_sdk.tests.constants_test import (CONTENT_REPO_EXAMPLE_ROOT,
-                                              TEST_PLAYBOOK, VALID_PACK)
+from demisto_sdk.commands.run_test_playbook.test_playbook_runner import TestPlaybookRunner
+from demisto_sdk.tests.constants_test import CONTENT_REPO_EXAMPLE_ROOT, TEST_PLAYBOOK, VALID_PACK
 from TestSuite.test_tools import ChangeCWD
 
 WAITING_MASSAGE = "Waiting for the test playbook to finish running.."

--- a/demisto_sdk/commands/secrets/secrets.py
+++ b/demisto_sdk/commands/secrets/secrets.py
@@ -9,17 +9,13 @@ import PyPDF2
 from bs4 import BeautifulSoup
 
 from demisto_sdk.commands.common.configuration import Configuration
-from demisto_sdk.commands.common.constants import (
-    PACKS_DIR, PACKS_INTEGRATION_README_REGEX, PACKS_WHITELIST_FILE_NAME,
-    FileType, re)
+from demisto_sdk.commands.common.constants import (PACKS_DIR, PACKS_INTEGRATION_README_REGEX, PACKS_WHITELIST_FILE_NAME,
+                                                   FileType, re)
 from demisto_sdk.commands.common.content import Content
 from demisto_sdk.commands.common.git_util import GitUtil
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.common.tools import (LOG_COLORS, find_type,
-                                               get_pack_name,
-                                               is_file_path_in_pack,
-                                               print_color, print_error,
-                                               print_warning, run_command)
+from demisto_sdk.commands.common.tools import (LOG_COLORS, find_type, get_pack_name, is_file_path_in_pack, print_color,
+                                               print_error, print_warning, run_command)
 
 json = JSON_Handler()
 

--- a/demisto_sdk/commands/split/jsonsplitter.py
+++ b/demisto_sdk/commands/split/jsonsplitter.py
@@ -2,12 +2,9 @@ import os
 
 import click
 
-from demisto_sdk.commands.common.constants import (DASHBOARDS_DIR,
-                                                   GENERIC_MODULES_DIR,
-                                                   PACKS_DIR)
+from demisto_sdk.commands.common.constants import DASHBOARDS_DIR, GENERIC_MODULES_DIR, PACKS_DIR
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.common.tools import (get_pack_name,
-                                               is_external_repository)
+from demisto_sdk.commands.common.tools import get_pack_name, is_external_repository
 
 json = JSON_Handler()
 

--- a/demisto_sdk/commands/split/tests/jsonsplitter_test.py
+++ b/demisto_sdk/commands/split/tests/jsonsplitter_test.py
@@ -2,8 +2,7 @@ import os
 
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.split.jsonsplitter import JsonSplitter
-from demisto_sdk.tests.test_files.validate_integration_test_valid_types import (
-    GENERIC_MODULE, UNIFIED_GENERIC_MODULE)
+from demisto_sdk.tests.test_files.validate_integration_test_valid_types import GENERIC_MODULE, UNIFIED_GENERIC_MODULE
 from TestSuite.test_tools import ChangeCWD
 
 json = JSON_Handler()

--- a/demisto_sdk/commands/split/tests/ymlsplitter_test.py
+++ b/demisto_sdk/commands/split/tests/ymlsplitter_test.py
@@ -8,10 +8,8 @@ from demisto_sdk.commands.common.constants import DEFAULT_IMAGE_BASE64
 from demisto_sdk.commands.common.handlers import JSON_Handler, YAML_Handler
 from demisto_sdk.commands.common.legacy_git_tools import git_path
 from demisto_sdk.commands.split.ymlsplitter import YmlSplitter
-from demisto_sdk.commands.unify.integration_script_unifier import \
-    IntegrationScriptUnifier
-from demisto_sdk.commands.unify.tests.yml_unifier_test import (DUMMY_MODULE,
-                                                               DUMMY_SCRIPT)
+from demisto_sdk.commands.unify.integration_script_unifier import IntegrationScriptUnifier
+from demisto_sdk.commands.unify.tests.yml_unifier_test import DUMMY_MODULE, DUMMY_SCRIPT
 from TestSuite.test_tools import ChangeCWD
 
 yaml = YAML_Handler()

--- a/demisto_sdk/commands/split/ymlsplitter.py
+++ b/demisto_sdk/commands/split/ymlsplitter.py
@@ -8,20 +8,14 @@ from io import open
 from pathlib import Path
 from typing import Optional
 
-from ruamel.yaml.scalarstring import (PlainScalarString,
-                                      SingleQuotedScalarString)
+from ruamel.yaml.scalarstring import PlainScalarString, SingleQuotedScalarString
 
 from demisto_sdk.commands.common.configuration import Configuration
-from demisto_sdk.commands.common.constants import (TYPE_PWSH, TYPE_PYTHON,
-                                                   TYPE_TO_EXTENSION)
+from demisto_sdk.commands.common.constants import TYPE_PWSH, TYPE_PYTHON, TYPE_TO_EXTENSION
 from demisto_sdk.commands.common.handlers import YAML_Handler
-from demisto_sdk.commands.common.tools import (LOG_COLORS,
-                                               get_all_docker_images,
-                                               get_pipenv_dir,
-                                               get_python_version, pascal_case,
-                                               print_color, print_error)
-from demisto_sdk.commands.unify.integration_script_unifier import \
-    IntegrationScriptUnifier
+from demisto_sdk.commands.common.tools import (LOG_COLORS, get_all_docker_images, get_pipenv_dir, get_python_version,
+                                               pascal_case, print_color, print_error)
+from demisto_sdk.commands.unify.integration_script_unifier import IntegrationScriptUnifier
 
 yaml = YAML_Handler()
 

--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -22,22 +22,16 @@ from demisto_client.demisto_api import DefaultApi, Incident
 from demisto_client.demisto_api.rest import ApiException
 from slack import WebClient as SlackClient
 
-from demisto_sdk.commands.common.constants import (
-    DEFAULT_CONTENT_ITEM_FROM_VERSION, DEFAULT_CONTENT_ITEM_TO_VERSION,
-    FILTER_CONF, PB_Status)
+from demisto_sdk.commands.common.constants import (DEFAULT_CONTENT_ITEM_FROM_VERSION, DEFAULT_CONTENT_ITEM_TO_VERSION,
+                                                   FILTER_CONF, PB_Status)
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.tools import get_demisto_version
-from demisto_sdk.commands.test_content.constants import (
-    CONTENT_BUILD_SSH_USER, LOAD_BALANCER_DNS)
+from demisto_sdk.commands.test_content.constants import CONTENT_BUILD_SSH_USER, LOAD_BALANCER_DNS
 from demisto_sdk.commands.test_content.Docker import Docker
-from demisto_sdk.commands.test_content.IntegrationsLock import \
-    acquire_test_lock
-from demisto_sdk.commands.test_content.mock_server import (RESULT, MITMProxy,
-                                                           run_with_mock)
-from demisto_sdk.commands.test_content.ParallelLoggingManager import \
-    ParallelLoggingManager
-from demisto_sdk.commands.test_content.tools import (
-    get_ui_url, is_redhat_instance, update_server_configuration)
+from demisto_sdk.commands.test_content.IntegrationsLock import acquire_test_lock
+from demisto_sdk.commands.test_content.mock_server import RESULT, MITMProxy, run_with_mock
+from demisto_sdk.commands.test_content.ParallelLoggingManager import ParallelLoggingManager
+from demisto_sdk.commands.test_content.tools import get_ui_url, is_redhat_instance, update_server_configuration
 
 json = JSON_Handler()
 

--- a/demisto_sdk/commands/test_content/execute_test_content.py
+++ b/demisto_sdk/commands/test_content/execute_test_content.py
@@ -4,10 +4,8 @@ from threading import Thread
 
 import requests
 
-from demisto_sdk.commands.test_content.ParallelLoggingManager import \
-    ParallelLoggingManager
-from demisto_sdk.commands.test_content.TestContentClasses import (
-    BuildContext, ServerContext)
+from demisto_sdk.commands.test_content.ParallelLoggingManager import ParallelLoggingManager
+from demisto_sdk.commands.test_content.TestContentClasses import BuildContext, ServerContext
 
 SKIPPED_CONTENT_COMMENT = 'The following integrations/tests were collected by the CI build but are currently skipped. ' \
                           'The collected tests are related to this pull request and might be critical.'

--- a/demisto_sdk/commands/test_content/mock_server.py
+++ b/demisto_sdk/commands/test_content/mock_server.py
@@ -7,8 +7,7 @@ import time
 import unicodedata
 from contextlib import contextmanager
 from pprint import pformat
-from subprocess import (STDOUT, CalledProcessError, call, check_call,
-                        check_output)
+from subprocess import STDOUT, CalledProcessError, call, check_call, check_output
 from threading import Lock
 from typing import Dict, Iterator
 

--- a/demisto_sdk/commands/test_content/tests/ParallelLoggingManager_test.py
+++ b/demisto_sdk/commands/test_content/tests/ParallelLoggingManager_test.py
@@ -2,8 +2,7 @@ from threading import Thread, currentThread
 
 import pytest
 
-from demisto_sdk.commands.test_content.ParallelLoggingManager import \
-    ParallelLoggingManager
+from demisto_sdk.commands.test_content.ParallelLoggingManager import ParallelLoggingManager
 
 
 class TestParallelLoggingManager:

--- a/demisto_sdk/commands/test_content/tests/build_context_test.py
+++ b/demisto_sdk/commands/test_content/tests/build_context_test.py
@@ -1,8 +1,7 @@
 import pytest
 
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.test_content.ParallelLoggingManager import \
-    ParallelLoggingManager
+from demisto_sdk.commands.test_content.ParallelLoggingManager import ParallelLoggingManager
 from demisto_sdk.commands.test_content.TestContentClasses import BuildContext
 
 json = JSON_Handler()

--- a/demisto_sdk/commands/test_content/tests/execute_test_content_test.py
+++ b/demisto_sdk/commands/test_content/tests/execute_test_content_test.py
@@ -5,8 +5,8 @@ import pytest
 import requests_mock
 
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.test_content.execute_test_content import (
-    COVERAGE_REPORT_COMMENT, SKIPPED_CONTENT_COMMENT, _add_pr_comment)
+from demisto_sdk.commands.test_content.execute_test_content import (COVERAGE_REPORT_COMMENT, SKIPPED_CONTENT_COMMENT,
+                                                                    _add_pr_comment)
 
 json = JSON_Handler()
 

--- a/demisto_sdk/commands/test_content/tests/integration_test.py
+++ b/demisto_sdk/commands/test_content/tests/integration_test.py
@@ -2,10 +2,8 @@ from copy import deepcopy
 
 import pytest
 
-from demisto_sdk.commands.test_content.ParallelLoggingManager import \
-    ParallelLoggingManager
-from demisto_sdk.commands.test_content.TestContentClasses import (BuildContext,
-                                                                  Integration)
+from demisto_sdk.commands.test_content.ParallelLoggingManager import ParallelLoggingManager
+from demisto_sdk.commands.test_content.TestContentClasses import BuildContext, Integration
 
 CONFIGURATION = {
     'configuration': [

--- a/demisto_sdk/commands/test_content/tests/mock_unit_test.py
+++ b/demisto_sdk/commands/test_content/tests/mock_unit_test.py
@@ -3,11 +3,8 @@ from __future__ import print_function
 import time
 from threading import Thread
 
-from demisto_sdk.commands.test_content.mock_server import (MITMProxy,
-                                                           clean_filename,
-                                                           get_folder_path,
-                                                           get_log_file_path,
-                                                           get_mock_file_path)
+from demisto_sdk.commands.test_content.mock_server import (MITMProxy, clean_filename, get_folder_path,
+                                                           get_log_file_path, get_mock_file_path)
 
 
 def test_clean_filename():

--- a/demisto_sdk/commands/test_content/tests/server_context_test.py
+++ b/demisto_sdk/commands/test_content/tests/server_context_test.py
@@ -1,12 +1,11 @@
 from demisto_sdk.commands.test_content.mock_server import MITMProxy
-from demisto_sdk.commands.test_content.TestContentClasses import (
-    BuildContext, ServerContext)
-from demisto_sdk.commands.test_content.tests.build_context_test import (
-    generate_content_conf_json, generate_integration_configuration,
-    generate_secret_conf_json, generate_test_configuration,
-    get_mocked_build_context)
-from demisto_sdk.commands.test_content.tests.DemistoClientMock import \
-    DemistoClientMock
+from demisto_sdk.commands.test_content.TestContentClasses import BuildContext, ServerContext
+from demisto_sdk.commands.test_content.tests.build_context_test import (generate_content_conf_json,
+                                                                        generate_integration_configuration,
+                                                                        generate_secret_conf_json,
+                                                                        generate_test_configuration,
+                                                                        get_mocked_build_context)
+from demisto_sdk.commands.test_content.tests.DemistoClientMock import DemistoClientMock
 
 
 def test_execute_tests(mocker, tmp_path):

--- a/demisto_sdk/commands/test_content/tests/test_context_test.py
+++ b/demisto_sdk/commands/test_content/tests/test_context_test.py
@@ -7,16 +7,15 @@ import pytest
 from demisto_sdk.commands.common.constants import PB_Status
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.test_content.Docker import Docker
-from demisto_sdk.commands.test_content.TestContentClasses import (
-    Integration, TestConfiguration, TestContext, TestPlaybook)
-from demisto_sdk.commands.test_content.tests.build_context_test import (
-    generate_content_conf_json, generate_integration_configuration,
-    generate_secret_conf_json, generate_test_configuration,
-    get_mocked_build_context)
-from demisto_sdk.commands.test_content.tests.DemistoClientMock import \
-    DemistoClientMock
-from demisto_sdk.commands.test_content.tests.server_context_test import \
-    generate_mocked_server_context
+from demisto_sdk.commands.test_content.TestContentClasses import (Integration, TestConfiguration, TestContext,
+                                                                  TestPlaybook)
+from demisto_sdk.commands.test_content.tests.build_context_test import (generate_content_conf_json,
+                                                                        generate_integration_configuration,
+                                                                        generate_secret_conf_json,
+                                                                        generate_test_configuration,
+                                                                        get_mocked_build_context)
+from demisto_sdk.commands.test_content.tests.DemistoClientMock import DemistoClientMock
+from demisto_sdk.commands.test_content.tests.server_context_test import generate_mocked_server_context
 
 json = JSON_Handler()
 
@@ -588,8 +587,8 @@ def test_replacing_pb_inputs(mocker, current, new_configuration, expected):
     """
     from demisto_client.demisto_api import DefaultApi
 
-    from demisto_sdk.commands.test_content.TestContentClasses import (
-        demisto_client, replace_external_playbook_configuration)
+    from demisto_sdk.commands.test_content.TestContentClasses import (demisto_client,
+                                                                      replace_external_playbook_configuration)
 
     class clientMock(DefaultApi):
         def generic_request(self, path, method, body=None, **kwargs):
@@ -664,8 +663,8 @@ def test_replacing_pb_inputs_fails_with_build_pass(mocker, current, new_configur
     """
     from demisto_client.demisto_api import DefaultApi
 
-    from demisto_sdk.commands.test_content.TestContentClasses import (
-        demisto_client, replace_external_playbook_configuration)
+    from demisto_sdk.commands.test_content.TestContentClasses import (demisto_client,
+                                                                      replace_external_playbook_configuration)
 
     class clientMock(DefaultApi):
         def generic_request(self, path, method, body=None, **kwargs):
@@ -744,8 +743,8 @@ def test_replacing_pb_inputs_fails_with_build_fail(mocker, current, new_configur
     """
     from demisto_client.demisto_api import DefaultApi
 
-    from demisto_sdk.commands.test_content.TestContentClasses import (
-        demisto_client, replace_external_playbook_configuration)
+    from demisto_sdk.commands.test_content.TestContentClasses import (demisto_client,
+                                                                      replace_external_playbook_configuration)
 
     class clientMock(DefaultApi):
         def generic_request(self, path, method, body=None, **kwargs):

--- a/demisto_sdk/commands/test_content/tests/testplaybook_test.py
+++ b/demisto_sdk/commands/test_content/tests/testplaybook_test.py
@@ -3,14 +3,11 @@ from unittest.mock import ANY
 import demisto_client
 import pytest
 
-from demisto_sdk.commands.test_content.TestContentClasses import (
-    Integration, IntegrationConfiguration, TestConfiguration, TestPlaybook)
-from demisto_sdk.commands.test_content.tests.build_context_test import (
-    create_xsiam_build, get_mocked_build_context)
-from demisto_sdk.commands.test_content.tests.DemistoClientMock import \
-    DemistoClientMock
-from demisto_sdk.commands.test_content.tests.server_context_test import \
-    generate_mocked_server_context
+from demisto_sdk.commands.test_content.TestContentClasses import (Integration, IntegrationConfiguration,
+                                                                  TestConfiguration, TestPlaybook)
+from demisto_sdk.commands.test_content.tests.build_context_test import create_xsiam_build, get_mocked_build_context
+from demisto_sdk.commands.test_content.tests.DemistoClientMock import DemistoClientMock
+from demisto_sdk.commands.test_content.tests.server_context_test import generate_mocked_server_context
 
 
 def test_set_prev_server_keys(mocker, tmp_path):

--- a/demisto_sdk/commands/test_content/tests/timestamp_replacer_test.py
+++ b/demisto_sdk/commands/test_content/tests/timestamp_replacer_test.py
@@ -7,8 +7,7 @@ import pytest
 from mitmproxy.http import Headers, HTTPFlow, Request
 
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.test_content.timestamp_replacer import \
-    TimestampReplacer
+from demisto_sdk.commands.test_content.timestamp_replacer import TimestampReplacer
 
 json = JSON_Handler()
 

--- a/demisto_sdk/commands/unify/integration_script_unifier.py
+++ b/demisto_sdk/commands/unify/integration_script_unifier.py
@@ -11,16 +11,12 @@ import click
 from inflection import dasherize, underscore
 from ruamel.yaml.scalarstring import FoldedScalarString
 
-from demisto_sdk.commands.common.constants import (
-    DEFAULT_CONTENT_ITEM_FROM_VERSION, DEFAULT_CONTENT_ITEM_TO_VERSION,
-    DEFAULT_IMAGE_PREFIX, INTEGRATIONS_DIR, SCRIPTS_DIR, TYPE_TO_EXTENSION,
-    FileType)
+from demisto_sdk.commands.common.constants import (DEFAULT_CONTENT_ITEM_FROM_VERSION, DEFAULT_CONTENT_ITEM_TO_VERSION,
+                                                   DEFAULT_IMAGE_PREFIX, INTEGRATIONS_DIR, SCRIPTS_DIR,
+                                                   TYPE_TO_EXTENSION, FileType)
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.common.tools import (LOG_COLORS, arg_to_list,
-                                               find_type, get_mp_tag_parser,
-                                               get_pack_name, get_yaml,
-                                               get_yml_paths_in_dir,
-                                               print_color, print_warning,
+from demisto_sdk.commands.common.tools import (LOG_COLORS, arg_to_list, find_type, get_mp_tag_parser, get_pack_name,
+                                               get_yaml, get_yml_paths_in_dir, print_color, print_warning,
                                                server_version_compare)
 from demisto_sdk.commands.unify.yaml_unifier import YAMLUnifier
 

--- a/demisto_sdk/commands/unify/tests/generic_module_unifier_test.py
+++ b/demisto_sdk/commands/unify/tests/generic_module_unifier_test.py
@@ -3,10 +3,9 @@ import os
 import pytest
 
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.unify.generic_module_unifier import \
-    GenericModuleUnifier
-from demisto_sdk.tests.test_files.validate_integration_test_valid_types import (
-    DASHBOARD, GENERIC_MODULE, UNIFIED_GENERIC_MODULE)
+from demisto_sdk.commands.unify.generic_module_unifier import GenericModuleUnifier
+from demisto_sdk.tests.test_files.validate_integration_test_valid_types import (DASHBOARD, GENERIC_MODULE,
+                                                                                UNIFIED_GENERIC_MODULE)
 from TestSuite.test_tools import ChangeCWD
 
 json = JSON_Handler()

--- a/demisto_sdk/commands/unify/tests/xdrc_template_unifier_test.py
+++ b/demisto_sdk/commands/unify/tests/xdrc_template_unifier_test.py
@@ -2,8 +2,7 @@ import json
 import os
 
 from demisto_sdk.commands.common.legacy_git_tools import git_path
-from demisto_sdk.commands.unify.xdrc_template_unifier import \
-    XDRCTemplateUnifier
+from demisto_sdk.commands.unify.xdrc_template_unifier import XDRCTemplateUnifier
 
 TESTS_DIR = f'{git_path()}/demisto_sdk/tests'
 

--- a/demisto_sdk/commands/unify/tests/yml_unifier_test.py
+++ b/demisto_sdk/commands/unify/tests/yml_unifier_test.py
@@ -14,8 +14,7 @@ from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.common.handlers import JSON_Handler, YAML_Handler
 from demisto_sdk.commands.common.legacy_git_tools import git_path
 from demisto_sdk.commands.common.tools import get_yaml
-from demisto_sdk.commands.unify.integration_script_unifier import \
-    IntegrationScriptUnifier
+from demisto_sdk.commands.unify.integration_script_unifier import IntegrationScriptUnifier
 from TestSuite.test_tools import ChangeCWD
 
 json = JSON_Handler()
@@ -649,8 +648,7 @@ final test: hi
         Then
         - Ensure Unify command works with default output given relative path to current directory.
         """
-        from demisto_sdk.commands.unify.integration_script_unifier import \
-            IntegrationScriptUnifier
+        from demisto_sdk.commands.unify.integration_script_unifier import IntegrationScriptUnifier
         abs_path_mock = mocker.patch('demisto_sdk.commands.unify.integration_script_unifier.os.path.abspath')
         abs_path_mock.return_value = TESTS_DIR + '/test_files/Packs/DummyPack/Integrations/UploadTest'
         input_path_integration = '.'

--- a/demisto_sdk/commands/unify/yaml_unifier.py
+++ b/demisto_sdk/commands/unify/yaml_unifier.py
@@ -4,9 +4,7 @@ import sys
 from abc import ABC, abstractmethod
 from typing import Optional
 
-from demisto_sdk.commands.common.constants import (DIR_TO_PREFIX,
-                                                   INTEGRATIONS_DIR,
-                                                   SCRIPTS_DIR)
+from demisto_sdk.commands.common.constants import DIR_TO_PREFIX, INTEGRATIONS_DIR, SCRIPTS_DIR
 from demisto_sdk.commands.common.errors import Errors
 from demisto_sdk.commands.common.handlers import YAML_Handler
 from demisto_sdk.commands.common.tools import get_yml_paths_in_dir, print_error

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_manager_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_manager_test.py
@@ -1,7 +1,6 @@
 import pytest
 
-from demisto_sdk.commands.update_release_notes.update_rn_manager import \
-    UpdateReleaseNotesManager
+from demisto_sdk.commands.update_release_notes.update_rn_manager import UpdateReleaseNotesManager
 
 
 class TestUpdateRNManager:
@@ -109,8 +108,7 @@ class TestUpdateRNManager:
         Then:
             - execute_update in UpdateRN should be called.
         """
-        from demisto_sdk.commands.update_release_notes.update_rn_manager import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn_manager import UpdateRN
 
         mng = UpdateReleaseNotesManager()
         mock_func = mocker.patch.object(UpdateRN, 'execute_update', return_result=True)
@@ -153,8 +151,7 @@ class TestUpdateRNManager:
         Then:
             - The update is successfully executed and no error is raised.
         """
-        from demisto_sdk.commands.update_release_notes.update_rn_manager import \
-            UpdateReleaseNotesManager
+        from demisto_sdk.commands.update_release_notes.update_rn_manager import UpdateReleaseNotesManager
         mocker.patch.object(UpdateReleaseNotesManager, 'get_git_changed_files',
                             return_value=({'Packs/test1', 'Packs/test2'}, set(), set()))
         mocker.patch.object(UpdateReleaseNotesManager, 'check_existing_rn')
@@ -173,10 +170,8 @@ class TestUpdateRNManager:
         Then:
             - The update is successfully executed on both packs and no error is raised.
         """
-        from demisto_sdk.commands.update_release_notes.update_rn_manager import \
-            UpdateReleaseNotesManager
-        from demisto_sdk.commands.validate.validate_manager import \
-            ValidateManager
+        from demisto_sdk.commands.update_release_notes.update_rn_manager import UpdateReleaseNotesManager
+        from demisto_sdk.commands.validate.validate_manager import ValidateManager
         mocker.patch.object(ValidateManager, 'setup_git_params')
         mocker.patch.object(ValidateManager, 'filter_to_relevant_files', side_effect=(lambda x: (set(x), set(), True)))
         mocker.patch.object(ValidateManager, 'get_unfiltered_changed_files_from_git',

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -10,15 +10,13 @@ from typing import Dict, Optional
 import mock
 import pytest
 
-from demisto_sdk.commands.common.constants import (
-    DEFAULT_CONTENT_ITEM_TO_VERSION, FileType)
+from demisto_sdk.commands.common.constants import DEFAULT_CONTENT_ITEM_TO_VERSION, FileType
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.legacy_git_tools import git_path
 from demisto_sdk.commands.common.tools import get_json
 from demisto_sdk.commands.common.update_id_set import DEFAULT_ID_SET_PATH
-from demisto_sdk.commands.update_release_notes.update_rn import (
-    CLASS_BY_FILE_TYPE, UpdateRN, deprecated_commands,
-    get_deprecated_comment_from_desc, get_deprecated_rn)
+from demisto_sdk.commands.update_release_notes.update_rn import (CLASS_BY_FILE_TYPE, UpdateRN, deprecated_commands,
+                                                                 get_deprecated_comment_from_desc, get_deprecated_rn)
 
 json = JSON_Handler()
 
@@ -133,8 +131,7 @@ class TestRNUpdate:
                 - return a markdown string
         """
         expected_result = "\n#### Playbooks\n##### New: Hello World Playbook\n- Hello World Playbook description\n"
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mock_master.return_value = '1.0.0'
         update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='minor', modified_files_in_pack={'HelloWorld'},
                              added_files=set())
@@ -155,8 +152,7 @@ class TestRNUpdate:
                 - return a markdown string
         """
         expected_result = '\n#### Playbooks\n##### Hello World Playbook\n- %%UPDATE_RN%%\n'
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mocker.patch.object(UpdateRN, 'get_master_version', return_value='1.0.0')
         mocker.patch('demisto_sdk.commands.update_release_notes.update_rn.get_deprecated_rn', return_value='')
         update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='minor', modified_files_in_pack={'HelloWorld'},
@@ -180,8 +176,7 @@ class TestRNUpdate:
                 - return a markdown string
         """
         expected_result = '\n#### Incident Fields\n- **Hello World IncidentField**\n'
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mock_master.return_value = '1.0.0'
         update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='minor', modified_files_in_pack={'HelloWorld'},
                              added_files=set())
@@ -204,8 +199,7 @@ class TestRNUpdate:
         """
         expected_result = "\n#### Integrations\n##### Hello World Integration\n" \
                           "- Documentation and metadata improvements.\n"
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mock_master.return_value = '1.0.0'
         update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='documentation',
                              modified_files_in_pack={'HelloWorld'},
@@ -227,8 +221,7 @@ class TestRNUpdate:
             - return a markdown string
         """
         expected_result = "\n#### Integrations\n##### HelloWorld\n- Documentation and metadata improvements.\n"
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mock_master.return_value = '1.0.0'
         update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='minor', modified_files_in_pack=set(),
                              added_files=set(),
@@ -253,8 +246,7 @@ class TestRNUpdate:
             - case 3: validate that the output of the function is True
             - case 4: validate that the output of the function is False
         """
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mock_master.return_value = '1.0.0'
 
         # case 1:
@@ -309,8 +301,7 @@ class TestRNUpdate:
                 - return only the yml of the changed file
         """
         expected_result = "Integration/HelloWorld.yml"
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mock_master.return_value = '1.0.0'
         update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='minor', modified_files_in_pack={'HelloWorld'},
                              added_files=set())
@@ -329,8 +320,7 @@ class TestRNUpdate:
                 - the filepath of the correct release notes.
         """
         expected_result = 'Packs/HelloWorld/ReleaseNotes/1_1_1.md'
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mock_master.return_value = '1.0.0'
         update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='minor', modified_files_in_pack={'HelloWorld'},
                              added_files=set())
@@ -351,8 +341,7 @@ class TestRNUpdate:
         shutil.copy(src=os.path.join(TestRNUpdate.FILES_PATH, 'fake_pack/pack_metadata.json'),
                     dst=os.path.join(TestRNUpdate.FILES_PATH, 'fake_pack/_pack_metadata.json'))
         expected_version = '1.1.0'
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mock_master.return_value = '1.0.0'
         update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='minor', modified_files_in_pack={'HelloWorld'},
                              added_files=set())
@@ -376,8 +365,7 @@ class TestRNUpdate:
         shutil.copy(src=os.path.join(TestRNUpdate.FILES_PATH, 'fake_pack/pack_metadata.json'),
                     dst=os.path.join(TestRNUpdate.FILES_PATH, 'fake_pack/_pack_metadata.json'))
         expected_version = '2.0.0'
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mock_master.return_value = '1.0.0'
         update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='major', modified_files_in_pack={'HelloWorld'},
                              added_files=set())
@@ -401,8 +389,7 @@ class TestRNUpdate:
         shutil.copy(src=os.path.join(TestRNUpdate.FILES_PATH, 'fake_pack/pack_metadata.json'),
                     dst=os.path.join(TestRNUpdate.FILES_PATH, 'fake_pack/_pack_metadata.json'))
         expected_version = '1.0.1'
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mock_master.return_value = '1.0.0'
         update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='revision',
                              modified_files_in_pack={'HelloWorld'}, added_files=set())
@@ -426,8 +413,7 @@ class TestRNUpdate:
         shutil.copy(src=os.path.join(TestRNUpdate.FILES_PATH, 'fake_pack/pack_metadata.json'),
                     dst=os.path.join(TestRNUpdate.FILES_PATH, 'fake_pack/_pack_metadata.json'))
         expected_version = '2.0.0'
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mock_master.return_value = '1.0.0'
         update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type=None, specific_version='2.0.0',
                              modified_files_in_pack={'HelloWorld'}, added_files=set())
@@ -452,8 +438,7 @@ class TestRNUpdate:
         """
         shutil.copy(src=os.path.join(TestRNUpdate.FILES_PATH, 'fake_pack_invalid/pack_metadata.json'),
                     dst=os.path.join(TestRNUpdate.FILES_PATH, 'fake_pack_invalid/_pack_metadata.json'))
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mock_master.return_value = '0.0.0'
         update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='revision',
                              modified_files_in_pack={'HelloWorld'}, added_files=set())
@@ -476,8 +461,7 @@ class TestRNUpdate:
         """
         shutil.copy(src=os.path.join(TestRNUpdate.FILES_PATH, 'fake_pack_invalid/pack_metadata.json'),
                     dst=os.path.join(TestRNUpdate.FILES_PATH, 'fake_pack_invalid/_pack_metadata.json'))
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mock_master.return_value = '0.0.0'
         update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='minor', modified_files_in_pack={'HelloWorld'},
                              added_files=set())
@@ -500,8 +484,7 @@ class TestRNUpdate:
         """
         shutil.copy(src=os.path.join(TestRNUpdate.FILES_PATH, 'fake_pack_invalid/pack_metadata.json'),
                     dst=os.path.join(TestRNUpdate.FILES_PATH, 'fake_pack_invalid/_pack_metadata.json'))
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mock_master.return_value = '0.0.0'
         update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='major', modified_files_in_pack={'HelloWorld'},
                              added_files=set())
@@ -522,8 +505,7 @@ class TestRNUpdate:
             Then:
                 - return ValueError
         """
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mock_master.return_value = '0.0.0'
         update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='major', modified_files_in_pack={'HelloWorld'},
                              added_files=set())
@@ -542,8 +524,7 @@ class TestRNUpdate:
             Then:
                 - return ValueError
         """
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mock_master.return_value = '1.0.0'
         update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type=None, modified_files_in_pack={'HelloWorld'},
                              added_files=set())
@@ -561,8 +542,7 @@ class TestRNUpdate:
             Then
                 - Validate That from-version added to the rn description.
             """
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
 
         update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='minor', modified_files_in_pack={'HelloWorld'},
                              added_files=set())
@@ -581,8 +561,7 @@ class TestRNUpdate:
             Then
                 - Validate That from-version was not added to the rn description.
             """
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
 
         update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='minor', modified_files_in_pack={'HelloWorld'},
                              added_files=set())
@@ -601,8 +580,7 @@ class TestRNUpdate:
             Then
                 - Validate That from-version added to each of rn descriptions.
             """
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
 
         changed_items = {
             ('Hello World Integration', FileType.INTEGRATION): {'description': "", 'is_new_file': True,
@@ -630,8 +608,7 @@ class TestRNUpdate:
             Then
                - could not bump version number and system exit occurs
             """
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mock_bump_version_number.side_effect = ValueError('Test')
         mock_is_bump_required.return_value = True
         with pytest.raises(ValueError) as e:
@@ -650,8 +627,7 @@ class TestRNUpdate:
             Then
                - bump version number is not required
             """
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mock_master.return_value = True
         client = UpdateRN(pack_path="Packs/Test", update_type='minor', modified_files_in_pack={
             'Packs/Test/Integrations/Test.yml'}, added_files=set('Packs/Test/some_added_file.py'))
@@ -669,10 +645,8 @@ class TestRNUpdate:
         Then:
         - Ensure file is filtered.
         """
-        from demisto_sdk.commands.update_release_notes.update_rn_manager import \
-            UpdateReleaseNotesManager
-        from demisto_sdk.commands.validate.validate_manager import \
-            ValidateManager
+        from demisto_sdk.commands.update_release_notes.update_rn_manager import UpdateReleaseNotesManager
+        from demisto_sdk.commands.validate.validate_manager import ValidateManager
         manager = UpdateReleaseNotesManager(user_input='BitcoinAbuse')
         validate_manager: ValidateManager = ValidateManager(check_is_unskipped=False)
         filtered_set, old_format_files, _ = manager.filter_to_relevant_files(
@@ -774,8 +748,7 @@ class TestRNUpdate:
                 Ensure the function returns a valid rn when the command is deprecated compared to last yml and the
                  text is added
         """
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         FILES_PATH = os.path.normpath(os.path.join(__file__, f'{git_path()}/demisto_sdk/tests', 'test_files'))
         NOT_DEP_INTEGRATION_PATH = pathlib.Path(FILES_PATH, 'deprecated_rn_test', 'not_deprecated_integration.yml')
 
@@ -986,8 +959,7 @@ class TestRNUpdateUnit:
             Then:
                 - return tuple where first value is the pack name, and second is the item type
         """
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mocker.patch.object(UpdateRN, 'get_master_version', return_value='0.0.0')
         update_rn = UpdateRN(pack_path=pack_name, update_type='minor', modified_files_in_pack={'HelloWorld'},
                              added_files=set())
@@ -1007,8 +979,7 @@ class TestRNUpdateUnit:
             Then:
                 - create the directory if it does not exist
         """
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mocker.patch.object(UpdateRN, 'get_master_version', return_value='0.0.0')
         filepath = os.path.join(TestRNUpdate.FILES_PATH, 'ReleaseNotes')
         update_rn = UpdateRN(pack_path="Packs/VulnDB", update_type='minor', modified_files_in_pack={'HelloWorld'},
@@ -1024,8 +995,7 @@ class TestRNUpdateUnit:
             Then:
                 - create the file or skip if it exists.
         """
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mocker.patch.object(UpdateRN, 'get_master_version', return_value='0.0.0')
         update_rn = UpdateRN(pack_path="Packs/VulnDB", update_type='minor', modified_files_in_pack={'HelloWorld'},
                              added_files=set())
@@ -1042,8 +1012,7 @@ class TestRNUpdateUnit:
             Then:
                 - return updated release notes while preserving the integrity of the existing notes.
         """
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mocker.patch.object(UpdateRN, 'get_master_version', return_value='0.0.0')
         mocker.patch('demisto_sdk.commands.update_release_notes.update_rn.get_definition_name', return_value="Asset")
         update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='minor', modified_files_in_pack={'HelloWorld'},
@@ -1062,8 +1031,7 @@ class TestRNUpdateUnit:
         """
         ORIGINAL = os.path.join(TestRNUpdate.FILES_PATH, 'fake_pack_invalid/pack_metadata.json')
         TEMP_FILE = os.path.join(TestRNUpdate.FILES_PATH, 'fake_pack_invalid/_pack_metadata.json')
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mocker.patch.object(UpdateRN, 'get_master_version', return_value='0.0.0')
         update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='minor', modified_files_in_pack={'HelloWorld'},
                              added_files=set())
@@ -1083,8 +1051,7 @@ class TestRNUpdateUnit:
             Then:
                 - return a list of relevant pack files which were added.
         """
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         added_files = {'HelloWorld/something_new.md', 'HelloWorld/test_data/nothing.md'}
         mocker.patch.object(UpdateRN, 'get_master_version', return_value='0.0.0')
         update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='minor', modified_files_in_pack=set(),
@@ -1101,8 +1068,7 @@ class TestRNUpdateUnit:
             Then:
                 - return False to indicate it does not exist.
         """
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mocker.patch.object(UpdateRN, 'get_master_version', return_value='0.0.0')
         update_rn = UpdateRN(pack_path="Packs/HelloWorld", update_type='minor', modified_files_in_pack=set(),
                              added_files=set())
@@ -1119,8 +1085,7 @@ class TestRNUpdateUnit:
             Then:
                 - return an error message and exit.
         """
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mocker.patch.object(UpdateRN, 'get_master_version', return_value='0.0.0')
         update_rn = UpdateRN(pack_path="Packs/Legacy", update_type='minor', modified_files_in_pack=set(),
                              added_files=set())
@@ -1157,8 +1122,7 @@ class TestRNUpdateUnit:
         """
         from subprocess import Popen
 
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mocker.patch.object(UpdateRN, 'get_master_version', return_value=git_current_version)
         update_rn = UpdateRN(pack_path="Packs/Base", update_type='minor', modified_files_in_pack=set(),
                              added_files=set())
@@ -1180,8 +1144,7 @@ class TestRNUpdateUnit:
         Then:
             file list should contain the new file path and ignore the old path.
         """
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         mocker.patch.object(UpdateRN, 'get_master_version', return_value='0.0.0')
         modified_files = {
             'file1',
@@ -1208,8 +1171,7 @@ class TestRNUpdateUnit:
             case 1 & 2: change the file path to the corresponding yml file.
             case 3: file path remains unchnaged
         """
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         integration_image_file_path = "Packs/DNSDB/Integrations/DNSDB_v2/DNSDB_v2_image.png"
         xsiam_image_file_path = "Packs/Dropbox/XSIAMDashboards/DropboxDashboard_image.png"
         description_file_path = "Packs/DNSDB/Integrations/DNSDB_v2/DNSDB_v2_description.md"
@@ -1231,8 +1193,7 @@ class TestRNUpdateUnit:
             - Call print_error with the appropriate error message
         """
         import demisto_sdk.commands.update_release_notes.update_rn
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            update_api_modules_dependents_rn
+        from demisto_sdk.commands.update_release_notes.update_rn import update_api_modules_dependents_rn
         if os.path.exists(DEFAULT_ID_SET_PATH):
             os.remove(DEFAULT_ID_SET_PATH)
         print_error_mock = mocker.patch.object(demisto_sdk.commands.update_release_notes.update_rn, "print_error")
@@ -1252,8 +1213,7 @@ class TestRNUpdateUnit:
         Then
             - Ensure execute_update_mock is called
         """
-        from demisto_sdk.commands.update_release_notes.update_rn import (
-            UpdateRN, update_api_modules_dependents_rn)
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN, update_api_modules_dependents_rn
         mocker.patch.object(UpdateRN, 'get_master_version', return_value='0.0.0')
 
         modified = {'/Packs/ApiModules/Scripts/ApiModules_script/ApiModules_script.yml'}
@@ -1287,8 +1247,7 @@ class TestRNUpdateUnit:
         Then
             - No changes should be done in release notes
         """
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            check_docker_image_changed
+        from demisto_sdk.commands.update_release_notes.update_rn import check_docker_image_changed
 
         return_value = '+category: Utilities\
                         +commonfields:\
@@ -1325,8 +1284,7 @@ class TestRNUpdateUnit:
             - Case 1: Should extract the dockerimage version for integration yml demonstration.
             - Case 2: Should extract the dockerimage version for script yml demonstration.
         """
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            check_docker_image_changed
+        from demisto_sdk.commands.update_release_notes.update_rn import check_docker_image_changed
 
         return_value = '+  dockerimage: demisto/python3:3.9.8.24399'
 
@@ -1346,8 +1304,7 @@ class TestRNUpdateUnit:
         """
         import os
 
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         expected_res = "diff --git a/Packs/test1/Integrations/test1/test1.yml b/Packs/test1/Integrations/test1/test1.yml\n" \
                        "--- a/Packs/test1/Integrations/test1/test1.yml\n" \
                        "+++ b/Packs/test1/Integrations/test1/test1.yml\n" \
@@ -1393,8 +1350,7 @@ class TestRNUpdateUnit:
         Then
             - A new record with the updated docker image is added.
         """
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         with open('demisto_sdk/commands/update_release_notes/tests_data/Packs/Test/pack_metadata.json', 'r') as file:
             pack_data = json.load(file)
         with open('demisto_sdk/commands/update_release_notes/tests_data/Packs/release_notes/1_0_0.md', 'w') as file:
@@ -1434,8 +1390,7 @@ class TestRNUpdateUnit:
         """
         import os
 
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         with open('demisto_sdk/commands/update_release_notes/tests_data/Packs/Test/pack_metadata.json', 'r') as file:
             pack_data = json.load(file)
         mocker.patch('demisto_sdk.commands.update_release_notes.update_rn.run_command',
@@ -1470,8 +1425,7 @@ class TestRNUpdateUnit:
         """
         import os
 
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         with open('demisto_sdk/commands/update_release_notes/tests_data/Packs/Test/pack_metadata.json', 'r') as file:
             pack_data = json.load(file)
         mocker.patch('demisto_sdk.commands.update_release_notes.update_rn.run_command',
@@ -1537,8 +1491,7 @@ class TestRNUpdateUnit:
         Case d: Conf JSON file generated with old value for breakingChangesNotes, and true value for breakingChanges.
 
         """
-        from demisto_sdk.commands.update_release_notes.update_rn import \
-            UpdateRN
+        from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
         client = UpdateRN(pack_path=pack.path, update_type=None, modified_files_in_pack=set(), added_files=set(),
                           is_bc=is_bc)
         conf_path: str = f'{pack.path}/ReleaseNotes/1_0_1.json'
@@ -1565,8 +1518,7 @@ def test_get_from_version_at_update_rn(integration):
             - Case 1: Assert that the `fromversion` value is 5.0.0
             - Case 2: Assert that the `fromversion` value is None
         """
-    from demisto_sdk.commands.update_release_notes.update_rn import \
-        get_from_version_at_update_rn
+    from demisto_sdk.commands.update_release_notes.update_rn import get_from_version_at_update_rn
 
     integration.yml.write_dict({'fromversion': '5.0.0'})
     fromversion = get_from_version_at_update_rn(integration.yml.path)

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -9,29 +9,20 @@ from distutils.version import LooseVersion
 from pathlib import Path
 from typing import Any, Optional, Tuple, Union
 
-from demisto_sdk.commands.common.constants import (
-    ALL_FILES_VALIDATION_IGNORE_WHITELIST, DEPRECATED_REGEXES,
-    IGNORED_PACK_NAMES, RN_HEADER_BY_FILE_TYPE, XSIAM_DASHBOARDS_DIR,
-    XSIAM_REPORTS_DIR, FileType)
+from demisto_sdk.commands.common.constants import (ALL_FILES_VALIDATION_IGNORE_WHITELIST, DEPRECATED_REGEXES,
+                                                   IGNORED_PACK_NAMES, RN_HEADER_BY_FILE_TYPE, XSIAM_DASHBOARDS_DIR,
+                                                   XSIAM_REPORTS_DIR, FileType)
 from demisto_sdk.commands.common.content import Content
-from demisto_sdk.commands.common.content.objects.pack_objects import (
-    Integration, Playbook, Script)
+from demisto_sdk.commands.common.content.objects.pack_objects import Integration, Playbook, Script
 from demisto_sdk.commands.common.content.objects.pack_objects.abstract_pack_objects.yaml_content_object import \
     YAMLContentObject
-from demisto_sdk.commands.common.content_constant_paths import \
-    DEFAULT_ID_SET_PATH
+from demisto_sdk.commands.common.content_constant_paths import DEFAULT_ID_SET_PATH
 from demisto_sdk.commands.common.git_util import GitUtil
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.common.tools import (LOG_COLORS, find_type,
-                                               get_api_module_ids,
-                                               get_api_module_integrations_set,
-                                               get_definition_name,
-                                               get_display_name,
-                                               get_from_version, get_json,
-                                               get_latest_release_notes_text,
-                                               get_pack_name, get_remote_file,
-                                               get_yaml, pack_name_to_path,
-                                               print_color, print_error,
+from demisto_sdk.commands.common.tools import (LOG_COLORS, find_type, get_api_module_ids,
+                                               get_api_module_integrations_set, get_definition_name, get_display_name,
+                                               get_from_version, get_json, get_latest_release_notes_text, get_pack_name,
+                                               get_remote_file, get_yaml, pack_name_to_path, print_color, print_error,
                                                print_warning, run_command)
 
 json = JSON_Handler()

--- a/demisto_sdk/commands/update_release_notes/update_rn_manager.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn_manager.py
@@ -4,17 +4,11 @@ from typing import Optional, Tuple
 
 import git
 
-from demisto_sdk.commands.common.constants import (
-    API_MODULES_PACK, SKIP_RELEASE_NOTES_FOR_TYPES)
-from demisto_sdk.commands.common.tools import (LOG_COLORS,
-                                               filter_files_by_type,
-                                               filter_files_on_pack,
-                                               get_pack_name,
-                                               get_pack_names_from_files,
-                                               pack_name_to_path, print_color,
-                                               print_warning, suppress_stdout)
-from demisto_sdk.commands.update_release_notes.update_rn import (
-    UpdateRN, update_api_modules_dependents_rn)
+from demisto_sdk.commands.common.constants import API_MODULES_PACK, SKIP_RELEASE_NOTES_FOR_TYPES
+from demisto_sdk.commands.common.tools import (LOG_COLORS, filter_files_by_type, filter_files_on_pack, get_pack_name,
+                                               get_pack_names_from_files, pack_name_to_path, print_color, print_warning,
+                                               suppress_stdout)
+from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN, update_api_modules_dependents_rn
 from demisto_sdk.commands.validate.validate_manager import ValidateManager
 
 

--- a/demisto_sdk/commands/update_xsoar_config_file/tests/update_xsoar_config_file_test.py
+++ b/demisto_sdk/commands/update_xsoar_config_file/tests/update_xsoar_config_file_test.py
@@ -8,8 +8,7 @@ import pytest
 from demisto_sdk.__main__ import xsoar_config_file_update
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.tools import src_root
-from demisto_sdk.commands.update_xsoar_config_file.update_xsoar_config_file import \
-    XSOARConfigFileUpdater
+from demisto_sdk.commands.update_xsoar_config_file.update_xsoar_config_file import XSOARConfigFileUpdater
 
 json = JSON_Handler()
 

--- a/demisto_sdk/commands/upload/tests/uploader_test.py
+++ b/demisto_sdk/commands/upload/tests/uploader_test.py
@@ -17,21 +17,17 @@ from packaging.version import parse
 
 from demisto_sdk.__main__ import main, upload
 from demisto_sdk.commands.common import constants
-from demisto_sdk.commands.common.constants import (CLASSIFIERS_DIR,
-                                                   INTEGRATIONS_DIR,
-                                                   LAYOUTS_DIR, SCRIPTS_DIR,
-                                                   TEST_PLAYBOOKS_DIR,
-                                                   FileType)
-from demisto_sdk.commands.common.content.objects.pack_objects.pack import (
-    DELETE_VERIFY_KEY_ACTION, TURN_VERIFICATION_ERROR_MSG, Pack)
+from demisto_sdk.commands.common.constants import (CLASSIFIERS_DIR, INTEGRATIONS_DIR, LAYOUTS_DIR, SCRIPTS_DIR,
+                                                   TEST_PLAYBOOKS_DIR, FileType)
+from demisto_sdk.commands.common.content.objects.pack_objects.pack import (DELETE_VERIFY_KEY_ACTION,
+                                                                           TURN_VERIFICATION_ERROR_MSG, Pack)
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.legacy_git_tools import git_path
 from demisto_sdk.commands.common.tools import get_yml_paths_in_dir, src_root
 from demisto_sdk.commands.test_content import tools
 from demisto_sdk.commands.upload import uploader
-from demisto_sdk.commands.upload.uploader import (
-    ItemDetacher, Uploader, parse_error_response, print_summary,
-    sort_directories_based_on_dependencies)
+from demisto_sdk.commands.upload.uploader import (ItemDetacher, Uploader, parse_error_response, print_summary,
+                                                  sort_directories_based_on_dependencies)
 from TestSuite.test_tools import ChangeCWD
 
 json = JSON_Handler()

--- a/demisto_sdk/commands/upload/uploader.py
+++ b/demisto_sdk/commands/upload/uploader.py
@@ -10,31 +10,18 @@ from demisto_client.demisto_api.rest import ApiException
 from packaging.version import Version
 from tabulate import tabulate
 
-from demisto_sdk.commands.common.constants import (CLASSIFIERS_DIR,
-                                                   CONTENT_ENTITIES_DIRS,
-                                                   DASHBOARDS_DIR,
-                                                   INCIDENT_FIELDS_DIR,
-                                                   INCIDENT_TYPES_DIR,
-                                                   INDICATOR_FIELDS_DIR,
-                                                   INDICATOR_TYPES_DIR,
-                                                   INTEGRATIONS_DIR, JOBS_DIR,
-                                                   LAYOUTS_DIR, LISTS_DIR,
-                                                   PLAYBOOKS_DIR, REPORTS_DIR,
-                                                   SCRIPTS_DIR,
-                                                   TEST_PLAYBOOKS_DIR,
-                                                   WIDGETS_DIR, FileType)
+from demisto_sdk.commands.common.constants import (CLASSIFIERS_DIR, CONTENT_ENTITIES_DIRS, DASHBOARDS_DIR,
+                                                   INCIDENT_FIELDS_DIR, INCIDENT_TYPES_DIR, INDICATOR_FIELDS_DIR,
+                                                   INDICATOR_TYPES_DIR, INTEGRATIONS_DIR, JOBS_DIR, LAYOUTS_DIR,
+                                                   LISTS_DIR, PLAYBOOKS_DIR, REPORTS_DIR, SCRIPTS_DIR,
+                                                   TEST_PLAYBOOKS_DIR, WIDGETS_DIR, FileType)
 from demisto_sdk.commands.common.content.errors import ContentFactoryError
-from demisto_sdk.commands.common.content.objects.abstract_objects import (
-    JSONObject, YAMLObject)
+from demisto_sdk.commands.common.content.objects.abstract_objects import JSONObject, YAMLObject
 from demisto_sdk.commands.common.content.objects.pack_objects.pack import Pack
-from demisto_sdk.commands.common.content.objects_factory import \
-    path_to_pack_object
+from demisto_sdk.commands.common.content.objects_factory import path_to_pack_object
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.common.tools import (find_type,
-                                               get_child_directories,
-                                               get_demisto_version, get_file,
-                                               get_parent_directory_name,
-                                               print_v)
+from demisto_sdk.commands.common.tools import (find_type, get_child_directories, get_demisto_version, get_file,
+                                               get_parent_directory_name, print_v)
 
 json = JSON_Handler()
 

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -11,76 +11,58 @@ from mock import patch
 
 import demisto_sdk.commands.validate.validate_manager
 from demisto_sdk.commands.common import tools
-from demisto_sdk.commands.common.constants import (
-    FILETYPE_TO_DEFAULT_FROMVERSION, PACKS_PACK_META_FILE_NAME, TEST_PLAYBOOK,
-    FileType)
+from demisto_sdk.commands.common.constants import (FILETYPE_TO_DEFAULT_FROMVERSION, PACKS_PACK_META_FILE_NAME,
+                                                   TEST_PLAYBOOK, FileType)
 from demisto_sdk.commands.common.content_constant_paths import CONF_PATH
 from demisto_sdk.commands.common.errors import Errors
 from demisto_sdk.commands.common.git_util import GitUtil
 from demisto_sdk.commands.common.handlers import JSON_Handler
-from demisto_sdk.commands.common.hook_validations.base_validator import \
-    BaseValidator
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
-from demisto_sdk.commands.common.hook_validations.dashboard import \
-    DashboardValidator
-from demisto_sdk.commands.common.hook_validations.description import \
-    DescriptionValidator
-from demisto_sdk.commands.common.hook_validations.generic_field import \
-    GenericFieldValidator
+from demisto_sdk.commands.common.hook_validations.base_validator import BaseValidator
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
+from demisto_sdk.commands.common.hook_validations.dashboard import DashboardValidator
+from demisto_sdk.commands.common.hook_validations.description import DescriptionValidator
+from demisto_sdk.commands.common.hook_validations.generic_field import GenericFieldValidator
 from demisto_sdk.commands.common.hook_validations.image import ImageValidator
-from demisto_sdk.commands.common.hook_validations.incident_field import \
-    IncidentFieldValidator
-from demisto_sdk.commands.common.hook_validations.integration import \
-    IntegrationValidator
-from demisto_sdk.commands.common.hook_validations.layout import (
-    LayoutsContainerValidator, LayoutValidator)
-from demisto_sdk.commands.common.hook_validations.old_release_notes import \
-    OldReleaseNotesValidator
-from demisto_sdk.commands.common.hook_validations.pack_unique_files import \
-    PackUniqueFilesValidator
-from demisto_sdk.commands.common.hook_validations.playbook import \
-    PlaybookValidator
-from demisto_sdk.commands.common.hook_validations.release_notes import \
-    ReleaseNotesValidator
-from demisto_sdk.commands.common.hook_validations.reputation import \
-    ReputationValidator
+from demisto_sdk.commands.common.hook_validations.incident_field import IncidentFieldValidator
+from demisto_sdk.commands.common.hook_validations.integration import IntegrationValidator
+from demisto_sdk.commands.common.hook_validations.layout import LayoutsContainerValidator, LayoutValidator
+from demisto_sdk.commands.common.hook_validations.old_release_notes import OldReleaseNotesValidator
+from demisto_sdk.commands.common.hook_validations.pack_unique_files import PackUniqueFilesValidator
+from demisto_sdk.commands.common.hook_validations.playbook import PlaybookValidator
+from demisto_sdk.commands.common.hook_validations.release_notes import ReleaseNotesValidator
+from demisto_sdk.commands.common.hook_validations.reputation import ReputationValidator
 from demisto_sdk.commands.common.hook_validations.script import ScriptValidator
-from demisto_sdk.commands.common.hook_validations.structure import \
-    StructureValidator
+from demisto_sdk.commands.common.hook_validations.structure import StructureValidator
 from demisto_sdk.commands.common.hook_validations.widget import WidgetValidator
 from demisto_sdk.commands.common.legacy_git_tools import git_path
-from demisto_sdk.commands.unify.integration_script_unifier import \
-    IntegrationScriptUnifier
+from demisto_sdk.commands.unify.integration_script_unifier import IntegrationScriptUnifier
 from demisto_sdk.commands.validate.validate_manager import ValidateManager
-from demisto_sdk.tests.constants_test import (
-    CONF_JSON_MOCK_PATH, DASHBOARD_TARGET, DIR_LIST, IGNORED_PNG,
-    INCIDENT_FIELD_TARGET, INCIDENT_TYPE_TARGET, INDICATOR_TYPE_TARGET,
-    INTEGRATION_RELEASE_NOTES_TARGET, INTEGRATION_TARGET,
-    INVALID_BETA_INTEGRATION, INVALID_DASHBOARD_PATH,
-    INVALID_IGNORED_UNIFIED_INTEGRATION, INVALID_INCIDENT_FIELD_PATH,
-    INVALID_INTEGRATION_ID_PATH, INVALID_INTEGRATION_NO_TESTS,
-    INVALID_INTEGRATION_NON_CONFIGURED_TESTS, INVALID_LAYOUT_CONTAINER_PATH,
-    INVALID_LAYOUT_PATH, INVALID_MULTI_LINE_1_CHANGELOG_PATH,
-    INVALID_MULTI_LINE_2_CHANGELOG_PATH, INVALID_ONE_LINE_1_CHANGELOG_PATH,
-    INVALID_ONE_LINE_2_CHANGELOG_PATH, INVALID_ONE_LINE_LIST_1_CHANGELOG_PATH,
-    INVALID_ONE_LINE_LIST_2_CHANGELOG_PATH, INVALID_PLAYBOOK_CONDITION_1,
-    INVALID_PLAYBOOK_CONDITION_2, INVALID_PLAYBOOK_ID_PATH,
-    INVALID_PLAYBOOK_PATH, INVALID_PLAYBOOK_PATH_FROM_ROOT,
-    INVALID_REPUTATION_PATH, INVALID_SCRIPT_PATH, INVALID_WIDGET_PATH,
-    LAYOUT_TARGET, LAYOUTS_CONTAINER_TARGET, MODELING_RULES_SCHEMA_FILE,
-    MODELING_RULES_YML_FILE, PLAYBOOK_TARGET, SCRIPT_RELEASE_NOTES_TARGET,
-    SCRIPT_TARGET, VALID_BETA_INTEGRATION, VALID_BETA_PLAYBOOK_PATH,
-    VALID_DASHBOARD_PATH, VALID_INCIDENT_FIELD_PATH, VALID_INCIDENT_TYPE_PATH,
-    VALID_INDICATOR_FIELD_PATH, VALID_INTEGRATION_ID_PATH,
-    VALID_INTEGRATION_TEST_PATH, VALID_LAYOUT_CONTAINER_PATH,
-    VALID_LAYOUT_PATH, VALID_MD, VALID_MULTI_LINE_CHANGELOG_PATH,
-    VALID_MULTI_LINE_LIST_CHANGELOG_PATH, VALID_ONE_LINE_CHANGELOG_PATH,
-    VALID_ONE_LINE_LIST_CHANGELOG_PATH, VALID_PACK, VALID_PLAYBOOK_CONDITION,
-    VALID_REPUTATION_PATH, VALID_SCRIPT_PATH, VALID_TEST_PLAYBOOK_PATH,
-    VALID_WIDGET_PATH, WIDGET_TARGET)
-from demisto_sdk.tests.test_files.validate_integration_test_valid_types import \
-    INCIDENT_FIELD
+from demisto_sdk.tests.constants_test import (CONF_JSON_MOCK_PATH, DASHBOARD_TARGET, DIR_LIST, IGNORED_PNG,
+                                              INCIDENT_FIELD_TARGET, INCIDENT_TYPE_TARGET, INDICATOR_TYPE_TARGET,
+                                              INTEGRATION_RELEASE_NOTES_TARGET, INTEGRATION_TARGET,
+                                              INVALID_BETA_INTEGRATION, INVALID_DASHBOARD_PATH,
+                                              INVALID_IGNORED_UNIFIED_INTEGRATION, INVALID_INCIDENT_FIELD_PATH,
+                                              INVALID_INTEGRATION_ID_PATH, INVALID_INTEGRATION_NO_TESTS,
+                                              INVALID_INTEGRATION_NON_CONFIGURED_TESTS, INVALID_LAYOUT_CONTAINER_PATH,
+                                              INVALID_LAYOUT_PATH, INVALID_MULTI_LINE_1_CHANGELOG_PATH,
+                                              INVALID_MULTI_LINE_2_CHANGELOG_PATH, INVALID_ONE_LINE_1_CHANGELOG_PATH,
+                                              INVALID_ONE_LINE_2_CHANGELOG_PATH, INVALID_ONE_LINE_LIST_1_CHANGELOG_PATH,
+                                              INVALID_ONE_LINE_LIST_2_CHANGELOG_PATH, INVALID_PLAYBOOK_CONDITION_1,
+                                              INVALID_PLAYBOOK_CONDITION_2, INVALID_PLAYBOOK_ID_PATH,
+                                              INVALID_PLAYBOOK_PATH, INVALID_PLAYBOOK_PATH_FROM_ROOT,
+                                              INVALID_REPUTATION_PATH, INVALID_SCRIPT_PATH, INVALID_WIDGET_PATH,
+                                              LAYOUT_TARGET, LAYOUTS_CONTAINER_TARGET, MODELING_RULES_SCHEMA_FILE,
+                                              MODELING_RULES_YML_FILE, PLAYBOOK_TARGET, SCRIPT_RELEASE_NOTES_TARGET,
+                                              SCRIPT_TARGET, VALID_BETA_INTEGRATION, VALID_BETA_PLAYBOOK_PATH,
+                                              VALID_DASHBOARD_PATH, VALID_INCIDENT_FIELD_PATH, VALID_INCIDENT_TYPE_PATH,
+                                              VALID_INDICATOR_FIELD_PATH, VALID_INTEGRATION_ID_PATH,
+                                              VALID_INTEGRATION_TEST_PATH, VALID_LAYOUT_CONTAINER_PATH,
+                                              VALID_LAYOUT_PATH, VALID_MD, VALID_MULTI_LINE_CHANGELOG_PATH,
+                                              VALID_MULTI_LINE_LIST_CHANGELOG_PATH, VALID_ONE_LINE_CHANGELOG_PATH,
+                                              VALID_ONE_LINE_LIST_CHANGELOG_PATH, VALID_PACK, VALID_PLAYBOOK_CONDITION,
+                                              VALID_REPUTATION_PATH, VALID_SCRIPT_PATH, VALID_TEST_PLAYBOOK_PATH,
+                                              VALID_WIDGET_PATH, WIDGET_TARGET)
+from demisto_sdk.tests.test_files.validate_integration_test_valid_types import INCIDENT_FIELD
 from TestSuite.pack import Pack
 from TestSuite.test_tools import ChangeCWD
 
@@ -478,8 +460,7 @@ class TestValidators:
                                                                 pack_error_ignore_list=[], is_modified=True)
 
     def test_files_validator_validate_pack_unique_files(self, mocker):
-        from demisto_sdk.commands.common.content.objects.pack_objects.pack import \
-            Pack
+        from demisto_sdk.commands.common.content.objects.pack_objects.pack import Pack
         mocker.patch.object(tools, 'get_dict_from_file', return_value=({'approved_list': {}}, 'json'))
         mocker.patch.object(Pack, 'should_be_deprecated', return_value=False)
         mocker.patch('demisto_sdk.commands.common.hook_validations.integration.tools.get_current_categories',
@@ -521,8 +502,7 @@ class TestValidators:
             Then:
                 - return a True validation response
         """
-        from demisto_sdk.commands.common.content.objects.pack_objects.pack import \
-            Pack
+        from demisto_sdk.commands.common.content.objects.pack_objects.pack import Pack
         id_set_path = os.path.normpath(
             os.path.join(__file__, git_path(), 'demisto_sdk', 'tests', 'test_files', 'id_set', 'id_set.json'))
         mocker.patch('demisto_sdk.commands.common.hook_validations.integration.tools.get_current_categories',
@@ -1357,8 +1337,7 @@ def test_skip_conf_json(mocker):
           - If set to `False`, the `ConfJsonValidator` should be called.
 
     """
-    from demisto_sdk.commands.common.hook_validations.conf_json import \
-        ConfJsonValidator
+    from demisto_sdk.commands.common.hook_validations.conf_json import ConfJsonValidator
     conf_json_init = mocker.patch.object(ConfJsonValidator, 'load_conf_file')
     ValidateManager(skip_conf_json=False)
     conf_json_init.asssert_called()

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -12,102 +12,65 @@ from packaging import version
 
 from demisto_sdk.commands.common import tools
 from demisto_sdk.commands.common.configuration import Configuration
-from demisto_sdk.commands.common.constants import (
-    API_MODULES_PACK, AUTHOR_IMAGE_FILE_NAME, CONTENT_ENTITIES_DIRS,
-    DEFAULT_CONTENT_ITEM_TO_VERSION, GENERIC_FIELDS_DIR, GENERIC_TYPES_DIR,
-    IGNORED_PACK_NAMES, OLDEST_SUPPORTED_VERSION, PACKS_DIR,
-    PACKS_PACK_META_FILE_NAME, SKIP_RELEASE_NOTES_FOR_TYPES,
-    VALIDATION_USING_GIT_IGNORABLE_DATA, FileType, FileType_ALLOWED_TO_DELETE,
-    PathLevel)
+from demisto_sdk.commands.common.constants import (API_MODULES_PACK, AUTHOR_IMAGE_FILE_NAME, CONTENT_ENTITIES_DIRS,
+                                                   DEFAULT_CONTENT_ITEM_TO_VERSION, GENERIC_FIELDS_DIR,
+                                                   GENERIC_TYPES_DIR, IGNORED_PACK_NAMES, OLDEST_SUPPORTED_VERSION,
+                                                   PACKS_DIR, PACKS_PACK_META_FILE_NAME, SKIP_RELEASE_NOTES_FOR_TYPES,
+                                                   VALIDATION_USING_GIT_IGNORABLE_DATA, FileType,
+                                                   FileType_ALLOWED_TO_DELETE, PathLevel)
 from demisto_sdk.commands.common.content import Content
-from demisto_sdk.commands.common.content_constant_paths import \
-    DEFAULT_ID_SET_PATH
-from demisto_sdk.commands.common.errors import (FOUND_FILES_AND_ERRORS,
-                                                FOUND_FILES_AND_IGNORED_ERRORS,
-                                                PRESET_ERROR_TO_CHECK,
-                                                PRESET_ERROR_TO_IGNORE, Errors,
+from demisto_sdk.commands.common.content_constant_paths import DEFAULT_ID_SET_PATH
+from demisto_sdk.commands.common.errors import (FOUND_FILES_AND_ERRORS, FOUND_FILES_AND_IGNORED_ERRORS,
+                                                PRESET_ERROR_TO_CHECK, PRESET_ERROR_TO_IGNORE, Errors,
                                                 get_all_error_codes)
 from demisto_sdk.commands.common.git_util import GitUtil
-from demisto_sdk.commands.common.hook_validations.author_image import \
-    AuthorImageValidator
-from demisto_sdk.commands.common.hook_validations.base_validator import (
-    BaseValidator, error_codes)
-from demisto_sdk.commands.common.hook_validations.classifier import \
-    ClassifierValidator
-from demisto_sdk.commands.common.hook_validations.conf_json import \
-    ConfJsonValidator
-from demisto_sdk.commands.common.hook_validations.correlation_rule import \
-    CorrelationRuleValidator
-from demisto_sdk.commands.common.hook_validations.dashboard import \
-    DashboardValidator
-from demisto_sdk.commands.common.hook_validations.deprecation import \
-    DeprecationValidator
-from demisto_sdk.commands.common.hook_validations.description import \
-    DescriptionValidator
-from demisto_sdk.commands.common.hook_validations.generic_definition import \
-    GenericDefinitionValidator
-from demisto_sdk.commands.common.hook_validations.generic_field import \
-    GenericFieldValidator
-from demisto_sdk.commands.common.hook_validations.generic_module import \
-    GenericModuleValidator
-from demisto_sdk.commands.common.hook_validations.generic_type import \
-    GenericTypeValidator
+from demisto_sdk.commands.common.hook_validations.author_image import AuthorImageValidator
+from demisto_sdk.commands.common.hook_validations.base_validator import BaseValidator, error_codes
+from demisto_sdk.commands.common.hook_validations.classifier import ClassifierValidator
+from demisto_sdk.commands.common.hook_validations.conf_json import ConfJsonValidator
+from demisto_sdk.commands.common.hook_validations.correlation_rule import CorrelationRuleValidator
+from demisto_sdk.commands.common.hook_validations.dashboard import DashboardValidator
+from demisto_sdk.commands.common.hook_validations.deprecation import DeprecationValidator
+from demisto_sdk.commands.common.hook_validations.description import DescriptionValidator
+from demisto_sdk.commands.common.hook_validations.generic_definition import GenericDefinitionValidator
+from demisto_sdk.commands.common.hook_validations.generic_field import GenericFieldValidator
+from demisto_sdk.commands.common.hook_validations.generic_module import GenericModuleValidator
+from demisto_sdk.commands.common.hook_validations.generic_type import GenericTypeValidator
 from demisto_sdk.commands.common.hook_validations.id import IDSetValidations
 from demisto_sdk.commands.common.hook_validations.image import ImageValidator
-from demisto_sdk.commands.common.hook_validations.incident_field import \
-    IncidentFieldValidator
-from demisto_sdk.commands.common.hook_validations.incident_type import \
-    IncidentTypeValidator
-from demisto_sdk.commands.common.hook_validations.indicator_field import \
-    IndicatorFieldValidator
-from demisto_sdk.commands.common.hook_validations.integration import \
-    IntegrationValidator
+from demisto_sdk.commands.common.hook_validations.incident_field import IncidentFieldValidator
+from demisto_sdk.commands.common.hook_validations.incident_type import IncidentTypeValidator
+from demisto_sdk.commands.common.hook_validations.indicator_field import IndicatorFieldValidator
+from demisto_sdk.commands.common.hook_validations.integration import IntegrationValidator
 from demisto_sdk.commands.common.hook_validations.job import JobValidator
-from demisto_sdk.commands.common.hook_validations.layout import (
-    LayoutsContainerValidator, LayoutValidator)
+from demisto_sdk.commands.common.hook_validations.layout import LayoutsContainerValidator, LayoutValidator
 from demisto_sdk.commands.common.hook_validations.lists import ListsValidator
 from demisto_sdk.commands.common.hook_validations.mapper import MapperValidator
-from demisto_sdk.commands.common.hook_validations.modeling_rule import \
-    ModelingRuleValidator
-from demisto_sdk.commands.common.hook_validations.pack_unique_files import \
-    PackUniqueFilesValidator
-from demisto_sdk.commands.common.hook_validations.parsing_rule import \
-    ParsingRuleValidator
-from demisto_sdk.commands.common.hook_validations.playbook import \
-    PlaybookValidator
-from demisto_sdk.commands.common.hook_validations.pre_process_rule import \
-    PreProcessRuleValidator
-from demisto_sdk.commands.common.hook_validations.python_file import \
-    PythonFileValidator
+from demisto_sdk.commands.common.hook_validations.modeling_rule import ModelingRuleValidator
+from demisto_sdk.commands.common.hook_validations.pack_unique_files import PackUniqueFilesValidator
+from demisto_sdk.commands.common.hook_validations.parsing_rule import ParsingRuleValidator
+from demisto_sdk.commands.common.hook_validations.playbook import PlaybookValidator
+from demisto_sdk.commands.common.hook_validations.pre_process_rule import PreProcessRuleValidator
+from demisto_sdk.commands.common.hook_validations.python_file import PythonFileValidator
 from demisto_sdk.commands.common.hook_validations.readme import ReadMeValidator
-from demisto_sdk.commands.common.hook_validations.release_notes import \
-    ReleaseNotesValidator
-from demisto_sdk.commands.common.hook_validations.release_notes_config import \
-    ReleaseNotesConfigValidator
+from demisto_sdk.commands.common.hook_validations.release_notes import ReleaseNotesValidator
+from demisto_sdk.commands.common.hook_validations.release_notes_config import ReleaseNotesConfigValidator
 from demisto_sdk.commands.common.hook_validations.report import ReportValidator
-from demisto_sdk.commands.common.hook_validations.reputation import \
-    ReputationValidator
+from demisto_sdk.commands.common.hook_validations.reputation import ReputationValidator
 from demisto_sdk.commands.common.hook_validations.script import ScriptValidator
-from demisto_sdk.commands.common.hook_validations.structure import \
-    StructureValidator
-from demisto_sdk.commands.common.hook_validations.test_playbook import \
-    TestPlaybookValidator
-from demisto_sdk.commands.common.hook_validations.triggers import \
-    TriggersValidator
+from demisto_sdk.commands.common.hook_validations.structure import StructureValidator
+from demisto_sdk.commands.common.hook_validations.test_playbook import TestPlaybookValidator
+from demisto_sdk.commands.common.hook_validations.triggers import TriggersValidator
 from demisto_sdk.commands.common.hook_validations.widget import WidgetValidator
 from demisto_sdk.commands.common.hook_validations.wizard import WizardValidator
-from demisto_sdk.commands.common.hook_validations.xsiam_dashboard import \
-    XSIAMDashboardValidator
-from demisto_sdk.commands.common.hook_validations.xsiam_report import \
-    XSIAMReportValidator
-from demisto_sdk.commands.common.hook_validations.xsoar_config_json import \
-    XSOARConfigJsonValidator
-from demisto_sdk.commands.common.tools import (
-    _get_file_id, find_type, get_api_module_ids,
-    get_api_module_integrations_set, get_content_path, get_file,
-    get_pack_ignore_file_path, get_pack_name, get_pack_names_from_files,
-    get_relative_path_from_packs_dir, get_remote_file, get_yaml,
-    open_id_set_file, print_warning, run_command_os)
+from demisto_sdk.commands.common.hook_validations.xsiam_dashboard import XSIAMDashboardValidator
+from demisto_sdk.commands.common.hook_validations.xsiam_report import XSIAMReportValidator
+from demisto_sdk.commands.common.hook_validations.xsoar_config_json import XSOARConfigJsonValidator
+from demisto_sdk.commands.common.tools import (_get_file_id, find_type, get_api_module_ids,
+                                               get_api_module_integrations_set, get_content_path, get_file,
+                                               get_pack_ignore_file_path, get_pack_name, get_pack_names_from_files,
+                                               get_relative_path_from_packs_dir, get_remote_file, get_yaml,
+                                               open_id_set_file, print_warning, run_command_os)
 from demisto_sdk.commands.create_id_set.create_id_set import IDSetCreator
 
 SKIPPED_FILES = ['CommonServerPython.py', 'CommonServerUserPython.py', 'demistomock.py']

--- a/demisto_sdk/commands/zip_packs/packs_zipper.py
+++ b/demisto_sdk/commands/zip_packs/packs_zipper.py
@@ -7,13 +7,12 @@ from shutil import make_archive
 
 import click
 
-from demisto_sdk.commands.common.constants import (PACKS_DIR,
-                                                   MarketplaceVersions)
+from demisto_sdk.commands.common.constants import PACKS_DIR, MarketplaceVersions
 from demisto_sdk.commands.common.content.objects.pack_objects.pack import Pack
 from demisto_sdk.commands.common.tools import arg_to_list
-from demisto_sdk.commands.create_artifacts.content_artifacts_creator import (
-    IGNORED_PACKS, ArtifactsManager, ContentObject, create_dirs, delete_dirs,
-    dump_pack, zip_packs)
+from demisto_sdk.commands.create_artifacts.content_artifacts_creator import (IGNORED_PACKS, ArtifactsManager,
+                                                                             ContentObject, create_dirs, delete_dirs,
+                                                                             dump_pack, zip_packs)
 
 EX_SUCCESS = 0
 EX_FAIL = 1

--- a/demisto_sdk/tests/conf_file_test.py
+++ b/demisto_sdk/tests/conf_file_test.py
@@ -2,8 +2,7 @@ from click.testing import CliRunner
 
 from demisto_sdk.__main__ import main
 from demisto_sdk.commands.common import tools
-from demisto_sdk.commands.common.hook_validations.integration import \
-    IntegrationValidator
+from demisto_sdk.commands.common.hook_validations.integration import IntegrationValidator
 from TestSuite.test_tools import ChangeCWD
 
 

--- a/demisto_sdk/tests/integration_tests/content_create_artifacts_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/content_create_artifacts_integration_test.py
@@ -7,8 +7,8 @@ from wcmatch.pathlib import Path
 from demisto_sdk.__main__ import main
 from demisto_sdk.commands.common.constants import ENV_DEMISTO_SDK_MARKETPLACE
 from demisto_sdk.commands.common.tools import src_root
-from demisto_sdk.commands.create_artifacts.tests.content_artifacts_creator_test import (
-    destroy_by_ext, duplicate_file, same_folders, temp_dir)
+from demisto_sdk.commands.create_artifacts.tests.content_artifacts_creator_test import (destroy_by_ext, duplicate_file,
+                                                                                        same_folders, temp_dir)
 from TestSuite.test_tools import ChangeCWD
 
 ARTIFACTS_CMD = 'create-content-artifacts'

--- a/demisto_sdk/tests/integration_tests/create_id_set_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/create_id_set_integration_test.py
@@ -35,9 +35,8 @@ class TestCreateIdSet:  # Use classes to speed up test - multi threaded py pytes
         """
         import demisto_sdk.commands.create_id_set.create_id_set as cis
         import demisto_sdk.commands.find_dependencies.find_dependencies as find_dependencies
-        from demisto_sdk.tests.test_files.create_id_set import (
-            excluded_items_by_pack, excluded_items_by_type,
-            packs_dependencies_results)
+        from demisto_sdk.tests.test_files.create_id_set import (excluded_items_by_pack, excluded_items_by_type,
+                                                                packs_dependencies_results)
 
         mock_id_set = self.open_json_file('demisto_sdk/tests/test_files/create_id_set/unfiltered_id_set.json')
         id_set_after_manual_removal = self.open_json_file('demisto_sdk/tests/test_files/create_id_set/id_set_after_manual_removal.json')
@@ -93,9 +92,9 @@ class TestCreateIdSet:  # Use classes to speed up test - multi threaded py pytes
         """
         import demisto_sdk.commands.create_id_set.create_id_set as cis
         import demisto_sdk.commands.find_dependencies.find_dependencies as find_dependencies
-        from demisto_sdk.tests.test_files.create_id_set.mini_id_set import (
-            excluded_items_by_pack, excluded_items_by_type,
-            packs_dependencies_results)
+        from demisto_sdk.tests.test_files.create_id_set.mini_id_set import (excluded_items_by_pack,
+                                                                            excluded_items_by_type,
+                                                                            packs_dependencies_results)
 
         mock_id_set = self.open_json_file('demisto_sdk/tests/test_files/create_id_set/unfiltered_id_set.json')
         id_set_after_manual_removal = self.open_json_file('demisto_sdk/tests/test_files/create_id_set/mini_id_set/id_set_after_manual_removal.json')

--- a/demisto_sdk/tests/integration_tests/format_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/format_integration_test.py
@@ -10,26 +10,21 @@ from demisto_sdk.__main__ import main
 from demisto_sdk.commands.common import tools
 from demisto_sdk.commands.common.constants import GENERAL_DEFAULT_FROMVERSION
 from demisto_sdk.commands.common.handlers import JSON_Handler, YAML_Handler
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
-from demisto_sdk.commands.common.hook_validations.integration import \
-    IntegrationValidator
-from demisto_sdk.commands.common.hook_validations.playbook import \
-    PlaybookValidator
-from demisto_sdk.commands.common.tools import (get_dict_from_file,
-                                               is_test_config_match)
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
+from demisto_sdk.commands.common.hook_validations.integration import IntegrationValidator
+from demisto_sdk.commands.common.hook_validations.playbook import PlaybookValidator
+from demisto_sdk.commands.common.tools import get_dict_from_file, is_test_config_match
 from demisto_sdk.commands.format import format_module, update_generic
 from demisto_sdk.commands.format.update_generic import BaseUpdate
 from demisto_sdk.commands.format.update_generic_yml import BaseUpdateYML
 from demisto_sdk.commands.format.update_integration import IntegrationYMLFormat
 from demisto_sdk.commands.format.update_playbook import PlaybookYMLFormat
 from demisto_sdk.commands.lint.commands_builder import excluded_files
-from demisto_sdk.tests.constants_test import (
-    DESTINATION_FORMAT_INTEGRATION_COPY, DESTINATION_FORMAT_PLAYBOOK_COPY,
-    INTEGRATION_WITH_TEST_PLAYBOOKS, PLAYBOOK_WITH_TEST_PLAYBOOKS,
-    SOURCE_FORMAT_INTEGRATION_COPY, SOURCE_FORMAT_PLAYBOOK_COPY)
-from demisto_sdk.tests.test_files.validate_integration_test_valid_types import (
-    GENERIC_DEFINITION, GENERIC_FIELD, GENERIC_MODULE, GENERIC_TYPE)
+from demisto_sdk.tests.constants_test import (DESTINATION_FORMAT_INTEGRATION_COPY, DESTINATION_FORMAT_PLAYBOOK_COPY,
+                                              INTEGRATION_WITH_TEST_PLAYBOOKS, PLAYBOOK_WITH_TEST_PLAYBOOKS,
+                                              SOURCE_FORMAT_INTEGRATION_COPY, SOURCE_FORMAT_PLAYBOOK_COPY)
+from demisto_sdk.tests.test_files.validate_integration_test_valid_types import (GENERIC_DEFINITION, GENERIC_FIELD,
+                                                                                GENERIC_MODULE, GENERIC_TYPE)
 from TestSuite.test_tools import ChangeCWD
 
 json = JSON_Handler()

--- a/demisto_sdk/tests/integration_tests/unify_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/unify_integration_test.py
@@ -6,8 +6,8 @@ from click.testing import CliRunner
 from demisto_sdk.__main__ import main
 from demisto_sdk.commands.common.constants import ENV_DEMISTO_SDK_MARKETPLACE
 from demisto_sdk.commands.common.handlers import JSON_Handler, YAML_Handler
-from demisto_sdk.tests.test_files.validate_integration_test_valid_types import (
-    DASHBOARD, GENERIC_MODULE, UNIFIED_GENERIC_MODULE)
+from demisto_sdk.tests.test_files.validate_integration_test_valid_types import (DASHBOARD, GENERIC_MODULE,
+                                                                                UNIFIED_GENERIC_MODULE)
 from TestSuite.test_tools import ChangeCWD
 
 json = JSON_Handler()

--- a/demisto_sdk/tests/integration_tests/update_release_notes_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/update_release_notes_integration_test.py
@@ -10,8 +10,7 @@ from demisto_sdk.__main__ import main
 from demisto_sdk.commands.common.git_util import GitUtil
 from demisto_sdk.commands.common.legacy_git_tools import git_path
 from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
-from demisto_sdk.commands.update_release_notes.update_rn_manager import \
-    UpdateReleaseNotesManager
+from demisto_sdk.commands.update_release_notes.update_rn_manager import UpdateReleaseNotesManager
 from demisto_sdk.commands.validate.validate_manager import ValidateManager
 from TestSuite.test_tools import ChangeCWD
 

--- a/demisto_sdk/tests/integration_tests/validate_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/validate_integration_test.py
@@ -9,33 +9,28 @@ from demisto_sdk.__main__ import main
 from demisto_sdk.commands.common import tools
 from demisto_sdk.commands.common.constants import DEFAULT_IMAGE_BASE64
 from demisto_sdk.commands.common.git_util import GitUtil
-from demisto_sdk.commands.common.hook_validations.base_validator import \
-    BaseValidator
-from demisto_sdk.commands.common.hook_validations.classifier import \
-    ClassifierValidator
-from demisto_sdk.commands.common.hook_validations.content_entity_validator import \
-    ContentEntityValidator
+from demisto_sdk.commands.common.hook_validations.base_validator import BaseValidator
+from demisto_sdk.commands.common.hook_validations.classifier import ClassifierValidator
+from demisto_sdk.commands.common.hook_validations.content_entity_validator import ContentEntityValidator
 from demisto_sdk.commands.common.hook_validations.image import ImageValidator
-from demisto_sdk.commands.common.hook_validations.integration import \
-    IntegrationValidator
+from demisto_sdk.commands.common.hook_validations.integration import IntegrationValidator
 from demisto_sdk.commands.common.hook_validations.mapper import MapperValidator
-from demisto_sdk.commands.common.hook_validations.pack_unique_files import \
-    PackUniqueFilesValidator
-from demisto_sdk.commands.common.hook_validations.playbook import \
-    PlaybookValidator
+from demisto_sdk.commands.common.hook_validations.pack_unique_files import PackUniqueFilesValidator
+from demisto_sdk.commands.common.hook_validations.playbook import PlaybookValidator
 from demisto_sdk.commands.common.hook_validations.readme import ReadMeValidator
 from demisto_sdk.commands.common.legacy_git_tools import git_path
 from demisto_sdk.commands.common.tools import get_yaml
-from demisto_sdk.commands.find_dependencies.find_dependencies import \
-    PackDependencies
+from demisto_sdk.commands.find_dependencies.find_dependencies import PackDependencies
 from demisto_sdk.commands.validate.validate_manager import ValidateManager
-from demisto_sdk.tests.constants_test import (CONTENT_REPO_EXAMPLE_ROOT,
-                                              NOT_VALID_IMAGE_PATH)
-from demisto_sdk.tests.test_files.validate_integration_test_valid_types import (
-    CONNECTION, DASHBOARD, EMPTY_ID_SET, GENERIC_DEFINITION, GENERIC_FIELD,
-    GENERIC_MODULE, GENERIC_TYPE, INCIDENT_FIELD, INCIDENT_TYPE,
-    INDICATOR_FIELD, LAYOUT, LAYOUTS_CONTAINER, MAPPER, NEW_CLASSIFIER,
-    OLD_CLASSIFIER, REPORT, REPUTATION, WIDGET)
+from demisto_sdk.tests.constants_test import CONTENT_REPO_EXAMPLE_ROOT, NOT_VALID_IMAGE_PATH
+from demisto_sdk.tests.test_files.validate_integration_test_valid_types import (CONNECTION, DASHBOARD, EMPTY_ID_SET,
+                                                                                GENERIC_DEFINITION, GENERIC_FIELD,
+                                                                                GENERIC_MODULE, GENERIC_TYPE,
+                                                                                INCIDENT_FIELD, INCIDENT_TYPE,
+                                                                                INDICATOR_FIELD, LAYOUT,
+                                                                                LAYOUTS_CONTAINER, MAPPER,
+                                                                                NEW_CLASSIFIER, OLD_CLASSIFIER, REPORT,
+                                                                                REPUTATION, WIDGET)
 from TestSuite.test_tools import ChangeCWD
 
 VALIDATE_CMD = "validate"

--- a/demisto_sdk/tests/integration_tests/xsoar_linter_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/xsoar_linter_integration_test.py
@@ -13,9 +13,8 @@ import pytest
 from wcmatch.pathlib import Path
 
 from demisto_sdk.commands.lint import linter
-from demisto_sdk.tests.constants_test import (
-    GIT_ROOT, XSOAR_LINTER_PY3_INVALID, XSOAR_LINTER_PY3_INVALID_WARNINGS,
-    XSOAR_LINTER_PY3_INVALID_WARNINGS_PARTNER, XSOAR_LINTER_PY3_VALID)
+from demisto_sdk.tests.constants_test import (GIT_ROOT, XSOAR_LINTER_PY3_INVALID, XSOAR_LINTER_PY3_INVALID_WARNINGS,
+                                              XSOAR_LINTER_PY3_INVALID_WARNINGS_PARTNER, XSOAR_LINTER_PY3_VALID)
 
 files = [
 

--- a/demisto_sdk/utils/circle-ci/circle_ci_slack_notifier_test.py
+++ b/demisto_sdk/utils/circle-ci/circle_ci_slack_notifier_test.py
@@ -159,9 +159,7 @@ def test_slack_notifier_on_failed_circle_ci_jobs():
     Then -
         make sure the correct message with the correct failures is returned even if some of the jobs succeeded.
     """
-    from circle_ci_slack_notifier import (CircleCIClient,
-                                          CircleCiFailedJobsParser,
-                                          construct_failed_jobs_slack_message)
+    from circle_ci_slack_notifier import CircleCIClient, CircleCiFailedJobsParser, construct_failed_jobs_slack_message
 
     parser = CircleCiFailedJobsParser(circle_client=CircleCIClient(), workflow_id=WORKFLOW_ID)
     assert construct_failed_jobs_slack_message(parser) == [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,12 +19,6 @@ exclude = ["TestSuite/**", "*/tests/*", "tests"]
 [tool.poetry.scripts]
 demisto-sdk = "demisto_sdk.__main__:main"
 
-[tool.vulture]
-exclude = ["*/tests/*"]
-min_confidence = 80
-paths = ["demisto_sdk", "TestSuite"]
-sort_by_size = true
-
 [tool.poetry.dependencies]
 python = "^3.8"
 autopep8 = "^1.6.0"
@@ -137,6 +131,16 @@ follow_imports = "silent"
 pretty = true
 allow_redefinition = true
 exclude = "tests/.*|demisto_sdk/commands/init/templates/.*"
+
+[tool.vulture]
+exclude = ["*/tests/*"]
+min_confidence = 80
+paths = ["demisto_sdk", "TestSuite"]
+sort_by_size = true
+
+[tool.isort]
+atomic = true
+line_length = 120
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests_end_to_end/test_dockerserver.py
+++ b/tests_end_to_end/test_dockerserver.py
@@ -3,8 +3,7 @@ from requests.sessions import HTTPAdapter
 from urllib3 import Retry
 
 from demisto_sdk.commands.common.docker_helper import init_global_docker_client
-from demisto_sdk.commands.common.MDXServer import (DEMISTO_DEPS_DOCKER_NAME,
-                                                   start_docker_MDX_server)
+from demisto_sdk.commands.common.MDXServer import DEMISTO_DEPS_DOCKER_NAME, start_docker_MDX_server
 
 SERVER_DNS = 'docker'  # switch to localhost for testing locally
 


### PR DESCRIPTION
## Status
- [x] Ready

## Description
- Updates the `isort` `pre-commit` config so that the default line length is 120 instead of 79
- Updates the imports of the entire repo accordingly

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
