### PR TITLE
Skip deprecated integrations/scripts when running lint-a

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Fixed an issue where using **postman-codegen** failed converting strings containing digits to kebab-case.
 * Fixed an issue where the ***error-code*** command could not parse List[str] parameter.
 * Updated validation *LO107* to support more section types in XSIAM layouts.
-* Deprecated integrations and scripts will not run anymore when providing the --all-packs** to the **lint** command.
+* Deprecated integrations and scripts will not run anymore when providing the **--all-packs** to the **lint** command.
 
 ## 1.10.4
 * Added support for running **lint** in multiple native-docker images.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fixed an issue where using **postman-codegen** failed converting strings containing digits to kebab-case.
 * Fixed an issue where the ***error-code*** command could not parse List[str] parameter.
 * Updated validation *LO107* to support more section types in XSIAM layouts.
+* Deprecated integrations and scripts will not run anymore when providing the --all-packs** to the **lint** command.
 
 ## 1.10.4
 * Added support for running **lint** in multiple native-docker images.

--- a/conftest.py
+++ b/conftest.py
@@ -46,6 +46,12 @@ def get_playbook(
     return playbook
 
 
+def get_script(request: FixtureRequest, tmp_path_factory: TempPathFactory):
+    script = get_pack(request, tmp_path_factory).create_script()
+    script.create_default_script()
+    return script
+
+
 # Fixtures
 
 
@@ -53,6 +59,11 @@ def get_playbook(
 def pack(request: FixtureRequest, tmp_path_factory: TempPathFactory) -> Pack:
     """Mocking tmp_path"""
     return get_pack(request, tmp_path_factory)
+
+
+@pytest.fixture()
+def script(request: FixtureRequest, tmp_path_factory: TempPathFactory):
+    return get_script(request, tmp_path_factory)
 
 
 @pytest.fixture

--- a/demisto_sdk/commands/lint/lint_manager.py
+++ b/demisto_sdk/commands/lint/lint_manager.py
@@ -510,6 +510,7 @@ class LintManager:
                         docker_engine=self._facts["docker_engine"],
                         docker_timeout=docker_timeout,
                         docker_image_flag=docker_image_flag,
+                        all_packs=self._all_packs,
                     )
                     results.append(
                         executor.submit(

--- a/demisto_sdk/commands/lint/linter.py
+++ b/demisto_sdk/commands/lint/linter.py
@@ -97,6 +97,7 @@ class Linter:
         docker_engine(bool):  Whether docker engine detected by docker-sdk.
         docker_timeout(int): Timeout for docker requests.
         docker_image_flag(str): Indicates the desirable docker image to run lint on (default value is 'from-yml).
+        all_packs (bool): Indicates whether all the packs should go through lint
     """
 
     def __init__(
@@ -108,6 +109,7 @@ class Linter:
         docker_engine: bool,
         docker_timeout: int,
         docker_image_flag: str = DockerImageFlagOption.FROM_YML.value,
+        all_packs: bool = False,
     ):
         self._req_3 = req_3
         self._req_2 = req_2
@@ -180,6 +182,7 @@ class Linter:
                 self._pkg_lint_status["errors"].append(
                     "Unable to find yml file in package"
                 )
+        self._all_packs = all_packs
 
     @timer(group_name="lint")
     def run_pack(
@@ -289,6 +292,12 @@ class Linter:
                     if isinstance(yml_obj.get("script"), dict)
                     else yml_obj
                 )
+            # if the script/integration is deprecated and the -a flag
+            if self._all_packs and yml_obj.get("deprecated"):
+                logger.info(
+                    f"skipping lint for {self._pack_name} because its deprecated"
+                )
+                return True
             self._facts["is_script"] = (
                 True if "Scripts" in self._yml_file.parts else False
             )

--- a/demisto_sdk/commands/lint/tests/test_linter/conftest.py
+++ b/demisto_sdk/commands/lint/tests/test_linter/conftest.py
@@ -75,6 +75,7 @@ def create_integration(mocker) -> Callable:
         image_py_num: str = "3.7",
         test_reqs: bool = False,
         api_module: bool = False,
+        is_deprecated: bool = False,
     ) -> Path:
         """Creates tmp content repositry for integration test
 
@@ -96,6 +97,7 @@ def create_integration(mocker) -> Callable:
             image_py_num(str): Image python version.
             test_reqs(bool): True to include a test-requirements.txt file.
             api_module (bool): True if ApiModule should be in the integration folder, False if not.
+            is_deprecated (bool): True if integration is deprecated or not.
 
         Returns:
             Path: Path to tmp integration
@@ -142,7 +144,10 @@ def create_integration(mocker) -> Callable:
         if yml:
             yml_file.write_text("")
         else:
-            yml_dict = {"commonfields": {"id": integration_name}}
+            yml_dict = {
+                "commonfields": {"id": integration_name},
+                "deprecated": is_deprecated,
+            }
             if js_type:
                 yml_dict["type"] = "javascript"
                 if type_script_key:

--- a/demisto_sdk/commands/lint/tests/test_linter/gather_facts_test.py
+++ b/demisto_sdk/commands/lint/tests/test_linter/gather_facts_test.py
@@ -18,6 +18,7 @@ def initiate_linter(
     integration_path,
     docker_engine=False,
     docker_image_flag=linter.DockerImageFlagOption.FROM_YML.value,
+    all_packs=False,
 ):
     return linter.Linter(
         content_repo=demisto_content,
@@ -27,6 +28,7 @@ def initiate_linter(
         docker_engine=docker_engine,
         docker_timeout=60,
         docker_image_flag=docker_image_flag,
+        all_packs=all_packs,
     )
 
 
@@ -580,6 +582,103 @@ class TestTestsCollection:
         runner = initiate_linter(demisto_content, integration_path, True)
         runner._gather_facts(modules={})
         assert not runner._facts["test"]
+
+    @pytest.mark.parametrize(
+        argnames="all_packs, should_skip, deprecated_log",
+        argvalues=[
+            (True, True, True),
+            (False, False, False),
+        ],
+    )
+    def test_deprecated_integration(
+        self,
+        mocker,
+        demisto_content: Callable,
+        create_integration: Callable,
+        all_packs: bool,
+        should_skip: bool,
+        deprecated_log: bool,
+    ):
+        """
+        Given:
+        - Case A: run all packs flag and deprecated integration
+        - Case B: do not run on all packs and deprecated integration
+
+        When:
+        - calling gather facts
+
+        Then:
+        - Case A: gather facts should indicate integration is skipped
+        - Case B: gather father should indicate integration is not skipped
+        """
+        log = mocker.patch.object(logger, "info")
+        mocker.patch.object(linter.Linter, "_update_support_level")
+        integration_path: Path = create_integration(
+            content_path=demisto_content, is_deprecated=True
+        )
+        runner = initiate_linter(
+            demisto_content, integration_path, True, all_packs=all_packs
+        )
+        assert should_skip == runner._gather_facts(modules={})
+
+        if deprecated_log:
+            assert (
+                "skipping lint for Sample_integration because its deprecated"
+                == log.call_args_list[2].args[0]
+            )
+        else:
+            assert (
+                "skipping lint for Sample_integration because its deprecated"
+                != log.call_args_list[2].args[0]
+            )
+
+    @pytest.mark.parametrize(
+        argnames="all_packs, should_skip, deprecated_log",
+        argvalues=[
+            (True, True, True),
+            (False, False, False),
+        ],
+    )
+    def test_deprecated_script(
+        self,
+        mocker,
+        demisto_content: Callable,
+        script,
+        all_packs,
+        should_skip,
+        deprecated_log,
+    ):
+        """
+        Given:
+        - Case A: run all packs flag and deprecated script
+        - Case B: do not run on all packs and deprecated script
+
+        When:
+        - calling gather facts
+
+        Then:
+        - Case A: gather facts should indicate script is skipped
+        - Case B: gather father should indicate script is not skipped
+        """
+        script.yml.update({"deprecated": True})
+        log = mocker.patch.object(logger, "info")
+        mocker.patch.object(linter.Linter, "_update_support_level")
+        runner = initiate_linter(
+            demisto_content, script.path, True, all_packs=all_packs
+        )
+
+        assert should_skip == runner._gather_facts(modules={})
+
+        if deprecated_log:
+            assert (
+                "skipping lint for script0 because its deprecated"
+                == log.call_args_list[2].args[0]
+            )
+        else:
+            assert (
+                "skipping lint for script0 because its deprecated"
+                != log.call_args_list[2].args[0]
+            )
 
 
 class TestLintFilesCollection:

--- a/demisto_sdk/commands/lint/tests/test_linter/gather_facts_test.py
+++ b/demisto_sdk/commands/lint/tests/test_linter/gather_facts_test.py
@@ -584,10 +584,10 @@ class TestTestsCollection:
         assert not runner._facts["test"]
 
     @pytest.mark.parametrize(
-        argnames="all_packs, should_skip, deprecated_log",
+        argnames="all_packs, should_skip",
         argvalues=[
-            (True, True, True),
-            (False, False, False),
+            (True, True),
+            (False, False),
         ],
     )
     def test_deprecated_integration(
@@ -597,7 +597,6 @@ class TestTestsCollection:
         create_integration: Callable,
         all_packs: bool,
         should_skip: bool,
-        deprecated_log: bool,
     ):
         """
         Given:
@@ -611,7 +610,6 @@ class TestTestsCollection:
         - Case A: gather facts should indicate integration is skipped
         - Case B: gather father should indicate integration is not skipped
         """
-        log = mocker.patch.object(logger, "info")
         mocker.patch.object(linter.Linter, "_update_support_level")
         integration_path: Path = create_integration(
             content_path=demisto_content, is_deprecated=True
@@ -621,22 +619,11 @@ class TestTestsCollection:
         )
         assert should_skip == runner._gather_facts(modules={})
 
-        if deprecated_log:
-            assert (
-                "skipping lint for Sample_integration because its deprecated"
-                == log.call_args_list[2].args[0]
-            )
-        else:
-            assert (
-                "skipping lint for Sample_integration because its deprecated"
-                != log.call_args_list[2].args[0]
-            )
-
     @pytest.mark.parametrize(
-        argnames="all_packs, should_skip, deprecated_log",
+        argnames="all_packs, should_skip",
         argvalues=[
-            (True, True, True),
-            (False, False, False),
+            (True, True),
+            (False, False),
         ],
     )
     def test_deprecated_script(
@@ -646,7 +633,6 @@ class TestTestsCollection:
         script,
         all_packs,
         should_skip,
-        deprecated_log,
     ):
         """
         Given:
@@ -661,24 +647,12 @@ class TestTestsCollection:
         - Case B: gather father should indicate script is not skipped
         """
         script.yml.update({"deprecated": True})
-        log = mocker.patch.object(logger, "info")
         mocker.patch.object(linter.Linter, "_update_support_level")
         runner = initiate_linter(
             demisto_content, script.path, True, all_packs=all_packs
         )
 
         assert should_skip == runner._gather_facts(modules={})
-
-        if deprecated_log:
-            assert (
-                "skipping lint for script0 because its deprecated"
-                == log.call_args_list[2].args[0]
-            )
-        else:
-            assert (
-                "skipping lint for script0 because its deprecated"
-                != log.call_args_list[2].args[0]
-            )
 
 
 class TestLintFilesCollection:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-5344

## Description
do not run deprecated scripts/integrations when running **lint -a**