### PR TITLE
[generate-outputs] json-to-outputs - generate context paths for empty lists or dictionaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 * Fixed an issue where **update-release-notes** command failed when running on a pack that contains deprecated integrations without the `commands` section.
 * Fixed an issue where **validate** failed when attempting to map null values in a classifier.
+* Fixed an issue where **generate-outputs** did not generate context paths for empty lists or dictionaries in the response.
 
 ## 1.14.0
 * Added the `DEMISTO_SDK_GRAPH_FORCE_CREATE` environment variable. Use it to force the SDK to recreate the graph, rather than update it.

--- a/demisto_sdk/commands/generate_outputs/json_to_outputs/json_to_outputs.py
+++ b/demisto_sdk/commands/generate_outputs/json_to_outputs/json_to_outputs.py
@@ -99,10 +99,10 @@ def flatten_json(nested_json, camelize=False):
         except IndexError:
             name = name.title() if camelize else name
 
-        if isinstance(x, dict):
+        if isinstance(x, dict) and x:
             for a in x:
                 flatten(x[a], name + a + ".")
-        elif isinstance(x, list):
+        elif isinstance(x, list) and x:
             for a in x:
                 flatten(a, name[:-1] + ".")
         else:

--- a/demisto_sdk/commands/generate_outputs/json_to_outputs/tests/json_to_outputs_test.py
+++ b/demisto_sdk/commands/generate_outputs/json_to_outputs/tests/json_to_outputs_test.py
@@ -360,3 +360,46 @@ def test_determine_type(value, type):
         - ensure the returned type is correct
     """
     assert determine_type(value) == type
+
+
+def test_json_to_outputs__empty_list_or_dict():
+    """
+        Given
+            - valid json file: {"empty_dict":{},"empty_list":[]}
+            - prefix: XDR.Incident
+            - command: xdr-get-incidents
+        When
+            - passed to json_to_outputs
+        Then
+            - ensure outputs generated in the following format
+
+    arguments: []
+    name: xdr-get-incidents
+    outputs:
+    - contextPath: XDR.Incident.empty_dict
+      description: ''
+      type: Unknown
+    - contextPath: XDR.Incident.empty_list
+      description: ''
+      type: Unknown
+
+    """
+    yaml_output = parse_json(
+        data='{"empty_dict":{},"empty_list":[]}',
+        command_name="xdr-get-incidents",
+        prefix="XDR.Incident",
+    )
+
+    assert (
+            yaml_output
+            == """arguments: []
+name: xdr-get-incidents
+outputs:
+- contextPath: XDR.Incident.empty_dict
+  description: ''
+  type: Unknown
+- contextPath: XDR.Incident.empty_list
+  description: ''
+  type: Unknown
+"""
+    )


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-5925

## Description
* Fixed an issue where **generate-outputs** did not generate context paths for empty lists or dictionaries in the response.
