### PR TITLE
ignore MSAPIModule validations when changing only the integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-* Fixed an issue where **validate** failed with **is_valid_integration_file_path_in_folder** in cases of integrations with MSAPIModule.
+* Fixed an issue where **validate** failed with **is_valid_integration_file_path_in_folder** on integrations that use the `MSAPIModule`.
 
 ## 1.10.6
 * Fixed an issue where running **validate** with the `-g` flag would skip some validations for old-formatted (unified) integration/script files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Fixed an issue where **validate** failed with **is_valid_integration_file_path_in_folder** in cases of integrations with MSAPIModule.
 
 ## 1.10.6
 * Fixed an issue where running **validate** with the `-g` flag would skip some validations for old-formatted (unified) integration/script files.

--- a/demisto_sdk/commands/common/hook_validations/integration.py
+++ b/demisto_sdk/commands/common/hook_validations/integration.py
@@ -1720,7 +1720,7 @@ class IntegrationValidator(ContentEntityValidator):
             "CommonServerPython.py",
             "CommonServerUserPython.py",
             ".vulture_whitelist.py",
-            "MicrosoftApiModule.py",
+            "MicrosoftApiModule.py",  # won't affect the actual API module since it's a script not an integration.
         ]
         files_to_check = get_files_in_dir(
             os.path.dirname(self.file_path), ["py"], False

--- a/demisto_sdk/commands/common/hook_validations/integration.py
+++ b/demisto_sdk/commands/common/hook_validations/integration.py
@@ -1720,7 +1720,7 @@ class IntegrationValidator(ContentEntityValidator):
             "CommonServerPython.py",
             "CommonServerUserPython.py",
             ".vulture_whitelist.py",
-            "MicrosoftApiModule.py"
+            "MicrosoftApiModule.py",
         ]
         files_to_check = get_files_in_dir(
             os.path.dirname(self.file_path), ["py"], False

--- a/demisto_sdk/commands/common/hook_validations/integration.py
+++ b/demisto_sdk/commands/common/hook_validations/integration.py
@@ -1720,6 +1720,7 @@ class IntegrationValidator(ContentEntityValidator):
             "CommonServerPython.py",
             "CommonServerUserPython.py",
             ".vulture_whitelist.py",
+            "MicrosoftApiModule.py"
         ]
         files_to_check = get_files_in_dir(
             os.path.dirname(self.file_path), ["py"], False


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: [5605](https://jira-hq.paloaltonetworks.local/browse/CIAC-5605)

## Description
* Fixed an issue where **validate** failed with **is_valid_integration_file_path_in_folder** in cases of integrations with MSAPIModule.