### PR TITLE
log the output file in prepare_content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Added the pack version to the code files when calling **unify**. The same value is removed when calling **split**.
+* Added a message showing the output path when `prepare-content` is called.
 * Contribution PRs that update outdated packs now display a warning message.
 
 ## 1.12.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 * Added the pack version to the code files when calling **unify**. The same value is removed when calling **split**.
-* Added a message showing the output path when `prepare-content` is called.
+* Added a message showing the output path when **prepare-content** is called.
 * Contribution PRs that update outdated packs now display a warning message.
 
 ## 1.12.0

--- a/demisto_sdk/commands/prepare_content/prepare_upload_manager.py
+++ b/demisto_sdk/commands/prepare_content/prepare_upload_manager.py
@@ -1,7 +1,8 @@
+import logging
 import shutil
 from pathlib import Path
 from typing import Optional, Union
-import logging
+
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.interface.neo4j.neo4j_graph import (
     Neo4jContentGraphInterface,
@@ -11,6 +12,8 @@ from demisto_sdk.commands.content_graph.objects.content_item import ContentItem
 from demisto_sdk.commands.content_graph.objects.pack import Pack
 
 logger = logging.getLogger("demisto-sdk")
+
+
 class PrepareUploadManager:
     @staticmethod
     def prepare_for_upload(
@@ -67,6 +70,6 @@ class PrepareUploadManager:
             )
         with output.open("w") as f:
             content_item.handler.dump(data, f)
-            
+
         logger.info(f"[green]Output saved in: {str(output.absolute())}[/green]")
         return output

--- a/demisto_sdk/commands/prepare_content/prepare_upload_manager.py
+++ b/demisto_sdk/commands/prepare_content/prepare_upload_manager.py
@@ -1,7 +1,7 @@
 import shutil
 from pathlib import Path
 from typing import Optional, Union
-
+import logging
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.interface.neo4j.neo4j_graph import (
     Neo4jContentGraphInterface,
@@ -10,7 +10,7 @@ from demisto_sdk.commands.content_graph.objects.base_content import BaseContent
 from demisto_sdk.commands.content_graph.objects.content_item import ContentItem
 from demisto_sdk.commands.content_graph.objects.pack import Pack
 
-
+logger = logging.getLogger("demisto-sdk")
 class PrepareUploadManager:
     @staticmethod
     def prepare_for_upload(
@@ -67,5 +67,6 @@ class PrepareUploadManager:
             )
         with output.open("w") as f:
             content_item.handler.dump(data, f)
-
+            
+        logger.info(f"[green]Output saved in: {str(output.absolute())}[/green]")
         return output


### PR DESCRIPTION

## Related Issues
fixes: https://github.com/demisto/demisto-sdk/issues/2906

## Description
Currently we log only the unify step and print that we were succeeded to unify the YML, but we don't log the output file path so the user does not know where the file is saved.
