### PR TITLE
fail if modeling rules command fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fixed an issue where **run-unit-tests** failed on python2 content items.
 * Fixed an issue where **modeling-rules test** did not properly handle query fields that pointed to a string.
 * Fixed an issue when trying to fetch remote files when not under the content repo.
+* Fixed a validation that the **modeling-rules test** command will fail if no test data file exist.
 
 ## 1.14.3
 * Fixed an issue where **run-unit-tests** failed running on items with `test_data`.

--- a/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
+++ b/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
@@ -488,13 +488,14 @@ def validate_modeling_rule(
                     extra={"markup": True},
                 )
                 printr(execd_cmd)
-                raise typer.Abort()
+                raise typer.Exit(1)
         else:
             logger.error(
                 f"[red]Please create a test data file for {mrule_dir} and then rerun,[/red]",
                 extra={"markup": True},
             )
             printr(execd_cmd)
+            raise typer.Exit(1)
     else:
         logger.info(
             f"[cyan]Test data file found at {mr_entity.testdata_path}[/cyan]",


### PR DESCRIPTION
Fix fail if modeling rules command fails. 
Currently, it only prints the error in red, but it should fail the command as well. Adding exitcode 1.
## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-6618


