### PR TITLE
Lint: Don't fail if CommonServerUserPython does not exists

### DIFF
--- a/demisto_sdk/commands/lint/helpers.py
+++ b/demisto_sdk/commands/lint/helpers.py
@@ -164,6 +164,11 @@ def get_test_modules(
                 else:
                     modules_content[module] = (module_full_path).read_bytes()
             except FileNotFoundError:
+                if module.name == "CommonServerUserPython.py":
+                    logger.debug(
+                        "CommonServerUserPython.py was not found, skipping as it will be created later."
+                    )
+                    continue
                 module_not_found = True
                 logger.warning(
                     f"Module {module} was not found, possibly deleted due to being in a feature branch"


### PR DESCRIPTION
## Related Issues
fixes: 

## Description
See failure here: https://code.pan.run/xsoar/content-internal-dist/-/pipelines/5577499

We should not fail if CommonServerUserPython is not found, because we create it later in the pipeline
![image](https://github.com/demisto/demisto-sdk/assets/88267954/3061a8ca-2b35-4ab4-86ab-1414e1cf728b)

