### PR TITLE
Validation for dashboard image name starts with the pack name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## Unreleased
+* Added a validation that the **validate** command will fail if the pack name is not prefixed on XSIAM dashboard images.
 
 ## 1.15.5
 * **Breaking Change**: The default of the **upload** command `--zip` argument is `true`. To upload packs as custom content items use the `--no-zip` argument.

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -4485,7 +4485,7 @@ class Errors:
 
     @staticmethod
     @error_code_decorator
-    def xsiam_dashboards_file_name_is_not_equal_to_image_name(
+    def xsiam_dashboards_file_name_is_not_equal_to_pack_name(
         dashboard_name: str, image_name: str
     ):
         return f"The XSIAM dashboard name: {dashboard_name} is not equal to image name: {image_name}."

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -1790,8 +1790,7 @@ ERROR_CODE = {
         "ui_applicable": False,
         "related_field": "",
     },
-    # XD - XSIAM Dashboards
-    "xsiam_dashboards_file_name_is_not_equal_to_image_name": {
+    "xsiam_dashboard_or_image_file_name_not_begin_with_pack_name": {
         "code": "XD101",
         "ui_applicable": False,
         "related_field": "",
@@ -4485,10 +4484,8 @@ class Errors:
 
     @staticmethod
     @error_code_decorator
-    def xsiam_dashboards_file_name_is_not_equal_to_pack_name(
-        dashboard_name: str, image_name: str
-    ):
-        return f"The XSIAM dashboard name: {dashboard_name} is not equal to image name: {image_name}."
+    def xsiam_dashboard_or_image_file_name_not_begin_with_pack_name(files: list):
+        return f"The following XSIAM dashboard/image file name does not start with the pack name: [{', '.join(files)}]."
 
     @staticmethod
     @error_code_decorator

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -4472,7 +4472,7 @@ class Errors:
     @error_code_decorator
     def xsiam_dashboards_files_naming_error(invalid_files: list):
         return (
-            f"The following XSIAM dashboards do not match the naming conventions:: {', '.join(invalid_files)}.\n"
+            f"The following XSIAM dashboards do not match the naming conventions: {', '.join(invalid_files)}.\n"
             f"Files name in the XSIAM dashboards directory must use the pack's name as a prefix, "
             f"e.g. `MyPack_dashboard.json` or `MyPack_dashboard_image.png`."
         )

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -1790,11 +1790,6 @@ ERROR_CODE = {
         "ui_applicable": False,
         "related_field": "",
     },
-    "xsiam_dashboard_or_image_file_name_not_begin_with_pack_name": {
-        "code": "XD101",
-        "ui_applicable": False,
-        "related_field": "",
-    },
     # GR - Graph validations
     "uses_items_not_in_marketplaces": {
         "code": "GR100",
@@ -4481,11 +4476,6 @@ class Errors:
             f"Files name in the XSIAM dashboards directory must use the pack's name as a prefix, "
             f"e.g. `MyPack_dashboard.json` or `MyPack_dashboard_image.png`."
         )
-
-    @staticmethod
-    @error_code_decorator
-    def xsiam_dashboard_or_image_file_name_not_begin_with_pack_name(files: list):
-        return f"The following XSIAM dashboard/image file name does not start with the pack name: [{', '.join(files)}]."
 
     @staticmethod
     @error_code_decorator

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -1790,6 +1790,12 @@ ERROR_CODE = {
         "ui_applicable": False,
         "related_field": "",
     },
+    # XD - XSIAM Dashboards
+    "xsiam_dashboards_file_name_is_not_equal_to_image_name": {
+        "code": "XD101",
+        "ui_applicable": False,
+        "related_field": "",
+    },
     # GR - Graph validations
     "uses_items_not_in_marketplaces": {
         "code": "GR100",
@@ -4476,6 +4482,13 @@ class Errors:
             f"Files name in the XSIAM dashboards directory must use the pack's name as a prefix, "
             f"e.g. `myPack-report1.yml` "
         )
+
+    @staticmethod
+    @error_code_decorator
+    def xsiam_dashboards_file_name_is_not_equal_to_image_name(
+        dashboard_name: str, image_name: str
+    ):
+        return f"The XSIAM dashboard name: {dashboard_name} is not equal to image name: {image_name}."
 
     @staticmethod
     @error_code_decorator

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -4474,7 +4474,7 @@ class Errors:
         return (
             f"The following XSIAM dashboards do not match the naming conventions: {', '.join(invalid_files)}.\n"
             f"Files name in the XSIAM dashboards directory must use the pack's name as a prefix, "
-            f"e.g. `MyPack_dashboard.json` or `MyPack_dashboard_image.png`."
+            f"e.g. `MyPack_dashboard.json` AND `MyPack_dashboard_image.png`."
         )
 
     @staticmethod

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -4477,9 +4477,9 @@ class Errors:
     @error_code_decorator
     def xsiam_dashboards_files_naming_error(invalid_files: list):
         return (
-            f"The following XSIAM dashboards do not match the naming conventions:: {','.join(invalid_files)}.\n"
+            f"The following XSIAM dashboards do not match the naming conventions:: {', '.join(invalid_files)}.\n"
             f"Files name in the XSIAM dashboards directory must use the pack's name as a prefix, "
-            f"e.g. `myPack-report1.yml` "
+            f"e.g. `MyPack_dashboard.json` or `MyPack_dashboard_image.png`."
         )
 
     @staticmethod

--- a/demisto_sdk/commands/common/hook_validations/xsiam_dashboard.py
+++ b/demisto_sdk/commands/common/hook_validations/xsiam_dashboard.py
@@ -57,9 +57,9 @@ class XSIAMDashboardValidator(ContentEntityValidator):
         return True
 
     @error_codes("XD101")
-    def is_dashboard_file_name_equal_to_image_file_name(self):
+    def is_dashboard_and_image_file_name_equals_to_pack_name(self):
         """
-        Validates the dashboard file name equals the image file name.
+        Validates the dashboard and image file name equals the pack name.
         """
         dashboard_name = self.file_path
         dashboard_image = self.file_path
@@ -67,7 +67,7 @@ class XSIAMDashboardValidator(ContentEntityValidator):
             (
                 error_message,
                 error_code,
-            ) = Errors.xsiam_dashboards_file_name_is_not_equal_to_image_name(
+            ) = Errors.xsiam_dashboards_file_name_is_not_equal_to_pack_name(
                 dashboard_name, dashboard_image
             )
             if self.handle_error(error_message, error_code, file_path=self.file_path):

--- a/demisto_sdk/commands/common/hook_validations/xsiam_dashboard.py
+++ b/demisto_sdk/commands/common/hook_validations/xsiam_dashboard.py
@@ -1,14 +1,12 @@
 """
 This module is designed to validate the correctness of generic definition entities in content.
 """
-from pathlib import Path
 
 from demisto_sdk.commands.common.errors import Errors
 from demisto_sdk.commands.common.hook_validations.base_validator import error_codes
 from demisto_sdk.commands.common.hook_validations.content_entity_validator import (
     ContentEntityValidator,
 )
-from demisto_sdk.commands.common.tools import get_pack_name
 
 
 class XSIAMDashboardValidator(ContentEntityValidator):
@@ -36,7 +34,6 @@ class XSIAMDashboardValidator(ContentEntityValidator):
         https://github.com/demisto/etc/issues/48151#issuecomment-1109660727
         """
         self.is_files_naming_correct()
-        # self.are_dashboard_and_image_file_names_begin_with_pack_name()
         return self._is_valid
 
     def is_valid_version(self):
@@ -57,30 +54,4 @@ class XSIAMDashboardValidator(ContentEntityValidator):
             if self.handle_error(error_message, error_code, file_path=self.file_path):
                 self._is_valid = False
                 return False
-        return True
-
-    @error_codes("XD101")
-    def are_dashboard_and_image_file_names_begin_with_pack_name(self):
-        """
-        Validates the dashboard and image file name equals the pack name.
-        """
-        pack_name = get_pack_name(self.file_path)
-        dashboard_folder = Path(self.file_path).parent
-
-        if invalid_prefix := list(
-            filter(
-                lambda x: not x.startswith(pack_name),
-                (file.name for file in Path(dashboard_folder).iterdir()),
-            )
-        ):
-            (
-                error_message,
-                error_code,
-            ) = Errors.xsiam_dashboard_or_image_file_name_not_begin_with_pack_name(
-                invalid_prefix
-            )
-            if self.handle_error(error_message, error_code, file_path=invalid_prefix):
-                self._is_valid = False
-                return False
-
         return True

--- a/demisto_sdk/commands/common/hook_validations/xsiam_dashboard.py
+++ b/demisto_sdk/commands/common/hook_validations/xsiam_dashboard.py
@@ -57,7 +57,7 @@ class XSIAMDashboardValidator(ContentEntityValidator):
         return True
 
     @error_codes("XD101")
-    def is_dashboard_and_image_file_name_equals_to_pack_name(self):
+    def are_dashboard_and_image_file_names_begin_with_pack_name(self):
         """
         Validates the dashboard and image file name equals the pack name.
         """

--- a/demisto_sdk/commands/common/hook_validations/xsiam_dashboard.py
+++ b/demisto_sdk/commands/common/hook_validations/xsiam_dashboard.py
@@ -55,3 +55,22 @@ class XSIAMDashboardValidator(ContentEntityValidator):
                 self._is_valid = False
                 return False
         return True
+
+    @error_codes("XD101")
+    def is_dashboard_file_name_equal_to_image_file_name(self):
+        """
+        Validates the dashboard file name equals the image file name.
+        """
+        dashboard_name = self.file_path
+        dashboard_image = self.file_path
+        if dashboard_name != dashboard_image:
+            (
+                error_message,
+                error_code,
+            ) = Errors.xsiam_dashboards_file_name_is_not_equal_to_image_name(
+                dashboard_name, dashboard_image
+            )
+            if self.handle_error(error_message, error_code, file_path=self.file_path):
+                self._is_valid = False
+                return False
+        return True

--- a/demisto_sdk/commands/common/hook_validations/xsiam_dashboard.py
+++ b/demisto_sdk/commands/common/hook_validations/xsiam_dashboard.py
@@ -1,12 +1,14 @@
 """
 This module is designed to validate the correctness of generic definition entities in content.
 """
+from pathlib import Path
 
 from demisto_sdk.commands.common.errors import Errors
 from demisto_sdk.commands.common.hook_validations.base_validator import error_codes
 from demisto_sdk.commands.common.hook_validations.content_entity_validator import (
     ContentEntityValidator,
 )
+from demisto_sdk.commands.common.tools import get_pack_name
 
 
 class XSIAMDashboardValidator(ContentEntityValidator):
@@ -34,6 +36,7 @@ class XSIAMDashboardValidator(ContentEntityValidator):
         https://github.com/demisto/etc/issues/48151#issuecomment-1109660727
         """
         self.is_files_naming_correct()
+        # self.are_dashboard_and_image_file_names_begin_with_pack_name()
         return self._is_valid
 
     def is_valid_version(self):
@@ -61,16 +64,23 @@ class XSIAMDashboardValidator(ContentEntityValidator):
         """
         Validates the dashboard and image file name equals the pack name.
         """
-        dashboard_name = self.file_path
-        dashboard_image = self.file_path
-        if dashboard_name != dashboard_image:
+        pack_name = get_pack_name(self.file_path)
+        dashboard_folder = Path(self.file_path).parent
+
+        if invalid_prefix := list(
+            filter(
+                lambda x: not x.startswith(pack_name),
+                (file.name for file in Path(dashboard_folder).iterdir()),
+            )
+        ):
             (
                 error_message,
                 error_code,
-            ) = Errors.xsiam_dashboards_file_name_is_not_equal_to_pack_name(
-                dashboard_name, dashboard_image
+            ) = Errors.xsiam_dashboard_or_image_file_name_not_begin_with_pack_name(
+                invalid_prefix
             )
-            if self.handle_error(error_message, error_code, file_path=self.file_path):
+            if self.handle_error(error_message, error_code, file_path=invalid_prefix):
                 self._is_valid = False
                 return False
+
         return True

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -27,6 +27,7 @@ from demisto_sdk.commands.common.constants import (
     FileType,
     FileType_ALLOWED_TO_DELETE,
     PathLevel,
+    XSIAM_DASHBOARDS_DIR,
 )
 from demisto_sdk.commands.common.content import Content
 from demisto_sdk.commands.common.content_constant_paths import (
@@ -630,8 +631,10 @@ class ValidateManager:
                         file_path.endswith(".json")
                         or file_path.endswith(".yml")
                         or file_path.endswith(".md")
-                        or content_entity_dir_path.endswith("XSIAMDashboards")
-                        and file_path.endswith(".png")  # add XSIAM dashboard images
+                        or (
+                            content_entity_dir_path.endswith(XSIAM_DASHBOARDS_DIR)
+                            and file_path.endswith(".png")
+                        )
                     ):
                         content_entities_validation_results.add(
                             self.run_validations_on_file(

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -630,6 +630,8 @@ class ValidateManager:
                         file_path.endswith(".json")
                         or file_path.endswith(".yml")
                         or file_path.endswith(".md")
+                        or content_entity_dir_path.endswith("XSIAMDashboards")
+                        and file_path.endswith(".png")  # add XSIAM dashboard images
                     ):
                         content_entities_validation_results.add(
                             self.run_validations_on_file(


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-4572

## Description
Validation has been added to XSIAM image dashboard names that begin with the pack name.

valid example:
pack_name => `Example`, dashboard_image => `Example_dashboard_image.png`
invalid example:
pack_name => `Example`, dashboard_image => `example_dashboard_image.png`