### PR TITLE
Fix for optional command description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## Unreleased
 * Fixed an issue where `register_module_line()` was not removed from python scripts when the script had no trailing newline.
+* Fixed an issue where an integration containing a command without a description would fail to upload while using the **upload** command.
 * Fixed an issue where attempting to individually upload `Preprocess Rule` files raised an unclear error message. Note: preprocess rules can not be individually uploaded, but only as part of a pack.
 
 

--- a/demisto_sdk/commands/content_graph/objects/integration.py
+++ b/demisto_sdk/commands/content_graph/objects/integration.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Callable, List
+from typing import TYPE_CHECKING, Callable, List, Optional
 
 import demisto_client
 
@@ -23,7 +23,7 @@ class Command(BaseContent, content_type=ContentType.COMMAND):  # type: ignore[ca
 
     # From HAS_COMMAND relationship
     deprecated: bool = False
-    description: str = ""
+    description: Optional[str] = ""
 
     # missing attributes in DB
     node_id: str = ""


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-25606

## Description
* Fixed an issue where an integration containing a command without a description would fail to upload while using the **upload** command.
