### PR TITLE
add onChangeRepAlg, reputationCalc value 3

### DIFF
--- a/demisto_sdk/commands/common/schemas/generictype.yml
+++ b/demisto_sdk/commands/common/schemas/generictype.yml
@@ -54,10 +54,10 @@ mapping:
     type: bool
   reputationCalc:
     type: int
-    enum: [0, 1, 2]
+    enum: [0, 1, 2, 3]
   onChangeRepAlg:
     type: int
-    enum: [0, 1, 2]
+    enum: [0, 1, 2, 3]
   detached:
     type: bool
   fromVersion:

--- a/demisto_sdk/commands/common/schemas/incidenttype.yml
+++ b/demisto_sdk/commands/common/schemas/incidenttype.yml
@@ -54,10 +54,10 @@ mapping:
     type: bool
   reputationCalc:
     type: int
-    enum: [0, 1, 2]
+    enum: [0, 1, 2, 3]
   onChangeRepAlg:
     type: int
-    enum: [0, 1, 2]
+    enum: [0, 1, 2, 3]
   detached:
     type: bool
   fromVersion:


### PR DESCRIPTION
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-5710

Added the value `3` (out of bounds) to the `onChangeRepAlg` and `reputationCalc` fields under the `IncidentType` and `GenericType` schemas. **validate** will allow using it now.
