### PR TITLE
Fix execute tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 # Changelog
 
 ## Unreleased
-* Skip reset containers for XSOAR NG and XSIAM(PANW-internal only)
 * **Breaking Change**: the **upload** command now only supports XSOAR 6.5 or newer (and all XSIAM versions).
 * **upload** now uses content models, and calls the `prepare` method of each model before uploading (unless uploading a zipped pack).
 * Added a validation that the **validate** command will fail if the `dockerimage` field in scripts/integrations uses any py3-native docker image.
 * Fixed an issue in **create-content-graph** which caused missing detection of duplicated content items.
 * Fixed an issue where **run-unit-tests** failed on python2 content items.
-* Fixed an issue where **lint** failed fetching docker image details from a PANW GitLab CI environment. (PANW-internal only)
 * Fixed an issue in **validate** where core packs validations were checked against the core packs defined on master branch, rather than on the current branch.
 * Fixed an issue in **pre-commit** where `--input` flag was not filtered by the git files.
+* Skip reset containers for XSOAR NG and XSIAM(PANW-internal only).
+* Fixed an issue where **lint** failed fetching docker image details from a PANW GitLab CI environment. (PANW-internal only).
 
 ## 1.14.5
 * Added logging in case the container fails to run in **run-unit-tests**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Skip reset containers for XSOAR NG and XSIAM(PANW-internal only)
 * **Breaking Change**: the **upload** command now only supports XSOAR 6.5 or newer (and all XSIAM versions).
 * **upload** now uses content models, and calls the `prepare` method of each model before uploading (unless uploading a zipped pack).
 * Added a validation that the **validate** command will fail if the `dockerimage` field in scripts/integrations uses any py3-native docker image.

--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -2712,9 +2712,7 @@ class ServerContext:
             )
         return
 
-        self.build_context.logging_module.info(
-            "Resetting containers\n", real_time=True
-        )
+        self.build_context.logging_module.info("Resetting containers\n", real_time=True)
 
         body, status_code, _ = demisto_client.generic_request_func(
             self=self.client, method="POST", path="/containers/reset"

--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -2710,7 +2710,7 @@ class ServerContext:
             self.build_context.logging_module.info(
                 "Skip reset containers - this API is not supported.", real_time=True
             )
-        return
+            return
 
         self.build_context.logging_module.info("Resetting containers\n", real_time=True)
 

--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -2706,18 +2706,21 @@ class ServerContext:
         )
 
     def _reset_containers(self):
-        self.build_context.logging_module.info("Resetting containers\n", real_time=True)
+        if self.build_context.server_numeric_version == '99.99.98':
+            self.build_context.logging_module.info("Skip reset containers - this API is not supported.", real_time=True)
+        else:
+            self.build_context.logging_module.info("Resetting containers\n", real_time=True)
 
-        body, status_code, _ = demisto_client.generic_request_func(
-            self=self.client, method="POST", path="/containers/reset"
-        )
-        if status_code != 200:
-            self.build_context.logging_module.critical(
-                f'Request to reset containers failed with status code "{status_code}"\n{body}',
-                real_time=True,
+            body, status_code, _ = demisto_client.generic_request_func(
+                self=self.client, method="POST", path="/containers/reset"
             )
-            sys.exit(1)
-        time.sleep(10)
+            if status_code != 200:
+                self.build_context.logging_module.critical(
+                    f'Request to reset containers failed with status code "{status_code}"\n{body}',
+                    real_time=True,
+                )
+                sys.exit(1)
+            time.sleep(10)
 
     def execute_tests(self):
 

--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -2706,10 +2706,14 @@ class ServerContext:
         )
 
     def _reset_containers(self):
-        if self.build_context.server_numeric_version == '99.99.98':
-            self.build_context.logging_module.info("Skip reset containers - this API is not supported.", real_time=True)
+        if self.build_context.server_numeric_version == "99.99.98":
+            self.build_context.logging_module.info(
+                "Skip reset containers - this API is not supported.", real_time=True
+            )
         else:
-            self.build_context.logging_module.info("Resetting containers\n", real_time=True)
+            self.build_context.logging_module.info(
+                "Resetting containers\n", real_time=True
+            )
 
             body, status_code, _ = demisto_client.generic_request_func(
                 self=self.client, method="POST", path="/containers/reset"

--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -2706,7 +2706,7 @@ class ServerContext:
         )
 
     def _reset_containers(self):
-        if self.build_context.server_numeric_version == "99.99.98":
+        if self.build_context.is_xsiam:
             self.build_context.logging_module.info(
                 "Skip reset containers - this API is not supported.", real_time=True
             )

--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -2710,21 +2710,22 @@ class ServerContext:
             self.build_context.logging_module.info(
                 "Skip reset containers - this API is not supported.", real_time=True
             )
-        else:
-            self.build_context.logging_module.info(
-                "Resetting containers\n", real_time=True
-            )
+        return
 
-            body, status_code, _ = demisto_client.generic_request_func(
-                self=self.client, method="POST", path="/containers/reset"
+        self.build_context.logging_module.info(
+            "Resetting containers\n", real_time=True
+        )
+
+        body, status_code, _ = demisto_client.generic_request_func(
+            self=self.client, method="POST", path="/containers/reset"
+        )
+        if status_code != 200:
+            self.build_context.logging_module.critical(
+                f'Request to reset containers failed with status code "{status_code}"\n{body}',
+                real_time=True,
             )
-            if status_code != 200:
-                self.build_context.logging_module.critical(
-                    f'Request to reset containers failed with status code "{status_code}"\n{body}',
-                    real_time=True,
-                )
-                sys.exit(1)
-            time.sleep(10)
+            sys.exit(1)
+        time.sleep(10)
 
     def execute_tests(self):
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-6653

## Description
Reset containers request(POST request to`/containers/reset`) failed in NG machines with the error:

>  {"id":"errUnsupportedAPI","status":400,"title":"this API is not supported","detail":"this API is not supported","error":"this API is not supported (52000)","encrypted":false,"multires":null}

see[ this build](https://code.pan.run/xsoar/content/-/jobs/25947200) for example

I updated the **_reset_containers** method to continue and not reset containers when the version is XSAIM or NG.
