### PR TITLE
v1.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+
+## 1.15.1
 * Fixed an issue where **generate-docs** generated fields with double html escaping.
 * Fixed an issue where **upload** failed when using the `-z` flag.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "demisto-sdk"
-version = "1.15.0"
+version = "1.15.1"
 description = "\"A Python library for the Demisto SDK\""
 authors = ["Demisto"]
 license = "MIT"


### PR DESCRIPTION
* Fixed an issue where **generate-docs** generated fields with double html escaping.
* Fixed an issue where **upload** failed when using the `-z` flag.