### PR TITLE
Factor Upload Command Logic to Separate File

### DIFF
--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -2,10 +2,7 @@
 import copy
 import logging
 import os
-import shutil
 import sys
-import tempfile
-from configparser import ConfigParser, MissingSectionHeaderError
 from pathlib import Path
 from typing import IO, Any, Dict
 
@@ -15,13 +12,15 @@ from pkg_resources import DistributionNotFound, get_distribution
 
 from demisto_sdk.commands.common.configuration import Configuration
 from demisto_sdk.commands.common.constants import (ENV_DEMISTO_SDK_MARKETPLACE, MODELING_RULES_DIR, PARSING_RULES_DIR,
-                                                   FileType, MarketplaceVersions)
+                                                   FileType)
 from demisto_sdk.commands.common.content_constant_paths import ALL_PACKS_DEPENDENCIES_DEFAULT_PATH
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.tools import (find_type, get_last_remote_release_version, get_release_note_entries,
                                                is_external_repository, print_error, print_success, print_warning)
 from demisto_sdk.commands.content_graph.interface.neo4j.neo4j_graph import Neo4jContentGraphInterface
 from demisto_sdk.commands.split.ymlsplitter import YmlSplitter
+from demisto_sdk.commands.upload.upload import upload_content_entity
+from demisto_sdk.utils.utils import check_configuration_file
 
 json = JSON_Handler()
 
@@ -83,38 +82,6 @@ class DemistoSDK:
 
 
 pass_config = click.make_pass_decorator(DemistoSDK, ensure=True)
-
-
-def check_configuration_file(command, args):
-    config_file_path = '.demisto-sdk-conf'
-    true_synonyms = ['true', 'True', 't', '1']
-    if os.path.isfile(config_file_path):
-        try:
-            config = ConfigParser(allow_no_value=True)
-            config.read(config_file_path)
-
-            if command in config.sections():
-                for key in config[command]:
-                    if key in args:
-                        # if the key exists in the args we will run it over if it is either:
-                        # a - a flag currently not set and is defined in the conf file
-                        # b - not a flag but an arg that is currently None and there is a value for it in the conf file
-                        if args[key] is False and config[command][key] in true_synonyms:
-                            args[key] = True
-
-                        elif args[key] is None and config[command][key] is not None:
-                            args[key] = config[command][key]
-
-                    # if the key does not exist in the current args, add it
-                    else:
-                        if config[command][key] in true_synonyms:
-                            args[key] = True
-
-                        else:
-                            args[key] = config[command][key]
-
-        except MissingSectionHeaderError:
-            pass
 
 
 @click.group(invoke_without_command=True, no_args_is_help=True, context_settings=dict(max_content_width=100), )
@@ -925,41 +892,7 @@ def upload(**kwargs):
     DEMISTO_API_KEY environment variable should contain a valid Demisto API Key.
     * Note: Uploading classifiers to Cortex XSOAR is available from version 6.0.0 and up. *
     """
-    from demisto_sdk.commands.upload.uploader import ConfigFileParser, Uploader
-    from demisto_sdk.commands.zip_packs.packs_zipper import EX_FAIL, PacksZipper
-    keep_zip = kwargs.pop('keep_zip')
-    is_zip = kwargs.pop('zip', False)
-    config_file_path = kwargs.pop('input_config_file')
-    is_xsiam = kwargs.pop('xsiam', False)
-    if is_zip or config_file_path:
-        if is_zip:
-            pack_path = kwargs['input']
-
-        else:
-            config_file_to_parse = ConfigFileParser(config_file_path=config_file_path)
-            pack_path = config_file_to_parse.parse_file()
-            kwargs['detached_files'] = True
-        if is_xsiam:
-            marketplace = MarketplaceVersions.MarketplaceV2.value
-        else:
-            marketplace = MarketplaceVersions.XSOAR.value
-        os.environ[ENV_DEMISTO_SDK_MARKETPLACE] = marketplace.lower()
-
-        output_zip_path = keep_zip or tempfile.mkdtemp()
-        packs_unifier = PacksZipper(pack_paths=pack_path, output=output_zip_path,
-                                    content_version='0.0.0', zip_all=True, quiet_mode=True, marketplace=marketplace)
-        packs_zip_path, pack_names = packs_unifier.zip_packs()
-        if packs_zip_path is None and not kwargs.get('detached_files'):
-            return EX_FAIL
-
-        kwargs['input'] = packs_zip_path
-        kwargs['pack_names'] = pack_names
-
-    check_configuration_file('upload', kwargs)
-    upload_result = Uploader(**kwargs).upload()
-    if (is_zip or config_file_path) and not keep_zip:
-        shutil.rmtree(output_zip_path, ignore_errors=True)
-    return upload_result
+    return upload_content_entity(**kwargs)
 
 
 # ====================== download ====================== #

--- a/demisto_sdk/commands/upload/upload.py
+++ b/demisto_sdk/commands/upload/upload.py
@@ -1,0 +1,44 @@
+import os
+import shutil
+import tempfile
+
+from demisto_sdk.commands.common.constants import ENV_DEMISTO_SDK_MARKETPLACE, MarketplaceVersions
+from demisto_sdk.utils.utils import check_configuration_file
+
+
+def upload_content_entity(**kwargs):
+    from demisto_sdk.commands.upload.uploader import ConfigFileParser, Uploader
+    from demisto_sdk.commands.zip_packs.packs_zipper import EX_FAIL, PacksZipper
+    keep_zip = kwargs.pop('keep_zip')
+    is_zip = kwargs.pop('zip', False)
+    config_file_path = kwargs.pop('input_config_file')
+    is_xsiam = kwargs.pop('xsiam', False)
+    if is_zip or config_file_path:
+        if is_zip:
+            pack_path = kwargs['input']
+
+        else:
+            config_file_to_parse = ConfigFileParser(config_file_path=config_file_path)
+            pack_path = config_file_to_parse.parse_file()
+            kwargs['detached_files'] = True
+        if is_xsiam:
+            marketplace = MarketplaceVersions.MarketplaceV2.value
+        else:
+            marketplace = MarketplaceVersions.XSOAR.value
+        os.environ[ENV_DEMISTO_SDK_MARKETPLACE] = marketplace.lower()
+
+        output_zip_path = keep_zip or tempfile.mkdtemp()
+        packs_unifier = PacksZipper(pack_paths=pack_path, output=output_zip_path,
+                                    content_version='0.0.0', zip_all=True, quiet_mode=True, marketplace=marketplace)
+        packs_zip_path, pack_names = packs_unifier.zip_packs()
+        if packs_zip_path is None and not kwargs.get('detached_files'):
+            return EX_FAIL
+
+        kwargs['input'] = packs_zip_path
+        kwargs['pack_names'] = pack_names
+
+    check_configuration_file('upload', kwargs)
+    upload_result = Uploader(**kwargs).upload()
+    if (is_zip or config_file_path) and not keep_zip:
+        shutil.rmtree(output_zip_path, ignore_errors=True)
+    return upload_result

--- a/demisto_sdk/utils/utils.py
+++ b/demisto_sdk/utils/utils.py
@@ -1,0 +1,58 @@
+import os
+from configparser import ConfigParser, MissingSectionHeaderError
+from typing import Union
+
+from demisto_sdk.commands.common.content.objects.pack_objects.abstract_pack_objects.json_content_object import \
+    JSONContentObject
+from demisto_sdk.commands.common.content.objects.pack_objects.abstract_pack_objects.yaml_content_object import \
+    YAMLContentObject
+from demisto_sdk.commands.common.content.objects.pack_objects.abstract_pack_objects.yaml_unify_content_object import \
+    YAMLContentUnifiedObject
+from demisto_sdk.commands.common.content.objects.pack_objects.pack import Pack
+
+ContentEntity = Union[YAMLContentUnifiedObject, YAMLContentObject, JSONContentObject]
+
+
+def get_containing_pack(content_entity: ContentEntity) -> Pack:
+    """Get pack object that contains the content entity.
+    Args:
+        content_entity: Content entity object.
+    Returns:
+        Pack: Pack object that contains the content entity.
+    """
+    pack_path = content_entity.path
+    while pack_path.parent.name.casefold() != 'packs':
+        pack_path = pack_path.parent
+    return Pack(pack_path)
+
+
+def check_configuration_file(command, args):
+    config_file_path = '.demisto-sdk-conf'
+    true_synonyms = ['true', 'True', 't', '1']
+    if os.path.isfile(config_file_path):
+        try:
+            config = ConfigParser(allow_no_value=True)
+            config.read(config_file_path)
+
+            if command in config.sections():
+                for key in config[command]:
+                    if key in args:
+                        # if the key exists in the args we will run it over if it is either:
+                        # a - a flag currently not set and is defined in the conf file
+                        # b - not a flag but an arg that is currently None and there is a value for it in the conf file
+                        if args[key] is False and config[command][key] in true_synonyms:
+                            args[key] = True
+
+                        elif args[key] is None and config[command][key] is not None:
+                            args[key] = config[command][key]
+
+                    # if the key does not exist in the current args, add it
+                    else:
+                        if config[command][key] in true_synonyms:
+                            args[key] = True
+
+                        else:
+                            args[key] = config[command][key]
+
+        except MissingSectionHeaderError:
+            pass


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
relates to: https://github.com/demisto/demisto-sdk/pull/2482

## Description
- Factors the upload command logic to a separate file so that it can be invoked elsewhere
- Puts its dependency function `check_configuration_file` in `utils.py`
- Adds helper function `get_containing_pack` to `utils.py`

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
