### PR TITLE
update pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,14 @@
 exclude: demisto_sdk/tests/test_files/.*|.circleci/config.yml|demisto_sdk/commands/.*/tests/test_files/.*
 repos:
+    - repo: https://github.com/charliermarsh/ruff-pre-commit
+      rev: "v0.0.262"
+      hooks:
+        - id: ruff
+          args: [--fix, --exit-non-zero-on-fix]
+    - repo: https://github.com/psf/black
+      rev: "22.12.0"
+      hooks:
+          - id: black
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.4.0
       hooks:
@@ -13,15 +22,6 @@ repos:
             language_version: python3
           - id: name-tests-test
             exclude: test_tools.py|demisto_sdk/commands/download/tests/tests_env/.*|demisto_sdk/commands/create_artifacts/tests/data|demisto_sdk/commands/common/content/tests/objects/pack_objects/script/script_test/TestNotUnifiedScript|demisto_sdk/commands/common/content/tests/objects/pack_objects/integration/integration_test/TestNotUnifiedIntegration|demisto_sdk/commands/test_content/tests/DemistoClientMock
-    - repo: https://github.com/charliermarsh/ruff-pre-commit
-      rev: "v0.0.260"
-      hooks:
-        - id: ruff
-          args: [--fix, --exit-non-zero-on-fix]
-    - repo: https://github.com/psf/black
-      rev: "22.12.0"
-      hooks:
-          - id: black
     - repo: https://github.com/pre-commit/mirrors-mypy
       rev: v0.982
       hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,8 +10,6 @@ repos:
           - id: check-json
             exclude: .vscode/.*
           - id: check-yaml
-          - id: check-ast
-          - id: debug-statements
             language_version: python3
           - id: name-tests-test
             exclude: test_tools.py|demisto_sdk/commands/download/tests/tests_env/.*|demisto_sdk/commands/create_artifacts/tests/data|demisto_sdk/commands/common/content/tests/objects/pack_objects/script/script_test/TestNotUnifiedScript|demisto_sdk/commands/common/content/tests/objects/pack_objects/integration/integration_test/TestNotUnifiedIntegration|demisto_sdk/commands/test_content/tests/DemistoClientMock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,7 @@ select = [
     "PLE",
     "RUF100",
     "W",
+    "T10"
 ]
 
 target-version = "py38"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,7 @@ ignore = [
     "F403",
     "F405",
     "E501",
+    "W293",  # handled by Black
 ]
 
 
@@ -167,7 +168,7 @@ select = [
     "PLE",
     "RUF100",
     "W",
-    "T10"
+    "T10",
 ]
 
 target-version = "py38"


### PR DESCRIPTION
- Remove `check-ast` (py files) pre-commit step, as `ruff` does it faster
- Remove `debug-statements` pre-commit step
- Add `T10` rule for ruff
- Move `ruff`,`Black` before other pre-commit hooks
- Update ruff 0.260 to 0.262