### PR TITLE
[demisto-sdk download] Add init flag

### DIFF
--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -1437,6 +1437,18 @@ def upload(ctx, **kwargs):
         case_sensitive=False,
     ),
 )
+@click.option(
+    "--init",
+    help="Create a directory structure and download all the custom content items",
+    is_flag=True,
+    default=False,
+)
+@click.option(
+    "--keep-empty-folders",
+    help="Keep empty folders when using the --init flag",
+    is_flag=True,
+    default=False,
+)
 @click.pass_context
 @logging_setup_decorator
 def download(ctx, **kwargs):


### PR DESCRIPTION
## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-6701

## Description
To facilitate the migration process from dev/prod to ci/cd, the init flag was added to the download command.