### PR TITLE
hotfix for categories validation for private repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 * Added the ability to limit the number of CPU cores with `DEMISTO_SDK_MAX_CPU_CORES` envirment variable.
 * Fixed an issue where **update-release-notes** failed when changing only xif file in **Modeling Rules**.
+* Fixed an issue where **is_valid_category** and **is_categories_field_match_standard** failed on private repo due to approved_list not imported.
 
 ## 1.7.9
 * Fixed an issue where an error message in **validate** would not include the suggested fix.

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -2431,10 +2431,8 @@ def get_current_categories() -> list:
     Returns:
         List of approved categories from current branch
     """
-    if not is_external_repository():
-        approved_categories_json, _ = get_dict_from_file('Tests/Marketplace/approved_categories.json')
-        return approved_categories_json.get('approved_list', [])
-    return []
+    approved_categories_json, _ = get_dict_from_file('Tests/Marketplace/approved_categories.json')
+    return approved_categories_json.get('approved_list', [])
 
 
 @contextmanager

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -471,6 +471,7 @@ class TestValidators:
         mocker.patch.object(IntegrationValidator, 'has_no_fromlicense_key_in_contributions_integration',
                             return_value=True)
         mocker.patch.object(IntegrationValidator, 'is_api_token_in_credential_type', return_value=True)
+        mocker.patch.object(IntegrationValidator, 'is_valid_category', return_value=True)
         with ChangeCWD(integration.repo_path):
             validate_manager = ValidateManager(skip_conf_json=True)
             assert not validate_manager.run_validations_on_file(file_path=integration.yml.path,
@@ -2009,6 +2010,7 @@ def test_run_validation_using_git_on_metadata_with_invalid_tags(mocker, repo, pa
     pack = repo.create_pack()
     pack.pack_metadata.write_json(pack_metadata_info)
     mocker.patch.object(ValidateManager, 'setup_git_params', return_value=True)
+    mocker.patch.object(PackUniqueFilesValidator, 'is_categories_field_match_standard', return_value=True)
     mocker.patch.object(ValidateManager, 'get_unfiltered_changed_files_from_git',
                         return_value=({pack.pack_metadata.path}, set(), set()))
     mocker.patch.object(GitUtil, 'deleted_files', return_value=set())

--- a/demisto_sdk/tests/integration_tests/validate_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/validate_integration_test.py
@@ -803,6 +803,7 @@ class TestIntegrationValidation:
         """
         mocker.patch.object(tools, 'is_external_repository', return_value=True)
         mocker.patch.object(BaseValidator, 'check_file_flags', return_value='')
+        mocker.patch.object(IntegrationValidator, 'is_valid_category', return_value=True)
         pack = repo.create_pack('PackName')
         pack_integration_path = join(AZURE_FEED_PACK_PATH, "Integrations/FeedAzure/FeedAzure.yml")
         invalid_integration_yml = get_yaml(pack_integration_path, cache_clear=True)
@@ -903,6 +904,7 @@ class TestIntegrationValidation:
         """
         mocker.patch.object(tools, 'is_external_repository', return_value=True)
         mocker.patch.object(BaseValidator, 'check_file_flags', return_value='')
+        mocker.patch.object(IntegrationValidator, 'is_valid_category', return_value=True)
         pack = repo.create_pack('PackName')
         pack_integration_path = join(AZURE_FEED_PACK_PATH, "Integrations/FeedAzure/FeedAzure.yml")
         invalid_integration_yml = get_yaml(pack_integration_path, cache_clear=True)
@@ -950,7 +952,8 @@ class TestIntegrationValidation:
 
     @pytest.mark.parametrize('field,description,should_pass', (('DBotScore.Score', 'my custom description', True),
                                                                ('DBotScore.Score', '', False)))
-    def test_empty_default_descriptions(self, repo, field: str, description: str, should_pass: bool):
+    def test_empty_default_descriptions(self, mocker, repo, field: str, description: str, should_pass: bool):
+        mocker.patch.object(IntegrationValidator, 'is_valid_category', return_value=True)
         pack = repo.create_pack(f'{field}-{description}')
         integration = pack.create_integration()
         integration.create_default_integration()


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [CIAC-4735](https://jira-hq.paloaltonetworks.local/browse/CIAC-4735)

## Description
Hotfix for **is_valid_category** and **is_categories_field_match_standard** which failed due to limits for pulling the approved categories list on content private build.
