### PR TITLE
Graph validate fix

### DIFF
--- a/demisto_sdk/commands/common/hook_validations/graph_validator.py
+++ b/demisto_sdk/commands/common/hook_validations/graph_validator.py
@@ -31,9 +31,10 @@ class GraphValidator(BaseValidator):
         self.file_paths: List[str] = git_files or get_all_content_objects_paths_in_dir(
             input_files
         )
-        self.pack_ids: List[str] = list(
-            {get_pack_name(file_path) for file_path in self.file_paths}
-        )
+        self.pack_ids: List[str] = []
+        for file_path in self.file_paths:
+            if (pack_name := get_pack_name(file_path)) not in self.pack_ids:
+                self.pack_ids.append(pack_name)
 
     def __enter__(self):
         return self

--- a/demisto_sdk/commands/common/hook_validations/graph_validator.py
+++ b/demisto_sdk/commands/common/hook_validations/graph_validator.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from demisto_sdk.commands.common.errors import Errors
 from demisto_sdk.commands.common.hook_validations.base_validator import (
@@ -33,7 +33,8 @@ class GraphValidator(BaseValidator):
         )
         self.pack_ids: List[str] = []
         for file_path in self.file_paths:
-            if (pack_name := get_pack_name(file_path)) not in self.pack_ids:
+            pack_name: Optional[str] = get_pack_name(file_path)
+            if pack_name and pack_name not in self.pack_ids:
                 self.pack_ids.append(pack_name)
 
     def __enter__(self):

--- a/demisto_sdk/commands/content_graph/tests/graph_validator_test.py
+++ b/demisto_sdk/commands/content_graph/tests/graph_validator_test.py
@@ -610,3 +610,13 @@ def test_validate_duplicate_id(repository: ContentDTO, mocker):
         logger_info.call_args_list,
         "[GR105] - The ID 'SamplePlaybook' already exists in",
     )
+
+
+def test_pack_ids_collection():
+    git_files = [
+        "Tests/conf.json",
+        "Packs/MicrosoftExchangeOnline/Integrations/EwsExtension/README.md",
+    ]
+    expected_pack_ids = ["MicrosoftExchangeOnline"]
+    with GraphValidator(should_update=False, git_files=git_files) as graph_validator:
+        assert graph_validator.pack_ids == expected_pack_ids


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Description
fixes a Neo4j exception during validate:
```
neo4j.exceptions.CypherSyntaxError: {code: Neo.ClientError.Statement.SyntaxError} {message: Variable `None` not defined (line 7, column 50 (offset: 381))
"AND (p1.object_id in ['MicrosoftExchangeOnline', None] OR p2.object_id in ['MicrosoftExchangeOnline', None])"
```

occurred in https://github.com/demisto/content/pull/25594