### PR TITLE
Content Models: supporting preprocess rules and enhancements and

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@
 * Fixed an issue where the **download** command failed when the playbook has different `name` and `id`.
 * Moved the **pre-commmit** command template to the `demisto/content` repository, where it's easier to maintain.
 * Fixed an issue where an internal method caused warning messages when reading md files.
-* Added support to the **upload** command to upload packs contains Pre Process Rules.
-* Fixed an issue in **upload** and **prepare-content** where the content items were skipping where the `maketplaces` field was an empty list.
+* Added support for Pre Process Rules in the **upload** command.
+* Fixed an issue where **upload** would not upload items whose `maketplaces` value was an empty list.
 
 ## 1.16.0
 * Added a check to **is_docker_image_latest_tag** to only fail the validation on non-latest image tag when the current tag is older than 3 days.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 * Fixed an issue where the **download** command failed when the playbook has different `name` and `id`.
 * Moved the **pre-commmit** command template to the `demisto/content` repository, where it's easier to maintain.
 * Fixed an issue where an internal method caused warning messages when reading md files.
+* Added support to the **upload** command to upload packs contains Pre Process Rules.
+* Fixed an issue in **upload** and **prepare-content** where the content items were skipping where the `maketplaces` field was an empty list.
 
 ## 1.16.0
 * Added a check to **is_docker_image_latest_tag** to only fail the validation on non-latest image tag when the current tag is older than 3 days.

--- a/TestSuite/pack.py
+++ b/TestSuite/pack.py
@@ -450,7 +450,7 @@ class Pack:
         self.layouts.append(layout)
         return layout
 
-    def create_layoutcontainer(self, name, content: dict = None) -> JSONBased:
+    def create_layoutcontainer(self, name, content: Optional[dict] = None) -> JSONBased:
         if not content:
             content = {"group": "default"}
         prefix = "layoutscontainer"

--- a/TestSuite/pack.py
+++ b/TestSuite/pack.py
@@ -451,6 +451,8 @@ class Pack:
         return layout
 
     def create_layoutcontainer(self, name, content: dict = None) -> JSONBased:
+        if not content:
+            content = {"group": "default"}
         prefix = "layoutscontainer"
         layoutcontainer = self._create_json_based(
             name, prefix, content, dir_path=self._layout_path

--- a/demisto_sdk/commands/content_graph/common.py
+++ b/demisto_sdk/commands/content_graph/common.py
@@ -102,7 +102,7 @@ class ContentType(str, enum.Enum):
         elif self == ContentType.LAYOUT:
             return "layoutscontainer"
         elif self == ContentType.PREPROCESS_RULE:
-            return "pre-process-rule"
+            return "preprocessrule"
         elif self == ContentType.TEST_PLAYBOOK:
             return ContentType.PLAYBOOK.server_name
         elif self == ContentType.MAPPER:

--- a/demisto_sdk/commands/content_graph/objects/__init__.py
+++ b/demisto_sdk/commands/content_graph/objects/__init__.py
@@ -31,6 +31,7 @@ __all__ = [
     "XDRCTemplate",
     "RelationshipData",
     "LayoutRule",
+    "PreProcessRule",
 ]
 
 from demisto_sdk.commands.content_graph.objects.classifier import Classifier
@@ -56,6 +57,7 @@ from demisto_sdk.commands.content_graph.objects.modeling_rule import ModelingRul
 from demisto_sdk.commands.content_graph.objects.pack import Pack
 from demisto_sdk.commands.content_graph.objects.parsing_rule import ParsingRule
 from demisto_sdk.commands.content_graph.objects.playbook import Playbook
+from demisto_sdk.commands.content_graph.objects.pre_process_rule import PreProcessRule
 from demisto_sdk.commands.content_graph.objects.relationship import RelationshipData
 from demisto_sdk.commands.content_graph.objects.report import Report
 from demisto_sdk.commands.content_graph.objects.script import Script

--- a/demisto_sdk/commands/content_graph/objects/pack.py
+++ b/demisto_sdk/commands/content_graph/objects/pack.py
@@ -59,6 +59,7 @@ from demisto_sdk.commands.content_graph.objects.mapper import Mapper
 from demisto_sdk.commands.content_graph.objects.modeling_rule import ModelingRule
 from demisto_sdk.commands.content_graph.objects.parsing_rule import ParsingRule
 from demisto_sdk.commands.content_graph.objects.playbook import Playbook
+from demisto_sdk.commands.content_graph.objects.pre_process_rule import PreProcessRule
 from demisto_sdk.commands.content_graph.objects.report import Report
 from demisto_sdk.commands.content_graph.objects.script import Script
 from demisto_sdk.commands.content_graph.objects.test_playbook import TestPlaybook
@@ -174,6 +175,9 @@ class PackContentItems(BaseModel):
     xsiam_report: List[XSIAMReport] = Field([], alias=ContentType.XSIAM_REPORT.value)
     xdrc_template: List[XDRCTemplate] = Field([], alias=ContentType.XDRC_TEMPLATE.value)
     layout_rule: List[LayoutRule] = Field([], alias=ContentType.LAYOUT_RULE.value)
+    preprocess_rule: List[PreProcessRule] = Field(
+        [], alias=ContentType.PREPROCESS_RULE.value
+    )
 
     def __iter__(self) -> Generator[ContentItem, Any, Any]:  # type: ignore
         """Defines the iteration of the object. Each iteration yields a single content item."""

--- a/demisto_sdk/commands/content_graph/objects/pre_process_rule.py
+++ b/demisto_sdk/commands/content_graph/objects/pre_process_rule.py
@@ -1,0 +1,9 @@
+from typing import Set
+
+from demisto_sdk.commands.content_graph.common import ContentType
+from demisto_sdk.commands.content_graph.objects.base_content import BaseContent
+
+
+class PreProcessRule(BaseContent, content_type=ContentType.PREPROCESS_RULE):
+    def metadata_fields(self) -> Set[str]:
+        raise NotImplementedError("PreprocessRule not included in metadata")

--- a/demisto_sdk/commands/content_graph/objects/pre_process_rule.py
+++ b/demisto_sdk/commands/content_graph/objects/pre_process_rule.py
@@ -1,9 +1,9 @@
 from typing import Set
 
 from demisto_sdk.commands.content_graph.common import ContentType
-from demisto_sdk.commands.content_graph.objects.base_content import BaseContent
+from demisto_sdk.commands.content_graph.objects.content_item import ContentItem
 
 
-class PreProcessRule(BaseContent, content_type=ContentType.PREPROCESS_RULE):
+class PreProcessRule(ContentItem, content_type=ContentType.PREPROCESS_RULE):
     def metadata_fields(self) -> Set[str]:
-        raise NotImplementedError("PreprocessRule not included in metadata")
+        return {"name", "description"}

--- a/demisto_sdk/commands/content_graph/parsers/__init__.py
+++ b/demisto_sdk/commands/content_graph/parsers/__init__.py
@@ -29,6 +29,7 @@ __all__ = [
     "XSIAMReportParser",
     "XDRCTemplateParser",
     "LayoutRuleParser",
+    "PreProcessRuleParser",
 ]
 
 from demisto_sdk.commands.content_graph.parsers.classifier import ClassifierParser
@@ -63,6 +64,9 @@ from demisto_sdk.commands.content_graph.parsers.mapper import MapperParser
 from demisto_sdk.commands.content_graph.parsers.modeling_rule import ModelingRuleParser
 from demisto_sdk.commands.content_graph.parsers.parsing_rule import ParsingRuleParser
 from demisto_sdk.commands.content_graph.parsers.playbook import PlaybookParser
+from demisto_sdk.commands.content_graph.parsers.pre_process_rule import (
+    PreProcessRuleParser,
+)
 from demisto_sdk.commands.content_graph.parsers.report import ReportParser
 from demisto_sdk.commands.content_graph.parsers.script import ScriptParser
 from demisto_sdk.commands.content_graph.parsers.test_playbook import TestPlaybookParser

--- a/demisto_sdk/commands/content_graph/parsers/layout.py
+++ b/demisto_sdk/commands/content_graph/parsers/layout.py
@@ -17,7 +17,7 @@ class LayoutParser(JSONContentItemParser, content_type=ContentType.LAYOUT):
         self, path: Path, pack_marketplaces: List[MarketplaceVersions]
     ) -> None:
         super().__init__(path, pack_marketplaces)
-        if not self.json_data.get("group"):
+        if "group" not in self.json_data:
             logger.debug(f"{path}: Not a layout container, skipping.")
             raise NotAContentItemException
 

--- a/demisto_sdk/commands/content_graph/parsers/layout.py
+++ b/demisto_sdk/commands/content_graph/parsers/layout.py
@@ -16,11 +16,11 @@ class LayoutParser(JSONContentItemParser, content_type=ContentType.LAYOUT):
     def __init__(
         self, path: Path, pack_marketplaces: List[MarketplaceVersions]
     ) -> None:
+        super().__init__(path, pack_marketplaces)
         if not self.json_data.get("group"):
             logger.debug(f"{path}: Not a layout container, skipping.")
             raise NotAContentItemException
 
-        super().__init__(path, pack_marketplaces)
         self.kind = self.json_data.get("kind")
         self.tabs = self.json_data.get("tabs")
         self.definition_id = self.json_data.get("definitionId")

--- a/demisto_sdk/commands/content_graph/parsers/layout.py
+++ b/demisto_sdk/commands/content_graph/parsers/layout.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import List, Set
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
+from demisto_sdk.commands.common.logger import logger
 from demisto_sdk.commands.content_graph.common import ContentType
 from demisto_sdk.commands.content_graph.parsers.content_item import (
     NotAContentItemException,
@@ -15,7 +16,8 @@ class LayoutParser(JSONContentItemParser, content_type=ContentType.LAYOUT):
     def __init__(
         self, path: Path, pack_marketplaces: List[MarketplaceVersions]
     ) -> None:
-        if "layoutscontainer" not in path.name:
+        if not self.json_data.get("group"):
+            logger.debug(f"{path}: Not a layout container, skipping.")
             raise NotAContentItemException
 
         super().__init__(path, pack_marketplaces)

--- a/demisto_sdk/commands/content_graph/parsers/pack.py
+++ b/demisto_sdk/commands/content_graph/parsers/pack.py
@@ -69,6 +69,9 @@ class PackContentItems:
         self.xsiam_report = ContentItemsList(content_type=ContentType.XSIAM_REPORT)
         self.xdrc_template = ContentItemsList(content_type=ContentType.XDRC_TEMPLATE)
         self.layout_rule = ContentItemsList(content_type=ContentType.LAYOUT_RULE)
+        self.preprocess_rule = ContentItemsList(
+            content_type=ContentType.PREPROCESS_RULE
+        )
 
     def iter_lists(self) -> Iterator[ContentItemsList]:
         yield from vars(self).values()

--- a/demisto_sdk/commands/content_graph/parsers/pack.py
+++ b/demisto_sdk/commands/content_graph/parsers/pack.py
@@ -123,8 +123,8 @@ class PackMetadataParser:
         self.vendor_id: Optional[str] = metadata.get("vendorId")
         self.vendor_name: Optional[str] = metadata.get("vendorName")
         self.preview_only: Optional[bool] = metadata.get("previewOnly")
-        self.marketplaces: List[MarketplaceVersions] = metadata.get(
-            "marketplaces", DEFAULT_MARKETPLACES
+        self.marketplaces: List[MarketplaceVersions] = (
+            metadata.get("marketplaces") or DEFAULT_MARKETPLACES
         )
         self.excluded_dependencies: List[str] = metadata.get("excludedDependencies", [])
 

--- a/demisto_sdk/commands/content_graph/parsers/pre_process_rule.py
+++ b/demisto_sdk/commands/content_graph/parsers/pre_process_rule.py
@@ -1,10 +1,15 @@
+from typing import Set
+
+from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
 from demisto_sdk.commands.content_graph.parsers.json_content_item import (
     JSONContentItemParser,
 )
 
 
-class PreprocessRuleParser(
+class PreProcessRuleParser(
     JSONContentItemParser, content_type=ContentType.PREPROCESS_RULE
 ):
-    pass
+    @property
+    def supported_marketplaces(self) -> Set[MarketplaceVersions]:
+        return {MarketplaceVersions.XSOAR}

--- a/demisto_sdk/commands/content_graph/parsers/pre_process_rule.py
+++ b/demisto_sdk/commands/content_graph/parsers/pre_process_rule.py
@@ -1,0 +1,10 @@
+from demisto_sdk.commands.content_graph.common import ContentType
+from demisto_sdk.commands.content_graph.parsers.json_content_item import (
+    JSONContentItemParser,
+)
+
+
+class PreprocessRuleParser(
+    JSONContentItemParser, content_type=ContentType.PREPROCESS_RULE
+):
+    pass

--- a/demisto_sdk/commands/content_graph/tests/parsers_and_models_test.py
+++ b/demisto_sdk/commands/content_graph/tests/parsers_and_models_test.py
@@ -8,13 +8,16 @@ from demisto_sdk.commands.common.constants import (
     DEFAULT_CONTENT_ITEM_TO_VERSION,
     MarketplaceVersions,
 )
+from demisto_sdk.commands.common.legacy_git_tools import git_path
 from demisto_sdk.commands.content_graph.common import (
     ContentType,
     Relationships,
     RelationshipType,
 )
+from demisto_sdk.commands.content_graph.objects.base_content import BaseContent
 from demisto_sdk.commands.content_graph.objects.content_item import ContentItem
 from demisto_sdk.commands.content_graph.objects.pack import Pack as PackModel
+from demisto_sdk.commands.content_graph.objects.pre_process_rule import PreProcessRule
 from demisto_sdk.commands.content_graph.parsers.content_item import (
     NotAContentItemException,
 )
@@ -1457,6 +1460,16 @@ class TestParsersAndModels:
             expected_fromversion="8.1.0",
             expected_toversion="8.3.0",
         )
+
+    def test_preprocess_parser(self):
+        pre_process_rule = BaseContent.from_path(
+            Path(
+                f"{git_path()}/demisto_sdk/tests/test_files/content_slim/Packs/Sample01/PreProcessRules/preprocessrule-Drop.json"
+            )
+        )
+        assert isinstance(pre_process_rule, PreProcessRule)
+        assert pre_process_rule.name == "Drop"
+        assert pre_process_rule.object_id == "preprocessrule-Drop-id"
 
     def test_pack_parser(self, repo: Repo):
         """


### PR DESCRIPTION
## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-25326?filter=-1

## Description
* Add PreProcessRule content item
* Handle correctly a case where `marketplace` field in `pack_metadata.json` is an empty list.
* Identify LayoutContainer by the data and not by name.