### PR TITLE
Fix server min version field in pack metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Fixed an issue where a pack `serverMinVersion` is calculated by its content items to be the minimum fromVersion.
 
 ## 1.10.5
 * Fixed an issue where running **run-test-playbook** would not use the `verify` parameter correctly. @ajoga

--- a/demisto_sdk/commands/content_graph/objects/pack.py
+++ b/demisto_sdk/commands/content_graph/objects/pack.py
@@ -205,12 +205,12 @@ class Pack(BaseContent, PackMetadata, content_type=ContentType.PACK):  # type: i
             content_item_dct[c.content_type.value].append(c)
 
         # If there is no server_min_version, set it to the maximum of its content items fromversion
-        max_content_items_version = MARKETPLACE_MIN_VERSION
+        min_content_items_version = MARKETPLACE_MIN_VERSION
         if content_items:
-            max_content_items_version = str(
-                max(parse(content_item.fromversion) for content_item in content_items)
+            min_content_items_version = str(
+                min(parse(content_item.fromversion) for content_item in content_items)
             )
-        self.server_min_version = self.server_min_version or max_content_items_version
+        self.server_min_version = self.server_min_version or min_content_items_version
         self.content_items = PackContentItems(**content_item_dct)
 
     def dump_metadata(self, path: Path, marketplace: MarketplaceVersions) -> None:

--- a/demisto_sdk/commands/content_graph/objects/pack.py
+++ b/demisto_sdk/commands/content_graph/objects/pack.py
@@ -204,7 +204,7 @@ class Pack(BaseContent, PackMetadata, content_type=ContentType.PACK):  # type: i
         for c in content_items:
             content_item_dct[c.content_type.value].append(c)
 
-        # If there is no server_min_version, set it to the maximum of its content items fromversion
+        # If there is no server_min_version, set it to the minimum of its content items fromversion
         min_content_items_version = MARKETPLACE_MIN_VERSION
         if content_items:
             min_content_items_version = str(


### PR DESCRIPTION
Fixed the serverMinVersion when dumping the pack metadata to calculating by the minimum from version of the pack's content items.

@YuvHayun FYI