### PR TITLE
Add git-blame-ignore-rev File

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# .git-blame-ignore-revs
+# read about it at,
+# https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view
+
+# updated the pre-commit isort hook to a line-length of 120 instead of 79 and updated all the import lines in the repo
+11bcb1692a4344c08dc417101355fa42de61969b


### PR DESCRIPTION
## Status
- [x] Ready

## Description
- Adds the `.git-blame-ignore-revs` file in the root of the project
- Adds the merge-commit in which all the import lines in the repo were updated to the new `isort` length of 120

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
