### PR TITLE
Reales notes fix bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@
 * Added the `DEMISTO_SDK_GRAPH_FORCE_CREATE` environment variable. Use it to force the SDK to recreate the graph, rather than update it.
 * Added support for code importing multi-level ApiModules to **lint**.
 * Added a validation that the **modeling-rules test** command will fail if no test data file exist.
+* Standardized repo-wide logging. All logs are now created in one logger instance.
 * Improved the clarity of error messages for cases where yml files cannot be parsed as a dictionary.
 * Fixed an issue where **update-release-notes** generated release notes for packs in their initial version (1.0.0).
-* Standardized repo-wide logging. All logs are now created in one logger instance.
 
 ## 1.13.0
 * Added the pack version to the code files when calling **unify**. The same value is removed when calling **split**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 * Added the `DEMISTO_SDK_GRAPH_FORCE_CREATE` environment variable. Use it to force the SDK to recreate the graph, rather than update it.
 * Added support for code importing multi-level ApiModules to **lint**.
 * Added a validation that the **modeling-rules test** command will fail if no test data file exist.
+* Added more informative message when yml file is not parsed as a dict
+* Fixed an issue where **update-release-notes** would generate a new file for first version. 
 
 ## 1.13.0
 * Added the pack version to the code files when calling **unify**. The same value is removed when calling **split**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@
 * Added the `DEMISTO_SDK_GRAPH_FORCE_CREATE` environment variable. Use it to force the SDK to recreate the graph, rather than update it.
 * Added support for code importing multi-level ApiModules to **lint**.
 * Added a validation that the **modeling-rules test** command will fail if no test data file exist.
-* Added more informative message when yml file is not parsed as a dict
-* Fixed an issue where **update-release-notes** would generate a new file for first version. 
+* Added a better informative message when yml file is not parsed as a dict **common/tools.py**.
+* Fixed an issue where **update-release-notes** would generate a new file for first version.
 
 ## 1.13.0
 * Added the pack version to the code files when calling **unify**. The same value is removed when calling **split**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@
 * Added the `DEMISTO_SDK_GRAPH_FORCE_CREATE` environment variable. Use it to force the SDK to recreate the graph, rather than update it.
 * Added support for code importing multi-level ApiModules to **lint**.
 * Added a validation that the **modeling-rules test** command will fail if no test data file exist.
-* Added a better informative message when yml file is not parsed as a dict **common/tools.py**.
-* Fixed an issue where **update-release-notes** would generate a new file for first version.
+* Improved the clarity of error messages for cases where yml files cannot be parsed as a dictionary.
+* Fixed an issue where **update-release-notes** generated release notes for packs in their initial version (1.0.0).
 
 ## 1.13.0
 * Added the pack version to the code files when calling **unify**. The same value is removed when calling **split**.

--- a/demisto_sdk/commands/common/tests/tools_test.py
+++ b/demisto_sdk/commands/common/tests/tools_test.py
@@ -64,6 +64,7 @@ from demisto_sdk.commands.common.tools import (
     get_file_displayed_name,
     get_file_version_suffix_if_exists,
     get_files_in_dir,
+    get_from_version,
     get_ignore_pack_skipped_tests,
     get_item_marketplaces,
     get_last_release_version,
@@ -2621,3 +2622,21 @@ def test_get_core_packs(mocker):
 )
 def test_extract_field_from_mapping(mapping_value, expected_output):
     assert extract_field_from_mapping(mapping_value) == expected_output
+
+
+@pytest.mark.parametrize(
+    "returned_yml, res_from_version",
+    [
+        ({"fromversion": "6.1.0"}, "6.1.0"),
+        (
+            ["item1, item2"],
+            pytest.param(
+                0,
+                marks=pytest.mark.xfail(reason="yml file returned is not of type dict"),
+            ),
+        ),
+    ],
+)
+def test_get_from_version(returned_yml, res_from_version, mocker):
+    mocker.patch.object(tools, "get_yaml", return_value=returned_yml)
+    assert get_from_version("fake_file_path.yml") == res_from_version

--- a/demisto_sdk/commands/common/tests/tools_test.py
+++ b/demisto_sdk/commands/common/tests/tools_test.py
@@ -2629,10 +2629,12 @@ def test_extract_field_from_mapping(mapping_value, expected_output):
     [
         ({"fromversion": "6.1.0"}, "6.1.0"),
         (
-            ["item1, item2"],
             pytest.param(
-                0,
-                marks=pytest.mark.xfail(reason="yml file returned is not of type dict"),
+                ["item1, item2"],
+                marks=pytest.mark.xfail(
+                    raises=ValueError,
+                    reason="yml file returned is not of type dict"
+                ),
             ),
         ),
     ],

--- a/demisto_sdk/commands/common/tests/tools_test.py
+++ b/demisto_sdk/commands/common/tests/tools_test.py
@@ -2624,21 +2624,14 @@ def test_extract_field_from_mapping(mapping_value, expected_output):
     assert extract_field_from_mapping(mapping_value) == expected_output
 
 
-@pytest.mark.parametrize(
-    "returned_yml, res_from_version",
-    [
-        ({"fromversion": "6.1.0"}, "6.1.0"),
-        (
-            pytest.param(
-                ["item1, item2"],
-                marks=pytest.mark.xfail(
-                    raises=ValueError,
-                    reason="yml file returned is not of type dict"
-                ),
-            ),
-        ),
-    ],
-)
-def test_get_from_version(returned_yml, res_from_version, mocker):
-    mocker.patch.object(tools, "get_yaml", return_value=returned_yml)
-    assert get_from_version("fake_file_path.yml") == res_from_version
+def test_get_from_version(mocker):
+    mocker.patch.object(tools, "get_yaml", return_value={"fromversion": "6.1.0"})
+    assert get_from_version("fake_file_path.yml") == "6.1.0"
+
+
+def test_get_from_version_error(mocker):
+    mocker.patch.object(tools, "get_yaml", return_value=["item1, item2"])
+    with pytest.raises(ValueError) as e:
+        get_from_version("fake_file_path.yml")
+
+    assert str(e.value) == "yml file returned is not of type dict"

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -920,6 +920,9 @@ def get_from_version(file_path):
         get_yaml(file_path) if file_path.endswith("yml") else get_json(file_path)
     )
 
+    if not isinstance(data_dictionary, dict):
+        return ValueError("yml file returned is not of type dict")
+
     if data_dictionary:
         from_version = (
             data_dictionary.get("fromversion")

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -921,7 +921,7 @@ def get_from_version(file_path):
     )
 
     if not isinstance(data_dictionary, dict):
-        return ValueError("yml file returned is not of type dict")
+        raise ValueError("yml file returned is not of type dict")
 
     if data_dictionary:
         from_version = (

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -878,7 +878,7 @@ class TestRNUpdate:
             update_rn.bump_version_number()
         assert (
             "The metadata file of pack HelloWorld was not found. \
-                Please verify the pack name is correct, and that the file exsits."
+                Please verify the pack name is correct, and that the file exists."
             in execinfo.value.args[0]
         )
 

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -877,7 +877,8 @@ class TestRNUpdate:
         with pytest.raises(Exception) as execinfo:
             update_rn.bump_version_number()
         assert (
-            "Pack HelloWorld was not found. Please verify the pack name is correct."
+            "The metadata file of pack HelloWorld was not found. \
+                Please verify the pack name is correct, and that the file exsits."
             in execinfo.value.args[0]
         )
 

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -2732,11 +2732,11 @@ def test_get_file_description(path, file_type, expected_results):
 def test_no_release_notes_for_first_version(mocker):
     """
     Given:
-        - an empty dict of changed items
+        - Changes made in the content repo.
     When:
-        - we want to produce release notes template for a pack where only the pack_metadata file changed
-    Then:
-        - return a markdown string
+        - runing update release notes for the first version of the pack (1.0.0).
+    Then
+        - validate the a proper error message is raised.
     """
     mocker.patch.object(UpdateRN, "get_master_version", return_value="0.0.0")
     mocker.patch.object(UpdateRN, "is_bump_required", return_value=False)

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -877,8 +877,8 @@ class TestRNUpdate:
         with pytest.raises(Exception) as execinfo:
             update_rn.bump_version_number()
         assert (
-            "The metadata file of pack HelloWorld was not found. \
-                Please verify the pack name is correct, and that the file exists."
+            "The metadata file of pack HelloWorld was not found."
+            " Please verify the pack name is correct, and that the file exists."
             in execinfo.value.args[0]
         )
 

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -2726,3 +2726,30 @@ def test_get_file_description(path, file_type, expected_results):
         Ensure the function extracted the information from the right field.
     """
     assert get_file_description(path, file_type) == expected_results
+
+
+def test_no_release_notes_for_first_version(mocker):
+    """
+    Given:
+        - an empty dict of changed items
+    When:
+        - we want to produce release notes template for a pack where only the pack_metadata file changed
+    Then:
+        - return a markdown string
+    """
+    mocker.patch.object(UpdateRN, "get_master_version", return_value="0.0.0")
+    mocker.patch.object(UpdateRN, "is_bump_required", return_value=False)
+    mocker.patch.object(
+        UpdateRN, "get_pack_metadata", return_value={"currentVersion": "1.0.0"}
+    )
+    update_rn = UpdateRN(
+        pack_path="Packs/HelloWorld",
+        update_type="minor",
+        modified_files_in_pack=set(),
+        added_files=set(),
+        pack_metadata_only=True,
+    )
+
+    with pytest.raises(ValueError) as e:
+        update_rn.get_new_version_and_metadata()
+        assert str(e) == "Release notes do not need to be updated for version '1.0.0'."

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -549,7 +549,7 @@ class UpdateRN:
             data_dictionary = get_json(self.metadata_path, cache_clear=True)
         except FileNotFoundError as e:
             raise FileNotFoundError(
-                f"Pack {self.pack} metadata file, was not found. Please verify the pack name is correct, and that the file exsits."
+                f"The metadata file of pack {self.pack} was not found. Please verify the pack name is correct, and that the file exsits."
             ) from e
         return data_dictionary
 

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -549,7 +549,7 @@ class UpdateRN:
             data_dictionary = get_json(self.metadata_path, cache_clear=True)
         except FileNotFoundError as e:
             raise FileNotFoundError(
-                f"The metadata file of pack {self.pack} was not found. Please verify the pack name is correct, and that the file exsits."
+                f"The metadata file of pack {self.pack} was not found. Please verify the pack name is correct, and that the file exists."
             ) from e
         return data_dictionary
 

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -383,6 +383,12 @@ class UpdateRN:
         else:
             new_metadata = self.get_pack_metadata()
             new_version = new_metadata.get("currentVersion", "99.99.99")
+
+        if self.master_version == "0.0.0" and new_version == "1.0.0":
+            raise ValueError(
+                "Release notes do not need to be updated for version '1.0.0'."
+            )
+
         return new_version, new_metadata
 
     def _does_pack_metadata_exist(self) -> bool:
@@ -543,7 +549,7 @@ class UpdateRN:
             data_dictionary = get_json(self.metadata_path, cache_clear=True)
         except FileNotFoundError as e:
             raise FileNotFoundError(
-                f"Pack {self.pack} was not found. Please verify the pack name is correct."
+                f"Pack {self.pack} metadata file, was not found. Please verify the pack name is correct, and that the file exsits."
             ) from e
         return data_dictionary
 


### PR DESCRIPTION
## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-5848
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-6176

## Description
Added fixes to open dev-bugs. 
1. validate that get yml return value is of type dict. 
2. validate that no new release notes are being generated when running update-release-notes on a first version