### PR TITLE
remove `assert stderr == ''` from integration tests

### DIFF
--- a/demisto_sdk/tests/integration_tests/create_id_set_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/create_id_set_integration_test.py
@@ -94,7 +94,6 @@ class TestCreateIdSet:  # Use classes to speed up test - multi threaded py pytes
 
         assert IsEqualFunctions.is_dicts_equal(id_set_result, expected_id_set)
         assert result.exit_code == 0
-        assert result.stderr == ""
 
     def test_create_id_set_with_excluded_items_mini(self, mocker, repo):
         """
@@ -183,7 +182,6 @@ class TestCreateIdSet:  # Use classes to speed up test - multi threaded py pytes
 
         assert IsEqualFunctions.is_dicts_equal(id_set_result, expected_id_set)
         assert result.exit_code == 0
-        assert result.stderr == ""
 
     @staticmethod
     def test_excluded_items_contain_aliased_field(mocker, repo: Repo):

--- a/demisto_sdk/tests/integration_tests/error_code_info_test.py
+++ b/demisto_sdk/tests/integration_tests/error_code_info_test.py
@@ -13,7 +13,6 @@ def test_error_code_info_sanity():
         in result.output
     )
     assert result.exit_code == 0
-    assert result.stderr == ""
 
 
 def test_error_code_info_failure():
@@ -22,4 +21,3 @@ def test_error_code_info_failure():
 
     assert "No such error" in result.output
     assert result.exit_code == 1
-    assert result.stderr == ""


### PR DESCRIPTION
Fixed an issue where integration tests [failed](https://app.circleci.com/pipelines/github/demisto/demisto-sdk/23349/workflows/be5ae52c-9882-4f3e-ab0e-c63bd1f72440/jobs/187245/tests) on logger outputs