### PR TITLE
1.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+
+## 1.15.2
 * Fixed an issue where **format** added default arguments to reputation commands which already have one.
 * Fixed an issue where **validate** fails when adding the *advance* field to the integration required fields.
 * Updated the integration Traffic Light Protocol (TLP) color list schema in the **validate** command.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "demisto-sdk"
-version = "1.15.1"
+version = "1.15.2"
 description = "\"A Python library for the Demisto SDK\""
 authors = ["Demisto"]
 license = "MIT"


### PR DESCRIPTION
* Fixed an issue where **format** added default arguments to reputation commands which already have one.
* Fixed an issue where **validate** fails when adding the *advance* field to the integration required fields.
* Updated the integration Traffic Light Protocol (TLP) color list schema in the **validate** command.
* Fixed an issue where **upload** would not read a repo configuration file properly.
* Fixed an issue where **upload** would not handle the `-x`/`--xsiam` flag properly.
