### PR TITLE
fix - xdrctemplate was missing 'external' prefix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ## Unreleased
 * Fixed an issue where modeling rules with arbitrary whitespace characters were not parsed correctly.
 * Added support for the **nativeImage** key for an integration/script in the **prepare-content** command.
+* Fixed an issue where **xdrctemplate** was missing 'external' prefix.
+* Fixed an issue in **prepare-content** command providing output path.
 
 ## 1.8.1
 * Fixed an issue where **format** created duplicate configuration parameters.

--- a/demisto_sdk/commands/common/content/objects/pack_objects/xdrc_template/xdrc_template.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/xdrc_template/xdrc_template.py
@@ -45,7 +45,7 @@ class XDRCTemplate(JSONContentObject):
         if isinstance(dest_dir, str):
             dest_dir = Path(dest_dir)
         # Unify step
-        return [Path(str(PrepareUploadManager.prepare_for_upload(input=self.path, output=dest_dir)))]
+        return [Path(str(PrepareUploadManager.prepare_for_upload(input=self.path, output=dest_dir/self.normalize_file_name())))]
 
     def _create_target_dump_dir(self, dest_dir: Optional[Union[Path, str]] = None) -> Path:
         """Create destination directory, Destination must be valid directory, If not specified dump in

--- a/demisto_sdk/commands/common/content/objects/pack_objects/xdrc_template/xdrc_template.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/xdrc_template/xdrc_template.py
@@ -45,7 +45,8 @@ class XDRCTemplate(JSONContentObject):
         if isinstance(dest_dir, str):
             dest_dir = Path(dest_dir)
         # Unify step
-        return [Path(str(PrepareUploadManager.prepare_for_upload(input=self.path, output=dest_dir / self.normalize_file_name())))]
+        return [Path(str(PrepareUploadManager.prepare_for_upload(input=self.path,
+                                                                 output=dest_dir / self.normalize_file_name())))]  # type: ignore
 
     def _create_target_dump_dir(self, dest_dir: Optional[Union[Path, str]] = None) -> Path:
         """Create destination directory, Destination must be valid directory, If not specified dump in

--- a/demisto_sdk/commands/common/content/objects/pack_objects/xdrc_template/xdrc_template.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/xdrc_template/xdrc_template.py
@@ -46,7 +46,7 @@ class XDRCTemplate(JSONContentObject):
             dest_dir = Path(dest_dir)
         # Unify step
         return [Path(str(PrepareUploadManager.prepare_for_upload(input=self.path,
-                                                                 output=dest_dir / self.normalize_file_name())))]  # type: ignore
+                                                                 output=dest_dir / self.normalize_file_name())))]  # type: ignore[operator]
 
     def _create_target_dump_dir(self, dest_dir: Optional[Union[Path, str]] = None) -> Path:
         """Create destination directory, Destination must be valid directory, If not specified dump in

--- a/demisto_sdk/commands/common/content/objects/pack_objects/xdrc_template/xdrc_template.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/xdrc_template/xdrc_template.py
@@ -45,7 +45,7 @@ class XDRCTemplate(JSONContentObject):
         if isinstance(dest_dir, str):
             dest_dir = Path(dest_dir)
         # Unify step
-        return [Path(str(PrepareUploadManager.prepare_for_upload(input=self.path, output=dest_dir/self.normalize_file_name())))]
+        return [Path(str(PrepareUploadManager.prepare_for_upload(input=self.path, output=dest_dir / self.normalize_file_name())))]
 
     def _create_target_dump_dir(self, dest_dir: Optional[Union[Path, str]] = None) -> Path:
         """Create destination directory, Destination must be valid directory, If not specified dump in

--- a/demisto_sdk/commands/prepare_content/prepare_upload_manager.py
+++ b/demisto_sdk/commands/prepare_content/prepare_upload_manager.py
@@ -32,7 +32,7 @@ class PrepareUploadManager:
                 input = input.parent
             output = input / content_item.normalize_name
         else:
-            if not output.is_file():
+            if output.is_dir():
                 output = output / content_item.normalize_name
 
         if isinstance(content_item, Pack):


### PR DESCRIPTION

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-4952

## Description
* Fixed an issue where **xdrctemplate** was missing 'external' prefix.
* Fixed an issue in **prepare-content** command providing output path.
