### PR TITLE
Checkout Content with commit history

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,7 +254,7 @@ jobs:
         - run:
             name: Checkout the Content Repo
             command: |
-              git clone --depth 1 https://github.com/demisto/content.git
+              git clone https://github.com/demisto/content.git
               cd content
               git config diff.renameLimit 5000
               git --no-pager log -1


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
We currently checkout the content repo without the git commit history because we didn't use it.
However the update graph needs it to tell which packs were changed. Example: https://app.circleci.com/pipelines/github/demisto/demisto-sdk/21469/workflows/f89ca2f5-f127-48ac-986d-29ab8ab70404/jobs/162971

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
