### PR TITLE
update-release-notes failure on 1.8.3 bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Updated **lint** to use graph instead of id_set when running with `--check-dependent-api-module` flag.
 * Added the marketplaces field to all schemas.
 * Added the flag `--xsoar-only` to the **doc-review** command which enables reviewing documents that belong to XSOAR-supported Packs.
-* Fixed an issue in **update-release-notes** command where an error occurred during the double execution of the command.
+* Fixed an issue in **update-release-notes** command where an error occurred when executing the command a second time.
 
 ## 1.8.3
 * Changed **validate** to allow hiding parameters of type 0, 4, 12 and 14 when replacing with type 9 (credentials) with the same name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Updated **lint** to use graph instead of id_set when running with `--check-dependent-api-module` flag.
 * Added the marketplaces field to all schemas.
 * Added the flag `--xsoar-only` to the **doc-review** command which enables reviewing documents that belong to XSOAR-supported Packs.
+* Fixed an issue in **update-release-notes** command where an error occurred during the double execution of the command.
 
 ## 1.8.3
 * Changed **validate** to allow hiding parameters of type 0, 4, 12 and 14 when replacing with type 9 (credentials) with the same name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Updated **lint** to use graph instead of id_set when running with `--check-dependent-api-module` flag.
 * Added the marketplaces field to all schemas.
 * Added the flag `--xsoar-only` to the **doc-review** command which enables reviewing documents that belong to XSOAR-supported Packs.
-* Fixed an issue in **update-release-notes** command where an error occurred when executing the command a second time.
+* Fixed an issue in **update-release-notes** command where an error occurred when executing the same command a second time.
 
 ## 1.8.3
 * Changed **validate** to allow hiding parameters of type 0, 4, 12 and 14 when replacing with type 9 (credentials) with the same name.

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -819,6 +819,7 @@ class UpdateRN:
             desc = data.get("description", "")
             docker_image = data.get("dockerimage")
             rn_desc = ""
+            path = data.get("path")
             if _type is None:
                 continue
 
@@ -829,6 +830,7 @@ class UpdateRN:
                 desc=desc,
                 is_new_file=is_new_file,
                 docker_image=docker_image,
+                path=path,
             )
             if _header_by_type and _header_by_type in current_rn_without_docker_images:
                 if self.does_content_item_header_exist_in_rns(


### PR DESCRIPTION
## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-5255

## Description
When the command was executed twice, it failed.

## Screenshots
In the ticket.

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
