### PR TITLE
updated versions properties for xsiam content items in graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added support to run **validate** with `--git` flag on detached HEAD.
 * Added a validation that the **validate** command will fail if the pack name is not prefixed on XSIAM dashboard images.
 * Fixed the **generate-test-playbook** which failed on an unexpected keyword argument - 'console_log_threshold'.
+* Fixed an issue **prepare-content** with `--graph` did not parse the server min version correctly from XSIAM dashboard and report content items.
 * Fixed an issue where **validate** command did not fail on non-existent dependency ids of non-mandatory dependant content.
 
 ## 1.15.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Added support to run **validate** with `--git` flag on detached HEAD.
 * Added a validation that the **validate** command will fail if the pack name is not prefixed on XSIAM dashboard images.
 * Fixed the **generate-test-playbook** which failed on an unexpected keyword argument - 'console_log_threshold'.
-* Fixed an issue **prepare-content** with `--graph` did not parse the server min version correctly from XSIAM dashboard and report content items.
+* Fixed an issue where **prepare-content** would not properly parse the `fromVersion` and `toVersion` attributes of XSIAM-Dashbaord and XSIAM-Report content items.
 * Fixed an issue where **validate** command did not fail on non-existent dependency ids of non-mandatory dependant content.
 
 ## 1.15.5

--- a/demisto_sdk/commands/content_graph/parsers/json_content_item.py
+++ b/demisto_sdk/commands/content_graph/parsers/json_content_item.py
@@ -20,6 +20,7 @@ class JSONContentItemParser(ContentItemParser):
     ) -> None:
         super().__init__(path, pack_marketplaces)
         self.json_data: Dict[str, Any] = self.get_json()
+        self.original_json_data: Dict[str, Any] = self.get_json()
         if not isinstance(self.json_data, dict):
             raise InvalidContentItemException(
                 f"The content of {self.path} must be in a JSON dictionary format"

--- a/demisto_sdk/commands/content_graph/parsers/xsiam_dashboard.py
+++ b/demisto_sdk/commands/content_graph/parsers/xsiam_dashboard.py
@@ -1,7 +1,11 @@
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
-from demisto_sdk.commands.common.constants import MarketplaceVersions
+from demisto_sdk.commands.common.constants import (
+    DEFAULT_CONTENT_ITEM_FROM_VERSION,
+    DEFAULT_CONTENT_ITEM_TO_VERSION,
+    MarketplaceVersions,
+)
 from demisto_sdk.commands.content_graph.common import ContentType
 from demisto_sdk.commands.content_graph.parsers.json_content_item import (
     JSONContentItemParser,
@@ -15,6 +19,7 @@ class XSIAMDashboardParser(
         self, path: Path, pack_marketplaces: List[MarketplaceVersions]
     ) -> None:
         super().__init__(path, pack_marketplaces)
+        self.original_json_data = self.get_json()
         self.json_data: Dict[str, Any] = self.json_data.get("dashboards_data", [{}])[0]
 
     @property
@@ -24,3 +29,16 @@ class XSIAMDashboardParser(
     @property
     def object_id(self) -> Optional[str]:
         return self.json_data.get("global_id")
+
+    @property
+    def fromversion(self) -> str:
+        return (
+            self.original_json_data.get("fromVersion")
+            or DEFAULT_CONTENT_ITEM_FROM_VERSION
+        )
+
+    @property
+    def toversion(self) -> str:
+        return (
+            self.original_json_data.get("toVersion") or DEFAULT_CONTENT_ITEM_TO_VERSION
+        )

--- a/demisto_sdk/commands/content_graph/parsers/xsiam_dashboard.py
+++ b/demisto_sdk/commands/content_graph/parsers/xsiam_dashboard.py
@@ -19,7 +19,6 @@ class XSIAMDashboardParser(
         self, path: Path, pack_marketplaces: List[MarketplaceVersions]
     ) -> None:
         super().__init__(path, pack_marketplaces)
-        self.original_json_data = self.get_json()
         self.json_data: Dict[str, Any] = self.json_data.get("dashboards_data", [{}])[0]
 
     @property

--- a/demisto_sdk/commands/content_graph/parsers/xsiam_report.py
+++ b/demisto_sdk/commands/content_graph/parsers/xsiam_report.py
@@ -1,7 +1,11 @@
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
-from demisto_sdk.commands.common.constants import MarketplaceVersions
+from demisto_sdk.commands.common.constants import (
+    DEFAULT_CONTENT_ITEM_FROM_VERSION,
+    DEFAULT_CONTENT_ITEM_TO_VERSION,
+    MarketplaceVersions,
+)
 from demisto_sdk.commands.content_graph.common import ContentType
 from demisto_sdk.commands.content_graph.parsers.json_content_item import (
     JSONContentItemParser,
@@ -13,6 +17,7 @@ class XSIAMReportParser(JSONContentItemParser, content_type=ContentType.XSIAM_RE
         self, path: Path, pack_marketplaces: List[MarketplaceVersions]
     ) -> None:
         super().__init__(path, pack_marketplaces)
+        self.original_json_data = self.get_json()
         self.json_data: Dict[str, Any] = self.json_data.get("templates_data", [{}])[0]
 
     @property
@@ -26,3 +31,16 @@ class XSIAMReportParser(JSONContentItemParser, content_type=ContentType.XSIAM_RE
     @property
     def supported_marketplaces(self) -> Set[MarketplaceVersions]:
         return {MarketplaceVersions.MarketplaceV2}
+
+    @property
+    def fromversion(self) -> str:
+        return (
+            self.original_json_data.get("fromVersion")
+            or DEFAULT_CONTENT_ITEM_FROM_VERSION
+        )
+
+    @property
+    def toversion(self) -> str:
+        return (
+            self.original_json_data.get("toVersion") or DEFAULT_CONTENT_ITEM_TO_VERSION
+        )

--- a/demisto_sdk/commands/content_graph/parsers/xsiam_report.py
+++ b/demisto_sdk/commands/content_graph/parsers/xsiam_report.py
@@ -17,7 +17,6 @@ class XSIAMReportParser(JSONContentItemParser, content_type=ContentType.XSIAM_RE
         self, path: Path, pack_marketplaces: List[MarketplaceVersions]
     ) -> None:
         super().__init__(path, pack_marketplaces)
-        self.original_json_data = self.get_json()
         self.json_data: Dict[str, Any] = self.json_data.get("templates_data", [{}])[0]
 
     @property

--- a/demisto_sdk/commands/content_graph/tests/parsers_and_models_test.py
+++ b/demisto_sdk/commands/content_graph/tests/parsers_and_models_test.py
@@ -1421,8 +1421,8 @@ class TestParsersAndModels:
             expected_name="New Import test ",
             expected_path=xsiam_dashboard_path,
             expected_content_type=ContentType.XSIAM_DASHBOARD,
-            expected_fromversion=DEFAULT_CONTENT_ITEM_FROM_VERSION,
-            expected_toversion=DEFAULT_CONTENT_ITEM_TO_VERSION,
+            expected_fromversion="8.1.0",
+            expected_toversion="8.3.0",
         )
 
     def test_xsiam_report_parser(self, pack: Pack):
@@ -1454,8 +1454,8 @@ class TestParsersAndModels:
             expected_name="sample",
             expected_path=xsiam_report_path,
             expected_content_type=ContentType.XSIAM_REPORT,
-            expected_fromversion=DEFAULT_CONTENT_ITEM_FROM_VERSION,
-            expected_toversion=DEFAULT_CONTENT_ITEM_TO_VERSION,
+            expected_fromversion="8.1.0",
+            expected_toversion="8.3.0",
         )
 
     def test_pack_parser(self, repo: Repo):

--- a/demisto_sdk/commands/content_graph/tests/test_data/xsiam_dashboard.json
+++ b/demisto_sdk/commands/content_graph/tests/test_data/xsiam_dashboard.json
@@ -1,4 +1,6 @@
 {
+    "fromVersion": "8.1.0",
+    "toVersion": "8.3.0",
     "dashboards_data": [
       {
         "name": "New Import test ",

--- a/demisto_sdk/commands/content_graph/tests/test_data/xsiam_report.json
+++ b/demisto_sdk/commands/content_graph/tests/test_data/xsiam_report.json
@@ -1,4 +1,6 @@
 {
+    "fromVersion": "8.1.0",
+    "toVersion": "8.3.0",
     "templates_data": [
       {
         "report_name": "sample",


### PR DESCRIPTION
## Related Issues
fixes:

## Description
Edited the parser of XSIAM Dashboard and reports to parse the fromVersion, toVersion fields from the top level of those json files (it caused an issue in the parsing of the pack server min version that led us to install packs that should not be installed)
