### PR TITLE
Fix Changelog after sdk release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## Unreleased
+* Fixed an issue where lock integartions failed on FileNotFound.(PANW-internal only).
 
 ## 1.16.0
 * Added a check to **is_docker_image_latest_tag** to only fail the validation on non-latest image tag when the current tag is older than 3 days.
@@ -21,7 +22,6 @@
 * Added a **validate** check, and a **format** auto fix for the `fromversion` field in Correlation Rules and XSIAM Dashboards.
 * Update the format used for dev-dependencies in pyproject.toml to match modern versions of Poetry.
 * Added timestamps to logging messages when running in a CI build.
-* Fixed an issue where lock integartions failed on FileNotFound.(PANW-internal only).
 
 ## 1.15.5
 * **Breaking Change**: The default of the **upload** command `--zip` argument is `true`. To upload packs as custom content items use the `--no-zip` argument.


### PR DESCRIPTION
## Description
due to wrong git merge - there is wrong entry in the Changelog for version `1.16.0`
move it to the `unreleased` section