### PR TITLE
fix for sdk linter retuning false warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ## Unreleased
-- Fixed an issue in *lint* where it returned warnings for some unrelated files.
+- Fixed an issue in *lint* where it returned a warning regarding usage of `demisto.results` function in entities that have to use it and can't use `CommandResults` instead.
 
 ## 1.15.5
 * **Breaking Change**: The default of the **upload** command `--zip` argument is `true`. To upload packs as custom content items use the `--no-zip` argument.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## Unreleased
+- Fixed an issue in *lint* where it returned warnings for some unrelated files.
 
 ## 1.15.5
 * **Breaking Change**: The default of the **upload** command `--zip` argument is `true`. To upload packs as custom content items use the `--no-zip` argument.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Fixed an issue where **upload** would not properly show the installed version in the UI.
 * Fixed an issue where the `contribution_converter` failed replacing generated release notes with the contribution form release notes.
 * Fixed an issue where an extra levelname was added to a logging message.
-* Fixed an issue in *lint* where it returned a warning regarding usage of `demisto.results` function in entities that have to use it and can't use `CommandResults` instead.
+* Fixed an issue where **lint** falsely warned of using `demisto.results`.
 
 ## 1.15.5
 * **Breaking Change**: The default of the **upload** command `--zip` argument is `true`. To upload packs as custom content items use the `--no-zip` argument.

--- a/demisto_sdk/commands/lint/resources/pylint_plugins/certified_partner_level_checker.py
+++ b/demisto_sdk/commands/lint/resources/pylint_plugins/certified_partner_level_checker.py
@@ -152,7 +152,7 @@ class CertifiedPartnerChecker(BaseChecker):
             if node.func.attrname == "results" and node.func.expr.name == "demisto":
                 self.add_message("demisto-results-exists", node=node)
         except Exception as e:
-            logger.info(
+            logger.error(
                 f"An error occured while checking `demisto results`, Error: {e}"
             )
 

--- a/demisto_sdk/commands/lint/resources/pylint_plugins/certified_partner_level_checker.py
+++ b/demisto_sdk/commands/lint/resources/pylint_plugins/certified_partner_level_checker.py
@@ -162,7 +162,7 @@ class CertifiedPartnerChecker(BaseChecker):
         Adds the relevant error message using `add_message` function if one of the above exists.
         """
         try:
-            file_path = node.root().file.replace(".py", ".yml")
+            file_path = node.root().file.replace(".py", ".yml") if node else ""
             with open(file_path) as file_obj:
                 loaded_file_data = yaml.load(file_obj)
                 if "indicator-format" not in loaded_file_data.get("tags", []):

--- a/demisto_sdk/commands/lint/resources/pylint_plugins/certified_partner_level_checker.py
+++ b/demisto_sdk/commands/lint/resources/pylint_plugins/certified_partner_level_checker.py
@@ -20,6 +20,7 @@ from pylint.checkers import BaseChecker
 from pylint.interfaces import IAstroidChecker
 
 from demisto_sdk.commands.common.handlers import YAML_Handler
+from demisto_sdk.commands.common.logger import logger
 
 # -------------------------------------------- Messages ------------------------------------------------
 
@@ -150,8 +151,10 @@ class CertifiedPartnerChecker(BaseChecker):
         try:
             if node.func.attrname == "results" and node.func.expr.name == "demisto":
                 self.add_message("demisto-results-exists", node=node)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.info(
+                f"An error occured while checking `demisto results`, Error: {e}"
+            )
 
     def _demisto_results_checker(self, node):
         """

--- a/demisto_sdk/tests/constants_test.py
+++ b/demisto_sdk/tests/constants_test.py
@@ -459,9 +459,6 @@ XSOAR_LINTER_PY3_INVALID_WARNINGS = (
 )
 
 XSOAR_LINTER_PY3_NO_DEMISTO_RESULTS_WARNINGS = f"{GIT_ROOT}/demisto_sdk/tests/test_files/py3_XSOARLinter_demisto_results_warnings.py"
-# XSOAR_LINTER_PY3_DEMISTO_RESULTS_WARNINGS_YML = (
-#     f"{GIT_ROOT}/demisto_sdk/tests/test_files/py3_XSOARLinter_demisto_results_warnings.yml"
-# )
 
 XSOAR_LINTER_PY3_INVALID_WARNINGS_PARTNER = f"{GIT_ROOT}/demisto_sdk/tests/test_files/invalid_py3_XSOARLinter_warnings_partner.py"
 

--- a/demisto_sdk/tests/constants_test.py
+++ b/demisto_sdk/tests/constants_test.py
@@ -457,6 +457,12 @@ XSOAR_LINTER_PY3_INVALID = (
 XSOAR_LINTER_PY3_INVALID_WARNINGS = (
     f"{GIT_ROOT}/demisto_sdk/tests/test_files/invalid_py3_XSOARLinter_warnings.py"
 )
+
+XSOAR_LINTER_PY3_NO_DEMISTO_RESULTS_WARNINGS = f"{GIT_ROOT}/demisto_sdk/tests/test_files/py3_XSOARLinter_demisto_results_warnings.py"
+# XSOAR_LINTER_PY3_DEMISTO_RESULTS_WARNINGS_YML = (
+#     f"{GIT_ROOT}/demisto_sdk/tests/test_files/py3_XSOARLinter_demisto_results_warnings.yml"
+# )
+
 XSOAR_LINTER_PY3_INVALID_WARNINGS_PARTNER = f"{GIT_ROOT}/demisto_sdk/tests/test_files/invalid_py3_XSOARLinter_warnings_partner.py"
 
 DESTINATION_FORMAT_INTEGRATION = "Integrations/integration.yml"

--- a/demisto_sdk/tests/integration_tests/xsoar_linter_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/xsoar_linter_integration_test.py
@@ -227,8 +227,10 @@ files = [
         "3.8",
         "certified partner",
         False,
-        0,
-        [],
+        4,
+        [
+            "Do not use return_outputs function. Please return CommandResults object instead."
+        ],
         [],
     ),
     # --------------------- For Warning file with support level xsoar------------- -----------------------------------

--- a/demisto_sdk/tests/integration_tests/xsoar_linter_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/xsoar_linter_integration_test.py
@@ -18,6 +18,7 @@ from demisto_sdk.tests.constants_test import (
     XSOAR_LINTER_PY3_INVALID,
     XSOAR_LINTER_PY3_INVALID_WARNINGS,
     XSOAR_LINTER_PY3_INVALID_WARNINGS_PARTNER,
+    XSOAR_LINTER_PY3_NO_DEMISTO_RESULTS_WARNINGS,
     XSOAR_LINTER_PY3_VALID,
 )
 
@@ -218,6 +219,16 @@ files = [
             "Initialize of args was found outside of main function. Please use demisto.args() only inside main func",
             "Hardcoded http URL was found in the code, using https (when possible) is recommended.",
         ],
+        [],
+    ),
+    # ------------- For Warning file with support level certified partner with indicator format file -------------------
+    (
+        Path(f"{XSOAR_LINTER_PY3_NO_DEMISTO_RESULTS_WARNINGS}"),
+        "3.8",
+        "certified partner",
+        False,
+        0,
+        [],
         [],
     ),
     # --------------------- For Warning file with support level xsoar------------- -----------------------------------

--- a/demisto_sdk/tests/test_files/py3_XSOARLinter_demisto_results_warnings.py
+++ b/demisto_sdk/tests/test_files/py3_XSOARLinter_demisto_results_warnings.py
@@ -1,0 +1,112 @@
+from demisto_sdk.commands.common.handlers import JSON_Handler
+
+json = JSON_Handler()
+
+from typing import Any, Callable, Dict, Tuple
+
+import dateparser
+import demistomock as demisto
+import requests
+from CommonServerPython import *
+from CommonServerUserPython import *
+
+# Disable insecure warnings
+requests.packages.urllib3.disable_warnings()
+
+
+class Client(BaseClient):
+    """
+    Client to use in the integration, overrides BaseClient.
+    Used for communication with the api.
+    """
+
+    def __init__(
+        self, url: str, username: str, password: str, verify: bool, proxy: bool
+    ):
+        super().__init__(base_url=f"{url}/api", verify=verify, proxy=proxy)
+        self._url = url
+        self._username = username
+        self._password = password
+
+
+def test_module(client: Client, *_) -> Tuple[str, dict, dict]:
+    """Function which checks if there is a connection with the api.
+     Args:
+         client : Integration client which communicates with the api.
+         args: Users arguments of the command.
+    Returns:
+        human readable, context, raw response of this command.
+    """
+    return "ok", {}, {}
+
+
+def parse_incidents(
+    items: list, fetch_limit: str, time_format: str, parsed_last_time: datetime
+) -> Tuple[list, Any]:
+    """
+    This function will create a list of incidents
+    Args:
+        items : List of tickets of the api response.
+        fetch_limit: Limit for incidents of fetch cycle.
+        time_format: Time format of the integration.
+        parsed_last_time: limit for number of fetch incidents per fetch.
+    Returns:
+        incidents: List of incidents.
+        parsed_last_time: Time of last incident.
+    """
+    count = 0
+    incidents = []
+    for item in items:
+        if count >= int(fetch_limit):
+            break
+
+        incident_created_time = dateparser.parse(item["created"])
+
+        incident = {
+            "name": item["title"],
+            "occurred": incident_created_time.strftime(time_format),
+            "rawJSON": json.dumps(item),
+        }
+        return_error("error")
+        incidents.append(incident)
+        count += 1
+        parsed_last_time = incident_created_time
+    return incidents, parsed_last_time
+
+
+def fetch_incidents():
+    return []
+
+
+def main():
+    """
+    PARSE AND VALIDATE INTEGRATION PARAMS
+    """
+    params = demisto.params()
+    username = params.get("credentials").get("identifier")
+    password = params.get("credentials").get("password")
+    base_url = params.get("url")
+    proxy = demisto.params().get("proxy", False)
+    verify_certificate = not params.get("insecure", False)
+
+    client = Client(
+        url=base_url,
+        username=username,
+        password=password,
+        verify=verify_certificate,
+        proxy=proxy,
+    )
+    command = demisto.command()
+    LOG(f"Command being called is {command}")
+    # Commands dict
+    commands: Dict[str, Callable[[Client, Dict[str, str]], Tuple[str, dict, dict]]] = {
+        "test-module": test_module,
+    }
+    if command in commands:
+        return_outputs(*commands[command](client, demisto.args()))
+    elif command == "fetch-incidents":
+        incidents = fetch_incidents()
+        demisto.incidents(incidents)
+        demisto.results(incidents)
+    else:
+        raise NotImplementedError(f"{command} is not an existing QuestKace command")

--- a/demisto_sdk/tests/test_files/py3_XSOARLinter_demisto_results_warnings.yml
+++ b/demisto_sdk/tests/test_files/py3_XSOARLinter_demisto_results_warnings.yml
@@ -1,0 +1,9 @@
+category: Data Enrichment & Threat Intelligence
+commonfields:
+  id: Test File
+  version: -1
+description: Description.
+display: Test File
+name: Test File
+tags:
+- indicator-format


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-6738

## Description
 - Fixed an issue where **lint** falsely warned of using `demisto.results` command, for files who have to use it, for example scripts/integrations with `indicator- format` tag, they can't use `CommandResults`, so they have to use `demisto.results`.
