### PR TITLE
fix: Skip upload override prompt if skip_validation is True

### DIFF
--- a/demisto_sdk/commands/upload/uploader.py
+++ b/demisto_sdk/commands/upload/uploader.py
@@ -297,7 +297,7 @@ class Uploader:
             if not self.pack_names:
                 self.pack_names = [zipped_pack.path.stem]
 
-            if self.notify_user_should_override_packs():
+            if self.notify_user_should_override_packs(skip_validation):
                 zipped_pack.upload(logger, self.client, skip_validation)
                 self.successfully_uploaded_files.extend([(pack_name, FileType.PACK.value) for pack_name in self.pack_names])
                 return SUCCESS_RETURN_CODE
@@ -310,8 +310,13 @@ class Uploader:
             self.failed_uploaded_files.append((file_name, FileType.PACK.value, message))
             return ERROR_RETURN_CODE
 
-    def notify_user_should_override_packs(self):
-        """Notify the user about possible overridden packs"""
+    def notify_user_should_override_packs(self, skip_validation: bool):
+        """
+        Notify the user about possible overridden packs.
+
+        Args:
+            skip_validation (bool): Skips user confirmation prompt.
+        """
 
         response = self.client.generic_request('/contentpacks/metadata/installed', "GET")
         installed_packs = eval(response[0])
@@ -321,10 +326,11 @@ class Uploader:
             if common_packs:
                 pack_names = '\n'.join(common_packs)
                 click.secho(f'This command will overwrite the following packs:\n{pack_names}.\n'
-                            'Any changes made on XSOAR will be lost.\n'
-                            'Are you sure you want to continue? Y/[N]', fg='bright_red')
-                answer = str(input())
-                return answer in ['y', 'Y', 'yes']
+                            'Any changes made on XSOAR will be lost.', fg='bright_red')
+                if not skip_validation:
+                    click.secho('Are you sure you want to continue? Y/[N]', fg='bright_red')
+                    answer = str(input())
+                    return answer in ['y', 'Y', 'yes']
 
         return True
 


### PR DESCRIPTION
## Status
- [] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/demisto-sdk/issues/2579

## Description
This change uses the `--skip_validation` option value to determine if the user should be presented a confirmation prompt when attempting to upload a content pack that is already installed on the demisto server. This allows the upload command to be used within non-interactive shells.

## Screenshots
N/A

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
