### PR TITLE
Pack metadata schema

### DIFF
--- a/demisto_sdk/commands/common/constants.py
+++ b/demisto_sdk/commands/common/constants.py
@@ -1246,6 +1246,7 @@ SCHEMA_TO_REGEX = {
     "trigger": [TRIGGER_JSON_REGEX],
     "xdrctemplate": [XDRC_TEMPLATE_JSON_REGEX],
     LAYOUT_RULE: JSON_ALL_LAYOUT_RULES_REGEXES,
+    "pack-metadata": 
 }
 
 EXTERNAL_PR_REGEX = r"^pull/(\d+)$"

--- a/demisto_sdk/commands/common/hook_validations/pack_unique_files.py
+++ b/demisto_sdk/commands/common/hook_validations/pack_unique_files.py
@@ -550,7 +550,7 @@ class PackUniqueFilesValidator(BaseValidator):
                 raise BlockingValidationFailureException()
 
             description_name = metadata.get(PACK_METADATA_DESC, "").lower()
-            if not description_name or "fill mandatory field" in description_name:
+            if "fill mandatory field" in description_name:
                 if self._add_error(
                     Errors.pack_metadata_field_invalid(), self.pack_meta_file
                 ):

--- a/demisto_sdk/commands/common/schemas/pack_metadata.yml
+++ b/demisto_sdk/commands/common/schemas/pack_metadata.yml
@@ -1,0 +1,64 @@
+type: map
+mapping:
+  name:
+    type: str
+    required: true
+  description:
+    type: str
+    required: true
+  support:
+    type: str
+    enum: ['xsoar', 'partner', 'community', 'developer']
+    required: true
+  currentVersion:
+    type: str
+    required: true
+  author:
+    type: str
+    required: true
+  serverMinVersion:
+    type: str
+    required: false
+  url:
+    type: str
+    required: true
+  email:
+    type: str
+    required: true
+  created:
+    type: str
+    required: true
+  tags:
+    type: seq
+    sequence:
+      - type: str
+    required: true
+  categories:
+    type: seq
+    sequence:
+      - type: str
+    required: true
+  useCases:
+    type: seq
+    sequence:
+      - type: str
+    required: true
+  keywords:
+    type: seq
+    sequence:
+      - type: str
+    required: true
+  dependencies:
+    type: map
+    required: true
+  marketplaces:
+    type: seq
+    required: true
+    sequence:
+      - type: str
+        enum: ['xsoar', 'marketplacev2', 'xpanse']
+
+
+
+
+  


### PR DESCRIPTION
Check what parts of `_is_pack_meta_file_structure_valid` can be converted to the schema.
Validate that the error codes you remove are **not** ignorable (as the schema will fail on them).
Make sure nothing fails with the change.