### PR TITLE
Update the IN124 error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Updated the **validate** and **update-release-notes** commands to skip the *Triggers Recommendations* content type.
 * Added a new validation to the **validate** command to verify that the release notes headers are in the correct format.
 * Changed the **validate** command to fail on the IN140 error code only when the skipped integration has no unit tests.
+* Changed the **validate** command to don't fall on the IN124 error code when the parameter is of type 4 and is replaced with a new parameter of type 9.
 
 ## 1.8.1
 * Fixed an issue where **format** created duplicate configuration parameters.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Updated the **validate** and **update-release-notes** commands to skip the *Triggers Recommendations* content type.
 * Added a new validation to the **validate** command to verify that the release notes headers are in the correct format.
 * Changed the **validate** command to fail on the IN140 error code only when the skipped integration has no unit tests.
-* Changed the **validate** command to don't fall on the IN124 error code when the parameter is of type 4 and is replaced with a new parameter of type 9.
+* Changed **validate** to allow hiding parameters of type 4 (secret) when replacing with type 9 (credentials) with the same name.
 
 ## 1.8.1
 * Fixed an issue where **format** created duplicate configuration parameters.

--- a/demisto_sdk/commands/common/hook_validations/integration.py
+++ b/demisto_sdk/commands/common/hook_validations/integration.py
@@ -1446,6 +1446,20 @@ class IntegrationValidator(ContentEntityValidator):
 
         return True
 
+    def _is_type4_replaced_by_type9(self, display_name: str) -> bool:
+        """
+        This function is used to check the case where a parameter is hidden but because is type 4 and is replaced by a type 9 parameter.
+        Returns:
+            bool. True if the parameter is hidden but because is replaced by a type 9 parameter. False otherwise.
+        """
+        for param in self.current_file.get("configuration", []):
+            if param.get("type") == 9 and display_name.lower() in (
+                param.get("display", "").lower(),
+                param.get("displaypassword", "").lower(),
+            ):
+                return True
+        return False
+
     @error_codes("IN124,IN156")
     def is_valid_hidden_params(self) -> bool:
         """
@@ -1470,6 +1484,8 @@ class IntegrationValidator(ContentEntityValidator):
 
         for param in self.current_file.get("configuration", ()):
             name = param.get("name", "")
+            display_name = param.get("display", "")
+            type_ = param.get("type")
             hidden = param.get("hidden")
 
             invalid_type = not isinstance(hidden, (type(None), bool, list, str))
@@ -1489,6 +1505,8 @@ class IntegrationValidator(ContentEntityValidator):
             ) == set(MarketplaceVersions)
 
             if invalid_bool or hidden_in_all_marketplaces:
+                if type_ == 4 and self._is_type4_replaced_by_type9(display_name):
+                    continue
                 error_message, error_code = Errors.param_not_allowed_to_hide(name)
                 if self.handle_error(
                     error_message, error_code, file_path=self.file_path

--- a/demisto_sdk/commands/common/hook_validations/integration.py
+++ b/demisto_sdk/commands/common/hook_validations/integration.py
@@ -1452,7 +1452,7 @@ class IntegrationValidator(ContentEntityValidator):
         Returns:
             bool. True if the parameter is hidden but because is replaced by a type 9 parameter. False otherwise.
         """
-        for param in self.current_file.get("configuration", []):
+        for param in self.current_file.get("configuration", ()):
             if param.get("type") == 9 and display_name.lower() in (
                 param.get("display", "").lower(),
                 param.get("displaypassword", "").lower(),

--- a/demisto_sdk/commands/common/tests/integration_test.py
+++ b/demisto_sdk/commands/common/tests/integration_test.py
@@ -2179,6 +2179,25 @@ class TestIsFeedParamsExist:
             {"name": "feedReputation", "required": "false", "hidden": True}
         ]
     }
+    HIDDEN_TRUE_BUT_REPLACED_USER = {
+        "configuration": [
+            {"type": 4, "display": "Username", "hidden": True},
+            {"type": 9, "display": "Username"},
+        ]
+    }
+    HIDDEN_TRUE_BUT_REPLACED_PASSWORD = {
+        "configuration": [
+            {"type": 4, "display": "Api key", "hidden": True},
+            {"type": 9, "displaypassword": "API key"},
+        ]
+    }
+    HIDDEN_TRUE_BUT_REPLACED_AND_NOT_REPLACED = {
+        "configuration": [
+            {"type": 4, "display": "API key", "hidden": True},
+            {"type": 9, "displaypassword": "API key"},
+            {"type": 4, "display": "Username", "hidden": True},
+        ]
+    }
 
     IS_VALID_HIDDEN_PARAMS = [
         (NO_HIDDEN, True),
@@ -2187,6 +2206,9 @@ class TestIsFeedParamsExist:
         (HIDDEN_TRUE_AND_FALSE, False),
         (HIDDEN_ALLOWED_TRUE, True),
         (HIDDEN_ALLOWED_FEED_REPUTATION, True),
+        (HIDDEN_TRUE_BUT_REPLACED_USER, True),
+        (HIDDEN_TRUE_BUT_REPLACED_PASSWORD, True),
+        (HIDDEN_TRUE_BUT_REPLACED_AND_NOT_REPLACED, False),
     ]
 
     @pytest.mark.parametrize("current, answer", IS_VALID_HIDDEN_PARAMS)

--- a/demisto_sdk/commands/common/tests/integration_test.py
+++ b/demisto_sdk/commands/common/tests/integration_test.py
@@ -2191,7 +2191,7 @@ class TestIsFeedParamsExist:
             {"type": 9, "displaypassword": "API key"},
         ]
     }
-    HIDDEN_TRUE_BUT_REPLACED_AND_NOT_REPLACED = {
+    HIDDEN_ONE_REPLACED_4_TO_9_OTHER_NOT = {
         "configuration": [
             {"type": 4, "display": "API key", "hidden": True},
             {"type": 9, "displaypassword": "API key"},
@@ -2208,7 +2208,7 @@ class TestIsFeedParamsExist:
         (HIDDEN_ALLOWED_FEED_REPUTATION, True),
         (HIDDEN_TRUE_BUT_REPLACED_USER, True),
         (HIDDEN_TRUE_BUT_REPLACED_PASSWORD, True),
-        (HIDDEN_TRUE_BUT_REPLACED_AND_NOT_REPLACED, False),
+        (HIDDEN_ONE_REPLACED_4_TO_9_OTHER_NOT, False),
     ]
 
     @pytest.mark.parametrize("current, answer", IS_VALID_HIDDEN_PARAMS)


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Changed the **validate** command to don't fall on the IN124 error code when the parameter is of type 4 and is replaced with a new parameter of type 9.

## Must have
- [x] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
