### PR TITLE
handle docker_native_image_config.json file not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 * Changed **validate** to allow hiding parameters of type 0, 4, 12 and 14 when replacing with type 9 (credentials) with the same name.
 * Fixed an issue where **update-release-notes** fails to update *MicrosoftApiModule* dependent integrations.
+* Fixed an issue where the **upload** command failed because `docker_native_image_config.json` file could not be found.
 
 ## 1.8.2
 * Fixed an issue where demisto-py failed to upload content to XSIAM when `DEMISTO_USERNAME` environment variable is set.

--- a/demisto_sdk/commands/content_graph/objects/integration_script.py
+++ b/demisto_sdk/commands/content_graph/objects/integration_script.py
@@ -39,13 +39,13 @@ class IntegrationScript(ContentItem):
     def get_supported_native_images(
         self, marketplace: MarketplaceVersions, ignore_native_image: bool = False
     ) -> List[str]:
-        try:
-            if marketplace == MarketplaceVersions.XSOAR and not ignore_native_image:
+        if marketplace == MarketplaceVersions.XSOAR and not ignore_native_image:
+            try:
                 return ScriptIntegrationSupportedNativeImages(
                     _id=self.object_id,
                     docker_image=self.docker_image,
                     native_image_config=file_to_native_image_config(),
                 ).get_supported_native_image_versions(get_raw_version=True)
-            return []
-        except FileNotFoundError:
-            return []
+            except FileNotFoundError:
+                return []
+        return []

--- a/demisto_sdk/commands/content_graph/objects/integration_script.py
+++ b/demisto_sdk/commands/content_graph/objects/integration_script.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 from typing import List, Optional
 
 from pydantic import Field
@@ -50,6 +51,10 @@ class IntegrationScript(ContentItem):
                     native_image_config=file_to_native_image_config(),
                 ).get_supported_native_image_versions(get_raw_version=True)
             except FileNotFoundError:
-                logger.debug(f"The {NATIVE_IMAGE_FILE_NAME} file could not be found.")
-                return []
+                if not Path(f"Tests/{NATIVE_IMAGE_FILE_NAME}").exists():
+                    logger.debug(
+                        f"The {NATIVE_IMAGE_FILE_NAME} file could not be found."
+                    )
+                    return []
+                raise
         return []

--- a/demisto_sdk/commands/content_graph/objects/integration_script.py
+++ b/demisto_sdk/commands/content_graph/objects/integration_script.py
@@ -3,7 +3,10 @@ from typing import List, Optional
 
 from pydantic import Field
 
-from demisto_sdk.commands.common.constants import MarketplaceVersions
+from demisto_sdk.commands.common.constants import (
+    NATIVE_IMAGE_FILE_NAME,
+    MarketplaceVersions,
+)
 from demisto_sdk.commands.common.handlers import YAML_Handler
 from demisto_sdk.commands.common.native_image import (
     ScriptIntegrationSupportedNativeImages,
@@ -47,5 +50,6 @@ class IntegrationScript(ContentItem):
                     native_image_config=file_to_native_image_config(),
                 ).get_supported_native_image_versions(get_raw_version=True)
             except FileNotFoundError:
+                logger.debug(f"The {NATIVE_IMAGE_FILE_NAME} could not be found.")
                 return []
         return []

--- a/demisto_sdk/commands/content_graph/objects/integration_script.py
+++ b/demisto_sdk/commands/content_graph/objects/integration_script.py
@@ -44,17 +44,12 @@ class IntegrationScript(ContentItem):
         self, marketplace: MarketplaceVersions, ignore_native_image: bool = False
     ) -> List[str]:
         if marketplace == MarketplaceVersions.XSOAR and not ignore_native_image:
-            try:
-                return ScriptIntegrationSupportedNativeImages(
-                    _id=self.object_id,
-                    docker_image=self.docker_image,
-                    native_image_config=file_to_native_image_config(),
-                ).get_supported_native_image_versions(get_raw_version=True)
-            except FileNotFoundError:
-                if not Path(f"Tests/{NATIVE_IMAGE_FILE_NAME}").exists():
-                    logger.debug(
-                        f"The {NATIVE_IMAGE_FILE_NAME} file could not be found."
-                    )
-                    return []
-                raise
+            if not Path(f"Tests/{NATIVE_IMAGE_FILE_NAME}").exists():
+                logger.debug(f"The {NATIVE_IMAGE_FILE_NAME} file could not be found.")
+                return []
+            return ScriptIntegrationSupportedNativeImages(
+                _id=self.object_id,
+                docker_image=self.docker_image,
+                native_image_config=file_to_native_image_config(),
+            ).get_supported_native_image_versions(get_raw_version=True)
         return []

--- a/demisto_sdk/commands/content_graph/objects/integration_script.py
+++ b/demisto_sdk/commands/content_graph/objects/integration_script.py
@@ -39,10 +39,13 @@ class IntegrationScript(ContentItem):
     def get_supported_native_images(
         self, marketplace: MarketplaceVersions, ignore_native_image: bool = False
     ) -> List[str]:
-        if marketplace == MarketplaceVersions.XSOAR and not ignore_native_image:
-            return ScriptIntegrationSupportedNativeImages(
-                _id=self.object_id,
-                docker_image=self.docker_image,
-                native_image_config=file_to_native_image_config(),
-            ).get_supported_native_image_versions(get_raw_version=True)
-        return []
+        try:
+            if marketplace == MarketplaceVersions.XSOAR and not ignore_native_image:
+                return ScriptIntegrationSupportedNativeImages(
+                    _id=self.object_id,
+                    docker_image=self.docker_image,
+                    native_image_config=file_to_native_image_config(),
+                ).get_supported_native_image_versions(get_raw_version=True)
+            return []
+        except FileNotFoundError:
+            return []

--- a/demisto_sdk/commands/content_graph/objects/integration_script.py
+++ b/demisto_sdk/commands/content_graph/objects/integration_script.py
@@ -50,6 +50,6 @@ class IntegrationScript(ContentItem):
                     native_image_config=file_to_native_image_config(),
                 ).get_supported_native_image_versions(get_raw_version=True)
             except FileNotFoundError:
-                logger.debug(f"The {NATIVE_IMAGE_FILE_NAME} could not be found.")
+                logger.debug(f"The {NATIVE_IMAGE_FILE_NAME} file could not be found.")
                 return []
         return []


### PR DESCRIPTION
## Description
Handles issue where docker_native_image_config was not found in 1.8.2 when running the upload command causing it to fail if not updated from content master

edit: managed to test that this PR fix works on a content branch where i deleted the `docker_native_image_config.json`file. 
