### PR TITLE
fix issue in the prepare-content command with custom automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## Unreleased
+* Fixed an issue where the **prepare-content** command output invalid automation name when used with the --*custom* argument.
 * Fixed an issue where modeling rules with arbitrary whitespace characters were not parsed correctly.
 * Added support for the **nativeimage** key for an integration/script in the **prepare-content** command.
 * Fixed an issue where downloading content layouts with `detailsV2=None` resulted in an error.

--- a/demisto_sdk/commands/prepare_content/integration_script_unifier.py
+++ b/demisto_sdk/commands/prepare_content/integration_script_unifier.py
@@ -111,13 +111,13 @@ class IntegrationScriptUnifier(Unifier):
     @staticmethod
     def add_custom_section(unified_yml: Dict, custom: str = '', is_script_package: bool = False) -> Dict:
         """
-            Args:
-                unified_yml - The unified_yml
-            Returns:
-                 the unified yml with the id/name/display appended with the custom label
-                 if the fields exsits.
+        Args:
+            unified_yml - The unified_yml
+        Returns:
+             the unified yml with the id/name/display appended with the custom label
+             if the fields exsits.
         """
-        to_append = f' - {custom}'
+        to_append = custom if is_script_package else f' - {custom}'
         if unified_yml.get('name'):
             unified_yml['name'] += to_append
         if unified_yml.get('commonfields', {}).get('id'):

--- a/demisto_sdk/tests/integration_tests/unify_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/unify_integration_test.py
@@ -205,7 +205,7 @@ class TestIntegrationScriptUnifier:
             runner.invoke(main, [UNIFY_CMD, '-i', f'{script.path}', '-c', 'Test'])
             with open(os.path.join(script.path, 'script-dummy-script.yml')) as unified_yml:
                 unified_yml_data = yaml.load(unified_yml)
-                assert unified_yml_data.get('name') == 'sample_script - Test'
+                assert unified_yml_data.get('name') == 'sample_scriptTest'
                 assert unified_yml_data.get('nativeimage') == ['8.1', '8.2']
 
     def test_ignore_native_image_integration(self, repo):


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-4978

## Description
Fixes an issue that if a custom automation was created with -c, then make sure it gets created without any spaces so that the server will know how to read it properly.


## Must have
- [x] Tests

