### PR TITLE
avoid exception when tabs are none in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Fixed an issue where **is_valid_category** and **is_categories_field_match_standard** failed on private repo due to approved_list not imported.
 * Fixed an issue where **validate** didn't fail on the MR103 validation error.
 * Fixed an issue where **validate** failed when changing only xif file in **Modeling Rules**.
-* Fixed an issue where **format** failed when indicator file has None in tabs.
+* Fixed an issue where **format** failed on indicator files with a `None` value under the `tabs` key.
 
 ## 1.7.9
 * Fixed an issue where an error message in **validate** would not include the suggested fix.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fixed an issue where **is_valid_category** and **is_categories_field_match_standard** failed on private repo due to approved_list not imported.
 * Fixed an issue where **validate** didn't fail on the MR103 validation error.
 * Fixed an issue where **validate** failed when changing only xif file in **Modeling Rules**.
+* Fixed an issue where **format** failed when indicator file has None in tabs.
 
 ## 1.7.9
 * Fixed an issue where an error message in **validate** would not include the suggested fix.

--- a/demisto_sdk/commands/format/tests/test_formatting_json_test.py
+++ b/demisto_sdk/commands/format/tests/test_formatting_json_test.py
@@ -1511,7 +1511,7 @@ class TestFormattingReport:
         bs.run_format()
         assert bs.data['fromVersion'] == VERSION_5_5_0
         
-    def test_none_tabs_does_not_throw_exception(self, mocker, pack):
+    def test_none_tabs_do_not_throw_exception(self, mocker, pack):
         """
         Given
             - An indicator file with None indicatorsDetails tabs.
@@ -1521,15 +1521,15 @@ class TestFormattingReport:
             - Ensure command will not throw an exception.
         """
 
-        layout = pack.create_layout(name='TestType', content={"cacheVersn": 0, "close": None, "definitionId": "", "description": "",
+        layout = pack.create_layout(name='TestType', content={"name": "SHA256_Indicator_dev", "cacheVersn": 0,
+                                                              "close": None, "definitionId": "", "description": "",
                                                               "detached": False, "details": None, "detailsV2": None,
                                                               "edit": None, "fromServerVersion": "", "group": "indicator",
-                                                              "id": "SHA256 Indicator", "indicatorsDetails": {"TypeName": "", "tabs": None}})
+                                                              "id": "SHA256 Indicator", "indicatorsDetails": {"TypeName": "", "tabs": None},
+                                                              "fromVersion": ""})
         bs = LayoutBaseFormat(input=layout.path, assume_yes=True)
-        try:
-            bs.remove_copy_and_dev_suffixes_from_layoutscontainer()
-        except Exception as exc:
-            assert False, f"'remove_copy_and_dev_suffixes_from_layoutscontainer' raised an exception {exc}"
+        bs.remove_copy_and_dev_suffixes_from_layoutscontainer()
+        assert bs.data['name'] == "SHA256_Indicator"
 
     def test_json_run_format_old_classifier(self, mocker, pack):
         """

--- a/demisto_sdk/commands/format/tests/test_formatting_json_test.py
+++ b/demisto_sdk/commands/format/tests/test_formatting_json_test.py
@@ -1522,9 +1522,9 @@ class TestFormattingReport:
         """
 
         layout = pack.create_layout(name='TestType', content={"cacheVersn": 0, "close": None, "definitionId": "", "description": "",
-                                                                "detached": False, "details": None, "detailsV2": None, 
-                                                                "edit": None, "fromServerVersion": "", "group": "indicator",
-                                                                "id": "SHA256 Indicator", "indicatorsDetails": {"TypeName": "", "tabs": None}})
+                                                              "detached": False, "details": None, "detailsV2": None,
+                                                              "edit": None, "fromServerVersion": "", "group": "indicator",
+                                                              "id": "SHA256 Indicator", "indicatorsDetails": {"TypeName": "", "tabs": None}})
         bs = LayoutBaseFormat(input=layout.path, assume_yes=True)
         try:
             bs.remove_copy_and_dev_suffixes_from_layoutscontainer()

--- a/demisto_sdk/commands/format/tests/test_formatting_json_test.py
+++ b/demisto_sdk/commands/format/tests/test_formatting_json_test.py
@@ -1510,6 +1510,23 @@ class TestFormattingReport:
         bs = LayoutBaseFormat(input=layout.path, assume_yes=True)
         bs.run_format()
         assert bs.data['fromVersion'] == VERSION_5_5_0
+        
+    def test_none_tabs_does_not_throw_exception(self, mocker, pack):
+        """
+        Given
+            - An indicator file with None indicatorsDetails tabs.
+        When
+            - Run format command.
+        Then
+            - Ensure command will not throw an exception.
+        """
+
+        layout = pack.create_layout(name='TestType', content = {"cacheVersn": 0, "close": None, "definitionId": "", "description": "", "detached": False, "details": None, "detailsV2": None, "edit": None, "fromServerVersion": "", "group": "indicator", "id": "SHA256 Indicator", "indicatorsDetails": {"TypeName": "", "tabs": None}})
+        bs = LayoutBaseFormat(input=layout.path, assume_yes=True)
+        try:
+            bs.remove_copy_and_dev_suffixes_from_layoutscontainer()
+        except Exception as exc:
+            assert False, f"'remove_copy_and_dev_suffixes_from_layoutscontainer' raised an exception {exc}"
 
     def test_json_run_format_old_classifier(self, mocker, pack):
         """

--- a/demisto_sdk/commands/format/tests/test_formatting_json_test.py
+++ b/demisto_sdk/commands/format/tests/test_formatting_json_test.py
@@ -1521,7 +1521,7 @@ class TestFormattingReport:
             - Ensure command will not throw an exception.
         """
 
-        layout = pack.create_layout(name='TestType', content = {"cacheVersn": 0, "close": None, "definitionId": "", "description": "",
+        layout = pack.create_layout(name='TestType', content={"cacheVersn": 0, "close": None, "definitionId": "", "description": "",
                                                                 "detached": False, "details": None, "detailsV2": None, 
                                                                 "edit": None, "fromServerVersion": "", "group": "indicator",
                                                                 "id": "SHA256 Indicator", "indicatorsDetails": {"TypeName": "", "tabs": None}})

--- a/demisto_sdk/commands/format/tests/test_formatting_json_test.py
+++ b/demisto_sdk/commands/format/tests/test_formatting_json_test.py
@@ -1521,7 +1521,10 @@ class TestFormattingReport:
             - Ensure command will not throw an exception.
         """
 
-        layout = pack.create_layout(name='TestType', content = {"cacheVersn": 0, "close": None, "definitionId": "", "description": "", "detached": False, "details": None, "detailsV2": None, "edit": None, "fromServerVersion": "", "group": "indicator", "id": "SHA256 Indicator", "indicatorsDetails": {"TypeName": "", "tabs": None}})
+        layout = pack.create_layout(name='TestType', content = {"cacheVersn": 0, "close": None, "definitionId": "", "description": "",
+                                                                "detached": False, "details": None, "detailsV2": None, 
+                                                                "edit": None, "fromServerVersion": "", "group": "indicator",
+                                                                "id": "SHA256 Indicator", "indicatorsDetails": {"TypeName": "", "tabs": None}})
         bs = LayoutBaseFormat(input=layout.path, assume_yes=True)
         try:
             bs.remove_copy_and_dev_suffixes_from_layoutscontainer()

--- a/demisto_sdk/commands/format/tests/test_formatting_json_test.py
+++ b/demisto_sdk/commands/format/tests/test_formatting_json_test.py
@@ -1510,7 +1510,7 @@ class TestFormattingReport:
         bs = LayoutBaseFormat(input=layout.path, assume_yes=True)
         bs.run_format()
         assert bs.data['fromVersion'] == VERSION_5_5_0
-        
+
     def test_none_tabs_do_not_throw_exception(self, mocker, pack):
         """
         Given

--- a/demisto_sdk/commands/format/update_layout.py
+++ b/demisto_sdk/commands/format/update_layout.py
@@ -238,8 +238,8 @@ class LayoutBaseFormat(BaseUpdateJSON, ABC):
                 container = self.data.get(kind)
                 break
         if container:
-            for tab in container.get('tabs', ()) or ():
-                for section in tab.get('sections', ()) or ():
+            for tab in (container.get('tabs') or ()):
+                for section in (tab.get('sections') or ()):
                     if section.get('queryType') == SCRIPT_QUERY_TYPE:
                         section['query'] = remove_copy_and_dev_suffixes_from_str(section.get('query'))
                         section['name'] = remove_copy_and_dev_suffixes_from_str(section.get('name'))

--- a/demisto_sdk/commands/format/update_layout.py
+++ b/demisto_sdk/commands/format/update_layout.py
@@ -238,8 +238,8 @@ class LayoutBaseFormat(BaseUpdateJSON, ABC):
                 container = self.data.get(kind)
                 break
         if container:
-            for tab in container.get('tabs', ()):
-                for section in tab.get('sections', ()):
+            for tab in container.get('tabs', ()) or ():
+                for section in tab.get('sections', ()) or ():
                     if section.get('queryType') == SCRIPT_QUERY_TYPE:
                         section['query'] = remove_copy_and_dev_suffixes_from_str(section.get('query'))
                         section['name'] = remove_copy_and_dev_suffixes_from_str(section.get('name'))


### PR DESCRIPTION
indicator file

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-18875

## Description
Prevent failure in setting the fromversion using format command, Caused by None in tabs object in indicator file.


## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
