### PR TITLE
removed unnecessary logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Added support for the `<~XPANSE>` marketplace tag in release notes.
 * Added support for marketplace tags in the **doc-review** command.
 * Updated the logs shown during lint when running in docker.
+* Fixed an issue in **validate** command where errors in unique files printed twice.
 * Added **generate-unit-tests** documentation to the repo README.
 * Added the `hiddenpassword` field to the integration schema, allowing **validate** to run on integrations with username-only inputs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Added support for the `<~XPANSE>` marketplace tag in release notes.
 * Added support for marketplace tags in the **doc-review** command.
 * Updated the logs shown during lint when running in docker.
-* Fixed an issue in **validate** command where errors in unique files printed twice.
+* Fixed an issue where **validate** showed errors twice.
 * Added **generate-unit-tests** documentation to the repo README.
 * Added the `hiddenpassword` field to the integration schema, allowing **validate** to run on integrations with username-only inputs.
 

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -1901,7 +1901,6 @@ class ValidateManager:
             self.id_set_validations
         )
         if pack_errors:
-            logger.info(f"[red]{pack_errors}[/red]")
             files_valid = False
 
         # check author image


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes:https://jira-hq.paloaltonetworks.local/browse/CIAC-6195

## Description
Fixed an issue where validate printed errors in uniqe files twice.
The line removed in not necessary because of https://github.com/demisto/demisto-sdk/blob/master/demisto_sdk/commands/common/hook_validations/base_validator.py#L258