### PR TITLE
Add XSIAM compliance module

### DIFF
--- a/demisto_sdk/commands/common/constants.py
+++ b/demisto_sdk/commands/common/constants.py
@@ -741,6 +741,7 @@ PACK_METADATA_AUTHOR = "author"
 PACK_METADATA_URL = "url"
 PACK_METADATA_EMAIL = "email"
 PACK_METADATA_CATEGORIES = "categories"
+PACK_METADATA_MODULES = "modules"
 PACK_METADATA_TAGS = "tags"
 PACK_METADATA_CREATED = "created"
 PACK_METADATA_CERTIFICATION = "certification"
@@ -1340,6 +1341,7 @@ XSOAR_SUPPORT_URL = "https://www.paloaltonetworks.com/cortex"
 MARKETPLACE_LIVE_DISCUSSIONS = "https://live.paloaltonetworks.com/t5/cortex-xsoar-discussions/bd-p/Cortex_XSOAR_Discussions"
 EXCLUDED_DISPLAY_NAME_WORDS = ["partner", "community"]
 MARKETPLACES = ["xsoar", "marketplacev2"]
+MODULES = ["compliance"]
 
 # From Version constants
 FILETYPE_TO_DEFAULT_FROMVERSION = {

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -15,6 +15,7 @@ from demisto_sdk.commands.common.constants import (
     RN_HEADER_BY_FILE_TYPE,
     FileType,
     MarketplaceVersions,
+    MODULES,
 )
 from demisto_sdk.commands.common.content_constant_paths import CONF_PATH
 
@@ -1198,6 +1199,16 @@ ERROR_CODE = {
     },
     "categories_field_does_not_match_standard": {
         "code": "PA134",
+        "ui_applicable": False,
+        "related_field": "",
+    },
+    "pack_metadata_invalid_modules": {
+        "code": "PA135",
+        "ui_applicable": False,
+        "related_field": "",
+    },
+    "pack_metadata_modules_for_non_xsiam": {
+        "code": "PA136",
         "ui_applicable": False,
         "related_field": "",
     },
@@ -3431,6 +3442,16 @@ class Errors:
     @error_code_decorator
     def is_wrong_usage_of_usecase_tag():
         return "pack_metadata.json file contains the Use Case tag, without having any PB, incidents Types or Layouts"
+
+    @staticmethod
+    @error_code_decorator
+    def pack_metadata_invalid_modules():
+        return f"Module field should be one of the following: {', '.join(MODULES)}."
+
+    @staticmethod
+    @error_code_decorator
+    def pack_metadata_modules_for_non_xsiam():
+        return "Module field can be added only for XSIAM packs (marketplacev2)."
 
     @staticmethod
     @error_code_decorator

--- a/demisto_sdk/commands/common/tests/pack_metadata_validator_test.py
+++ b/demisto_sdk/commands/common/tests/pack_metadata_validator_test.py
@@ -51,6 +51,7 @@ class TestPackMetadataValidator:
         "metadata",
         [
             os.path.join(FILES_PATH, "pack_metadata__valid.json"),
+            os.path.join(FILES_PATH, "pack_metadata__valid_module.json"),
             os.path.join(FILES_PATH, "pack_metadata__valid__community.json"),
         ],
     )
@@ -85,6 +86,8 @@ class TestPackMetadataValidator:
             os.path.join(FILES_PATH, "pack_metadata_invalid_keywords.json"),
             os.path.join(FILES_PATH, "pack_metadata_invalid_tags.json"),
             os.path.join(FILES_PATH, "pack_metadata_invalid_format_version.json"),
+            os.path.join(FILES_PATH, "pack_metadata__invalid_module.json"),
+            os.path.join(FILES_PATH, "pack_metadata__module_non_xsiam.json"),
         ],
     )
     def test_metadata_validator_invalid__non_breaking(self, mocker, metadata):

--- a/demisto_sdk/tests/test_files/pack_metadata__invalid_module.json
+++ b/demisto_sdk/tests/test_files/pack_metadata__invalid_module.json
@@ -1,0 +1,23 @@
+{
+    "name": "AWS Feed",
+    "description": "Indicators feed from AWS",
+    "support": "xsoar",
+    "serverMinVersion": "5.5.0",
+    "currentVersion": "1.0.0",
+    "author": "Cortex XSOAR",
+    "url": "https://www.paloaltonetworks.com/cortex",
+    "email": "",
+    "categories": [
+        "Data Enrichment & Threat Intelligence"
+    ],
+    "tags": [],
+    "deprecated": false,
+    "certification": "certified",
+    "useCases": [],
+    "keywords": ["AWS", "Feed"],
+    "marketplaces": [
+        "xsoar",
+        "marketplacev2"
+    ],
+    "modules": ["not valid", "compliance"]
+}

--- a/demisto_sdk/tests/test_files/pack_metadata__module_non_xsiam.json
+++ b/demisto_sdk/tests/test_files/pack_metadata__module_non_xsiam.json
@@ -1,0 +1,22 @@
+{
+    "name": "AWS Feed",
+    "description": "Indicators feed from AWS",
+    "support": "xsoar",
+    "serverMinVersion": "5.5.0",
+    "currentVersion": "1.0.0",
+    "author": "Cortex XSOAR",
+    "url": "https://www.paloaltonetworks.com/cortex",
+    "email": "",
+    "categories": [
+        "Data Enrichment & Threat Intelligence"
+    ],
+    "tags": [],
+    "deprecated": false,
+    "certification": "certified",
+    "useCases": [],
+    "keywords": ["AWS", "Feed"],
+    "marketplaces": [
+        "xsoar"
+    ],
+    "modules": ["compliance"]
+}

--- a/demisto_sdk/tests/test_files/pack_metadata__valid_module.json
+++ b/demisto_sdk/tests/test_files/pack_metadata__valid_module.json
@@ -1,0 +1,23 @@
+{
+    "name": "AWS Feed",
+    "description": "Indicators feed from AWS",
+    "support": "xsoar",
+    "serverMinVersion": "5.5.0",
+    "currentVersion": "1.0.0",
+    "author": "Cortex XSOAR",
+    "url": "https://www.paloaltonetworks.com/cortex",
+    "email": "",
+    "categories": [
+        "Data Enrichment & Threat Intelligence"
+    ],
+    "tags": [],
+    "deprecated": false,
+    "certification": "certified",
+    "useCases": [],
+    "keywords": ["AWS", "Feed"],
+    "marketplaces": [
+        "xsoar",
+        "marketplacev2"
+    ],
+    "modules": ["compliance"]
+}


### PR DESCRIPTION
## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-5821

## Description
Add support in the `pack_metadata.json` file for the `modules` field, which holds an array of strings, and is used only for XSIAM. The field is optional and currently only supports population of the `compliance` value.