### PR TITLE
Fixed default value for server_min_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fixed an issue where the **lint** command ran on `native:dev` supported content when passing the `--docker-image all` flag, instead it will run on `native:candidate`.
 * Added support for `native:candidate` as a docker image flag for **lint** command.
 * Fixed an issue where logs and messages would not show when using the **download** command.
+* Fixed an issue where the `server_min_version` field in metadata was empty when parsing packs without content items.
 
 ## 1.11.0
 * **Note: Demisto-SDK will soon stop supporting Python 3.8**

--- a/demisto_sdk/commands/content_graph/parsers/pack.py
+++ b/demisto_sdk/commands/content_graph/parsers/pack.py
@@ -2,7 +2,10 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
-from demisto_sdk.commands.common.constants import MarketplaceVersions, MARKETPLACE_MIN_VERSION
+from demisto_sdk.commands.common.constants import (
+    MARKETPLACE_MIN_VERSION,
+    MarketplaceVersions,
+)
 from demisto_sdk.commands.common.tools import get_json
 from demisto_sdk.commands.content_graph.common import (
     PACK_CONTRIBUTORS_FILENAME,
@@ -104,7 +107,9 @@ class PackMetadataParser:
             "certified" if self.support.lower() in ["xsoar", "partner"] else ""
         )
         self.hidden: bool = metadata.get("hidden", False)
-        self.server_min_version: str = metadata.get("serverMinVersion", MARKETPLACE_MIN_VERSION)
+        self.server_min_version: str = metadata.get(
+            "serverMinVersion", MARKETPLACE_MIN_VERSION
+        )
         self.current_version: str = metadata["currentVersion"]
         self.tags: List[str] = metadata["tags"]
         self.categories: List[str] = metadata["categories"]

--- a/demisto_sdk/commands/content_graph/parsers/pack.py
+++ b/demisto_sdk/commands/content_graph/parsers/pack.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
-from demisto_sdk.commands.common.constants import MarketplaceVersions
+from demisto_sdk.commands.common.constants import MarketplaceVersions, MARKETPLACE_MIN_VERSION
 from demisto_sdk.commands.common.tools import get_json
 from demisto_sdk.commands.content_graph.common import (
     PACK_CONTRIBUTORS_FILENAME,
@@ -104,7 +104,7 @@ class PackMetadataParser:
             "certified" if self.support.lower() in ["xsoar", "partner"] else ""
         )
         self.hidden: bool = metadata.get("hidden", False)
-        self.server_min_version: str = metadata.get("serverMinVersion", "")
+        self.server_min_version: str = metadata.get("serverMinVersion", MARKETPLACE_MIN_VERSION)
         self.current_version: str = metadata["currentVersion"]
         self.tags: List[str] = metadata["tags"]
         self.categories: List[str] = metadata["categories"]


### PR DESCRIPTION
## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-6115

## Description
Fixed the default value for server_min_version when parsing packs without content items.