### PR TITLE
Fix layouts gets overriden in download without -f

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Fixed an issue in the **download** command where layouts were overriden even without the `-f` option.
+* Fixed an issue where Demisto-SDK did not detect layout ID when using the **download** command.
 * Fixed an issue where the **lint** command ran on `native:dev` supported content when passing the `--docker-image all` flag, instead it will run on `native:candidate`.
 * Added support for `native:candidate` as a docker image flag for **lint** command.
 * Fixed an issue where logs and messages would not show when using the **download** command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Fixed an issue in the **download** command where layouts were overriden even without the `-f` option.
 * Fixed an issue where the **lint** command ran on `native:dev` supported content when passing the `--docker-image all` flag, instead it will run on `native:candidate`.
 * Added support for `native:candidate` as a docker image flag for **lint** command.
 * Fixed an issue where logs and messages would not show when using the **download** command.

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -850,7 +850,7 @@ def get_entity_id_by_entity_type(data: dict, content_entity: str):
             return data.get("commonfields", {}).get("id", "")
         elif content_entity == LAYOUTS_DIR:
             # typeId is for old format layouts, id is for layoutscontainers
-            return data.get("typeId", "") or data.get("id", "")
+            return data.get("typeId", data.get("id", ""))
         else:
             return data.get("id", "")
 

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -849,7 +849,7 @@ def get_entity_id_by_entity_type(data: dict, content_entity: str):
         if content_entity in (INTEGRATIONS_DIR, SCRIPTS_DIR):
             return data.get("commonfields", {}).get("id", "")
         elif content_entity == LAYOUTS_DIR:
-            # typeId is for old format layouts, id is for layoutscontainers which
+            # typeId is for old format layouts, id is for layoutscontainers
             return data.get("typeId", "") or data.get("id", "")
         else:
             return data.get("id", "")

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -849,7 +849,8 @@ def get_entity_id_by_entity_type(data: dict, content_entity: str):
         if content_entity in (INTEGRATIONS_DIR, SCRIPTS_DIR):
             return data.get("commonfields", {}).get("id", "")
         elif content_entity == LAYOUTS_DIR:
-            return data.get("typeId", "")
+            # typeId is for old format layouts, id is for layoutscontainers which
+            return data.get("typeId", "") or data.get("id", "")
         else:
             return data.get("id", "")
 

--- a/demisto_sdk/commands/download/tests/downloader_test.py
+++ b/demisto_sdk/commands/download/tests/downloader_test.py
@@ -298,7 +298,7 @@ class Environment:
             INTEGRATIONS_DIR: [self.INTEGRATION_PACK_OBJECT],
             SCRIPTS_DIR: [self.SCRIPT_PACK_OBJECT],
             PLAYBOOKS_DIR: [self.PLAYBOOK_PACK_OBJECT],
-            LAYOUTS_DIR: [self.LAYOUT_PACK_OBJECT],
+            LAYOUTS_DIR: [self.LAYOUT_PACK_OBJECT, self.LAYOUTSCONTAINER_PACK_OBJECT],
             PRE_PROCESS_RULES_DIR: [],
             LISTS_DIR: [],
             JOBS_DIR: [],

--- a/demisto_sdk/commands/download/tests/downloader_test.py
+++ b/demisto_sdk/commands/download/tests/downloader_test.py
@@ -112,9 +112,11 @@ class Environment:
         tests_path = self.tmp_path / "tests"
         tests_env_path = tests_path / "tests_env"
         tests_data_path = tests_path / "tests_data"
-        shutil.copytree(src="tests_env", dst=str(tests_env_path))
         shutil.copytree(
-            src="tests_data",
+            src="demisto_sdk/commands/download/tests/tests_env", dst=str(tests_env_path)
+        )
+        shutil.copytree(
+            src="demisto_sdk/commands/download/tests/tests_data",
             dst=str(tests_data_path),
         )
 

--- a/demisto_sdk/commands/download/tests/downloader_test.py
+++ b/demisto_sdk/commands/download/tests/downloader_test.py
@@ -81,6 +81,7 @@ class Environment:
         self.SCRIPT_INSTANCE_PATH = None
         self.PLAYBOOK_INSTANCE_PATH = None
         self.LAYOUT_INSTANCE_PATH = None
+        self.LAYOUTSCONTAINER_INSTANCE_PATH = None
         self.PRE_PROCESS_RULES_INSTANCE_PATH = None
         self.LISTS_INSTANCE_PATH = None
         self.CUSTOM_CONTENT_SCRIPT_PATH = None
@@ -92,6 +93,7 @@ class Environment:
         self.SCRIPT_PACK_OBJECT = None
         self.PLAYBOOK_PACK_OBJECT = None
         self.LAYOUT_PACK_OBJECT = None
+        self.LAYOUTSCONTAINER_PACK_OBJECT = None
         self.LISTS_PACK_OBJECT = None
         self.JOBS_PACK_OBJECT = None
         self.JOBS_INSTANCE_PATH = None
@@ -110,11 +112,9 @@ class Environment:
         tests_path = self.tmp_path / "tests"
         tests_env_path = tests_path / "tests_env"
         tests_data_path = tests_path / "tests_data"
+        shutil.copytree(src="tests_env", dst=str(tests_env_path))
         shutil.copytree(
-            src="demisto_sdk/commands/download/tests/tests_env", dst=str(tests_env_path)
-        )
-        shutil.copytree(
-            src="demisto_sdk/commands/download/tests/tests_data",
+            src="tests_data",
             dst=str(tests_data_path),
         )
 
@@ -131,6 +131,9 @@ class Environment:
         )
         self.LAYOUT_INSTANCE_PATH = (
             f"{self.PACK_INSTANCE_PATH}/Layouts/layout-details-TestLayout.json"
+        )
+        self.LAYOUTSCONTAINER_INSTANCE_PATH = (
+            f"{self.PACK_INSTANCE_PATH}/Layouts/layoutscontainer-mytestlayout.json"
         )
         self.PRE_PROCESS_RULES_INSTANCE_PATH = (
             f"{self.PACK_INSTANCE_PATH}/PreProcessRules/preprocessrule-dummy.json"
@@ -244,6 +247,16 @@ class Environment:
                     "name": "Hello World Alert",
                     "id": "Hello World Alert",
                     "path": self.LAYOUT_INSTANCE_PATH,
+                    "file_ending": "json",
+                }
+            ]
+        }
+        self.LAYOUTSCONTAINER_PACK_OBJECT = {
+            "mylayout": [
+                {
+                    "name": "mylayout",
+                    "id": "mylayout",
+                    "path": self.LAYOUTSCONTAINER_INSTANCE_PATH,
                     "file_ending": "json",
                 }
             ]
@@ -640,6 +653,11 @@ class TestBuildPackContent:
                 "entity": LAYOUTS_DIR,
                 "path": "demisto_sdk/commands/download/tests/downloader_test.py",
                 "out": {},
+            },
+            {
+                "entity": LAYOUTS_DIR,
+                "path": env.LAYOUTSCONTAINER_INSTANCE_PATH,
+                "out": env.LAYOUTSCONTAINER_PACK_OBJECT,
             },
             {
                 "entity": PRE_PROCESS_RULES_DIR,

--- a/demisto_sdk/commands/download/tests/tests_env/content/Packs/TestPack/Layouts/layoutscontainer-mytestlayout.json
+++ b/demisto_sdk/commands/download/tests/tests_env/content/Packs/TestPack/Layouts/layoutscontainer-mytestlayout.json
@@ -1,0 +1,316 @@
+{
+    "detailsV2": {
+        "tabs": [
+            {
+                "id": "summary",
+                "name": "Legacy Summary",
+                "type": "summary"
+            },
+            {
+                "id": "caseinfoid",
+                "name": "Incident Info",
+                "sections": [
+                    {
+                        "displayType": "ROW",
+                        "h": 2,
+                        "i": "caseinfoid-fce71720-98b0-11e9-97d7-ed26ef9e46c8",
+                        "isVisible": true,
+                        "items": [
+                            {
+                                "endCol": 2,
+                                "fieldId": "type",
+                                "height": 22,
+                                "id": "incident-type-field",
+                                "index": 0,
+                                "sectionItemType": "field",
+                                "startCol": 0
+                            },
+                            {
+                                "endCol": 2,
+                                "fieldId": "severity",
+                                "height": 22,
+                                "id": "incident-severity-field",
+                                "index": 1,
+                                "sectionItemType": "field",
+                                "startCol": 0
+                            },
+                            {
+                                "endCol": 2,
+                                "fieldId": "owner",
+                                "height": 22,
+                                "id": "incident-owner-field",
+                                "index": 2,
+                                "sectionItemType": "field",
+                                "startCol": 0
+                            },
+                            {
+                                "endCol": 2,
+                                "fieldId": "sourcebrand",
+                                "height": 22,
+                                "id": "incident-sourceBrand-field",
+                                "index": 4,
+                                "sectionItemType": "field",
+                                "startCol": 0
+                            },
+                            {
+                                "endCol": 2,
+                                "fieldId": "sourceinstance",
+                                "height": 22,
+                                "id": "incident-sourceInstance-field",
+                                "index": 5,
+                                "sectionItemType": "field",
+                                "startCol": 0
+                            },
+                            {
+                                "endCol": 2,
+                                "fieldId": "playbookid",
+                                "height": 22,
+                                "id": "incident-playbookId-field",
+                                "index": 6,
+                                "sectionItemType": "field",
+                                "startCol": 0
+                            }
+                        ],
+                        "maxW": 3,
+                        "name": "Case Details",
+                        "w": 1,
+                        "x": 0,
+                        "y": 0
+                    },
+                    {
+                        "h": 2,
+                        "i": "caseinfoid-61263cc0-98b1-11e9-97d7-ed26ef9e46c8",
+                        "maxW": 3,
+                        "name": "Notes",
+                        "type": "notes",
+                        "w": 1,
+                        "x": 2,
+                        "y": 0
+                    },
+                    {
+                        "displayType": "ROW",
+                        "h": 2,
+                        "i": "caseinfoid-6aabad20-98b1-11e9-97d7-ed26ef9e46c8",
+                        "maxW": 3,
+                        "name": "Work Plan",
+                        "type": "workplan",
+                        "w": 1,
+                        "x": 1,
+                        "y": 0
+                    },
+                    {
+                        "displayType": "ROW",
+                        "h": 2,
+                        "i": "caseinfoid-770ec200-98b1-11e9-97d7-ed26ef9e46c8",
+                        "isVisible": true,
+                        "maxW": 3,
+                        "name": "Linked Incidents",
+                        "type": "linkedIncidents",
+                        "w": 1,
+                        "x": 1,
+                        "y": 6
+                    },
+                    {
+                        "displayType": "ROW",
+                        "h": 2,
+                        "i": "caseinfoid-842632c0-98b1-11e9-97d7-ed26ef9e46c8",
+                        "maxW": 3,
+                        "name": "Child Incidents",
+                        "type": "childInv",
+                        "w": 1,
+                        "x": 2,
+                        "y": 4
+                    },
+                    {
+                        "displayType": "ROW",
+                        "h": 2,
+                        "i": "caseinfoid-4a31afa0-98ba-11e9-a519-93a53c759fe0",
+                        "maxW": 3,
+                        "name": "Evidence",
+                        "type": "evidence",
+                        "w": 1,
+                        "x": 2,
+                        "y": 2
+                    },
+                    {
+                        "displayType": "ROW",
+                        "h": 2,
+                        "hideName": false,
+                        "i": "caseinfoid-7717e580-9bed-11e9-9a3f-8b4b2158e260",
+                        "maxW": 3,
+                        "name": "Team Members",
+                        "type": "team",
+                        "w": 1,
+                        "x": 2,
+                        "y": 6
+                    },
+                    {
+                        "displayType": "ROW",
+                        "h": 2,
+                        "i": "caseinfoid-7ce69dd0-a07f-11e9-936c-5395a1acf11e",
+                        "maxW": 3,
+                        "name": "Indicators",
+                        "query": "",
+                        "queryType": "input",
+                        "type": "indicators",
+                        "w": 2,
+                        "x": 0,
+                        "y": 4
+                    },
+                    {
+                        "displayType": "CARD",
+                        "h": 2,
+                        "i": "caseinfoid-ac32f620-a0b0-11e9-b27f-13ae1773d289",
+                        "items": [
+                            {
+                                "endCol": 1,
+                                "fieldId": "occurred",
+                                "height": 22,
+                                "id": "incident-occurred-field",
+                                "index": 0,
+                                "sectionItemType": "field",
+                                "startCol": 0
+                            },
+                            {
+                                "endCol": 1,
+                                "fieldId": "dbotmodified",
+                                "height": 22,
+                                "id": "incident-modified-field",
+                                "index": 1,
+                                "sectionItemType": "field",
+                                "startCol": 0
+                            },
+                            {
+                                "endCol": 2,
+                                "fieldId": "dbotduedate",
+                                "height": 22,
+                                "id": "incident-dueDate-field",
+                                "index": 2,
+                                "sectionItemType": "field",
+                                "startCol": 0
+                            },
+                            {
+                                "endCol": 2,
+                                "fieldId": "dbotcreated",
+                                "height": 22,
+                                "id": "incident-created-field",
+                                "index": 0,
+                                "sectionItemType": "field",
+                                "startCol": 1
+                            },
+                            {
+                                "endCol": 2,
+                                "fieldId": "dbotclosed",
+                                "height": 22,
+                                "id": "incident-closed-field",
+                                "index": 1,
+                                "sectionItemType": "field",
+                                "startCol": 1
+                            }
+                        ],
+                        "maxW": 3,
+                        "name": "Timeline Information",
+                        "w": 1,
+                        "x": 0,
+                        "y": 2
+                    },
+                    {
+                        "displayType": "ROW",
+                        "h": 2,
+                        "i": "caseinfoid-88e6bf70-a0b1-11e9-b27f-13ae1773d289",
+                        "isVisible": true,
+                        "items": [
+                            {
+                                "endCol": 2,
+                                "fieldId": "dbotclosed",
+                                "height": 22,
+                                "id": "incident-dbotClosed-field",
+                                "index": 0,
+                                "sectionItemType": "field",
+                                "startCol": 0
+                            },
+                            {
+                                "endCol": 2,
+                                "fieldId": "closereason",
+                                "height": 22,
+                                "id": "incident-closeReason-field",
+                                "index": 1,
+                                "sectionItemType": "field",
+                                "startCol": 0
+                            },
+                            {
+                                "endCol": 2,
+                                "fieldId": "closenotes",
+                                "height": 22,
+                                "id": "incident-closeNotes-field",
+                                "index": 2,
+                                "sectionItemType": "field",
+                                "startCol": 0
+                            }
+                        ],
+                        "maxW": 3,
+                        "name": "Closing Information",
+                        "w": 1,
+                        "x": 0,
+                        "y": 6
+                    },
+                    {
+                        "displayType": "CARD",
+                        "h": 2,
+                        "i": "caseinfoid-e54b1770-a0b1-11e9-b27f-13ae1773d289",
+                        "isVisible": true,
+                        "items": [
+                            {
+                                "endCol": 2,
+                                "fieldId": "details",
+                                "height": 22,
+                                "id": "incident-details-field",
+                                "index": 0,
+                                "sectionItemType": "field",
+                                "startCol": 0
+                            }
+                        ],
+                        "maxW": 3,
+                        "name": "Investigation Data",
+                        "w": 1,
+                        "x": 1,
+                        "y": 2
+                    }
+                ],
+                "type": "custom"
+            },
+            {
+                "id": "warRoom",
+                "name": "War Room",
+                "type": "warRoom"
+            },
+            {
+                "id": "workPlan",
+                "name": "Work Plan",
+                "type": "workPlan"
+            },
+            {
+                "id": "evidenceBoard",
+                "name": "Evidence Board",
+                "type": "evidenceBoard"
+            },
+            {
+                "id": "relatedIncidents",
+                "name": "Related Incidents",
+                "type": "relatedIncidents"
+            },
+            {
+                "id": "canvas",
+                "name": "Canvas",
+                "type": "canvas"
+            }
+        ]
+    },
+    "group": "incident",
+    "id": "mylayout",
+    "name": "mylayout",
+    "system": false,
+    "version": -1,
+    "fromVersion": "6.8.0",
+    "description": ""
+}


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-22748
fixes: https://github.com/demisto/demisto-sdk/issues/2138

## Description
Fixes an issue that when trying to download a layout without the `-f` arg, it would override the layout inside a pack.