### PR TITLE
Implement new upload logic to indicator types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 * Fixed an issue where `register_module_line()` was not removed from python scripts when the script had no trailing newline.
 * Fixed an issue where attempting to individually upload `Preprocess Rule` files raised an unclear error message. Note: preprocess rules can not be individually uploaded, but only as part of a pack.
+* Fixed an issue where Indicator Types would fail to upload when using the **upload** command.
 
 
 ## 1.17.0

--- a/demisto_sdk/commands/content_graph/objects/indicator_type.py
+++ b/demisto_sdk/commands/content_graph/objects/indicator_type.py
@@ -1,8 +1,12 @@
-from typing import Callable, List, Optional, Set
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import List, Optional, Set
 
 import demisto_client
 from pydantic import Field
 
+from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
 from demisto_sdk.commands.content_graph.objects.content_item import ContentItem
 
@@ -18,6 +22,14 @@ class IndicatorType(ContentItem, content_type=ContentType.INDICATOR_TYPE):  # ty
     def metadata_fields(self) -> Set[str]:
         return {"details", "reputation_script_name", "enhancement_script_names"}
 
-    @classmethod
-    def _client_upload_method(cls, client: demisto_client) -> Callable:
-        return client.import_reputation_handler  # TODO check file name
+    def _upload(
+        self,
+        client: demisto_client,
+        marketplace: MarketplaceVersions,
+    ) -> None:
+        with TemporaryDirectory() as dir:
+            file_path = Path(dir, self.normalize_name)
+            with open(file_path, "w") as f:
+                # Wrapping the dictionary with a list, as that's what the server expects
+                json.dump([self.prepare_for_upload(marketplace=marketplace)], f)
+            client.import_reputation_handler(str(file_path))


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-25578

## Description
As mentioned in the ticket, the server expects the indicator type to be uploaded as an array. This change is identical to the implementation in Incident Types.