### PR TITLE
layout parser fix

### DIFF
--- a/demisto_sdk/commands/content_graph/parsers/layout.py
+++ b/demisto_sdk/commands/content_graph/parsers/layout.py
@@ -74,7 +74,9 @@ class LayoutParser(JSONContentItemParser, content_type=ContentType.LAYOUT):
             elif isinstance(current_object, dict):
                 for key, value in current_object.items():
                     if key == "fieldId" and isinstance(value, str):
-                        values.add(value.replace("incident_", ""))
+                        values.add(
+                            value.replace("incident_", "").replace("indicator_", "")
+                        )
                     else:
                         get_values(value)
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

Fixed an issue where we pull relationships from layouts to indicator fields with the prefix "indicator_", while the fields' object_ids never include this prefix.
<img width="1242" alt="image" src="https://user-images.githubusercontent.com/38749041/222508783-2895231c-7651-43c2-8c93-20964ad21ae6.png">
<img width="1276" alt="image" src="https://user-images.githubusercontent.com/38749041/222509240-1d80498d-834d-48c1-bf71-18b6c4aaad78.png">
<img width="1083" alt="image" src="https://user-images.githubusercontent.com/38749041/222509568-9f19b0f4-bed3-47a0-8602-e917dc886ea1.png">

