### PR TITLE
Add a Validation To Assure Feed Integrations Have A Reliability Parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fixed an issue where **upload** failed when using the `-z` flag.
 * Fixed an issue where **validate** fails when adding the *advance* field to the integration required fields.
 * Updated the integration Traffic Light Protocol (TLP) color list schema in the **validate** command.
+* Added a validation that feed integrations implement the `integration_reliability` configuration parameter.
 
 ## 1.15.0
 * **Breaking Change**: the **upload** command now only supports **XSOAR 6.5** or newer (and all XSIAM versions).
@@ -22,7 +23,6 @@
 * Fixed an issue in **pre-commit** where `--input` flag was not filtered by the git files.
 * Skip reset containers for XSOAR NG and XSIAM(PANW-internal only).
 * Fixed an issue where **lint** failed fetching docker image details from a PANW GitLab CI environment. (PANW-internal only).
-* Added a validation that feed integrations implement the `integrationReliability` configuration parameter.
 
 ## 1.14.5
 * Added logging in case the container fails to run in **run-unit-tests**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@
 * Added a validation that the **validate** command will fail if the `dockerimage` field in scripts/integrations uses any py3-native docker image.
 * Fixed an issue in **create-content-graph** which caused missing detection of duplicated content items.
 * Fixed an issue where **run-unit-tests** failed on python2 content items.
+* Fixed an issue where **lint** failed fetching docker image details from a PANW GitLab CI environment. (PANW-internal only)
 * Fixed an issue in **validate** where core packs validations were checked against the core packs defined on master branch, rather than on the current branch.
 * Fixed an issue in **pre-commit** where `--input` flag was not filtered by the git files.
 * Skip reset containers for XSOAR NG and XSIAM(PANW-internal only).
 * Fixed an issue where **lint** failed fetching docker image details from a PANW GitLab CI environment. (PANW-internal only).
+* Added a validation that feed integrations implement the `integrationReliability` configuration parameter.
 
 ## 1.14.5
 * Added logging in case the container fails to run in **run-unit-tests**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 * Added a validation that the **validate** command will fail if the `dockerimage` field in scripts/integrations uses any py3-native docker image.
 * Fixed an issue in **create-content-graph** which caused missing detection of duplicated content items.
 * Fixed an issue where **run-unit-tests** failed on python2 content items.
-* Fixed an issue where **lint** failed fetching docker image details from a PANW GitLab CI environment. (PANW-internal only)
 * Fixed an issue in **validate** where core packs validations were checked against the core packs defined on master branch, rather than on the current branch.
 * Fixed an issue in **pre-commit** where `--input` flag was not filtered by the git files.
 * Skip reset containers for XSOAR NG and XSIAM(PANW-internal only).

--- a/demisto_sdk/commands/common/constants.py
+++ b/demisto_sdk/commands/common/constants.py
@@ -1307,6 +1307,9 @@ ACCEPTED_FILE_EXTENSIONS = [
 ]
 ENDPOINT_COMMAND_NAME = "endpoint"
 
+# First item is the one that should be used (will appear in errors), others are for backwards compatibility
+RELIABILITY_PARAMETER_NAMES = ["integrationReliability", "reliability"]
+
 REPUTATION_COMMAND_NAMES = {"file", "email", "domain", "url", "ip", "cve"}
 
 BANG_COMMAND_NAMES = {"file", "email", "domain", "url", "ip", "cve", "endpoint"}

--- a/demisto_sdk/commands/common/constants.py
+++ b/demisto_sdk/commands/common/constants.py
@@ -1307,7 +1307,7 @@ ACCEPTED_FILE_EXTENSIONS = [
 ]
 ENDPOINT_COMMAND_NAME = "endpoint"
 
-RELIABILITY_PARAMETER_NAMES = [
+RELIABILITY_PARAMETER_NAMES = [  # First item is the one that will be used in errors.
     "integrationReliability",
     "feedReliability",
     "reliability",

--- a/demisto_sdk/commands/common/constants.py
+++ b/demisto_sdk/commands/common/constants.py
@@ -1307,8 +1307,8 @@ ACCEPTED_FILE_EXTENSIONS = [
 ]
 ENDPOINT_COMMAND_NAME = "endpoint"
 
-RELIABILITY_PARAMETER_NAMES = [  # First item is the one that will be used in errors.
-    "integrationReliability",
+RELIABILITY_PARAMETER_NAMES = [
+    "integrationReliability",  # First item in the list will be used in errors
     "feedReliability",
     "reliability",
 ]

--- a/demisto_sdk/commands/common/constants.py
+++ b/demisto_sdk/commands/common/constants.py
@@ -1309,6 +1309,7 @@ ENDPOINT_COMMAND_NAME = "endpoint"
 
 RELIABILITY_PARAMETER_NAMES = [
     "integrationReliability",  # First item in the list will be used in errors
+    "integration_reliability",
     "feedReliability",
     "reliability",
 ]

--- a/demisto_sdk/commands/common/constants.py
+++ b/demisto_sdk/commands/common/constants.py
@@ -1308,8 +1308,8 @@ ACCEPTED_FILE_EXTENSIONS = [
 ENDPOINT_COMMAND_NAME = "endpoint"
 
 RELIABILITY_PARAMETER_NAMES = [
-    "integrationReliability",  # First item in the list will be used in errors
-    "integration_reliability",
+    "integration_reliability",  # First item in the list will be used in errors
+    "integrationReliability",
     "feedReliability",
     "reliability",
 ]

--- a/demisto_sdk/commands/common/constants.py
+++ b/demisto_sdk/commands/common/constants.py
@@ -1307,8 +1307,11 @@ ACCEPTED_FILE_EXTENSIONS = [
 ]
 ENDPOINT_COMMAND_NAME = "endpoint"
 
-# First item is the one that should be used (will appear in errors), others are for backwards compatibility
-RELIABILITY_PARAMETER_NAMES = ["integrationReliability", "reliability"]
+RELIABILITY_PARAMETER_NAMES = [
+    "integrationReliability",
+    "feedReliability",
+    "reliability",
+]
 
 REPUTATION_COMMAND_NAMES = {"file", "email", "domain", "url", "ip", "cve"}
 

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -2482,8 +2482,8 @@ class Errors:
     @error_code_decorator
     def dbot_invalid_output(command_name, missing_outputs, context_standard):
         return (
-            "The DBotScore outputs of the reputation command {} aren't valid. Missing: {}. "
-            "Fix according to context standard {} ".format(
+            "The DBotScore outputs specified in the YAML file for the reputation command {} aren't complete. "
+            "Missing: {}. Fix according to context standard {} ".format(
                 command_name, missing_outputs, context_standard
             )
         )

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -14,6 +14,7 @@ from demisto_sdk.commands.common.constants import (
     MODULES,
     PACK_METADATA_DESC,
     PACK_METADATA_NAME,
+    RELIABILITY_PARAMETER_NAMES,
     RN_CONTENT_ENTITY_WITH_STARS,
     RN_HEADER_BY_FILE_TYPE,
     FileType,
@@ -2364,12 +2365,24 @@ class Errors:
     @staticmethod
     @error_code_decorator
     def missing_reliability_parameter(is_feed: bool, command_name: str | None = None):
-        # Assure function is called properly, as 'command' is required when 'is_feed' is False
+        """
+        Returns an error message for missing reliability parameter, according to provided arguments.
+
+        Args:
+            is_feed (bool): Whether the integration is a feed integration or not.
+            command_name (str | None, optional): The name of the command that is missing the reliability parameter.
+                Defaults to None. Required when is_feed is False.
+
+        Returns:
+            str: The error message.
+        """
+        # Assure 'command' parameter was passed if 'is_feed' is False
         if not is_feed and not command_name:
-            raise ValueError("If is_feed is False, command must be provided.")
+            raise ValueError("If 'is_feed' is set to False, command must be provided.")
 
         error_message = (
-            "must implement a reliability configuration parameter in the YAML file.\n"
+            f"must implement a reliability ('{RELIABILITY_PARAMETER_NAMES[0]}') configuration parameter"
+            f"in the YAML file.\n"
             "For more information, refer to https://xsoar.pan.dev/docs/integrations/dbot#reliability-level"
         )
 

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -2385,12 +2385,12 @@ class Errors:
 
         else:
             specific_case_error = (
-                f"Integrations with reputation commands{0} "
-                f"must implement a reliability parameter.".format(
+                "Integrations with reputation commands{0} ".format(
                     f" ('{command_name}')"  # Add reputation command's name to error if provided
                     if command_name
                     else ""
                 )
+                + "must implement a reliability parameter."
             )
 
         return (

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -2370,8 +2370,7 @@ class Errors:
             raise ValueError("If is_feed is False, command must be provided.")
 
         error_message = (
-            f"must implement the '{RELIABILITY_PARAMETER_NAMES[0]}' configuration parameter "
-            f"in the YAML file.\n"
+            f"must implement a reliability configuration parameter in the YAML file.\n"
             "For more information, refer to https://xsoar.pan.dev/docs/integrations/dbot#reliability-level"
         )
 

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -14,7 +14,6 @@ from demisto_sdk.commands.common.constants import (
     MODULES,
     PACK_METADATA_DESC,
     PACK_METADATA_NAME,
-    RELIABILITY_PARAMETER_NAMES,
     RN_CONTENT_ENTITY_WITH_STARS,
     RN_HEADER_BY_FILE_TYPE,
     FileType,
@@ -2370,7 +2369,7 @@ class Errors:
             raise ValueError("If is_feed is False, command must be provided.")
 
         error_message = (
-            f"must implement a reliability configuration parameter in the YAML file.\n"
+            "must implement a reliability configuration parameter in the YAML file.\n"
             "For more information, refer to https://xsoar.pan.dev/docs/integrations/dbot#reliability-level"
         )
 

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -12,6 +12,7 @@ from demisto_sdk.commands.common.constants import (
     MODULES,
     PACK_METADATA_DESC,
     PACK_METADATA_NAME,
+    RELIABILITY_PARAMETER_NAMES,
     RN_CONTENT_ENTITY_WITH_STARS,
     RN_HEADER_BY_FILE_TYPE,
     FileType,
@@ -2361,12 +2362,26 @@ class Errors:
 
     @staticmethod
     @error_code_decorator
-    def missing_reliability_parameter(command: str):
-        return (
-            f'Missing "Reliability" parameter in the {command} reputation command.'
-            f"Please add it to the YAML file."
-            f"For more information, refer to https://xsoar.pan.dev/docs/integrations/dbot#reliability-level"
-        )
+    def missing_reliability_parameter(is_feed: bool, command: str | None = None):
+        # Assure function is called properly, as 'command' is required when 'is_feed' is False
+        if not is_feed and not command:
+            raise ValueError(
+                "If is_feed is False, command must be provided."
+            )
+
+        error_message = f"must implement the '{RELIABILITY_PARAMETER_NAMES[0]}' configuration parameter " \
+                        f"in the YAML file.\n" \
+                        "For more information, refer to https://xsoar.pan.dev/docs/integrations/dbot#reliability-level"
+
+        if is_feed:
+            return (
+                f"Feed integrations {error_message}"
+            )
+
+        else:
+            return (
+                f'Integrations that contain reputation commands ({command}) {error_message}'
+            )
 
     @staticmethod
     @error_code_decorator
@@ -4419,7 +4434,7 @@ class Errors:
     @error_code_decorator
     def xsiam_report_files_naming_error(invalid_files: list):
         return (
-            f"The following xsiam report files do not match the naming conventions: {','.join(invalid_files)}.\n"
+            f"The following XSIAM report files do not match the naming conventions: {','.join(invalid_files)}.\n"
             f"XSIAM reports file name must use the pack's name as a prefix, e.g. `myPack-report1.yml`"
         )
 

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -2138,7 +2138,7 @@ class Errors:
     @staticmethod
     @error_code_decorator
     def added_required_fields(field):
-        return f"You've added required, the field is '{field}'"
+        return f"A required field ('{field}') has been added to an existing integration."
 
     @staticmethod
     @error_code_decorator

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -2365,23 +2365,19 @@ class Errors:
     def missing_reliability_parameter(is_feed: bool, command: str | None = None):
         # Assure function is called properly, as 'command' is required when 'is_feed' is False
         if not is_feed and not command:
-            raise ValueError(
-                "If is_feed is False, command must be provided."
-            )
+            raise ValueError("If is_feed is False, command must be provided.")
 
-        error_message = f"must implement the '{RELIABILITY_PARAMETER_NAMES[0]}' configuration parameter " \
-                        f"in the YAML file.\n" \
-                        "For more information, refer to https://xsoar.pan.dev/docs/integrations/dbot#reliability-level"
+        error_message = (
+            f"must implement the '{RELIABILITY_PARAMETER_NAMES[0]}' configuration parameter "
+            f"in the YAML file.\n"
+            "For more information, refer to https://xsoar.pan.dev/docs/integrations/dbot#reliability-level"
+        )
 
         if is_feed:
-            return (
-                f"Feed integrations {error_message}"
-            )
+            return f"Feed integrations {error_message}"
 
         else:
-            return (
-                f'Integrations that contain reputation commands ({command}) {error_message}'
-            )
+            return f"Integrations that contain reputation commands ({command}) {error_message}"
 
     @staticmethod
     @error_code_decorator

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -2138,7 +2138,9 @@ class Errors:
     @staticmethod
     @error_code_decorator
     def added_required_fields(field):
-        return f"A required field ('{field}') has been added to an existing integration."
+        return (
+            f"A required field ('{field}') has been added to an existing integration."
+        )
 
     @staticmethod
     @error_code_decorator
@@ -2371,15 +2373,11 @@ class Errors:
         Args:
             is_feed (bool): Whether the integration is a feed integration or not.
             command_name (str | None, optional): The name of the command that is missing the reliability parameter.
-                Defaults to None. Required when is_feed is False.
+                Defaults to None. Used on error message when is_feed is False.
 
         Returns:
             str: The error message.
         """
-        # Assure 'command' parameter was passed if 'is_feed' is False
-        if not is_feed and not command_name:
-            raise ValueError("If 'is_feed' is set to False, command must be provided.")
-
         if is_feed:
             specific_case_error = (
                 "Feed integrations must implement a reliability parameter."
@@ -2387,8 +2385,12 @@ class Errors:
 
         else:
             specific_case_error = (
-                f"Integrations with reputation commands ('{command_name}') "
-                "must implement a reliability parameter."
+                f"Integrations with reputation commands{0} "
+                f"must implement a reliability parameter.".format(
+                    f" ('{command_name}')"  # Add reputation command's name to error if provided
+                    if command_name
+                    else ""
+                )
             )
 
         return (

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -2380,17 +2380,22 @@ class Errors:
         if not is_feed and not command_name:
             raise ValueError("If 'is_feed' is set to False, command must be provided.")
 
-        error_message = (
-            f"must implement a reliability ('{RELIABILITY_PARAMETER_NAMES[0]}') configuration parameter"
-            f"in the YAML file.\n"
-            "For more information, refer to https://xsoar.pan.dev/docs/integrations/dbot#reliability-level"
-        )
-
         if is_feed:
-            return f"Feed integrations {error_message}"
+            specific_case_error = (
+                "Feed integrations must implement a reliability parameter."
+            )
 
         else:
-            return f"Integrations that contain reputation commands ({command_name}) {error_message}"
+            specific_case_error = (
+                f"Integrations with reputation commands ('{command_name}') "
+                "must implement a reliability parameter."
+            )
+
+        return (
+            f"Missing a reliability ('{RELIABILITY_PARAMETER_NAMES[0]}') configuration parameter in the YAML file.\n"
+            f"{specific_case_error}\n"
+            "For more information, refer to https://xsoar.pan.dev/docs/integrations/dbot#reliability-level"
+        )
 
     @staticmethod
     @error_code_decorator

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -2386,9 +2386,7 @@ class Errors:
         else:
             specific_case_error = (
                 "Integrations with reputation commands{0} ".format(
-                    f" ('{command_name}')"  # Add reputation command's name to error if provided
-                    if command_name
-                    else ""
+                    f" ('{command_name}')" if command_name else ""
                 )
                 + "must implement a reliability parameter."
             )

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -2482,10 +2482,8 @@ class Errors:
     @error_code_decorator
     def dbot_invalid_output(command_name, missing_outputs, context_standard):
         return (
-            "The DBotScore outputs specified in the YAML file for the reputation command {} aren't complete. "
-            "Missing: {}. Fix according to context standard {} ".format(
-                command_name, missing_outputs, context_standard
-            )
+            f"The DBotScore outputs specified in the YAML file for the reputation command '{command_name}' "
+            f"aren't valid. Missing: {missing_outputs}. Fix according to context standard {context_standard}"
         )
 
     @staticmethod

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -2364,9 +2364,9 @@ class Errors:
 
     @staticmethod
     @error_code_decorator
-    def missing_reliability_parameter(is_feed: bool, command: str | None = None):
+    def missing_reliability_parameter(is_feed: bool, command_name: str | None = None):
         # Assure function is called properly, as 'command' is required when 'is_feed' is False
-        if not is_feed and not command:
+        if not is_feed and not command_name:
             raise ValueError("If is_feed is False, command must be provided.")
 
         error_message = (
@@ -2379,7 +2379,7 @@ class Errors:
             return f"Feed integrations {error_message}"
 
         else:
-            return f"Integrations that contain reputation commands ({command}) {error_message}"
+            return f"Integrations that contain reputation commands ({command_name}) {error_message}"
 
     @staticmethod
     @error_code_decorator

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from distutils.version import LooseVersion
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union

--- a/demisto_sdk/commands/common/hook_validations/integration.py
+++ b/demisto_sdk/commands/common/hook_validations/integration.py
@@ -205,7 +205,7 @@ class IntegrationValidator(ContentEntityValidator):
             self.is_valid_description(beta_integration=False),
             self.is_context_correct_in_readme(),
             self.verify_yml_commands_match_readme(is_modified),
-            self.verify_reputation_commands_has_reliability(is_modified),
+            self.verify_reputation_commands_has_reliability(),
             self.is_integration_deprecated_and_used(),
         ]
 
@@ -2217,18 +2217,14 @@ class IntegrationValidator(ContentEntityValidator):
         return is_valid
 
     @error_codes("IN154")
-    def verify_reputation_commands_has_reliability(self, is_modified: bool = False):
+    def verify_reputation_commands_has_reliability(self):
         """
         In case the integration has reputation command, ensure there is a reliability parameter.
-        Args:
-            is_modified (bool): Whether the given files are modified or not.
 
         Return:
             bool: True if there are no reputation commands or there is a reliability parameter
              and False if there is at least one reputation command without a reliability parameter in the configuration.
         """
-        if not is_modified:
-            return True
         commands_names = [
             command.get("name")
             for command in self.current_file.get("script", {}).get("commands", [])

--- a/demisto_sdk/commands/common/hook_validations/integration.py
+++ b/demisto_sdk/commands/common/hook_validations/integration.py
@@ -1257,7 +1257,6 @@ class IntegrationValidator(ContentEntityValidator):
         """
         fetch_params_exist = True
         if self.current_file.get("script", {}).get("isfetch") is True:
-
             # get the iten marketplaces to decide which are the required params
             # if no marketplaces or xsoar in marketplaces - the required params will be INCIDENT_FETCH_REQUIRED_PARAMS (with Incident type etc. )
             # otherwise it will be the ALERT_FETCH_REQUIRED_PARAMS (with Alert type etc. )
@@ -1676,7 +1675,6 @@ class IntegrationValidator(ContentEntityValidator):
 
         if integrations_folder == "Integrations":
             if not integration_file.startswith("integration-"):
-
                 (
                     error_message,
                     error_code,
@@ -1888,7 +1886,6 @@ class IntegrationValidator(ContentEntityValidator):
         valid_files = []
 
         for file_path in files_to_check:
-
             file_name = os.path.basename(file_path)
             if file_name.startswith("README"):
                 continue
@@ -1911,7 +1908,6 @@ class IntegrationValidator(ContentEntityValidator):
                 valid_files.append(valid_base_name.join(file_name.rsplit(base_name, 1)))
 
         if invalid_files:
-
             error_message, error_code = Errors.file_name_has_separators(
                 "integration", invalid_files, valid_files
             )
@@ -2227,14 +2223,15 @@ class IntegrationValidator(ContentEntityValidator):
              and False if there is at least one reputation command without a reliability parameter in the configuration.
         """
         yml_config_names = [
-                config_item["name"].casefold()
-                for config_item in self.current_file.get("configuration", {}) if config_item.get("name")
-            ]
+            config_item["name"].casefold()
+            for config_item in self.current_file.get("configuration", {})
+            if config_item.get("name")
+        ]
 
         # Integration has a reliability parameter
         if any(
-                reliability_parameter_name.casefold() in yml_config_names
-                for reliability_parameter_name in RELIABILITY_PARAMETER_NAMES
+            reliability_parameter_name.casefold() in yml_config_names
+            for reliability_parameter_name in RELIABILITY_PARAMETER_NAMES
         ):
             return True
 
@@ -2247,26 +2244,30 @@ class IntegrationValidator(ContentEntityValidator):
                 )
 
                 if self.handle_error(
-                        error_message, error_code, file_path=self.file_path
+                    error_message, error_code, file_path=self.file_path
                 ):
                     return False
 
             else:
                 commands_names = [
                     command.get("name")
-                    for command in self.current_file.get("script", {}).get("commands", [])
+                    for command in self.current_file.get("script", {}).get(
+                        "commands", []
+                    )
                 ]
 
                 for command in commands_names:
                     # Integration has a reputation command
                     if command in REPUTATION_COMMAND_NAMES:
-                        error_message, error_code = Errors.missing_reliability_parameter(
-                            is_feed=False,
-                            command_name=command
+                        (
+                            error_message,
+                            error_code,
+                        ) = Errors.missing_reliability_parameter(
+                            is_feed=False, command_name=command
                         )
 
                         if self.handle_error(
-                                error_message, error_code, file_path=self.file_path
+                            error_message, error_code, file_path=self.file_path
                         ):
                             return False
 

--- a/demisto_sdk/commands/common/hook_validations/integration.py
+++ b/demisto_sdk/commands/common/hook_validations/integration.py
@@ -2235,7 +2235,7 @@ class IntegrationValidator(ContentEntityValidator):
         ):
             return True
 
-        # Doesn't have reliability parameter
+        # Integration doesn't have a reliability parameter
         else:
             # Is a feed integration
             if bool(self.current_file.get("script", {}).get("feed")):

--- a/demisto_sdk/commands/common/tests/integration_test.py
+++ b/demisto_sdk/commands/common/tests/integration_test.py
@@ -1817,10 +1817,7 @@ class TestIntegrationValidator:
         structure = mock_structure("", current)
         validator = IntegrationValidator(structure)
         validator.current_file = current
-        assert (
-            validator.verify_reputation_commands_has_reliability()
-            is result
-        )
+        assert validator.verify_reputation_commands_has_reliability() is result
 
     @pytest.mark.parametrize(
         "hidden_value,is_valid",

--- a/demisto_sdk/commands/common/tests/integration_test.py
+++ b/demisto_sdk/commands/common/tests/integration_test.py
@@ -1782,17 +1782,22 @@ class TestIntegrationValidator:
         assert validator.is_unskipped_integration(conf_dict) is answer
 
     VERIFY_REPUTATION_COMMANDS = [
-        (["test1", "test2"], False, True),
-        (["test1", "url"], False, False),
-        (["test1", "url"], True, True),
-        (["domain", "url"], True, True),
+        # Test feed integration validation
+        (["test1", "test2"], True, False, False),
+        (["test3", "test4"], True, True, True),
+
+        # Test reputation commands validation
+        (["test5", "test6"], False, False, True),
+        (["test7", "url"], False, False, False),
+        (["test8", "url"], False, True, True),
+        (["domain", "url"], False, True, True),
     ]
 
     @pytest.mark.parametrize(
-        "commands, has_reliability, result", VERIFY_REPUTATION_COMMANDS
+        "commands, is_feed, has_reliability, result", VERIFY_REPUTATION_COMMANDS
     )
     def test_verify_reputation_commands_has_reliability(
-        self, commands, has_reliability, result
+        self, commands: list[str], is_feed: bool, has_reliability: bool, result: bool
     ):
         """
         Given
@@ -1802,20 +1807,19 @@ class TestIntegrationValidator:
         Then
             - Ensure the command fails when there is a reputation command without reliability parameter.
         """
+        current = {"script": {"commands": [{"name": command} for command in commands]}}
 
-        current = (
-            {
-                "script": {"commands": [{"name": command} for command in commands]},
-                "configuration": [{"name": "integrationReliability"}],
-            }
-            if has_reliability
-            else {"script": {"commands": [{"name": command} for command in commands]}}
-        )
+        if is_feed:
+            current["script"]["feed"] = True
+
+        if has_reliability:
+            current["configuration"] = [{"name": "integrationReliability"}]
+
         structure = mock_structure("", current)
         validator = IntegrationValidator(structure)
         validator.current_file = current
         assert (
-            validator.verify_reputation_commands_has_reliability(is_modified=True)
+            validator.verify_reputation_commands_has_reliability()
             is result
         )
 

--- a/demisto_sdk/commands/common/tests/integration_test.py
+++ b/demisto_sdk/commands/common/tests/integration_test.py
@@ -1785,7 +1785,6 @@ class TestIntegrationValidator:
         # Test feed integration validation
         (["test1", "test2"], True, False, False),
         (["test3", "test4"], True, True, True),
-
         # Test reputation commands validation
         (["test5", "test6"], False, False, True),
         (["test7", "url"], False, False, False),
@@ -1797,7 +1796,7 @@ class TestIntegrationValidator:
         "commands, is_feed, has_reliability, result", VERIFY_REPUTATION_COMMANDS
     )
     def test_verify_reputation_commands_has_reliability(
-        self, commands: list[str], is_feed: bool, has_reliability: bool, result: bool
+        self, commands, is_feed, has_reliability, result
     ):
         """
         Given


### PR DESCRIPTION
## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-3678

## Description
Make the existing `IN154` run on non-modified (new) files as well, and assure feeds have a reliability parameter as well.