### PR TITLE
1.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+
+## 1.15.3
 * Added the `--init` flag to **download**.
 * Added the `--keep-empty-folders` flag to **download**.
 * Added `markdown-lint` to **pre-commit**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "demisto-sdk"
-version = "1.15.2"
+version = "1.15.3"
 description = "\"A Python library for the Demisto SDK\""
 authors = ["Demisto"]
 license = "MIT"


### PR DESCRIPTION
* Added the `--init` flag to **download**.
* Added the `--keep-empty-folders` flag to **download**.
* Added `markdown-lint` to **pre-commit**
* Added the PEP484 (no-implicit-optional) hook to **pre-commit**.
* Fixed an issue where the content-graph parsing failed on mappers with undefined mapping.
* Fixed an issue in **validate** where `pack_metadata.json` files were not collected proplely in `--graph` option.
* Fixed an issue where *validate* reputation commands outputs were not checked for new content.
* Added *IN107* and *DB100* error codes to *ALLOWED_IGNORE_ERRORS* list.
* Added a validation that assures feed integrations implement the `integration_reliability` configuration parameter.
* Fixed an issue where the format command did not work as expected on pre-process rules files.
* Fixed an issue where **upload** command failed to upload when the XSOAR version is beta.
* Fixed an issue where **upload** command summary was inaccurate when uploading a `Pack` without the `-z` flag.
* Added pack name and pack version to **upload** command summary.
* Added support for modeling rules with multi datasets in ****modeling-rules test**** command.
* Fixed an issue where **validate** didn't recognize layouts with incident fields missing from `id_set.json` even when `--post-commit` was indicated.
