### PR TITLE
fix empty content items in create artifacts

### DIFF
--- a/demisto_sdk/commands/content_graph/objects/pack.py
+++ b/demisto_sdk/commands/content_graph/objects/pack.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field, validator
 from demisto_sdk.commands.common.constants import (
     BASE_PACK,
     CONTRIBUTORS_README_TEMPLATE,
+    MARKETPLACE_MIN_VERSION,
     MarketplaceVersions,
 )
 from demisto_sdk.commands.common.handlers import JSON_Handler
@@ -200,10 +201,10 @@ class Pack(BaseContent, PackMetadata, content_type=ContentType.PACK):  # type: i
             content_item_dct[c.content_type.value].append(c)
 
         # If there is no server_min_version, set it to the maximum of its content items fromversion
+        max_content_items_version = MARKETPLACE_MIN_VERSION
         if content_items:
-            self.server_min_version = self.server_min_version or str(
-                max(parse(content_item.fromversion) for content_item in content_items)
-            )
+            max_content_items_version = str(max(parse(content_item.fromversion) for content_item in content_items))
+        self.server_min_version = self.server_min_version or max_content_items_version
         self.content_items = PackContentItems(**content_item_dct)
 
     def dump_metadata(self, path: Path, marketplace: MarketplaceVersions) -> None:

--- a/demisto_sdk/commands/content_graph/objects/pack.py
+++ b/demisto_sdk/commands/content_graph/objects/pack.py
@@ -203,7 +203,9 @@ class Pack(BaseContent, PackMetadata, content_type=ContentType.PACK):  # type: i
         # If there is no server_min_version, set it to the maximum of its content items fromversion
         max_content_items_version = MARKETPLACE_MIN_VERSION
         if content_items:
-            max_content_items_version = str(max(parse(content_item.fromversion) for content_item in content_items))
+            max_content_items_version = str(
+                max(parse(content_item.fromversion) for content_item in content_items)
+            )
         self.server_min_version = self.server_min_version or max_content_items_version
         self.content_items = PackContentItems(**content_item_dct)
 

--- a/demisto_sdk/commands/content_graph/objects/pack.py
+++ b/demisto_sdk/commands/content_graph/objects/pack.py
@@ -200,9 +200,10 @@ class Pack(BaseContent, PackMetadata, content_type=ContentType.PACK):  # type: i
             content_item_dct[c.content_type.value].append(c)
 
         # If there is no server_min_version, set it to the maximum of its content items fromversion
-        self.server_min_version = self.server_min_version or str(
-            max(parse(content_item.fromversion) for content_item in content_items)
-        )
+        if content_items:
+            self.server_min_version = self.server_min_version or str(
+                max(parse(content_item.fromversion) for content_item in content_items)
+            )
         self.content_items = PackContentItems(**content_item_dct)
 
     def dump_metadata(self, path: Path, marketplace: MarketplaceVersions) -> None:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
We assumed that there can't be empty packs for specific marketplace. However, it is a possibility and we need to handle this.

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
