### PR TITLE
Add TestData file validation for Modeling Rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## Unreleased
+* Added validation of testdata files for **Modeling Rules**.
 * Added the ability to limit the number of CPU cores with `DEMISTO_SDK_MAX_CPU_CORES` envirment variable.
 * Fixed an issue where **update-release-notes** failed when changing only xif file in **Modeling Rules**.
 * Fixed an issue where **is_valid_category** and **is_categories_field_match_standard** failed on private repo due to approved_list not imported.

--- a/TestSuite/rule.py
+++ b/TestSuite/rule.py
@@ -35,6 +35,7 @@ class Rule:
         self.yml = YAML(self._tmpdir_rule_path / f'{self.name}.yml', self._repo.path)
         self.rules = File(self._tmpdir_rule_path / f'{self.name}.xif', self._repo.path)
         self.schema = JSONBased(self._tmpdir_rule_path, f'{self.name}_schema', '')
+        self.testdata = JSONBased(self._tmpdir_rule_path, f'{self.name}_testdata', '')
 
         self.samples: list[JSONBased] = []
         self.samples_dir_path = tmpdir / SAMPLES_DIR

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -483,6 +483,8 @@ ERROR_CODE = {
     "modeling_rule_keys_not_empty": {'code': "MR101", 'ui_applicable': False, 'related_field': ''},
     "modeling_rule_keys_are_missing": {'code': "MR102", 'ui_applicable': False, 'related_field': ''},
     "invalid_rule_name": {'code': "MR103", 'ui_applicable': False, 'related_field': ''},
+    "modeling_rule_missing_testdata_file": {'code': "MR104", 'ui_applicable': False, 'related_field': ''},
+    "modeling_rule_testdata_not_formatted_correctly": {'code': "MR105", 'ui_applicable': False, 'related_field': ''},
 }
 
 
@@ -2547,3 +2549,18 @@ class Errors:
     def invalid_rule_name(invalid_files):
         return f"The following rule file name is invalid {invalid_files} - make sure that the rule name is " \
                f"the same as the folder containing it."
+
+    @staticmethod
+    @error_code_decorator
+    def modeling_rule_missing_testdata_file(modeling_rule_dir: Path, minimum_from_version: str, from_version: str):
+        test_data_file = modeling_rule_dir / f'{modeling_rule_dir.name}_testdata.json'
+        return f'The modeling rule {modeling_rule_dir} is missing a testdata file at {test_data_file}. The modeling ' \
+               f'rule has a fromversion of {from_version} and modeling rules supporting fromversion' \
+               f' {minimum_from_version} and upwards are required to provide test data for modeling rule testing.' \
+               ' Please add a testdata file for this rule. See the "demisto-sdk modeling-rules init-test-data" ' \
+               ' command for more information on creating a test data file for modeling rules.'
+
+    @staticmethod
+    @error_code_decorator
+    def modeling_rule_testdata_not_formatted_correctly(error_message: str):
+        return f'The modeling rule testdata file is not formatted correctly. {error_message}'

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -2556,10 +2556,10 @@ class Errors:
     def modeling_rule_missing_testdata_file(modeling_rule_dir: Path, minimum_from_version: str, from_version: str):
         test_data_file = modeling_rule_dir / f'{modeling_rule_dir.name}_testdata.json'
         return f'The modeling rule {modeling_rule_dir} is missing a testdata file at {test_data_file}. The modeling ' \
-               f'rule has a fromversion of {from_version} and modeling rules supporting fromversion' \
-               f' {minimum_from_version} and upwards are required to provide test data for modeling rule testing.' \
-               ' Please add a testdata file for this rule. See the "demisto-sdk modeling-rules init-test-data" ' \
-               ' command for more information on creating a test data file for modeling rules.'
+               f'rule has a fromversion of {from_version} and modeling rules supporting fromversion ' \
+               f'{minimum_from_version} and upwards are required to provide test data for modeling rule testing. ' \
+               'Please add a testdata file for this rule. See the "demisto-sdk modeling-rules init-test-data" ' \
+               'command for more information on creating a test data file for modeling rules.'
 
     @staticmethod
     @error_code_decorator

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -27,6 +27,7 @@ ALLOWED_IGNORE_ERRORS = [
     'SC100', 'SC101', 'SC105', 'SC106',
     'IM111',
     'RN112',
+    'MR104', 'MR105',
 ]
 
 # predefined errors to be ignored in partner/community supported packs even if they do not appear in .pack-ignore

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -2563,5 +2563,5 @@ class Errors:
 
     @staticmethod
     @error_code_decorator
-    def modeling_rule_testdata_not_formatted_correctly(error_message: str):
-        return f'The modeling rule testdata file is not formatted correctly. {error_message}'
+    def modeling_rule_testdata_not_formatted_correctly(error_message: str, test_data_file: Path):
+        return f'The modeling rule testdata file at {test_data_file} is not formatted correctly. {error_message}'

--- a/demisto_sdk/commands/common/hook_validations/modeling_rule.py
+++ b/demisto_sdk/commands/common/hook_validations/modeling_rule.py
@@ -60,7 +60,9 @@ class ModelingRuleValidator(ContentEntityValidator):
         try:
             _ = CompletedTestData.parse_file(testdata_file_path.as_posix())
         except ValidationError as e:
-            error_message, error_code = Errors.modeling_rule_testdata_not_formatted_correctly(str(e))
+            error_message, error_code = Errors.modeling_rule_testdata_not_formatted_correctly(
+                str(e), testdata_file_path
+            )
             if self.handle_error(error_message, error_code, file_path=self.file_path):
                 self._is_valid = False
                 return False

--- a/demisto_sdk/commands/common/hook_validations/modeling_rule.py
+++ b/demisto_sdk/commands/common/hook_validations/modeling_rule.py
@@ -38,8 +38,9 @@ class ModelingRuleValidator(ContentEntityValidator):
         self.are_keys_empty_in_yml()
         self.is_valid_rule_names()
         if self.does_version_require_testdata():
-            self.does_testdata_file_exist()
-            self.is_testdata_formatted_correctly()
+            # this condition also marks the rule as invalid if the testdata file is missing
+            if self.does_testdata_file_exist():
+                self.is_testdata_formatted_correctly()
 
         return self._is_valid
 

--- a/demisto_sdk/commands/common/hook_validations/modeling_rule.py
+++ b/demisto_sdk/commands/common/hook_validations/modeling_rule.py
@@ -84,8 +84,9 @@ class ModelingRuleValidator(ContentEntityValidator):
 
         for file_path in files_to_check:
             file_name = os.path.basename(file_path)
-            # The schema has _schema.json suffix whereas the integration only has the .suffix
-            splitter = '_' if file_name.endswith('_schema.json') else '.'
+            # The schema has _schema.json suffix and the testdata file has _testdata.json suffix
+            # whereas the other content entity component files only has the .suffix
+            splitter = '_' if file_name.endswith('_schema.json') or file_name.endswith('_testdata.json') else '.'
             base_name = file_name.rsplit(splitter, 1)[0]
 
             if integrations_folder != base_name:

--- a/demisto_sdk/commands/common/hook_validations/modeling_rule.py
+++ b/demisto_sdk/commands/common/hook_validations/modeling_rule.py
@@ -69,16 +69,10 @@ class ModelingRuleValidator(ContentEntityValidator):
 
     def does_testdata_file_exist(self):
         """Check if the testdata file exists"""
-        files_to_check = get_files_in_dir(os.path.dirname(self.file_path), ['json'], False)
-        has_testdata = False
-        if files_to_check:
-            for file_path in files_to_check:
-                file_name = os.path.basename(file_path)
-                if file_name.endswith('_testdata.json'):
-                    has_testdata = True
-                    break
+        modeling_rule_dir = Path(self.file_path).parent
+        testdata_files = list(modeling_rule_dir.glob('*_[tT][eE][sS][tT][dD][aA][tT][aA].[jJ][sS][oO][nN]'))
+        has_testdata = len(testdata_files) > 0
         if not has_testdata:
-            modeling_rule_dir = Path(self.file_path).parent
             error_message, error_code = Errors.modeling_rule_missing_testdata_file(
                 modeling_rule_dir,
                 self.MIN_FROMVERSION_REQUIRES_TESTDATA,
@@ -100,20 +94,14 @@ class ModelingRuleValidator(ContentEntityValidator):
 
     def is_schema_file_exists(self):
         # Gets the schema.json file from the modeling rule folder
-        files_to_check = get_files_in_dir(os.path.dirname(self.file_path), ['json'], False)
-        has_schema = False
-        if files_to_check:
-            for file_path in files_to_check:
-                file_name = os.path.basename(file_path)
-                if file_name.endswith('_schema.json'):
-                    has_schema = True
-                    break
-        if not files_to_check or not has_schema:
+        schema_files = list(Path(self.file_path).parent.glob('*_[sS][cC][hH][eE][mM][aA].[jJ][sS][oO][nN]'))
+        has_schema = len(schema_files) > 0
+        if not has_schema:
             error_message, error_code = Errors.modeling_rule_missing_schema_file(self.file_path)
             if self.handle_error(error_message, error_code, file_path=self.file_path):
                 self._is_valid = False
-                return False
-        return True
+                return has_schema
+        return has_schema
 
     def are_keys_empty_in_yml(self):
         """

--- a/demisto_sdk/commands/common/hook_validations/modeling_rule.py
+++ b/demisto_sdk/commands/common/hook_validations/modeling_rule.py
@@ -137,9 +137,12 @@ class ModelingRuleValidator(ContentEntityValidator):
 
         for file_path in files_to_check:
             file_name = os.path.basename(file_path)
+            file_name_std = file_name.casefold()
             # The schema has _schema.json suffix and the testdata file has _testdata.json suffix
             # whereas the other content entity component files only has the .suffix
-            splitter = '_' if file_name.endswith('_schema.json') or file_name.endswith('_testdata.json') else '.'
+            splitter = '_' if (
+                file_name_std.endswith('_schema.json') or file_name_std.endswith('_testdata.json')
+            ) else '.'
             base_name = file_name.rsplit(splitter, 1)[0]
 
             if integrations_folder != base_name:

--- a/demisto_sdk/commands/common/hook_validations/modeling_rule.py
+++ b/demisto_sdk/commands/common/hook_validations/modeling_rule.py
@@ -43,7 +43,14 @@ class ModelingRuleValidator(ContentEntityValidator):
     def is_schema_file_exists(self):
         # Gets the schema.json file from the modeling rule folder
         files_to_check = get_files_in_dir(os.path.dirname(self.file_path), ['json'], False)
-        if not files_to_check:
+        has_schema = False
+        if files_to_check:
+            for file_path in files_to_check:
+                file_name = os.path.basename(file_path)
+                if file_name.endswith('_schema.json'):
+                    has_schema = True
+                    break
+        if not files_to_check or not has_schema:
             error_message, error_code = Errors.modeling_rule_missing_schema_file(self.file_path)
             if self.handle_error(error_message, error_code, file_path=self.file_path):
                 self._is_valid = False

--- a/demisto_sdk/commands/common/hook_validations/modeling_rule.py
+++ b/demisto_sdk/commands/common/hook_validations/modeling_rule.py
@@ -84,8 +84,8 @@ class ModelingRuleValidator(ContentEntityValidator):
             )
             if self.handle_error(error_message, error_code, file_path=self.file_path):
                 self._is_valid = False
-                return False
-        return True
+                return has_testdata
+        return has_testdata
 
     def does_version_require_testdata(self):
         """Modeling Rule Versions Starting with 6.10.0 require test data for testing"""

--- a/demisto_sdk/commands/common/tests/modeling_rules_test.py
+++ b/demisto_sdk/commands/common/tests/modeling_rules_test.py
@@ -155,6 +155,7 @@ def test_is_incomplete_testdata_file(repo):
     Then: Validate that the modeling rule is invalid
     """
     from typer.testing import CliRunner
+
     from demisto_sdk.commands.test_content.test_modeling_rule.init_test_data import app as init_td_app
     pack = repo.create_pack('TestPack')
     dummy_modeling_rule = pack.create_modeling_rule('MyRule')

--- a/demisto_sdk/commands/common/tests/modeling_rules_test.py
+++ b/demisto_sdk/commands/common/tests/modeling_rules_test.py
@@ -129,3 +129,46 @@ def test_is_invalid_rule_file_name(repo):
         modeling_rule_validator = ModelingRuleValidator(structure_validator)
         assert not modeling_rule_validator.is_valid_rule_names()
         assert not modeling_rule_validator._is_valid
+
+
+def test_is_missing_testdata_file(repo):
+    """
+    Given: A modeling rule with missing testdata file
+    When: running is_valid_file
+    Then: Validate that the modeling rule is invalid
+    """
+    pack = repo.create_pack('TestPack')
+    dummy_modeling_rule = pack.create_modeling_rule('MyRule')
+    structure_validator = StructureValidator(dummy_modeling_rule.yml.path)
+    dummy_modeling_rule.testdata._file_path.unlink(missing_ok=True)
+    with ChangeCWD(repo.path):
+        modeling_rule_validator = ModelingRuleValidator(structure_validator)
+        assert not modeling_rule_validator.does_testdata_file_exist()
+        assert not modeling_rule_validator.is_valid_file()
+        assert not modeling_rule_validator._is_valid
+
+
+def test_is_incomplete_testdata_file(repo):
+    """
+    Given: A modeling rule with an incomplete testdata file
+    When: running is_valid_file
+    Then: Validate that the modeling rule is invalid
+    """
+    from typer.testing import CliRunner
+    from demisto_sdk.commands.test_content.test_modeling_rule.init_test_data import app as init_td_app
+    pack = repo.create_pack('TestPack')
+    dummy_modeling_rule = pack.create_modeling_rule('MyRule')
+    structure_validator = StructureValidator(dummy_modeling_rule.yml.path)
+    dummy_modeling_rule.testdata._file_path.unlink()
+    with open('demisto_sdk/tests/test_files/modeling_rules.xif', 'r') as f:
+        xif_rules = f.read()
+        dummy_modeling_rule.rules.write(xif_rules)
+    runner = CliRunner()
+    result = runner.invoke(init_td_app, [dummy_modeling_rule.testdata._file_path.parent.as_posix()])
+    assert result.exit_code == 0
+    with ChangeCWD(repo.path):
+        modeling_rule_validator = ModelingRuleValidator(structure_validator)
+        assert modeling_rule_validator.does_testdata_file_exist()
+        assert not modeling_rule_validator.is_testdata_formatted_correctly()
+        assert not modeling_rule_validator.is_valid_file()
+        assert not modeling_rule_validator._is_valid

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -1347,6 +1347,8 @@ def find_type_by_path(path: Union[str, Path] = '') -> Optional[FileType]:
             return FileType.XDRC_TEMPLATE
         elif MODELING_RULES_DIR in path.parts and 'testdata' in path.stem.casefold():
             return FileType.MODELING_RULE_TEST_DATA
+        elif MODELING_RULES_DIR in path.parts and path.stem.casefold().endswith('_schema'):
+            return FileType.MODELING_RULE_SCHEMA
 
     elif path.name.endswith('_image.png'):
         if path.name.endswith('Author_image.png'):
@@ -1477,7 +1479,7 @@ def find_type(
             return FileType.CORRELATION_RULE
 
     if file_type == 'json' or path.lower().endswith('.json'):
-        if path.lower().endswith('_schema.json'):
+        if path.lower().endswith('_schema.json') and MODELING_RULES_DIR in Path(path).parts:
             return FileType.MODELING_RULE_SCHEMA
 
         if 'widgetType' in _dict:

--- a/demisto_sdk/commands/test_content/test_modeling_rule/tests/init_test_data_test.py
+++ b/demisto_sdk/commands/test_content/test_modeling_rule/tests/init_test_data_test.py
@@ -54,7 +54,8 @@ def test_init_test_data_create(pack):
     """
     from demisto_sdk.commands.test_content.test_modeling_rule.init_test_data import app as init_test_data_app
     runner = CliRunner()
-    pack.create_modeling_rule(DEFAULT_MODELING_RULE_NAME, rules=ONE_MODEL_RULE_TEXT)
+    mr = pack.create_modeling_rule(DEFAULT_MODELING_RULE_NAME, rules=ONE_MODEL_RULE_TEXT)
+    mr.testdata._file_path.unlink()
     mrule_dir = Path(pack._modeling_rules_path / DEFAULT_MODELING_RULE_NAME)
     test_data_file = mrule_dir / f'{DEFAULT_MODELING_RULE_NAME}_testdata.json'
     assert test_data_file.exists() is False
@@ -207,8 +208,10 @@ class TestInitTestDataMultiInput:
         """
         from demisto_sdk.commands.test_content.test_modeling_rule.init_test_data import app as init_test_data_app
         runner = CliRunner()
-        pack.create_modeling_rule(DEFAULT_MODELING_RULE_NAME, rules=ONE_MODEL_RULE_TEXT)
-        pack.create_modeling_rule(DEFAULT_MODELING_RULE_NAME_2, rules=ONE_MODEL_RULE_TEXT)
+        mr_1 = pack.create_modeling_rule(DEFAULT_MODELING_RULE_NAME, rules=ONE_MODEL_RULE_TEXT)
+        mr_2 = pack.create_modeling_rule(DEFAULT_MODELING_RULE_NAME_2, rules=ONE_MODEL_RULE_TEXT)
+        mr_1.testdata._file_path.unlink()
+        mr_2.testdata._file_path.unlink()
         mrule_dir = Path(pack._modeling_rules_path / DEFAULT_MODELING_RULE_NAME)
         mrule_dir_2 = Path(pack._modeling_rules_path / DEFAULT_MODELING_RULE_NAME_2)
         test_data_file = mrule_dir / f'{DEFAULT_MODELING_RULE_NAME}_testdata.json'
@@ -239,8 +242,10 @@ class TestInitTestDataMultiInput:
         """
         from demisto_sdk.commands.test_content.test_modeling_rule.init_test_data import app as init_test_data_app
         runner = CliRunner()
-        pack.create_modeling_rule(DEFAULT_MODELING_RULE_NAME, rules=ONE_MODEL_RULE_TEXT)
-        pack.create_modeling_rule(DEFAULT_MODELING_RULE_NAME_2, rules=ONE_MODEL_RULE_TEXT)
+        mr_1 = pack.create_modeling_rule(DEFAULT_MODELING_RULE_NAME, rules=ONE_MODEL_RULE_TEXT)
+        mr_2 = pack.create_modeling_rule(DEFAULT_MODELING_RULE_NAME_2, rules=ONE_MODEL_RULE_TEXT)
+        mr_1.testdata._file_path.unlink()
+        mr_2.testdata._file_path.unlink()
         mrule_dir = Path(pack._modeling_rules_path / DEFAULT_MODELING_RULE_NAME)
         mrule_dir_2 = Path(pack._modeling_rules_path / DEFAULT_MODELING_RULE_NAME_2)
         test_data_file = mrule_dir / f'{DEFAULT_MODELING_RULE_NAME}_testdata.json'

--- a/demisto_sdk/commands/test_content/xsiam_tools/test_data.py
+++ b/demisto_sdk/commands/test_content/xsiam_tools/test_data.py
@@ -23,3 +23,25 @@ class TestData(BaseModel):
                 err = "The expected values mapping keys are expected to start with 'xdm.' (case insensitive)"
                 raise ValueError(err)
         return v
+
+
+class CompletedTestData(TestData):
+
+    @validator('data')
+    def validate_expected_values(cls, v):
+        for test_data_event in v:
+            if not test_data_event.expected_values or not any(test_data_event.expected_values.values()):
+                err = "The expected values mapping is required for each test data event"
+                if not any(test_data_event.expected_values.values()):
+                    err = ("No values were provided in expected values mapping - all were null"
+                           " - you must provide at least one")
+                raise ValueError(err)
+        return v
+
+    @validator('data')
+    def validate_event_data(cls, v):
+        for test_data_event in v:
+            if not test_data_event.event_data:
+                err = "The event data is required for each test data event"
+                raise ValueError(err)
+        return v

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -52,6 +52,7 @@ from demisto_sdk.tests.constants_test import (CONF_JSON_MOCK_PATH, DASHBOARD_TAR
                                               INVALID_PLAYBOOK_PATH, INVALID_PLAYBOOK_PATH_FROM_ROOT,
                                               INVALID_REPUTATION_PATH, INVALID_SCRIPT_PATH, INVALID_WIDGET_PATH,
                                               LAYOUT_TARGET, LAYOUTS_CONTAINER_TARGET, MODELING_RULES_SCHEMA_FILE,
+                                              MODELING_RULES_TESTDATA_FILE, MODELING_RULES_XIF_FILE,
                                               MODELING_RULES_YML_FILE, PLAYBOOK_TARGET, SCRIPT_RELEASE_NOTES_TARGET,
                                               SCRIPT_TARGET, VALID_BETA_INTEGRATION, VALID_BETA_PLAYBOOK_PATH,
                                               VALID_DASHBOARD_PATH, VALID_INCIDENT_FIELD_PATH, VALID_INCIDENT_TYPE_PATH,
@@ -1960,23 +1961,30 @@ def test_image_error(capsys):
     assert expected_code in stdout
 
 
-def test_check_file_relevance_and_format_path(mocker):
+modeling_rule_file_changes = [
+    (MODELING_RULES_SCHEMA_FILE, FileType.MODELING_RULE_SCHEMA, MODELING_RULES_YML_FILE),
+    (MODELING_RULES_XIF_FILE, FileType.MODELING_RULE_XIF, MODELING_RULES_YML_FILE),
+    (MODELING_RULES_TESTDATA_FILE, FileType.MODELING_RULE_TEST_DATA, MODELING_RULES_YML_FILE),
+]
+
+
+@pytest.mark.parametrize('f_path, f_type, expected_result', modeling_rule_file_changes)
+def test_check_file_relevance_and_format_path(mocker, f_path, f_type, expected_result):
     """
 
-    Given: A modeling rules schema file that was changed.
+    Given: A modeling rules entity file that was changed.
 
-    When: Updating release notes
+    When: Validating changed files.
 
     Then: Update the file path to point the modeling rules yml file.
 
     """
     mocker.patch.object(ValidateManager, 'ignore_files_irrelevant_for_validation', return_value=False)
     mocker.patch.object(ValidateManager, 'is_old_file_format', return_value=False)
+    mocker.patch('demisto_sdk.commands.validate.validate_manager.find_type', return_value=f_type)
     validate_manager = ValidateManager()
-    file_path, old_path, _ = validate_manager.check_file_relevance_and_format_path(MODELING_RULES_SCHEMA_FILE,
-                                                                                   MODELING_RULES_SCHEMA_FILE,
-                                                                                   set())
-    assert file_path == old_path == MODELING_RULES_YML_FILE
+    file_path, old_path, _ = validate_manager.check_file_relevance_and_format_path(f_path, f_path, set())
+    assert file_path == old_path == expected_result
 
 
 pack_metadata_invalid_tags = {

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -2030,3 +2030,217 @@ def test_run_validation_using_git_on_metadata_with_invalid_tags(mocker, repo, pa
     captured_stdout = std_output.getvalue()
     assert "[PA123]" in captured_stdout, captured_stdout
     assert not res
+
+
+def test_run_validation_using_git_modify_existing_modeling_rule_yml_supports_td(mocker, repo):
+    """
+    Given:
+        - A pack with a modeling rule content entity defined exists.
+        - The modeling rule version supports testing via usage of testdata.
+        - No test data file exists.
+    When:
+        - The modeling rule yml file has been modified.
+    Then:
+        - Ensure the test data file is required.
+    """
+    pack = repo.create_pack()
+    modeling_rule_name = 'MyModelingRule'
+    modeling_rule_yml_content = {
+        'id': 'modeling-rule',
+        'name': modeling_rule_name,
+        'fromversion': '6.10.0',
+        'tags': 'tag',
+        'rules': '',
+        'schema': '',
+    }
+    modeling_rule = pack.create_modeling_rule(modeling_rule_name, modeling_rule_yml_content)
+    modeling_rule.testdata._file_path.unlink()
+    mocker.patch.object(ValidateManager, 'setup_git_params', return_value=True)
+    mocker.patch.object(ValidateManager, 'get_unfiltered_changed_files_from_git',
+                        return_value=({modeling_rule.yml.path}, set(), set()))
+    mocker.patch.object(GitUtil, 'deleted_files', return_value=set())
+    mocker.patch.object(ValidateManager, 'is_old_file_format', return_value=False)
+    mocker.patch.object(ValidateManager, 'ignore_files_irrelevant_for_validation', return_value=False)
+    validate_manager = ValidateManager(check_is_unskipped=False, skip_conf_json=True)
+    std_output = StringIO()
+    with contextlib.redirect_stdout(std_output):
+        with ChangeCWD(repo.path):
+            res = validate_manager.run_validation_using_git()
+    captured_stdout = std_output.getvalue()
+    assert "[MR104]" in captured_stdout, captured_stdout
+    assert not res
+
+
+def test_run_validation_using_git_modify_existing_modeling_rule_xif_supports_td(mocker, repo):
+    """
+    Given:
+        - A pack with a modeling rule content entity defined exists.
+        - The modeling rule version supports testing via usage of testdata.
+        - No test data file exists.
+    When:
+        - The modeling rule xif file has been modified.
+    Then:
+        - Ensure the test data file is required.
+    """
+    pack = repo.create_pack()
+    modeling_rule_name = 'MyModelingRule'
+    modeling_rule_yml_content = {
+        'id': 'modeling-rule',
+        'name': modeling_rule_name,
+        'fromversion': '6.10.0',
+        'tags': 'tag',
+        'rules': '',
+        'schema': '',
+    }
+    modeling_rule = pack.create_modeling_rule(modeling_rule_name, modeling_rule_yml_content)
+    modeling_rule.testdata._file_path.unlink()
+    mocker.patch.object(ValidateManager, 'setup_git_params', return_value=True)
+    mocker.patch.object(ValidateManager, 'get_unfiltered_changed_files_from_git',
+                        return_value=({modeling_rule.rules.path}, set(), set()))
+    mocker.patch.object(GitUtil, 'deleted_files', return_value=set())
+    mocker.patch.object(ValidateManager, 'is_old_file_format', return_value=False)
+    mocker.patch.object(ValidateManager, 'ignore_files_irrelevant_for_validation', return_value=False)
+    validate_manager = ValidateManager(check_is_unskipped=False, skip_conf_json=True)
+    std_output = StringIO()
+    with contextlib.redirect_stdout(std_output):
+        with ChangeCWD(repo.path):
+            res = validate_manager.run_validation_using_git()
+    captured_stdout = std_output.getvalue()
+    assert "[MR104]" in captured_stdout, captured_stdout
+    assert not res
+
+
+def test_run_validation_using_git_modify_existing_modeling_rule_schema_supports_td(mocker, repo):
+    """
+    Given:
+        - A pack with a modeling rule content entity defined exists.
+        - The modeling rule version supports testing via usage of testdata.
+        - No test data file exists.
+    When:
+        - The modeling rule schema file has been modified.
+    Then:
+        - Ensure the test data file is required.
+    """
+    pack = repo.create_pack()
+    modeling_rule_name = 'MyModelingRule'
+    modeling_rule_yml_content = {
+        'id': 'modeling-rule',
+        'name': modeling_rule_name,
+        'fromversion': '6.10.0',
+        'tags': 'tag',
+        'rules': '',
+        'schema': '',
+    }
+    modeling_rule = pack.create_modeling_rule(modeling_rule_name, modeling_rule_yml_content)
+    modeling_rule.testdata._file_path.unlink()
+    mocker.patch.object(ValidateManager, 'setup_git_params', return_value=True)
+    mocker.patch.object(ValidateManager, 'get_unfiltered_changed_files_from_git',
+                        return_value=({modeling_rule.schema.path}, set(), set()))
+    mocker.patch.object(GitUtil, 'deleted_files', return_value=set())
+    mocker.patch.object(ValidateManager, 'is_old_file_format', return_value=False)
+    mocker.patch.object(ValidateManager, 'ignore_files_irrelevant_for_validation', return_value=False)
+    validate_manager = ValidateManager(check_is_unskipped=False, skip_conf_json=True)
+    std_output = StringIO()
+    with contextlib.redirect_stdout(std_output):
+        with ChangeCWD(repo.path):
+            res = validate_manager.run_validation_using_git()
+    captured_stdout = std_output.getvalue()
+    assert "[MR104]" in captured_stdout, captured_stdout
+    assert not res
+
+
+@pytest.mark.parametrize('modified_file', ['yml', 'rules', 'schema', 'testdata'])
+def test_run_validation_using_git_modify_existing_incomplete_testdata(mocker, repo, modified_file):
+    """
+    Given:
+        - A pack with a modeling rule content entity defined exists.
+        - The modeling rule version supports testing via usage of testdata.
+        - The testdata file is incomplete.
+    When:
+        - One of the component files has been modified.
+    Then:
+        - Ensure an error about the incomplete test data file is returned.
+    """
+    from typer.testing import CliRunner
+
+    from demisto_sdk.commands.test_content.test_modeling_rule.init_test_data import app as init_td_app
+    pack = repo.create_pack()
+    modeling_rule_name = 'MyModelingRule'
+    modeling_rule_yml_content = {
+        'id': 'modeling-rule',
+        'name': modeling_rule_name,
+        'fromversion': '6.10.0',
+        'tags': 'tag',
+        'rules': '',
+        'schema': '',
+    }
+    modeling_rule = pack.create_modeling_rule(modeling_rule_name, modeling_rule_yml_content)
+    modeling_rule.testdata._file_path.unlink()
+    with open('demisto_sdk/tests/test_files/modeling_rules.xif', 'r') as f:
+        xif_rules = f.read()
+        modeling_rule.rules.write(xif_rules)
+    runner = CliRunner()
+    result = runner.invoke(init_td_app, [modeling_rule.testdata._file_path.parent.as_posix()])
+    assert result.exit_code == 0
+
+    mocker.patch.object(ValidateManager, 'setup_git_params', return_value=True)
+    modified_files = {modeling_rule.yml.path}
+    if modified_file == 'rules':
+        modified_files = {modeling_rule.rules.path}
+    elif modified_file == 'schema':
+        modified_files = {modeling_rule.schema.path}
+    elif modified_file == 'testdata':
+        modified_files = {modeling_rule.testdata.path}
+    mocker.patch.object(ValidateManager, 'get_unfiltered_changed_files_from_git',
+                        return_value=(modified_files, set(), set()))
+    mocker.patch.object(GitUtil, 'deleted_files', return_value=set())
+    mocker.patch.object(ValidateManager, 'is_old_file_format', return_value=False)
+    mocker.patch.object(ValidateManager, 'ignore_files_irrelevant_for_validation', return_value=False)
+    validate_manager = ValidateManager(check_is_unskipped=False, skip_conf_json=True)
+    std_output = StringIO()
+    with contextlib.redirect_stdout(std_output):
+        with ChangeCWD(repo.path):
+            res = validate_manager.run_validation_using_git()
+    captured_stdout = std_output.getvalue()
+    assert "[MR105]" in captured_stdout, captured_stdout
+    assert not res
+
+
+def test_run_validation_using_git_add_modeling_rule_that_supports_td(mocker, repo):
+    """
+    Given:
+        - A pack with a modeling rule content entity does not previously exist.
+        - The modeling rule being added has a version that supports testing via usage of testdata.
+    When:
+        - The modeling rule yml, xif, and schema file have been added.
+    Then:
+        - Ensure the validation fails on requiring a test data file be added.
+    """
+    pack = repo.create_pack()
+    modeling_rule_name = 'MyModelingRule'
+    modeling_rule_yml_content = {
+        'id': 'modeling-rule',
+        'name': modeling_rule_name,
+        'fromversion': '6.10.0',
+        'tags': 'tag',
+        'rules': '',
+        'schema': '',
+    }
+    modeling_rule = pack.create_modeling_rule(modeling_rule_name, modeling_rule_yml_content)
+    modeling_rule.testdata._file_path.unlink()
+    mocker.patch.object(ValidateManager, 'setup_git_params', return_value=True)
+    mocker.patch.object(
+        ValidateManager, 'get_unfiltered_changed_files_from_git',
+        return_value=(set(), {modeling_rule.yml.path, modeling_rule.rules.path, modeling_rule.schema.path}, set())
+    )
+    mocker.patch.object(GitUtil, 'deleted_files', return_value=set())
+    mocker.patch.object(ValidateManager, 'is_old_file_format', return_value=False)
+    mocker.patch.object(ValidateManager, 'ignore_files_irrelevant_for_validation', return_value=False)
+    validate_manager = ValidateManager(check_is_unskipped=False, skip_conf_json=True)
+    std_output = StringIO()
+    with contextlib.redirect_stdout(std_output):
+        with ChangeCWD(repo.path):
+            res = validate_manager.run_validation_using_git()
+    captured_stdout = std_output.getvalue()
+    assert "[MR104]" in captured_stdout, captured_stdout
+    assert not res

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -1744,7 +1744,8 @@ class ValidateManager:
                     '.xif', '.yml')
 
                 if old_path:
-                    old_path = old_path.replace('.py', '.yml').replace('.ps1', '.yml').replace('.js', '.yml')
+                    old_path = old_path.replace('.py', '.yml').replace('.ps1', '.yml').replace('.js', '.yml').replace(
+                        '.xif', '.yml')
             else:
                 return irrelevant_file_output
 
@@ -1760,6 +1761,13 @@ class ValidateManager:
 
             if old_path:
                 old_path = old_path.replace('_schema', '').replace('.json', '.yml')
+        
+        # redirect _testdata.json file to the associated yml file
+        if file_type == FileType.MODELING_RULE_TEST_DATA:
+            file_path = file_path.replace('_testdata.json', '.yml')
+
+            if old_path:
+                old_path = old_path.replace('_testdata.json', '.yml')
 
         # check for old file format
         if self.is_old_file_format(file_path, file_type):

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -1761,7 +1761,7 @@ class ValidateManager:
 
             if old_path:
                 old_path = old_path.replace('_schema', '').replace('.json', '.yml')
-        
+
         # redirect _testdata.json file to the associated yml file
         if file_type == FileType.MODELING_RULE_TEST_DATA:
             file_path = file_path.replace('_testdata.json', '.yml')

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -162,16 +162,16 @@ class ValidateManager:
         self.always_valid = False
         self.ignored_files = set()
         self.new_packs = set()
-        self.skipped_file_types = (FileType.CHANGELOG,
-                                   FileType.DOC_IMAGE,
-                                   FileType.MODELING_RULE_SCHEMA,
-                                   FileType.XSIAM_DASHBOARD_IMAGE,
-                                   FileType.XSIAM_REPORT_IMAGE,
-                                   FileType.XSIAM_DASHBOARD_IMAGE,
-                                   FileType.XDRC_TEMPLATE_YML,
-                                   FileType.XDRC_TEMPLATE,
-                                   FileType.MODELING_RULE_XIF,
-                                   )
+        self.skipped_file_types = (
+            FileType.CHANGELOG,
+            FileType.DOC_IMAGE,
+            FileType.MODELING_RULE_SCHEMA,
+            FileType.XSIAM_DASHBOARD_IMAGE,
+            FileType.XSIAM_REPORT_IMAGE,
+            FileType.XSIAM_DASHBOARD_IMAGE,
+            FileType.XDRC_TEMPLATE_YML,
+            FileType.XDRC_TEMPLATE,
+        )
 
         self.is_external_repo = is_external_repo
         if is_external_repo:
@@ -675,7 +675,13 @@ class ValidateManager:
         elif file_type == FileType.PARSING_RULE:
             return self.validate_parsing_rule(structure_validator, pack_error_ignore_list)
 
-        elif file_type == FileType.MODELING_RULE:
+        elif file_type in (FileType.MODELING_RULE, FileType.MODELING_RULE_XIF, FileType.MODELING_RULE_TEST_DATA):
+            print(f'Validating {file_type.value} file: {file_path}')
+            if self.validate_all:
+                error_ignore_list = pack_error_ignore_list.copy()
+                error_ignore_list.setdefault(os.path.basename(file_path), [])
+                error_ignore_list.get(os.path.basename(file_path)).append('MR104')
+                return self.validate_modeling_rule(structure_validator, error_ignore_list)
             return self.validate_modeling_rule(structure_validator, pack_error_ignore_list)
 
         elif file_type == FileType.CORRELATION_RULE:

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -168,7 +168,6 @@ class ValidateManager:
             FileType.MODELING_RULE_SCHEMA,
             FileType.XSIAM_DASHBOARD_IMAGE,
             FileType.XSIAM_REPORT_IMAGE,
-            FileType.XSIAM_DASHBOARD_IMAGE,
             FileType.XDRC_TEMPLATE_YML,
             FileType.XDRC_TEMPLATE,
         )

--- a/demisto_sdk/tests/constants_test.py
+++ b/demisto_sdk/tests/constants_test.py
@@ -110,6 +110,8 @@ PLAYBOOK_WITH_INCIDENT_INDICATOR_SCRIPTS = f"{GIT_ROOT}/demisto_sdk/tests/test_f
 INVALID_PLAYBOOK_INPUTS_USE = f'{GIT_ROOT}/demisto_sdk/tests/test_files/playbook_inputs_not_in_use.yml'
 VALID_PLAYBOOK_INPUTS_USE = f'{GIT_ROOT}/demisto_sdk/tests/test_files/playbook_valid_inputs.yml'
 MODELING_RULES_SCHEMA_FILE = f'{GIT_ROOT}/demisto_sdk/tests/test_files/modeling_rules_schema.json'
+MODELING_RULES_TESTDATA_FILE = f'{GIT_ROOT}/demisto_sdk/tests/test_files/modeling_rules_testdata.json'
+MODELING_RULES_XIF_FILE = f'{GIT_ROOT}/demisto_sdk/tests/test_files/modeling_rules.xif'
 MODELING_RULES_YML_FILE = f'{GIT_ROOT}/demisto_sdk/tests/test_files/modeling_rules.yml'
 
 INCORRECT_PLAYBOOK_REFERENCE_USE = f'{GIT_ROOT}/demisto_sdk/tests/test_files/incorrect_playbook_reference_use.yml'

--- a/demisto_sdk/tests/test_files/modeling_rules.xif
+++ b/demisto_sdk/tests/test_files/modeling_rules.xif
@@ -1,0 +1,8 @@
+[MODEL: dataset="fake_fakerson_raw"]
+filter
+    method contains "GET"
+| alter
+    xdm.target.sent_bytes = to_number(sent_bytes),
+    xdm.network.http.method = method,
+    xdm.network.http.url = URL,
+    xdm.network.http.referrer = referrer;

--- a/demisto_sdk/tests/test_files/modeling_rules_testdata.json
+++ b/demisto_sdk/tests/test_files/modeling_rules_testdata.json
@@ -1,0 +1,22 @@
+{
+    "data": [
+        {
+            "test_data_event_id": "abcdefgh-0000-1111-2222-hijklmnopqrs",
+            "vendor": "fake",
+            "product": "fakerson",
+            "dataset": "fake_fakerson_raw",
+            "event_data": {
+                "method": "GET",
+                "sent_bytes": 1,
+                "URL": "/icons/fake.png",
+                "referrer": "HTTP/1.1"
+            },
+            "expected_values": {
+                "xdm.target.sent_bytes": 1.0,
+                "xdm.network.http.method": "GET",
+                "xdm.network.http.url": "/icons/fake.png",
+                "xdm.network.http.referrer": "HTTP/1.1"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## Status
- [x] Ready

## Description
- `demisto-sdk validate` will now check for the existence and proper formatting of a modeling rule's testdata file (assuming the modeling rule `fromversion` field is 6.10.0 or greater)
- When running `demisto-sdk validate -a` AKA validating the entire `content` repository, the `MR104` (existence of a testdata file for version compatible modeling rules) will be ignored so that way the validation won't fail on existing modeling rules that did not have testdat added in our Nightly.

## Must have
- [x] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
