### PR TITLE
add support to prev-ver in update content graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 * Enhanced the **update-content-graph** command to support `--use-git`, `--imported_path` and `--output-path` arguments.
 * Fixed an issue where **doc-review** failed when reviewing command name in some cases.
 * Fixed an issue where **download** didn't identify playbooks properly, and downloaded files with UUIDs instead of file/script names.
-
+* Added `--prev-ver` argument to **update-release-notes** command, to update the content graph with the previous git Commit hash or branch.
 
 ## 1.8.1
 * Fixed an issue where **format** created duplicate configuration parameters.

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -4,7 +4,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import IO, Any, Dict
+from typing import IO, Any, Dict, Optional
 
 import click
 import git
@@ -2983,6 +2983,12 @@ def create_content_graph(
     help="Whether to use git to determine the packs to update",
 )
 @click.option(
+    "-pv",
+    "--prev-ver",
+    default=None,
+    help="Previous branch or SHA1 commit to update the content graph. Default is the latest upload flow commit."
+)
+@click.option(
     "-i",
     "--imported-path",
     type=click.Path(
@@ -3032,11 +3038,12 @@ def create_content_graph(
 )
 def update_content_graph(
     use_git: bool = False,
+    prev_ver: Optional[str] = None,
     marketplace: MarketplaceVersions = MarketplaceVersions.XSOAR,
     imported_path: Path = None,
-    packs: list = None,
+    packs: Optional[list] = None,
     no_dependencies: bool = False,
-    output_path: Path = None,
+    output_path: Optional[Path] = None,
     **kwargs,
 ):
     from demisto_sdk.commands.common.logger import logging_setup
@@ -3058,6 +3065,7 @@ def update_content_graph(
             content_graph_interface,
             marketplace=MarketplaceVersions(marketplace),
             use_git=use_git,
+            prev_ver=prev_ver,
             imported_path=imported_path,
             packs_to_update=packs or [],
             dependencies=not no_dependencies,

--- a/demisto_sdk/commands/content_graph/README.md
+++ b/demisto_sdk/commands/content_graph/README.md
@@ -67,6 +67,10 @@ This commands downloads the official content graph, imports it locally, and upda
 
     Whether to use git to determine the packs to update.
 
+* **-pv, --prev-ver**
+
+    Previous branch or SHA1 commit to update the content graph. Default is the latest upload flow commit.
+
 * **-p, --packs**
 
     A comma-separated list of packs to update.

--- a/demisto_sdk/commands/content_graph/content_graph_commands.py
+++ b/demisto_sdk/commands/content_graph/content_graph_commands.py
@@ -42,6 +42,7 @@ def update_content_graph(
     content_graph_interface: ContentGraphInterface,
     marketplace: MarketplaceVersions = MarketplaceVersions.XSOAR,
     use_git: bool = False,
+    prev_ver: Optional[str] = None,
     imported_path: Optional[Path] = None,
     packs_to_update: Optional[List[str]] = None,
     dependencies: bool = True,
@@ -69,8 +70,9 @@ def update_content_graph(
 
     if use_git:
         get_or_create_graph(content_graph_interface, builder)
-        latest_commit = get_latest_upload_flow_commit_hash()
-        packs_to_update.extend(GitUtil().get_all_changed_pack_ids(latest_commit))
+        if not prev_ver:
+            prev_ver = get_latest_upload_flow_commit_hash()
+        packs_to_update.extend(GitUtil().get_all_changed_pack_ids(prev_ver))
     else:
         content_graph_interface.import_graph(imported_path)
     logger.info(f"Updating the following packs: {packs_to_update}")


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
A few sentences describing the overall goals of the pull request's commits.

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
