### PR TITLE
reset client before executing unmockable tests

### DIFF
--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -2731,6 +2731,7 @@ class ServerContext:
             self.build_context.logging_module.info(
                 "Running mock-disabled tests", real_time=True
             )
+            self._configure_new_client()
             self._execute_unmockable_tests()
             if self.use_retries_mechanism:
                 self.build_context.logging_module.info(


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-5587)

## Description
reset client before executing unmockable tests
