### PR TITLE
upload --input-config-file error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Added the PEP484 (no-implicit-optional) hook to **pre-commit**.
+* Fixed an issue where **upload** failed to parse custom content packs.
 
 ## 1.15.2
 * Fixed an issue where **format** added default arguments to reputation commands which already have one.

--- a/demisto_sdk/commands/upload/upload.py
+++ b/demisto_sdk/commands/upload/upload.py
@@ -75,9 +75,7 @@ def zip_multiple_packs(
             were_zipped.append(path)
             continue
 
-        pack = None
-        with suppress(Exception):
-            pack = BaseContent.from_path(path)
+        pack = BaseContent.from_path(path)
         if (pack is None) or (not isinstance(pack, Pack)):
             logger.error(f"[red]could not parse pack from {path}, skipping[/red]")
             continue


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://github.com/demisto/demisto-sdk/issues/3066

## Description
```
(content-py3.10) ➜  heimdall git:(emailall) demisto-sdk upload  --input-config-file xsoar_config.json
You are using demisto-sdk 1.15.2.
Uploading files from config file
Parsing Pack:TEST
Dumped pack TEST.
Uploading /tmp/tmpoyv02zne/uploadable_packs.zip to https://xsoar.local...
UPLOAD SUMMARY:

SUCCESSFUL UPLOADS:
╒══════════════════════╤════════╕
│ NAME                 │ TYPE   │
╞══════════════════════╪════════╡
│ uploadable_packs.zip │ Pack   │
╘══════════════════════╧════════╛
```
