### PR TITLE
Linter: copy multi level ApiModules to the lint dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+* Fixed an issue where **lint** would not properly handle imports of multi level ApiModules.
 
 ## Unreleased
 * **lint** now prevents unit-tests from accessing online resources in runtime.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Fixed an issue where **doc-review** required dot suffixes in release notes describing new content.
 * Improved logs and error handling in the **modeling-rules test** command.
 * Fixed an issue where **download** command failed when running on a beta integration.
-* Fixed an issue where **lint** would not properly handle imports of multi level ApiModules.
+* Added support for code importing multi-level ApiModules to **lint**.
 
 ## 1.13.0
 * Added the pack version to the code files when calling **unify**. The same value is removed when calling **split**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
 # Changelog
-* Fixed an issue where **lint** would not properly handle imports of multi level ApiModules.
 
 ## Unreleased
 * **lint** now prevents unit-tests from accessing online resources in runtime.
@@ -11,6 +10,7 @@
 * Added the `hiddenpassword` field to the integration schema, allowing **validate** to run on integrations with username-only inputs.
 * Fixed an issue where **doc-review** required dot suffixes in release notes describing new content.
 * Improved logs and error handling in the **modeling-rules test** command.
+* Fixed an issue where **lint** would not properly handle imports of multi level ApiModules.
 
 ## 1.13.0
 * Added the pack version to the code files when calling **unify**. The same value is removed when calling **split**.

--- a/demisto_sdk/commands/lint/helpers.py
+++ b/demisto_sdk/commands/lint/helpers.py
@@ -62,7 +62,7 @@ PY_CHCEKS = ["flake8", "XSOAR_linter", "bandit", "mypy", "vulture", "pytest", "p
 # Line break
 RL = "\n"
 
-IMPORT_API_MODULE_REGEX = r"from ([\w\d]+ApiModule) import \*(?:  # noqa: E402)?"
+IMPORT_API_MODULE_REGEX = r"from (\w+ApiModule) import \*(?:  # noqa: E402)?"
 
 logger = logging.getLogger("demisto-sdk")
 
@@ -279,8 +279,8 @@ def add_tmp_lint_files(
                 copied_common_server_python_path.touch()
                 added_modules.append(copied_common_server_python_path)
 
-            added_api_modules = add_api_modules(lint_files, content_repo, pack_path)
-            added_modules.extend(added_api_modules)
+            api_modules = add_api_modules(lint_files, content_repo, pack_path)
+            added_modules.extend(api_modules)
 
         yield
     except Exception as e:
@@ -288,11 +288,13 @@ def add_tmp_lint_files(
         raise
 
 
-def add_api_modules(module_list: List[Path], content_repo: Path, pack_path: Path):
+def add_api_modules(
+    module_list: List[Path], content_repo: Path, pack_path: Path
+) -> List[Path]:
     """Add API modules to directory if needed
     Args:
         modules_list(list): Modules that might import Api Modules
-        content_repo(Path): Repository object
+        content_repo(Path): Absolute path of the repository
         pack_path(Path): Absolute path of pack
     Returns:
         list[Path]: Paths of the added ApiModules
@@ -318,6 +320,7 @@ def add_api_modules(module_list: List[Path], content_repo: Path, pack_path: Path
                 copied_api_module_path.write_bytes(api_content)
 
             added_modules.append(copied_api_module_path)
+    # if there is added_modules - we recursively check for ApiModules imported by them
     return (
         added_modules + add_api_modules(added_modules, content_repo, pack_path)
         if added_modules

--- a/demisto_sdk/commands/lint/helpers.py
+++ b/demisto_sdk/commands/lint/helpers.py
@@ -62,6 +62,8 @@ PY_CHCEKS = ["flake8", "XSOAR_linter", "bandit", "mypy", "vulture", "pytest", "p
 # Line break
 RL = "\n"
 
+IMPORT_API_MODULE_REGEX = r"from ([\w\d]+ApiModule) import \*(?:  # noqa: E402)?"
+
 logger = logging.getLogger("demisto-sdk")
 
 
@@ -277,32 +279,50 @@ def add_tmp_lint_files(
                 copied_common_server_python_path.touch()
                 added_modules.append(copied_common_server_python_path)
 
-            # Add API modules to directory if needed
-            module_regex = r"from ([\w\d]+ApiModule) import \*(?:  # noqa: E402)?"
-            for lint_file in lint_files:
-                data = lint_file.read_text()
-                for module_name in re.findall(module_regex, data):
-                    api_code_path = (
-                        Path("Packs/ApiModules/Scripts")
-                        / module_name
-                        / f"{module_name}.py"
-                    )
-                    copied_api_module_path = pack_path / f"{module_name}.py"
-                    if content_repo:  # if working in a repo
-                        module_path = content_repo / api_code_path
-                        shutil.copy(src=module_path, dst=copied_api_module_path)
-                    else:
-                        api_content = get_remote_file(
-                            full_file_path=f"https://raw.githubusercontent.com/demisto/content/master/{api_code_path}",
-                            return_content=True,
-                        )
-                        copied_api_module_path.write_bytes(api_content)
+            added_api_modules = add_api_modules(lint_files, content_repo, pack_path)
+            added_modules.extend(added_api_modules)
 
-                    added_modules.append(copied_api_module_path)
         yield
     except Exception as e:
         logger.error(f"add_tmp_lint_files unexpected exception: {str(e)}")
         raise
+
+
+def add_api_modules(module_list: List[Path], content_repo: Path, pack_path: Path):
+    """Add API modules to directory if needed
+    Args:
+        modules_list(list): Modules that might import Api Modules
+        content_repo(Path): Repository object
+        pack_path(Path): Absolute path of pack
+    Returns:
+        list[Path]: Paths of the added ApiModules
+    Raises:
+        IOError: if can't write to files due permissions or other reasons
+    """
+    added_modules: List[Path] = []
+    for module in module_list:
+        api_modules = re.findall(IMPORT_API_MODULE_REGEX, module.read_text())
+        for module_name in api_modules:
+            api_module_path = Path(
+                f"Packs/ApiModules/Scripts/{module_name}/{module_name}.py"
+            )
+            copied_api_module_path = pack_path / f"{module_name}.py"
+            if content_repo:  # if working in a repo
+                module_path = content_repo / api_module_path
+                shutil.copy(src=module_path, dst=copied_api_module_path)
+            else:
+                api_content = get_remote_file(
+                    full_file_path=f"https://raw.githubusercontent.com/demisto/content/master/{api_module_path}",
+                    return_content=True,
+                )
+                copied_api_module_path.write_bytes(api_content)
+
+            added_modules.append(copied_api_module_path)
+    return (
+        added_modules + add_api_modules(added_modules, content_repo, pack_path)
+        if added_modules
+        else []
+    )
 
 
 @lru_cache(maxsize=300)


### PR DESCRIPTION

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-6336

## Description
currently, if an integration imports ApiModuleA and ApiModuleA imports ApiModuleB
only the  ApiModuleA copied to the lint directory

fix: go recursively on the imported ApiModules and copy all of them