### PR TITLE
update-content-graph ignored parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Standardized repo-wide logging. All logs are now created in one logger instance.
 * Improved the clarity of error messages for cases where yml files cannot be parsed as a dictionary.
 * Fixed an issue where **update-release-notes** generated release notes for packs in their initial version (1.0.0).
+* Fixed an issue with **update-content-graph** where `--use-git` parameter was ignored when using `--imported-path` parameter.
 
 ## 1.13.0
 * Added the pack version to the code files when calling **unify**. The same value is removed when calling **split**.

--- a/demisto_sdk/commands/content_graph/content_graph_commands.py
+++ b/demisto_sdk/commands/content_graph/content_graph_commands.py
@@ -80,10 +80,10 @@ def update_content_graph(
             # getting the graph from remote, so we need to clean the import dir
             extract_remote_import_files(content_graph_interface, builder)
 
+    content_graph_interface.import_graph(imported_path)
+
     if use_git and (commit := content_graph_interface.commit):
         packs_to_update.extend(GitUtil().get_all_changed_pack_ids(commit))
-
-    content_graph_interface.import_graph(imported_path)
 
     packs_str = "\n".join([f"- {p}" for p in packs_to_update])
     logger.info(f"Updating the following packs:\n{packs_str}")

--- a/demisto_sdk/commands/content_graph/objects/base_content.py
+++ b/demisto_sdk/commands/content_graph/objects/base_content.py
@@ -95,7 +95,6 @@ class BaseContent(ABC, BaseModel, metaclass=BaseContentMetaclass):
             "__fields_set__": self.__fields_set__,
         }
 
-
     @property
     def normalize_name(self) -> str:
         # if has name attribute, return it, otherwise return the object id

--- a/demisto_sdk/commands/content_graph/objects/base_content.py
+++ b/demisto_sdk/commands/content_graph/objects/base_content.py
@@ -78,15 +78,23 @@ class BaseContent(ABC, BaseModel, metaclass=BaseContentMetaclass):
         dict_copy = self.__dict__.copy()
 
         # This avoids circular references when pickling store only the first level relationships.
-        # Remove when updating to pydantic 2
-        for _, relationship_data in dict_copy["relationships_data"].items():
+        relationships_data_copy = dict_copy["relationships_data"].copy()
+        dict_copy["relationships_data"] = defaultdict(set)
+        for _, relationship_data in relationships_data_copy.items():
             for r in relationship_data:
-                r.content_item_to.relationships_data = defaultdict(set)
+                # override the relationships_data of the content item to avoid circular references
+                r: RelationshipData  # type: ignore[no-redef]
+                r_copy = r.copy()
+                content_item_to_copy = r_copy.content_item_to.copy()
+                r_copy.content_item_to = content_item_to_copy
+                content_item_to_copy.relationships_data = defaultdict(set)
+                dict_copy["relationships_data"][r.relationship_type].add(r_copy)
 
         return {
             "__dict__": dict_copy,
             "__fields_set__": self.__fields_set__,
         }
+
 
     @property
     def normalize_name(self) -> str:

--- a/demisto_sdk/commands/content_graph/objects/base_content.py
+++ b/demisto_sdk/commands/content_graph/objects/base_content.py
@@ -76,7 +76,8 @@ class BaseContent(ABC, BaseModel, metaclass=BaseContentMetaclass):
     def __getstate__(self):
         """Needed to for the object to be pickled correctly (to use multiprocessing)"""
         dict_copy = self.__dict__.copy()
-
+        if "relationships_data" not in dict_copy:
+            return super().__getstate__()
         # This avoids circular references when pickling store only the first level relationships.
         relationships_data_copy = dict_copy["relationships_data"].copy()
         dict_copy["relationships_data"] = defaultdict(set)

--- a/demisto_sdk/commands/content_graph/objects/base_content.py
+++ b/demisto_sdk/commands/content_graph/objects/base_content.py
@@ -75,9 +75,11 @@ class BaseContent(ABC, BaseModel, metaclass=BaseContentMetaclass):
 
     def __getstate__(self):
         """Needed to for the object to be pickled correctly (to use multiprocessing)"""
-        dict_copy = self.__dict__.copy()
-        if "relationships_data" not in dict_copy:
+        if "relationships_data" not in se;f.__dict__:
+            # if we don't have relationships, we can use the default __getstate__ method
             return super().__getstate__()
+
+        dict_copy = self.__dict__.copy()
         # This avoids circular references when pickling store only the first level relationships.
         relationships_data_copy = dict_copy["relationships_data"].copy()
         dict_copy["relationships_data"] = defaultdict(set)

--- a/demisto_sdk/commands/content_graph/objects/base_content.py
+++ b/demisto_sdk/commands/content_graph/objects/base_content.py
@@ -75,7 +75,7 @@ class BaseContent(ABC, BaseModel, metaclass=BaseContentMetaclass):
 
     def __getstate__(self):
         """Needed to for the object to be pickled correctly (to use multiprocessing)"""
-        if "relationships_data" not in se;f.__dict__:
+        if "relationships_data" not in self.__dict__:
             # if we don't have relationships, we can use the default __getstate__ method
             return super().__getstate__()
 


### PR DESCRIPTION
* Fixed issue with `update-content-graph -i <path> -g` that ignored 
* Store first level dependencies when using multiprocessing (during the dump method).

## Related Issues
fixes:

## Description

## Nightly
https://code.pan.run/xsoar/content/-/pipelines/5158419