### PR TITLE
demisto-sdk validate doesn't catch file name mismatch for xif file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added support for marketplace tags in the **doc-review** command.
 * Updated the logs shown during lint when running in docker.
 * Added **generate-unit-tests** documentation to the repo README.
+* Fixed an issue where **validate** did not fail when xif files had wrong naming.
 * Added the `hiddenpassword` field to the integration schema, allowing **validate** to run on integrations with username-only inputs.
 
 ## 1.13.0

--- a/demisto_sdk/commands/common/hook_validations/base_validator.py
+++ b/demisto_sdk/commands/common/hook_validations/base_validator.py
@@ -416,6 +416,8 @@ class BaseValidator:
             FileType.MODELING_RULE,
             FileType.PARSING_RULE,
             FileType.XIF_FILE,
+            FileType.MODELING_RULE_XIF,
+            FileType.PARSING_RULE_XIF
         }:
             if file_name != dir_name:
                 return False


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes:https://jira-hq.paloaltonetworks.local/browse/CIAC-6346

## Description
Fixed an issue where **validate** did not fail when xif files had wrong naming.
