### PR TITLE
COLLECTOR_TOKEN --> XSIAM_COLLECTOR_TOKEN

### DIFF
--- a/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
+++ b/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
@@ -483,7 +483,7 @@ def test_modeling_rule(
     ),
     collector_token: Optional[str] = typer.Option(
         None,
-        envvar='COLLECTOR_TOKEN',
+        envvar='XSIAM_COLLECTOR_TOKEN',
         help='The token used to push event logs to a custom HTTP Collector',
         rich_help_panel='XSIAM Tenant Configuration',
         show_default=False,


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Changes the environment variable name default value for the `--collector-token` option to match what is defined in the `XsiamApiClientConfig` class in `demisto_sdk/commands/test_content/xsiam_tools/xsiam_client.py`.

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
