### PR TITLE
Configure poetry to install in .venv folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,7 @@ jobs:
               # remove the integration tests (integration tests as opposed to unit tests) from the list because those
               # tests shouldn't be parallelized.
               TEST_FILES=$(circleci tests glob "**/*_test.py")
+              TEST_FILES=$(echo "$TEST_FILES" | sed -E '.venv')
               TEST_FILES=$(echo "$TEST_FILES" | sed -E 's/\S*demisto_sdk\/commands\/init\/templates\S*\.py//g')
               TEST_FILES=$(echo "$TEST_FILES" | sed -E 's/\S*demisto_sdk\/tests\/integration_tests\S*\.py//g')
               TEST_FILES=$(echo "$TEST_FILES" | sed -E 's/\S*demisto_sdk\/commands\/content_graph\/tests\S*\.py//g')

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,8 @@ jobs:
               # remove the integration tests (integration tests as opposed to unit tests) from the list because those
               # tests shouldn't be parallelized.
               TEST_FILES=$(circleci tests glob "**/*_test.py")
-              TEST_FILES=$(echo "$TEST_FILES" | sed -E '.venv')
+              # filter out files which are in .venv directory
+              TEST_FILES=$(echo "$TEST_FILES" | sed -E 's/\S*\.venv\S*\.py//g')
               TEST_FILES=$(echo "$TEST_FILES" | sed -E 's/\S*demisto_sdk\/commands\/init\/templates\S*\.py//g')
               TEST_FILES=$(echo "$TEST_FILES" | sed -E 's/\S*demisto_sdk\/tests\/integration_tests\S*\.py//g')
               TEST_FILES=$(echo "$TEST_FILES" | sed -E 's/\S*demisto_sdk\/commands\/content_graph\/tests\S*\.py//g')

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,2 @@
+[virtualenvs]
+in-project = true


### PR DESCRIPTION

## Related Issues
fixes:

## Description
This will configure the `poetry` to install the virtualenv in `.venv` folder. 
This will make Demisto-SDK development configuration easier.