### PR TITLE
lock file when update graph

### DIFF
--- a/demisto_sdk/commands/content_graph/content_graph_commands.py
+++ b/demisto_sdk/commands/content_graph/content_graph_commands.py
@@ -2,7 +2,9 @@ import logging
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import List, Optional
+
 from filelock import FileLock
+
 import demisto_sdk.commands.content_graph.neo4j_service as neo4j_service
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.common.git_util import GitUtil

--- a/demisto_sdk/commands/content_graph/content_graph_commands.py
+++ b/demisto_sdk/commands/content_graph/content_graph_commands.py
@@ -28,16 +28,15 @@ def create_content_graph(
         dependencies (bool): Whether to create the dependencies.
         output_path (Path): The path to export the graph zip to.
     """
-    with FileLock("content_graph.lock"):
-        ContentGraphBuilder(content_graph_interface).create_graph()
-        if dependencies:
-            content_graph_interface.create_pack_dependencies()
-        if output_path:
-            output_path = output_path / marketplace.value
-        content_graph_interface.export_graph(output_path)
-        logger.info(
-            f"Successfully created the content graph. UI representation is available at {NEO4J_DATABASE_HTTP}"
-        )
+    ContentGraphBuilder(content_graph_interface).create_graph()
+    if dependencies:
+        content_graph_interface.create_pack_dependencies()
+    if output_path:
+        output_path = output_path / marketplace.value
+    content_graph_interface.export_graph(output_path)
+    logger.info(
+        f"Successfully created the content graph. UI representation is available at {NEO4J_DATABASE_HTTP}"
+    )
 
 
 def update_content_graph(

--- a/demisto_sdk/commands/content_graph/content_graph_commands.py
+++ b/demisto_sdk/commands/content_graph/content_graph_commands.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import List, Optional
-import lockfile
+from filelock import FileLock
 import demisto_sdk.commands.content_graph.neo4j_service as neo4j_service
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.common.git_util import GitUtil
@@ -28,7 +28,7 @@ def create_content_graph(
         dependencies (bool): Whether to create the dependencies.
         output_path (Path): The path to export the graph zip to.
     """
-    with lockfile.FileLock("content_graph.lock"):
+    with FileLock("content_graph.lock"):
         ContentGraphBuilder(content_graph_interface).create_graph()
         if dependencies:
             content_graph_interface.create_pack_dependencies()
@@ -61,7 +61,7 @@ def update_content_graph(
         dependencies (bool): Whether to create the dependencies.
         output_path (Path): The path to export the graph zip to.
     """
-    with lockfile.FileLock("content_graph.lock"):
+    with FileLock("content_graph.lock"):
         if packs_to_update is None:
             packs_to_update = []
         builder = ContentGraphBuilder(content_graph_interface)

--- a/poetry.lock
+++ b/poetry.lock
@@ -2837,7 +2837,7 @@ build = ["gsutil"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "8427118e943a643655d2f590ab7ae87b20168b36064da6f963bb9266a37d413d"
+content-hash = "287fe983e6f2fe229c071ebfba27efa55f21155682d1e37c7f284bf448156f55"
 
 [metadata.files]
 aiohttp = [
@@ -3416,6 +3416,7 @@ debugpy = [
     {file = "debugpy-1.6.6-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9b5d1b13d7c7bf5d7cf700e33c0b8ddb7baf030fcf502f76fc061ddd9405d16c"},
     {file = "debugpy-1.6.6-cp38-cp38-win32.whl", hash = "sha256:70ab53918fd907a3ade01909b3ed783287ede362c80c75f41e79596d5ccacd32"},
     {file = "debugpy-1.6.6-cp38-cp38-win_amd64.whl", hash = "sha256:c05349890804d846eca32ce0623ab66c06f8800db881af7a876dc073ac1c2225"},
+    {file = "debugpy-1.6.6-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:11a0f3a106f69901e4a9a5683ce943a7a5605696024134b522aa1bfda25b5fec"},
     {file = "debugpy-1.6.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a771739902b1ae22a120dbbb6bd91b2cae6696c0e318b5007c5348519a4211c6"},
     {file = "debugpy-1.6.6-cp39-cp39-win32.whl", hash = "sha256:549ae0cb2d34fc09d1675f9b01942499751d174381b6082279cf19cdb3c47cbe"},
     {file = "debugpy-1.6.6-cp39-cp39-win_amd64.whl", hash = "sha256:de4a045fbf388e120bb6ec66501458d3134f4729faed26ff95de52a754abddb1"},
@@ -4722,6 +4723,7 @@ ruamel-yaml-clib = [
     {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-win_amd64.whl", hash = "sha256:d000f258cf42fec2b1bbf2863c61d7b8918d31ffee905da62dede869254d3b8a"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:045e0626baf1c52e5527bd5db361bc83180faaba2ff586e763d3d5982a876a9e"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_12_6_arm64.whl", hash = "sha256:721bc4ba4525f53f6a611ec0967bdcee61b31df5a56801281027a3a6d1c2daf5"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:41d0f1fa4c6830176eef5b276af04c89320ea616655d01327d5ce65e50575c94"},
     {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:4b3a93bb9bc662fc1f99c5c3ea8e623d8b23ad22f861eb6fce9377ac07ad6072"},
     {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-macosx_12_0_arm64.whl", hash = "sha256:a234a20ae07e8469da311e182e70ef6b199d0fbeb6c6cc2901204dd87fb867e8"},
     {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:15910ef4f3e537eea7fe45f8a5d19997479940d9196f357152a09031c5be59f3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ typer = {extras = ["all"], version = ">=0.6.1,<0.8.0"}
 types-pkg-resources = "^0.1.3"
 packaging = "<22"
 orjson = "^3.8.3"
+filelock = "^3.9.0"
 
 [tool.poetry.dev-dependencies]
 mitmproxy = "^8.0.0"


### PR DESCRIPTION
## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-5733?filter=-2

## Description

Using [filelock library](https://py-filelock.readthedocs.io/en/latest/) to make sure that demisto-sdk update-content-graph can't be running simultaneously.
