### PR TITLE
Ignore API Module Files From Validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 * Fixed an issue where an error message in **unify** was unclear for invalid input.
-* Fixed an issue where **validate** failed with **is_valid_integration_file_path_in_folder** on integrations that use the `MSAPIModule`.
+* Fixed an issue where **validate** failed with **is_valid_integration_file_path_in_folder** on integrations that use API modules.
 
 ## 1.10.6
 * Fixed an issue where running **validate** with the `-g` flag would skip some validations for old-formatted (unified) integration/script files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 * Fixed an issue where an error message in **unify** was unclear for invalid input.
-* Fixed an issue where running **validate** localy failed with **is_valid_integration_file_path_in_folder** on integrations that use API modules.
+* Fixed an issue where running **validate** failed with **is_valid_integration_file_path_in_folder** on integrations that use API modules.
 
 ## 1.10.6
 * Fixed an issue where running **validate** with the `-g` flag would skip some validations for old-formatted (unified) integration/script files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 * Fixed an issue where an error message in **unify** was unclear for invalid input.
-* Fixed an issue where **validate** failed with **is_valid_integration_file_path_in_folder** on integrations that use API modules.
+* Fixed an issue where running **validate** localy failed with **is_valid_integration_file_path_in_folder** on integrations that use API modules.
 
 ## 1.10.6
 * Fixed an issue where running **validate** with the `-g` flag would skip some validations for old-formatted (unified) integration/script files.

--- a/demisto_sdk/commands/common/hook_validations/integration.py
+++ b/demisto_sdk/commands/common/hook_validations/integration.py
@@ -1724,7 +1724,7 @@ class IntegrationValidator(ContentEntityValidator):
 
         # Files that will be excluded from the check if they end with the given suffix (str.endswith).
         excluded_file_suffix = [
-            "ApiModule.py",
+            "ApiModule.py",  # won't affect the actual API module since it's a script not an integration.
         ]
 
         # Gets the all integration .py files from the integration folder.

--- a/demisto_sdk/commands/common/hook_validations/integration.py
+++ b/demisto_sdk/commands/common/hook_validations/integration.py
@@ -1723,7 +1723,7 @@ class IntegrationValidator(ContentEntityValidator):
         ]
 
         # Files that will be excluded from the check if they end with the given suffix (str.endswith).
-        excluded_file_suffix = [
+        excluded_file_suffixes = [
             "ApiModule.py",  # won't affect the actual API module since it's a script not an integration.
         ]
 
@@ -1737,9 +1737,9 @@ class IntegrationValidator(ContentEntityValidator):
         for file_path in files_to_check:
             file_name = os.path.basename(file_path)
 
-            # If the file is in an excluded list, skip it.
+            # If the file is in an exclusion list, skip it.
             if file_name in excluded_files or any(
-                file_name.endswith(extension) for extension in excluded_file_suffix
+                file_name.endswith(suffix) for suffix in excluded_file_suffixes
             ):
                 continue
 

--- a/demisto_sdk/commands/common/hook_validations/integration.py
+++ b/demisto_sdk/commands/common/hook_validations/integration.py
@@ -1713,15 +1713,21 @@ class IntegrationValidator(ContentEntityValidator):
 
     @error_codes("IN137")
     def is_valid_py_file_names(self):
-        # Gets the all integration .py files from the integration folder.
+        # Files that will be excluded from the check.
         excluded_files = [
             "demistomock.py",
             "conftest.py",
             "CommonServerPython.py",
             "CommonServerUserPython.py",
             ".vulture_whitelist.py",
-            "MicrosoftApiModule.py",  # won't affect the actual API module since it's a script not an integration.
         ]
+
+        # Files that will be excluded from the check if they end with the given suffix (str.endswith).
+        excluded_file_suffix = [
+            "ApiModule.py",
+        ]
+
+        # Gets the all integration .py files from the integration folder.
         files_to_check = get_files_in_dir(
             os.path.dirname(self.file_path), ["py"], False
         )
@@ -1730,13 +1736,19 @@ class IntegrationValidator(ContentEntityValidator):
 
         for file_path in files_to_check:
             file_name = os.path.basename(file_path)
-            if file_name not in excluded_files:
-                # The unittest has _test.py suffix whereas the integration only has the .py suffix
-                splitter = "_" if file_name.endswith("_test.py") else "."
-                base_name = file_name.rsplit(splitter, 1)[0]
 
-                if integrations_folder != base_name:
-                    invalid_files.append(file_name)
+            # If the file is in an excluded list, skip it.
+            if file_name in excluded_files or any(
+                file_name.endswith(extension) for extension in excluded_file_suffix
+            ):
+                continue
+
+            # The unittest has _test.py suffix whereas the integration only has the .py suffix
+            splitter = "_" if file_name.endswith("_test.py") else "."
+            base_name = file_name.rsplit(splitter, 1)[0]
+
+            if integrations_folder != base_name:
+                invalid_files.append(file_name)
 
         if invalid_files:
             error_message, error_code = Errors.is_valid_integration_file_path_in_folder(


### PR DESCRIPTION
## Description
This PR adds files with the `ApiModule.py` suffix to an ignore list so that they won't be validate.

Example of the current validation:

> [ERROR]: /Users/username/dev/demisto/content/Packs/AWS-SecurityHub/Integrations/AWSSecurityHubEventCollector/AWSSecurityHubEventCollector.yml: [IN137] - The integration file name: ['AWSApiModule.py'] is invalid, The integration file name and all the other files in the folder, should be the same as the name of the folder that contains it.
