### PR TITLE
[modeling-rules test] - increase timeout when querying for dataset existence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fixed an issue where **lint** falsely warned of using `demisto.results`.
 * Fixed an issue where **validate** always returned *XSIAM Dashboards* and *Correlation Rules* files as valid.
 * Added `GR107` validation to **validate** using the graph validations to check that no deprecated items are used by non-deprecated content.
+* Fixed an issue where the **modeling-rules test** command failed to get the existence of dataset in cases where the datset takes more than 1 minute to get indexed.
 
 ## 1.16.0
 * Added a check to **is_docker_image_latest_tag** to only fail the validation on non-latest image tag when the current tag is older than 3 days.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Fixed an issue where **lint** falsely warned of using `demisto.results`.
 * Fixed an issue where **validate** always returned *XSIAM Dashboards* and *Correlation Rules* files as valid.
 * Added `GR107` validation to **validate** using the graph validations to check that no deprecated items are used by non-deprecated content.
-* Fixed an issue where the **modeling-rules test** command failed to get the existence of dataset in cases where the datset takes more than 1 minute to get indexed.
+* Fixed an issue where the **modeling-rules test** command failed to get the existence of dataset in cases where the dataset takes more than 1 minute to get indexed.
 
 ## 1.16.0
 * Added a check to **is_docker_image_latest_tag** to only fail the validation on non-latest image tag when the current tag is older than 3 days.

--- a/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
+++ b/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
@@ -210,7 +210,7 @@ def validate_expected_values(
 def check_dataset_exists(
     xsiam_client: XsiamApiClient,
     test_data: init_test_data.TestData,
-    timeout: int = 60,
+    timeout: int = 120,
     interval: int = 5,
 ):
     """Check if the dataset in the test data file exists in the tenant.
@@ -218,7 +218,7 @@ def check_dataset_exists(
     Args:
         xsiam_client (XsiamApiClient): Xsiam API client.
         test_data (init_test_data.TestData): The data parsed from the test data file.
-        timeout (int, optional): The number of seconds to wait for the dataset to exist. Defaults to 60.
+        timeout (int, optional): The number of seconds to wait for the dataset to exist. Defaults to 120 seconds.
         interval (int, optional): The number of seconds to wait between checking for the dataset. Defaults to 5.
 
     Raises:


### PR DESCRIPTION
## Description
Fixed an issue where the **modeling-rules test** command failed to get the existence of dataset in cases where the dataset takes more than 1 minute to get indexed.

related: [conversation](https://panw-global.slack.com/archives/G011E63JXPB/p1687087774598549)
