### PR TITLE
Error code params parsing bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 * Added a newline at the end of README files generated in **generate-docs**.
 * Added the value `3` (out of bounds) to the `onChangeRepAlg` and `reputationCalc` fields under the `IncidentType` and `GenericType` schemas. **validate** will allow using it now.
 * Fixed an issue where **doc-review** required dot suffixes in release notes describing new content.
-* Added support for running **lint** in multiple native-docker images.
 * Fixed an issue where the ***error-code*** could not parse List[str] parameter.
+
+## 1.10.4
+* Added support for running **lint** in multiple native-docker images.
 
 ## 1.10.3
 * Fixed an issue where running **format** would fail after running npm install.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,8 @@
 * Added a newline at the end of README files generated in **generate-docs**.
 * Added the value `3` (out of bounds) to the `onChangeRepAlg` and `reputationCalc` fields under the `IncidentType` and `GenericType` schemas. **validate** will allow using it now.
 * Fixed an issue where **doc-review** required dot suffixes in release notes describing new content.
-
-## 1.10.4
 * Added support for running **lint** in multiple native-docker images.
+* Fixed an issue where the ***error-code*** could not parse List[str] parameter.
 
 ## 1.10.3
 * Fixed an issue where running **format** would fail after running npm install.

--- a/demisto_sdk/commands/error_code_info/error_code_info.py
+++ b/demisto_sdk/commands/error_code_info/error_code_info.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Any, Dict, Optional, Union, get_args, get_origin
+from typing import Any, Dict, List, Optional, Union, get_args, get_origin
 
 import click
 from colorama import Fore
@@ -21,6 +21,7 @@ TYPE_FILLER_MAPPING = {
     dict: {"key1": "value1", "key2": "value2"},
     Dict: {"key1": "value1", "key2": "value2"},
     list: ["element1", "element2"],
+    List[str]: ["element1", "element2"],
     constants.FileType: constants.FileType.INTEGRATION,
 }
 


### PR DESCRIPTION
Until now error code arguments used to have parameters with type 'list'. In the last SDK update, new error codes were added and were using List[str] in their arguments which caused the following exception:
`TypeError: Type List cannot be instantiated; use list() instead`

Fixed it by adding this type to the TYPE_FILLER_MAPPING dict.

FYI @MLainer1 @dantavori 