### PR TITLE
test-modeling-rules-fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ## Unreleased
-
+* Fixed an issue where the **modeling-rules test** command failed to get the existence of result from dataset in cases where the results take time to load.
 
 ## 1.17.0
 * **validate** will only fail on docker related errors if the pack is supported by xsoar.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Fixed an issue where the **upload** command failed parsing input paths.
 * added support for `isfetcheventsandassets` flag in content graph.
 * Updated **validate** on changed *APIModules* to use graph instead of id_set.
-Fixed an issue where the **modeling-rules test** command failed to get the existence of result from dataset in cases where the results take time to load.
+* Fixed an issue where the **modeling-rules test** command failed to get the existence of result from dataset in cases where the results take time to load.
 
 ## 1.17.0
 * **validate** will only fail on docker related errors if the pack is supported by xsoar.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 * Removed fields with default (false) value that used in the **validate** command.
 * Fixed an issue where Indicator Types would fail to upload when using the **upload** command.
 * Fixed an issue where the **upload** command return wrong error message when API key is invalid.
-* added support for `isfetcheventsandassets` flag in content graph
 * Fixed an issue where the **upload** command failed parsing input paths.
 * added support for `isfetcheventsandassets` flag in content graph.
 * Updated **validate** on changed *APIModules* to use graph instead of id_set.

--- a/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
+++ b/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
@@ -274,6 +274,9 @@ def check_dataset_exists(
     process_failed = False
     dataset_set = {data.dataset for data in test_data.data}
     for dataset in dataset_set:
+        number_of_events = len(
+            [data for data in test_data.data if data.dataset == dataset]
+        )
         dataset_exist = False
         logger.info(
             f'[cyan]Checking if dataset "{dataset}" exists on the tenant...[/cyan]',
@@ -293,6 +296,12 @@ def check_dataset_exists(
                         extra={"markup": True},
                     )
                     dataset_exist = True
+                elif (
+                    i < (timeout // interval) - 1
+                    and isinstance(results, list)
+                    and len(results) < number_of_events
+                ):
+                    continue
                 else:
                     err = (
                         f"[red]Dataset {dataset} exists but no results were returned. This could mean that your testdata "

--- a/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
+++ b/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
@@ -274,7 +274,6 @@ def check_dataset_exists(
     process_failed = False
     dataset_set = {data.dataset for data in test_data.data}
     for dataset in dataset_set:
-        len([data for data in test_data.data if data.dataset == dataset])
         dataset_exist = False
         logger.info(
             f'[cyan]Checking if dataset "{dataset}" exists on the tenant...[/cyan]',

--- a/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
+++ b/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
@@ -257,7 +257,7 @@ def validate_expected_values(
 def check_dataset_exists(
     xsiam_client: XsiamApiClient,
     test_data: init_test_data.TestData,
-    timeout: int = 180,
+    timeout: int = 300,
     interval: int = 5,
 ):
     """Check if the dataset in the test data file exists in the tenant.

--- a/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
+++ b/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
@@ -304,13 +304,14 @@ def check_dataset_exists(
                     dataset_exist = True
                     results_exist = False
                     logger.info(
-                        f"[cyan]try to get results from the data set, there are not results for the {i+1}th time. continue.[/cyan]",
+                        f"[cyan]trying to get results from the dataset for the {i+1}th time. continuing to try to get the results.[/cyan]",
                         extra={"markup": True},
                     )
+            # If the dataset doesn't exist HTTPError exception is raised.
             except requests.exceptions.HTTPError:
                 pass
             sleep(interval)
-        # There are no results from the dataset but it exists. If the dataset doesn't exist HTTPError exception is raised.
+        # There are no results from the dataset but it exists.
         if not results:
             err = (
                 f"[red]Dataset {dataset} exists but no results were returned. This could mean that your testdata "

--- a/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
+++ b/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
@@ -296,12 +296,13 @@ def check_dataset_exists(
                 # if we don't have results from the dataset immediately we will continue to try until the timeout.
                 # if we don't have any results until the timeout dataset_exist is set to False and we will raise an error.
                 elif i < (timeout // interval) - 1:
+                    dataset_exist = True
                     logger.info(
                         f"[cyan]try to get results from the data set, there are not results for the {i}th time. continue.[/cyan]",
                         extra={"markup": True},
                     )
                     continue
-                else:
+                elif dataset_exist:
                     err = (
                         f"[red]Dataset {dataset} exists but no results were returned. This could mean that your testdata "
                         "does not meet the criteria for an associated Parsing Rule and is therefore being dropped from "

--- a/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
+++ b/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
@@ -257,7 +257,7 @@ def validate_expected_values(
 def check_dataset_exists(
     xsiam_client: XsiamApiClient,
     test_data: init_test_data.TestData,
-    timeout: int = 120,
+    timeout: int = 180,
     interval: int = 5,
 ):
     """Check if the dataset in the test data file exists in the tenant.
@@ -297,7 +297,7 @@ def check_dataset_exists(
                 # if we don't have any results until the timeout dataset_exist is set to False and we will raise an error.
                 elif i < (timeout // interval) - 1:
                     logger.info(
-                        f"[cyan]try to get result from the data set, there are not results for the {i}th time. continue.[/cyan]",
+                        f"[cyan]try to get results from the data set, there are not results for the {i}th time. continue.[/cyan]",
                         extra={"markup": True},
                     )
                     continue

--- a/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
+++ b/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
@@ -274,9 +274,7 @@ def check_dataset_exists(
     process_failed = False
     dataset_set = {data.dataset for data in test_data.data}
     for dataset in dataset_set:
-        number_of_events = len(
-            [data for data in test_data.data if data.dataset == dataset]
-        )
+        len([data for data in test_data.data if data.dataset == dataset])
         dataset_exist = False
         logger.info(
             f'[cyan]Checking if dataset "{dataset}" exists on the tenant...[/cyan]',
@@ -296,11 +294,13 @@ def check_dataset_exists(
                         extra={"markup": True},
                     )
                     dataset_exist = True
-                elif (
-                    i < (timeout // interval) - 1
-                    and isinstance(results, list)
-                    and len(results) < number_of_events
-                ):
+                # if we don't have results from the dataset immediately we will continue to try until the timeout.
+                # if we don't have any results until the timeout dataset_exist is set to False and we will raise an error.
+                elif i < (timeout // interval) - 1:
+                    logger.info(
+                        f"[cyan]try to get result from the data set, there are not results for the {i}th time. continue.[/cyan]",
+                        extra={"markup": True},
+                    )
                     continue
                 else:
                     err = (


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-7147

## Description
Fixed an issue where the **modeling-rules test** command failed to get the existence of result from dataset in cases where the results take time to load.