### PR TITLE
Fixed --release-notes flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fixed an issue where **update-release-notes** failed when changing only xif file in **Modeling Rules**.
 * Fixed an issue where **is_valid_category** and **is_categories_field_match_standard** failed on private repo due to approved_list not imported.
 * Fixed an issue where **validate** didn't fail on the MR103 validation error.
+* Fixed the *--release-notes* flag in demisto-sdk to support the new CHANGELOG format.
 
 ## 1.7.9
 * Fixed an issue where an error message in **validate** would not include the suggested fix.

--- a/demisto_sdk/commands/common/tests/test_files/test_changelog.md
+++ b/demisto_sdk/commands/common/tests/test_files/test_changelog.md
@@ -1,4 +1,5 @@
 # Changelog
+## Unreleased
 * Fixed an issue in the **create-id-set** command where similar items from different marketplaces were reported as duplicated.
 * Fixed typo in demisto-sdk init
 * Fixed an issue where the **lint** command did not handle all container exit codes.
@@ -288,7 +289,7 @@
 * Fixed an issue where the demisto-sdk version check failed due to a rate limit.
 * Fixed an issue with playbooks scheme validation.
 
-# 1.3.8
+## 1.3.8
 * Updated the **secrets** command to work on forked branches.
 
 # 1.3.7

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -2385,12 +2385,12 @@ def get_release_note_entries(version='') -> list:
                                              ).decode('utf-8').split('\n')
 
     if not version or 'dev' in version:
-        version = 'Changelog'
+        version = 'Unreleased'
 
-    if f'# {version}' not in changelog_file_content:
+    if f'## {version}' not in changelog_file_content:
         return []
 
-    result = changelog_file_content[changelog_file_content.index(f'# {version}') + 1:]
+    result = changelog_file_content[changelog_file_content.index(f'## {version}') + 1:]
     result = result[:result.index('')]
 
     return result


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Fixed the `--release-notes` flag in demisto-sdk.
