### PR TITLE
fix upload config file parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
 ## Unreleased
-* Fixed an issue where **upload** failed parsing a configuration file.
 * Fixed an issue where **validate** fails when adding the *advance* field to the integration required fields.
 * Updated the integration Traffic Light Protocol (TLP) color list schema in the **validate** command.
+* Fixed an issue where **upload** would not read a repo configuration file properly.
+* Fixed an issue where **upload** would not handle the `-x`/`--xsiam` flag properly.
 
 ## 1.15.1
 * Fixed an issue where **generate-docs** generated fields with double html escaping.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Fixed an issue where **upload** failed parsing a configuration file.
 
 ## 1.15.1
 * Fixed an issue where **generate-docs** generated fields with double html escaping.

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -3581,11 +3581,11 @@ def get_id(file_content: Dict) -> Union[str, None]:
 
 def parse_marketplace_kwargs(kwargs: Dict[str, Any]) -> MarketplaceVersions:
     """
-    Supports both the `marketplace` argument and `is_xsiam`.
+    Supports both the `marketplace` argument and `xsiam`.
     Raises an error when both are supplied.
     """
     marketplace = kwargs.pop("marketplace", None)  # removing to not pass it twice later
-    is_xsiam = kwargs.get("is_xsiam")
+    is_xsiam = kwargs.get("xsiam")
 
     if (
         marketplace
@@ -3593,7 +3593,7 @@ def parse_marketplace_kwargs(kwargs: Dict[str, Any]) -> MarketplaceVersions:
         and MarketplaceVersions(marketplace) != MarketplaceVersions.MarketplaceV2
     ):
         raise ValueError(
-            "The arguments `marketplace` and `is_xsiam` cannot be used at the same time, remove one of them."
+            "The arguments `marketplace` and `xsiam` cannot be used at the same time, remove one of them."
         )
 
     if is_xsiam:

--- a/demisto_sdk/commands/upload/uploader.py
+++ b/demisto_sdk/commands/upload/uploader.py
@@ -479,7 +479,7 @@ class ConfigFileParser:
             self.content = json.load(f)
 
         self.custom_packs_paths: Tuple[Path, ...] = tuple(
-            Path(pack.get["url"]) for pack in self.content.get("custom_packs", ())
+            Path(pack["url"]) for pack in self.content.get("custom_packs", ())
         )
 
 


### PR DESCRIPTION
* Fixed an issue where **upload** would not read a repo configuration file properly.
* Fixed an issue where **upload** would not handle the `-x`/`--xsiam` flag properly.