### PR TITLE
added the time field to the test-modeling-rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-- Fixed an issue where *update-release-notes* and *doc-review* did not handle new content notes as expected.
+* Fixed an issue where *update-release-notes* and *doc-review* did not handle new content notes as expected.
 * Added the `_time` field to the compare table in the **modeling-rules test**.
 
 ## 1.15.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Fixed an issue where *update-release-notes* and *doc-review* did not handle new content notes as expected.
+* Added the `_time` field to the compare table in the **modeling-rules test**.
 
 ## 1.15.3
 * Added the `--init` flag to **download**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-* Added the `_time` field to the compare table in the **modeling-rules test**.
+* Added the `_time` field to the output compare table of the **modeling-rules test** command.
 
 ## 1.15.4
 * Fixed an issue where *update-release-notes* and *doc-review* did not handle new content notes as expected.

--- a/demisto_sdk/commands/common/content/objects/pack_objects/modeling_rule/modeling_rule.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/modeling_rule/modeling_rule.py
@@ -52,6 +52,7 @@ class SingleModelingRule:
         r"^\s*filter\s*(?P<condition>(?!.*(\||alter)).+$(\s*(^\s*(?!\||alter).+$))*)",
         flags=re.M,
     )
+    TIME_FIELD = "_time"
 
     def __init__(self, rule_text: str):
         self.rule_text = rule_text
@@ -112,7 +113,7 @@ class SingleModelingRule:
     def fields(self):
         if not self._fields:
             uniq_fields = set(re.findall(self.RULE_FIELDS_REGEX, self.rule_text))
-            uniq_fields.add("_time")  # The '_time' field is always required.
+            uniq_fields.add(self.TIME_FIELD)  # The '_time' field is always required.
             self.fields = uniq_fields
             if not self._fields:
                 raise ValueError(

--- a/demisto_sdk/commands/common/content/objects/pack_objects/modeling_rule/modeling_rule.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/modeling_rule/modeling_rule.py
@@ -112,6 +112,7 @@ class SingleModelingRule:
     def fields(self):
         if not self._fields:
             uniq_fields = set(re.findall(self.RULE_FIELDS_REGEX, self.rule_text))
+            uniq_fields.add("_time")  # The '_time' field is always required.
             self.fields = uniq_fields
             if not self._fields:
                 raise ValueError(

--- a/demisto_sdk/commands/common/content/tests/objects/pack_objects/modeling_rule/modeling_rule_test.py
+++ b/demisto_sdk/commands/common/content/tests/objects/pack_objects/modeling_rule/modeling_rule_test.py
@@ -50,6 +50,7 @@ filter activity in ("SignInEvent","Logout","Login Attempt","Login Successful","L
         XDM.Auth.Client.user_agent = useragent;
 """
 PRE_UNIFIED_RULE1_FIELDS = {
+    "_time",
     "xdm.network.original_event_type",
     "xdm.network.destination.host.os_family",
     "xdm.network.destination.host.hostname",
@@ -65,6 +66,7 @@ PRE_UNIFIED_RULE1_FIELDS = {
     "xdm.network.http.user_agent",
 }
 PRE_UNIFIED_RULE2_FIELDS = {
+    "_time",
     "xdm.audit.threat.severity",
     "xdm.audit.event_timestamp",
     "xdm.audit.triggeredby.identity.name",
@@ -81,6 +83,7 @@ PRE_UNIFIED_RULE2_FIELDS = {
     "xdm.audit.triggeredby.user_agent",
 }
 PRE_UNIFIED_RULE3_FIELDS = {
+    "_time",
     "xdm.auth.auth_method",
     "xdm.auth.original_event_type",
     "xdm.auth.target.application.name",
@@ -142,6 +145,7 @@ filter
     xdm.network.source.ipv4 = "8.8.8.8";
 """
 UNIFIED_RULE_FIELDS = {
+    "_time",
     "xdm.event.description",
     "xdm.event.outcome",
     "xdm.target.resource.id",

--- a/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
+++ b/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
@@ -64,8 +64,22 @@ def create_table(expected: Dict[str, Any], received: Dict[str, Any]) -> Table:
     return table
 
 
-# https://stackoverflow.com/questions/5891555/display-the-date-like-may-5th-using-pythons-strftime#answer-5891598
-def day_suffix(day: int):
+def day_suffix(day: int) -> str:
+    """
+    Returns a suffix string base on the day of the month.
+        for 1, 21, 31 => st
+        for 2, 22 => nd
+        for 3, 23 => rd
+        for to all the others => th
+
+        see here for more details: https://en.wikipedia.org/wiki/English_numerals#Ordinal_numbers
+
+    Args:
+        day: The day of the month represented by a number.
+
+    Returns:
+        suffix string (st, nd, rd, th).
+    """
     return "th" if 11 <= day <= 13 else {1: "st", 2: "nd", 3: "rd"}.get(day % 10, "th")
 
 

--- a/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
+++ b/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
@@ -148,9 +148,7 @@ def verify_results(
                 break
 
         if expected_values:
-            if expected_time_value := expected_values.get("_time") and (
-                time_value := result.get("_time")
-            ):
+            if (expected_time_value := expected_values.get("_time")) and (time_value := result.get("_time")):  # fmt: skip
                 time_with_ms = "." in expected_time_value
                 result["_time"] = convert_epoch_time_to_string_time(
                     time_value, timezone_delta, time_with_ms

--- a/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
+++ b/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
@@ -144,7 +144,7 @@ def verify_results(
         for e in test_data.data:
             if str(e.test_data_event_id) == td_event_id:
                 expected_values = e.expected_values
-                timezone_delta = int(e.event_data.get("timezone_delta") or 0)
+                timezone_delta = int(e.timezone_delta or 0)
                 break
 
         if expected_values:

--- a/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
+++ b/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
@@ -162,7 +162,9 @@ def verify_results(
                 break
 
         if expected_values:
-            if (expected_time_value := expected_values.get("_time")) and (time_value := result.get("_time")):  # fmt: skip
+            if (expected_time_value := expected_values.get("_time")) and (
+                time_value := result.get("_time")
+            ):
                 time_with_ms = "." in expected_time_value
                 result["_time"] = convert_epoch_time_to_string_time(
                     time_value, timezone_delta, time_with_ms

--- a/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
+++ b/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
@@ -148,8 +148,10 @@ def verify_results(
                 break
 
         if expected_values:
-            if time_value := result.get("_time"):
-                time_with_ms = "." in expected_values.get("_time")
+            if expected_time_value := expected_values.get("_time") and (
+                time_value := result.get("_time")
+            ):
+                time_with_ms = "." in expected_time_value
                 result["_time"] = convert_epoch_time_to_string_time(
                     time_value, timezone_delta, time_with_ms
                 )

--- a/demisto_sdk/commands/test_content/test_modeling_rule/tests/test_modeling_rule_test.py
+++ b/demisto_sdk/commands/test_content/test_modeling_rule/tests/test_modeling_rule_test.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 from uuid import UUID
 
+import pytest
 import requests_mock
 import typer
 from typer.testing import CliRunner
@@ -1084,3 +1085,48 @@ class TestTheTestModelingRuleCommandInteractive:
 
         except typer.Exit:
             assert False, "No exception should be raised in this scenario."
+
+
+@pytest.mark.parametrize(
+    "epoc_time, timezone_delta, with_ms, human_readable_time",
+    [
+        (1686231456000, 0, False, "Jun 08th 2023 16:37:36"),
+        (1686231456000, 3, False, "Jun 08th 2023 19:37:36"),
+        (1686231456000, -6, False, "Jun 08th 2023 10:37:36"),
+        (1686231456000, 0, True, "Jun 08th 2023 16:37:36.000000"),
+        (1686231456123, 0, True, "Jun 08th 2023 16:37:36.123000"),
+    ],
+)
+def test_convert_epoch_time_to_string_time(
+    epoc_time, timezone_delta, with_ms, human_readable_time
+):
+    from demisto_sdk.commands.test_content.test_modeling_rule.test_modeling_rule import (
+        convert_epoch_time_to_string_time,
+    )
+
+    assert (
+        convert_epoch_time_to_string_time(epoc_time, timezone_delta, with_ms)
+        == human_readable_time
+    )
+
+
+@pytest.mark.parametrize(
+    "day, suffix",
+    [
+        (1, "st"),
+        (2, "nd"),
+        (3, "rd"),
+        (4, "th"),
+        (10, "th"),
+        (11, "th"),
+        (12, "th"),
+        (21, "st"),
+        (31, "st"),
+    ],
+)
+def test_day_suffix(day, suffix):
+    from demisto_sdk.commands.test_content.test_modeling_rule.test_modeling_rule import (
+        day_suffix,
+    )
+
+    assert day_suffix(day) == suffix

--- a/demisto_sdk/commands/test_content/test_modeling_rule/tests/test_modeling_rule_test.py
+++ b/demisto_sdk/commands/test_content/test_modeling_rule/tests/test_modeling_rule_test.py
@@ -1098,11 +1098,15 @@ class TestTheTestModelingRuleCommandInteractive:
     ],
 )
 def test_convert_epoch_time_to_string_time(
-    epoc_time, timezone_delta, with_ms, human_readable_time
+    mocker, epoc_time, timezone_delta, with_ms, human_readable_time
 ):
+    from dateutil import tz
+
     from demisto_sdk.commands.test_content.test_modeling_rule.test_modeling_rule import (
         convert_epoch_time_to_string_time,
     )
+
+    mocker.patch("dateutil.tz.tzlocal", return_value=tz.gettz("Asia/Jerusalem"))
 
     assert (
         convert_epoch_time_to_string_time(epoc_time, timezone_delta, with_ms)

--- a/demisto_sdk/commands/test_content/test_modeling_rule/tests/test_modeling_rule_test.py
+++ b/demisto_sdk/commands/test_content/test_modeling_rule/tests/test_modeling_rule_test.py
@@ -1100,6 +1100,21 @@ class TestTheTestModelingRuleCommandInteractive:
 def test_convert_epoch_time_to_string_time(
     mocker, epoc_time, timezone_delta, with_ms, human_readable_time
 ):
+    """
+    Given:
+        - An Epoch time.
+            case-1: Epoch time without time zone and without MS.
+            case-2: Epoch time with time zone +3 and without MS.
+            case-3: Epoch time with time zone -6 and without MS.
+            case-4: Epoch time without time zone and with MS equal to 0.
+            case-5: Epoch time without time zone and with MS equal to 123.
+
+    When:
+        - The convert_epoch_time_to_string_time function is running.
+
+    Then:
+        - Verify we get the expected results.
+    """
     from dateutil import tz
 
     from demisto_sdk.commands.test_content.test_modeling_rule.test_modeling_rule import (
@@ -1129,6 +1144,25 @@ def test_convert_epoch_time_to_string_time(
     ],
 )
 def test_day_suffix(day, suffix):
+    """
+    Given:
+        - A day of a month.
+            case-1: 1 => st.
+            case-2: 2 => nd.
+            case-3: 3 => rd.
+            case-4: 4 => th.
+            case-5: 10 => th.
+            case-6: 11 => th.
+            case-7: 12 => th.
+            case-8: 21 => st.
+            case-9: 31 => st.
+
+    When:
+        - The day_suffix function is running.
+
+    Then:
+        - Verify we get the expected results.
+    """
     from demisto_sdk.commands.test_content.test_modeling_rule.test_modeling_rule import (
         day_suffix,
     )

--- a/demisto_sdk/commands/test_content/xsiam_tools/test_data.py
+++ b/demisto_sdk/commands/test_content/xsiam_tools/test_data.py
@@ -19,6 +19,8 @@ class TestData(BaseModel):
     @validator("data", each_item=True)
     def validate_expected_values(cls, v):
         for k in v.expected_values.keys():
+            if k == "_time":  # '_time' is a special field without the 'xdm.' prefix.
+                continue
             if not k.casefold().startswith("xdm."):
                 err = "The expected values mapping keys are expected to start with 'xdm.' (case insensitive)"
                 raise ValueError(err)

--- a/demisto_sdk/commands/test_content/xsiam_tools/test_data.py
+++ b/demisto_sdk/commands/test_content/xsiam_tools/test_data.py
@@ -9,6 +9,7 @@ class EventLog(BaseModel):
     vendor: Optional[str] = None
     product: Optional[str] = None
     dataset: Optional[str] = None
+    timezone_delta: Optional[int] = 0
     event_data: Optional[Dict[str, Any]] = {}
     expected_values: Optional[Dict[str, Any]] = {}
 


### PR DESCRIPTION
## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-4949

## Description
In order to test the parsing rules (time field) I added the time field by default to the `test-modeling-rules` command.

Before the fix:
![Screenshot 2023-06-08 at 15 53 16](https://github.com/demisto/demisto-sdk/assets/78307768/072b7f9a-1255-4622-95f4-c5bc7b23f49b)

After the fix (failed result):
![Screenshot 2023-06-08 at 15 49 06](https://github.com/demisto/demisto-sdk/assets/78307768/e7057ef8-c159-483a-a19d-0838ccb6defc)


After the fix (success result):
![Screenshot 2023-06-08 at 15 48 33](https://github.com/demisto/demisto-sdk/assets/78307768/53203cb9-66a5-471f-b5c0-c352de0c9e04)

