### PR TITLE
Improve invalid XSIAM dashboard error message

### DIFF
--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -4472,9 +4472,9 @@ class Errors:
     @error_code_decorator
     def xsiam_dashboards_files_naming_error(invalid_files: list):
         return (
-            f"The following XSIAM dashboards do not match the naming conventions:: {','.join(invalid_files)}.\n"
+            f"The following XSIAM dashboards do not match the naming conventions: {','.join(invalid_files)}.\n"
             f"Files name in the XSIAM dashboards directory must use the pack's name as a prefix, "
-            f"e.g. `myPack-report1.yml` "
+            f"e.g. `myPack_dashboard.json` "
         )
 
     @staticmethod


### PR DESCRIPTION

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-6876

## Description
Changed the error message on an invalid XSIAM dashboard from YML to JSON. (since a dashboard is a JSON file not a YML file).