### PR TITLE
Fix download when layout detailsV2 is None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fixed an issue where **validate** failed in private repo due to attempts to read from nonexisting file.
 * Fixed an issue where **validate** used absolute paths when getting the remote pack_metadata.json files in private repos.
 * Fixed an issue in **download**, where names of custom scripts were replaced with UUIDs in IncidentFields and Layouts.
+* Fixed an issue where **download** would fail if a layout did not have detailsV2. @maxgubler
 
 ## 1.8.0
 * Updated the supported python versions, as `>=3.8,<3.11`, as some of the dependencies are not supported on `3.11` yet.

--- a/demisto_sdk/commands/download/downloader.py
+++ b/demisto_sdk/commands/download/downloader.py
@@ -254,7 +254,7 @@ class Downloader:
         file_json_object = json.loads(layout_string)
         layout_name = file_json_object.get('name')
         if layout_name and (layout_name in self.input_files or self.all_custom_content):
-            for tab in file_json_object.get('detailsV2', {}).get('tabs', ()):
+            for tab in (file_json_object.get('detailsV2') or {}).get('tabs', ()):
                 for section in tab.get('sections', ()):
                     for item in section.get('items', ()):
                         script_id = item.get('scriptId')

--- a/demisto_sdk/commands/download/tests/downloader_test.py
+++ b/demisto_sdk/commands/download/tests/downloader_test.py
@@ -789,7 +789,14 @@ def test_build_file_name():
      '{\n\t"name":"TestingLayout",\n\t"detailsV2":{\n\t\t"tabs":[\n\t\t\t{\n\t\t\t\t"sections":[\n\t\t\t\t\t{\n\t\t\t\t'
      '\t\t"items":[\n\t\t\t\t\t\t\t{\n\t\t\t\t\t\t\t\t"scriptId":"TestingScript"\n\t\t\t\t\t\t'
      '\t}\n\t\t\t\t\t\t]\n\t\t\t\t\t}\n\t\t\t\t]\n\t\t\t}\n\t\t]\n\t}\n}',
-     {"f1e4c6e5-0d44-48a0-8020-a9711243e918": "TestingScript"})
+     {"f1e4c6e5-0d44-48a0-8020-a9711243e918": "TestingScript"}),
+    (
+        '{\n\t"name":"TestingLayout",\n\t"detailsV2":null\n}',
+        'layoutcontainer-TestingLayout.json',
+        {'f1e4c6e5-0d44-48a0-8020-a9711243e918': 'TestingScript'},
+        '{\n\t"name":"TestingLayout",\n\t"detailsV2":null\n}',
+        {'f1e4c6e5-0d44-48a0-8020-a9711243e918': 'TestingScript'}
+    )
 ])
 def test_handle_file(original_string, object_name, scripts_mapper, expected_string, expected_mapper):
     downloader = Downloader(output='', input='', regex='', all_custom_content=True)


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: #2599 

## Description
Fixes issues where when downloading a layout with its json value of detailsV2 `null`, an error occurs:
`'NoneType' object has no attribute 'get'`
