### PR TITLE
fixed specific invalid input error in unify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-
+* Fixed an issue where an error message in **unify** was unclear for invalid input.
 ## 1.10.6
 * Fixed an issue where running **validate** with the `-g` flag would skip some validations for old-formatted (unified) integration/script files.
 * Deprecated integrations and scripts will not run anymore when providing the **--all-packs** to the **lint** command.

--- a/demisto_sdk/commands/content_graph/common.py
+++ b/demisto_sdk/commands/content_graph/common.py
@@ -121,7 +121,7 @@ class ContentType(str, enum.Enum):
         for idx, folder in enumerate(path.parts):
             if folder == PACKS_FOLDER:
                 if len(path.parts) <= idx + 2:
-                    raise ValueError(f"Invalid content path.")
+                    raise ValueError("Invalid content path.")
                 content_type_dir = path.parts[idx + 2]
                 break
         else:

--- a/demisto_sdk/commands/content_graph/common.py
+++ b/demisto_sdk/commands/content_graph/common.py
@@ -120,6 +120,8 @@ class ContentType(str, enum.Enum):
     def by_path(cls, path: Path) -> "ContentType":
         for idx, folder in enumerate(path.parts):
             if folder == PACKS_FOLDER:
+                if len(path.parts) <= idx + 2:
+                    raise ValueError(f"Invalid content path.")
                 content_type_dir = path.parts[idx + 2]
                 break
         else:

--- a/demisto_sdk/commands/content_graph/objects/base_content.py
+++ b/demisto_sdk/commands/content_graph/objects/base_content.py
@@ -118,7 +118,9 @@ class BaseContent(ABC, BaseModel, metaclass=BaseContentMetaclass):
         try:
             content_item_parser = ContentItemParser.from_path(path)
         except ValueError as e:
-            raise ValueError(f"Invalid content path provided: {str(path)}. Please provide a valid content item or pack path.") from e
+            raise ValueError(
+                f"Invalid content path provided: {str(path)}. Please provide a valid content item or pack path."
+            ) from e
         if not content_item_parser:
             # This is a workaround because `create-content-artifacts` still creates deprecated content items
             demisto_sdk.commands.content_graph.parsers.content_item.MARKETPLACE_MIN_VERSION = (

--- a/demisto_sdk/commands/content_graph/objects/base_content.py
+++ b/demisto_sdk/commands/content_graph/objects/base_content.py
@@ -115,12 +115,7 @@ class BaseContent(ABC, BaseModel, metaclass=BaseContentMetaclass):
         logger.debug(f"Loading content item from path: {path}")
         if path.is_dir() and path.parent.name == "Packs":  # if the path given is a pack
             return content_type_to_model[ContentType.PACK].from_orm(PackParser(path))
-        try:
-            content_item_parser = ContentItemParser.from_path(path)
-        except ValueError as e:
-            raise ValueError(
-                f"Invalid content path provided: {str(path)}. Please provide a valid content item or pack path."
-            ) from e
+        content_item_parser = ContentItemParser.from_path(path)
         if not content_item_parser:
             # This is a workaround because `create-content-artifacts` still creates deprecated content items
             demisto_sdk.commands.content_graph.parsers.content_item.MARKETPLACE_MIN_VERSION = (
@@ -132,7 +127,7 @@ class BaseContent(ABC, BaseModel, metaclass=BaseContentMetaclass):
             )
 
         if not content_item_parser:  # if we still can't parse the content item
-            logger.error(f"Could not parse content item from path: {path}")
+            logger.error(f"Invalid content path provided: {str(path)}. Please provide a valid content item or pack path.")
             return None
 
         model = content_type_to_model.get(content_item_parser.content_type)

--- a/demisto_sdk/commands/content_graph/objects/base_content.py
+++ b/demisto_sdk/commands/content_graph/objects/base_content.py
@@ -115,8 +115,10 @@ class BaseContent(ABC, BaseModel, metaclass=BaseContentMetaclass):
         logger.debug(f"Loading content item from path: {path}")
         if path.is_dir() and path.parent.name == "Packs":  # if the path given is a pack
             return content_type_to_model[ContentType.PACK].from_orm(PackParser(path))
-        content_item_parser = ContentItemParser.from_path(path)
-
+        try:
+            content_item_parser = ContentItemParser.from_path(path)
+        except ValueError as e:
+            raise ValueError(f"Invalid content path provided: {str(path)}. Please provide a valid content item or pack path.") from e
         if not content_item_parser:
             # This is a workaround because `create-content-artifacts` still creates deprecated content items
             demisto_sdk.commands.content_graph.parsers.content_item.MARKETPLACE_MIN_VERSION = (

--- a/demisto_sdk/commands/content_graph/objects/base_content.py
+++ b/demisto_sdk/commands/content_graph/objects/base_content.py
@@ -127,7 +127,9 @@ class BaseContent(ABC, BaseModel, metaclass=BaseContentMetaclass):
             )
 
         if not content_item_parser:  # if we still can't parse the content item
-            logger.error(f"Invalid content path provided: {str(path)}. Please provide a valid content item or pack path.")
+            logger.error(
+                f"Invalid content path provided: {str(path)}. Please provide a valid content item or pack path."
+            )
             return None
 
         model = content_type_to_model.get(content_item_parser.content_type)

--- a/demisto_sdk/commands/content_graph/parsers/content_item.py
+++ b/demisto_sdk/commands/content_graph/parsers/content_item.py
@@ -101,8 +101,8 @@ class ContentItemParser(BaseContentParser, metaclass=ParserMetaclass):
                 return None
         try:
             content_type: ContentType = ContentType.by_path(path)
-        except ValueError:
-            logger.error(f"Invalid path: {path}")
+        except ValueError as e:
+            logger.error(e)
             return None
         if parser_cls := ContentItemParser.content_type_to_parser.get(content_type):
             try:

--- a/demisto_sdk/commands/content_graph/parsers/content_item.py
+++ b/demisto_sdk/commands/content_graph/parsers/content_item.py
@@ -99,7 +99,11 @@ class ContentItemParser(BaseContentParser, metaclass=ParserMetaclass):
                 path = path.parent
             else:
                 return None
-        content_type: ContentType = ContentType.by_path(path)
+        try:
+            content_type: ContentType = ContentType.by_path(path)
+        except ValueError:
+            logger.error(f"Invalid path: {path}")
+            return None
         if parser_cls := ContentItemParser.content_type_to_parser.get(content_type):
             try:
                 return ContentItemParser.parse(


### PR DESCRIPTION

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-5881

## Description
Added better handling for invalid input (invalid path) in the `unify` command.
