### PR TITLE
Fix pb inputs validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 * Added the pack version to the code files when calling **unify**. The same value is removed when calling **split**.
 * Contribution PRs that update outdated packs now display a warning message.
+* Fixed a bug where **validate** returned error on playbook inputs with special characters.
 
 ## 1.12.0
 * Added the **pre-commit** command, to improve code quality of XSOAR content.

--- a/demisto_sdk/commands/common/hook_validations/playbook.py
+++ b/demisto_sdk/commands/common/hook_validations/playbook.py
@@ -123,7 +123,10 @@ class PlaybookValidator(ContentEntityValidator):
             input = input.strip()
             splitted = input.split(".")
             if len(splitted) > 1 and splitted[1] and not splitted[1].startswith(" "):
-                result.add(splitted[1].replace('}', ''))
+                input_in_use = splitted[1]
+                if input_in_use.endswith('}'):
+                    input_in_use = input_in_use[:-1]
+                result.add(input_in_use)
         return result
 
     def collect_all_inputs_from_inputs_section(self) -> Set[str]:

--- a/demisto_sdk/commands/common/hook_validations/playbook.py
+++ b/demisto_sdk/commands/common/hook_validations/playbook.py
@@ -124,9 +124,9 @@ class PlaybookValidator(ContentEntityValidator):
             splitted = input.split(".")
             if len(splitted) > 1 and splitted[1] and not splitted[1].startswith(" "):
                 input_in_use = splitted[1]
-                if input_in_use.endswith("}"):
-                    input_in_use = input_in_use[:-1]
-                result.add(input_in_use)
+                result.add(
+                    input_in_use[:-1] if input_in_use.endswith("}") else input_in_use
+                )
         return result
 
     def collect_all_inputs_from_inputs_section(self) -> Set[str]:

--- a/demisto_sdk/commands/common/hook_validations/playbook.py
+++ b/demisto_sdk/commands/common/hook_validations/playbook.py
@@ -124,7 +124,7 @@ class PlaybookValidator(ContentEntityValidator):
             splitted = input.split(".")
             if len(splitted) > 1 and splitted[1] and not splitted[1].startswith(" "):
                 input_in_use = splitted[1]
-                if input_in_use.endswith('}'):
+                if input_in_use.endswith("}"):
                     input_in_use = input_in_use[:-1]
                 result.add(input_in_use)
         return result

--- a/demisto_sdk/commands/common/hook_validations/playbook.py
+++ b/demisto_sdk/commands/common/hook_validations/playbook.py
@@ -123,7 +123,7 @@ class PlaybookValidator(ContentEntityValidator):
             input = input.strip()
             splitted = input.split(".")
             if len(splitted) > 1 and splitted[1] and not splitted[1].startswith(" "):
-                result.add(splitted[1])
+                result.add(splitted[1].replace('}', ''))
         return result
 
     def collect_all_inputs_from_inputs_section(self) -> Set[str]:

--- a/demisto_sdk/tests/test_files/playbook_valid_inputs.yml
+++ b/demisto_sdk/tests/test_files/playbook_valid_inputs.yml
@@ -41,6 +41,24 @@ tasks:
           value:
             simple: 'True'
         ignorecase: true
+  '2':
+    id: '2'
+    task:
+    description: "This playbook identifies duplicate incidents using the Cortex\
+                \ XSOAR machine learning method (script).\n In this playbook, you can choose\
+                \ fields and/or indicators to be compared against other incidents in the Cortex\
+                \ XSOAR database. \n\n Note: To identify similar incidents you must must properly\
+                \ define the playbook inputs. "
+    condition:
+    - - operator: isEqualString
+        left:
+          value:
+            simple: ${inputs.ResourceName}
+          iscontext: true
+        right:
+          value:
+            simple: 'True'
+        ignorecase: true
 inputs:
 - key: TestInput
   value:
@@ -49,6 +67,12 @@ inputs:
   description: ''
   playbookInputQuery:
 - key: Is automated blocking activated ?
+  value:
+    simple: Administrator
+  required: true
+  description: ''
+  playbookInputQuery:
+- key: ResourceName
   value:
     simple: Administrator
   required: true


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-6206

## Description
- Updates the `collect_all_inputs_in_use` method to remove `}` from the PB input name.
- Added to **playbook_valid_inputs.yml** the input `ResourceName` and use it in the task like this:
`simple: ${inputs.ResourceName}`
 for testing the validation after the change.
