### PR TITLE
Graph: safe get file in graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Fixed an issue in **run-unit-tests** and **update-content-graph** where running commands in a docker container was done with insufficient permissions.
 * Added the `_time` field to the output compare table of the **modeling-rules test** command.
 * Changed the endpoint **download** uses to get system content items.
+* Fixed an issue where graph-related tasks failed when files were deleted from the repo.
 
 ## 1.15.5
 * **Breaking Change**: The default of the **upload** command `--zip` argument is `true`. To upload packs as custom content items use the `--no-zip` argument.

--- a/demisto_sdk/commands/content_graph/objects/content_item.py
+++ b/demisto_sdk/commands/content_graph/objects/content_item.py
@@ -238,6 +238,7 @@ class ContentItem(BaseContent):
     ) -> None:
         if not self.path.exists():
             logger.warning(f"Could not find file {self.path}, skipping dump")
+            return
         dir.mkdir(exist_ok=True, parents=True)
         try:
             with (dir / self.normalize_name).open("w") as f:

--- a/demisto_sdk/commands/content_graph/objects/content_item.py
+++ b/demisto_sdk/commands/content_graph/objects/content_item.py
@@ -150,6 +150,9 @@ class ContentItem(BaseContent):
 
     @property
     def data(self) -> dict:
+        if not self.path.exists():
+            logger.warning(f"Could not find file {self.path}")
+            return {}
         return get_file(self.path)
 
     def prepare_for_upload(
@@ -233,6 +236,8 @@ class ContentItem(BaseContent):
         dir: DirectoryPath,
         marketplace: MarketplaceVersions,
     ) -> None:
+        if not self.path.exists():
+            logger.warning(f"Could not find file {self.path}, skipping dump")
         dir.mkdir(exist_ok=True, parents=True)
         try:
             with (dir / self.normalize_name).open("w") as f:

--- a/demisto_sdk/commands/content_graph/objects/content_item.py
+++ b/demisto_sdk/commands/content_graph/objects/content_item.py
@@ -150,9 +150,6 @@ class ContentItem(BaseContent):
 
     @property
     def data(self) -> dict:
-        if not self.path.exists():
-            logger.warning(f"Could not find file {self.path}")
-            return {}
         return get_file(self.path)
 
     def prepare_for_upload(
@@ -160,6 +157,8 @@ class ContentItem(BaseContent):
         current_marketplace: MarketplaceVersions = MarketplaceVersions.XSOAR,
         **kwargs,
     ) -> dict:
+        if not self.path.exists():
+            raise FileNotFoundError(f"Could not find file {self.path}")
         data = self.data
         logger.debug(f"preparing {self.path}")
         return MarketplaceSuffixPreparer.prepare(

--- a/demisto_sdk/commands/upload/tests/uploader_test.py
+++ b/demisto_sdk/commands/upload/tests/uploader_test.py
@@ -1069,7 +1069,7 @@ class TestItemDetacher:
         # Tests that the function successfully zips and dumps multiple valid pack paths.
 
 
-def test_zip_multiple_packs(tmp_path: Path, mocker):
+def test_zip_multiple_packs(tmp_path: Path, integration, mocker):
     tmp_path = tmp_path / "Packs"
     tmp_path.mkdir()
 
@@ -1077,8 +1077,9 @@ def test_zip_multiple_packs(tmp_path: Path, mocker):
         pack = mock_pack(name=name, path=tmp_path / name)
         pack.path.mkdir(parents=True)
         pack.content_items.integration.append(
-            mock_integration(path=pack.path / "Integrations")
+            mock_integration(path=integration.yml.path)
         )
+
         (pack.path / "README.md").touch()
         (pack.path / "pack_metadata.json").touch()
         return pack
@@ -1117,13 +1118,13 @@ def test_zip_multiple_packs(tmp_path: Path, mocker):
     assert {str(path.relative_to(folder_path)) for path in folder_path.rglob("*")} == {
         "Pack0",
         "Pack0/Integrations",
-        "Pack0/Integrations/integration-Integrations",
+        "Pack0/Integrations/integration-integration_0.yml",
         "Pack0/README.md",
         "Pack0/metadata.json",
         "Pack0/pack_metadata.json",
         "Pack1",
         "Pack1/Integrations",
-        "Pack1/Integrations/integration-Integrations",
+        "Pack1/Integrations/integration-integration_0.yml",
         "Pack1/README.md",
         "Pack1/metadata.json",
         "Pack1/pack_metadata.json",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes:

## Description
This happens when content items deleted from content but the official graph in bucket (which is uploaded twice a day) contain those.
