### PR TITLE
fix e2e docker tests failing on 409

### DIFF
--- a/demisto_sdk/commands/common/MDXServer.py
+++ b/demisto_sdk/commands/common/MDXServer.py
@@ -52,11 +52,14 @@ def start_docker_MDX_server(
     """
     logging.info("Starting docker mdx server")
     get_docker().pull_image(DEPENDENCIES_DOCKER)
-    if running_container := init_global_docker_client().containers.list(
-        filters={"name": DEMISTO_DEPS_DOCKER_NAME}
-    ):
-        running_container[0].stop()
+
+    docker_client = init_global_docker_client()
+
     location_in_docker = f"/content/{_SERVER_SCRIPT_NAME}"
+    while running_container := docker_client.containers.list(
+        filters={"name": DEMISTO_DEPS_DOCKER_NAME}, all=True
+    ):
+        running_container[0].remove(force=True)
     container: docker.models.containers.Container = get_docker().create_container(
         name=DEMISTO_DEPS_DOCKER_NAME,
         image=DEPENDENCIES_DOCKER,

--- a/demisto_sdk/commands/common/MDXServer.py
+++ b/demisto_sdk/commands/common/MDXServer.py
@@ -40,7 +40,7 @@ def start_docker_MDX_server(
     """
         This function will start a docker container running a node server listening on port 6161.
         The container will erase itself after exit.
-        If there's a running server already with the same name it will be stopped before starting a new one.
+        If there's a running server already with the same name it will be removed before starting a new one.
 
     Args:
         handle_error: handle_error function
@@ -56,24 +56,34 @@ def start_docker_MDX_server(
     docker_client = init_global_docker_client()
 
     location_in_docker = f"/content/{_SERVER_SCRIPT_NAME}"
-    while running_container := docker_client.containers.list(
+    while mdx_container := docker_client.containers.list(
         filters={"name": DEMISTO_DEPS_DOCKER_NAME}, all=True
     ):
-        running_container[0].remove(force=True)
-    container: docker.models.containers.Container = get_docker().create_container(
-        name=DEMISTO_DEPS_DOCKER_NAME,
-        image=DEPENDENCIES_DOCKER,
-        command=["node", location_in_docker],
-        user=f"{os.getuid()}:4000",
-        files_to_push=[(server_script_path(), location_in_docker)],
-        auto_remove=True,
-        ports={"6161/tcp": 6161},
-    )
+        remove_container(mdx_container[0])
+
+    try:
+        container: docker.models.containers.Container = get_docker().create_container(
+            name=DEMISTO_DEPS_DOCKER_NAME,
+            image=DEPENDENCIES_DOCKER,
+            command=["node", location_in_docker],
+            user=f"{os.getuid()}:4000",
+            files_to_push=[(server_script_path(), location_in_docker)],
+            auto_remove=True,
+            ports={"6161/tcp": 6161},
+        )
+    except Exception as error:
+        print(
+            f"Error occurred when trying to create {DEMISTO_DEPS_DOCKER_NAME} container, {error=}"
+        )
+        print(
+            f"all available containers: {[container.name for container in docker_client.containers.list(all=True)]}"
+        )
+        raise error
     container.start()
     if EXPECTED_SUCCESS_MESSAGE not in (
         line := (str(next(container.logs(stream=True)).decode("utf-8")))
     ):
-        stop_docker_container(container)
+        remove_container(container)
         logging.error("Docker for MDX server was not started correctly")
         logging.error(f'docker logs:\n{container.logs().decode("utf-8")}')
         error_message, error_code = Errors.error_starting_docker_mdx_server(line=line)
@@ -86,13 +96,14 @@ def start_docker_MDX_server(
     try:
         yield True
     finally:
-        stop_docker_container(container)
+        remove_container(container)
 
 
-def stop_docker_container(container):
+def remove_container(container):
     if container:
-        logging.info("Stopping mdx docker server")
-        container.stop()  # type: ignore
+        print(f"Removing container {container.name}")
+        container.remove(force=True)
+        print(f"Successfully removed container {container.name}")
 
 
 @contextmanager

--- a/demisto_sdk/commands/common/MDXServer.py
+++ b/demisto_sdk/commands/common/MDXServer.py
@@ -59,7 +59,11 @@ def start_docker_MDX_server(
     while mdx_container := docker_client.containers.list(
         filters={"name": DEMISTO_DEPS_DOCKER_NAME}, all=True
     ):
+        iteration_num = 1
+        print(f"Found the following container(s): {mdx_container}")
+        print(f"{iteration_num=} when trying to remove {mdx_container}")
         remove_container(mdx_container[0])
+        iteration_num += 1
 
     try:
         container: docker.models.containers.Container = get_docker().create_container(
@@ -101,6 +105,7 @@ def start_docker_MDX_server(
 
 def remove_container(container):
     if container:
+        print("stopping and removing mdx server")
         print(f"Removing container {container.name}")
         container.remove(force=True)
         print(f"Successfully removed container {container.name}")


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-5598)

## Description
fixed an issue where e2e docker tests were failing on 409 conflict error

## Must have
- [x] Tests

