### PR TITLE
Fixed error message in `validate` getting MD, PNG files

### DIFF
--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -2685,6 +2685,8 @@ class ValidateManager:
 
     @staticmethod
     def is_old_file_format(file_path, file_type):
+        if file_type not in (FileType.INTEGRATION, FileType.SCRIPT):
+            return False
         file_yml = get_file(file_path)
         # check for unified integration
         if file_type == FileType.INTEGRATION and file_yml.get("script", {}).get(


### PR DESCRIPTION

## Related Issues
fixes:

## Description
This happens in `is_old_file_format` which is relevant only for integrations and scripts