### PR TITLE
New prefixes for release notes

### DIFF
--- a/demisto_sdk/commands/doc_reviewer/rn_checker.py
+++ b/demisto_sdk/commands/doc_reviewer/rn_checker.py
@@ -63,6 +63,11 @@ class ReleaseNotesChecker:
         'Note: ',
         'Started adoption process.',
         'Completed adoption process.',
+        "Improved layout"
+        "Created a new layout"
+        "Playbook now supports"
+        "Created a new playbook"
+        "Updated the"
     }
 
     RN_FULL_LINE_TEMPLATES = {


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-3919

## Description
The following prefixes has been added:
1. "Improved layout ..."
2. "Created a new layout..."
3. "Playbook now supports..."
4. "Created a new playbook..."
5. "Updated the..."

Approved by @ShirleyDenkberg 