### PR TITLE
Support gitutil on detached head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fixed an issue where **upload** would not properly show the installed version in the UI.
 * Fixed an issue where the `contribution_converter` failed replacing generated release notes with the contribution form release notes.
 * Fixed an issue where an extra levelname was added to a logging message.
+* Added support to run **validate** with `--git` flag on detached HEAD.
 
 ## 1.15.5
 * **Breaking Change**: The default of the **upload** command `--zip` argument is `true`. To upload packs as custom content items use the `--no-zip` argument.

--- a/demisto_sdk/commands/common/git_util.py
+++ b/demisto_sdk/commands/common/git_util.py
@@ -10,7 +10,6 @@ from git.diff import Lit_change_type
 from git.remote import Remote
 
 from demisto_sdk.commands.common.constants import PACKS_FOLDER
-from demisto_sdk.commands.common.logger import logger
 
 
 class GitUtil:
@@ -518,13 +517,13 @@ class GitUtil:
             Set: of Paths to files changed in the current branch.
         """
         remote, branch = self.handle_prev_ver(prev_ver)
-        current_branch_or_hash = self.get_current_commit_hash()
+        current_hash = self.get_current_commit_hash()
 
         if remote:
             return {
                 Path(os.path.join(item))
                 for item in self.repo.git.diff(
-                    "--name-only", f"{remote}/{branch}...{current_branch_or_hash}"
+                    "--name-only", f"{remote}/{branch}...{current_hash}"
                 ).split("\n")
                 if item
             }
@@ -534,7 +533,7 @@ class GitUtil:
             return {
                 Path(os.path.join(item))
                 for item in self.repo.git.diff(
-                    "--name-only", f"{branch}...{current_branch_or_hash}"
+                    "--name-only", f"{branch}...{current_hash}"
                 ).split("\n")
                 if item
             }
@@ -634,9 +633,6 @@ class GitUtil:
         try:
             return self.get_current_working_branch()
         except TypeError:
-            logger.warning(
-                "Unable to get the active branch because of detached HEAD. returning commit"
-            )
             return self.get_current_commit_hash()
 
     def get_current_working_branch(self) -> str:

--- a/demisto_sdk/commands/common/git_util.py
+++ b/demisto_sdk/commands/common/git_util.py
@@ -10,6 +10,7 @@ from git.diff import Lit_change_type
 from git.remote import Remote
 
 from demisto_sdk.commands.common.constants import PACKS_FOLDER
+from demisto_sdk.commands.common.logger import logger
 
 
 class GitUtil:
@@ -517,7 +518,7 @@ class GitUtil:
             Set: of Paths to files changed in the current branch.
         """
         remote, branch = self.handle_prev_ver(prev_ver)
-        current_branch_or_hash = self.get_current_git_branch_or_hash()
+        current_branch_or_hash = self.get_current_commit_hash()
 
         if remote:
             return {
@@ -550,7 +551,7 @@ class GitUtil:
             running on master against master.
         """
         # when checking branch against itself only return the last commit.
-        if self.get_current_working_branch() != self.handle_prev_ver(prev_ver)[1]:
+        if self.get_current_git_branch_or_hash() != self.handle_prev_ver(prev_ver)[1]:
             return set()
 
         try:
@@ -633,6 +634,9 @@ class GitUtil:
         try:
             return self.get_current_working_branch()
         except TypeError:
+            logger.warning(
+                "Unable to get the active branch because of detached HEAD. returning commit"
+            )
             return self.get_current_commit_hash()
 
     def get_current_working_branch(self) -> str:


### PR DESCRIPTION

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-6889?filter=-1

## Description
* When checkout the repo in GitHub actions, the default state it checks out is on detached head, meaning it is not aware the branch. We don't actually need the branch to run and the commit hash is enough.
* It is safer to run git diff on the current commit hash, since the branch name could be messy and not related to the actual commit we would like to check.