### PR TITLE
Add Missing `hiddenpassword` Field In Integration Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 * Added support for the `<~XPANSE>` marketplace tag in release notes.
 * Added support for marketplace tags in the **doc-review** command.
+* Fixed an issue where the **hiddenpassword** field was not recognized as a valid field.
 
 ## 1.13.0
 * Added the pack version to the code files when calling **unify**. The same value is removed when calling **split**.

--- a/demisto_sdk/commands/common/schemas/integration.yml
+++ b/demisto_sdk/commands/common/schemas/integration.yml
@@ -178,6 +178,8 @@ schema;configuration_schema:
       type: str
     hiddenusername:
       type: bool
+    hiddenpassword:
+      type: bool
     fromlicense:
       type: str
 


### PR DESCRIPTION
## Description
Add the `hiddenpassword` field to the integration schema, resolving an issue where the validation would fail when using this field (ex: https://github.com/demisto/content/pull/25917)

## Screenshots
**Before the changes:**
![Screenshot 2023-04-19 at 14 04 13](https://user-images.githubusercontent.com/8832013/233056158-632c53c4-902c-485d-9e62-1b5abdc54ee2.png)


**After the changes:**
![Screenshot 2023-04-19 at 14 05 31](https://user-images.githubusercontent.com/8832013/233056169-bee3070d-edd9-4b2e-ba38-ba3f1ddac5c1.png)
