### PR TITLE
safe dump of packs and content items

### DIFF
--- a/demisto_sdk/commands/content_graph/objects/content_item.py
+++ b/demisto_sdk/commands/content_graph/objects/content_item.py
@@ -176,8 +176,11 @@ class ContentItem(BaseContent):
     def dump(self, dir: DirectoryPath, _: MarketplaceVersions) -> None:
         dir.mkdir(exist_ok=True, parents=True)
         data = self.prepare_for_upload()
-        with (dir / self.normalize_name).open("w") as f:
-            self.handler.dump(data, f)
+        try:
+            with (dir / self.normalize_name).open("w") as f:
+                self.handler.dump(data, f)
+        except FileNotFoundError as e:
+            logger.warning(f"Failed to dump {self.path} to {dir}: {e}")
 
     def to_id_set_entity(self) -> dict:
         """

--- a/demisto_sdk/commands/content_graph/objects/pack.py
+++ b/demisto_sdk/commands/content_graph/objects/pack.py
@@ -251,6 +251,9 @@ class Pack(BaseContent, PackMetadata, content_type=ContentType.PACK):  # type: i
                 logger.error(f"Failed dumping readme: {e}")
 
     def dump(self, path: Path, marketplace: MarketplaceVersions):
+        if not self.path.exists():
+            logger.warning(f"Pack {self.name} does not exist in {self.path}")
+            return
         try:
             path.mkdir(exist_ok=True, parents=True)
             for content_item in self.content_items:


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-5618

## Description
This will not dump content items or packs which doesn't exist on local path

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
- [ ] [VS Code Extension](https://docs.gitlab.com/ee/ci/yaml/#tags)
  - [ ] Functionality implemented in the extension - <u>\<link-to-pr-here\></u>
  - [ ] N/A - Functionality cannot be implemented in the extension because <u>\<add-reason-here\></u>
