### PR TITLE
Bugfix: NamedTemporaryFile Windows error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Updated the **modeling-rules init & test** commands to support RULE section fields.
 * Stability improvements for **graph create** and **graph update** commands.
 * Fixed the *metadata* type in the XSIAM dashboard schema to *map*.
+* Fixed an issue where Incident Fields, Incident Types, Indicator Fields, and Indicator Types would fail to upload when using the **upload** command on Windows environments.
 
 ## 1.20.2
 * Updated the **pre-commit** command to run on all python versions in one run.

--- a/demisto_sdk/commands/common/content/objects/pack_objects/incident_field/incident_field.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/incident_field/incident_field.py
@@ -1,4 +1,3 @@
-import os
 import platform
 from tempfile import NamedTemporaryFile
 from typing import Union
@@ -53,7 +52,7 @@ class IncidentField(JSONContentObject):
         # This section only runs if Windows is the detected operating system
         res = client.import_incident_fields(file=filename)
         # Delete the NamedTemporaryFile object
-        os.remove(filename)
+        Path(filename).unlink()
         return res
 
     def type(self):

--- a/demisto_sdk/commands/common/content/objects/pack_objects/incident_field/incident_field.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/incident_field/incident_field.py
@@ -1,3 +1,5 @@
+import os
+import platform
 from tempfile import NamedTemporaryFile
 from typing import Union
 
@@ -29,12 +31,30 @@ class IncidentField(JSONContentObject):
         else:
             incident_fields_unified_data = {"incidentFields": self._as_dict}
 
-        with NamedTemporaryFile(suffix=".json") as incident_fields_unified_file:
+        is_win_os = platform.system() == "Windows"
+
+        # Set delete to False if a Windows operating system is detected
+        # On Windows operating systems, NamedTemporaryFile objects cannot be
+        # opened a second time while open in a context manager
+        with NamedTemporaryFile(
+            suffix=".json",
+            delete=not is_win_os,
+        ) as incident_fields_unified_file:
             incident_fields_unified_file.write(
                 bytes(json.dumps(incident_fields_unified_data), "utf-8")
             )
             incident_fields_unified_file.seek(0)
-            return client.import_incident_fields(file=incident_fields_unified_file.name)
+
+            filename = incident_fields_unified_file.name
+
+            if not is_win_os:
+                return client.import_incident_fields(file=filename)
+
+        # This section only runs if Windows is the detected operating system
+        res = client.import_incident_fields(file=filename)
+        # Delete the NamedTemporaryFile object
+        os.remove(filename)
+        return res
 
     def type(self):
         return FileType.INCIDENT_FIELD

--- a/demisto_sdk/commands/common/content/objects/pack_objects/incident_type/incident_type.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/incident_type/incident_type.py
@@ -1,3 +1,5 @@
+import os
+import platform
 from tempfile import NamedTemporaryFile
 from typing import Union
 
@@ -29,14 +31,30 @@ class IncidentType(JSONContentObject):
         else:
             incident_type_unified_data = self._as_dict
 
-        with NamedTemporaryFile(suffix=".json") as incident_type_unified_file:
+        is_win_os = platform.system() == "Windows"
+
+        # Set delete to False if a Windows operating system is detected
+        # On Windows operating systems, NamedTemporaryFile objects cannot be
+        # opened a second time while open in a context manager
+        with NamedTemporaryFile(
+            suffix=".json",
+            delete=not is_win_os,
+        ) as incident_type_unified_file:
             incident_type_unified_file.write(
                 bytes(json.dumps(incident_type_unified_data), "utf-8")
             )
             incident_type_unified_file.seek(0)
-            return client.import_incident_types_handler(
-                file=incident_type_unified_file.name
-            )
+
+            filename = incident_type_unified_file.name
+
+            if not is_win_os:
+                return client.import_incident_types_handler(file=filename)
+
+        # This section only runs if Windows is the detected operating system
+        res = client.import_incident_types_handler(file=filename)
+        # Delete the NamedTemporaryFile object
+        os.remove(filename)
+        return res
 
     def type(self):
         return FileType.INCIDENT_TYPE

--- a/demisto_sdk/commands/common/content/objects/pack_objects/incident_type/incident_type.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/incident_type/incident_type.py
@@ -1,4 +1,3 @@
-import os
 import platform
 from tempfile import NamedTemporaryFile
 from typing import Union
@@ -53,7 +52,7 @@ class IncidentType(JSONContentObject):
         # This section only runs if Windows is the detected operating system
         res = client.import_incident_types_handler(file=filename)
         # Delete the NamedTemporaryFile object
-        os.remove(filename)
+        Path(filename).unlink()
         return res
 
     def type(self):

--- a/demisto_sdk/commands/common/content/objects/pack_objects/indicator_field/indicator_field.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/indicator_field/indicator_field.py
@@ -1,4 +1,3 @@
-import os
 import platform
 from tempfile import NamedTemporaryFile
 from typing import Union
@@ -92,7 +91,7 @@ class IndicatorField(JSONContentObject):
         # This section only runs if Windows is the detected operating system
         res = client.import_incident_fields(file=filename)
         # Delete the NamedTemporaryFile object
-        os.remove(filename)
+        Path(filename).unlink()
         return res
 
     def type(self):

--- a/demisto_sdk/commands/common/content/objects/pack_objects/indicator_type/indicator_type.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/indicator_type/indicator_type.py
@@ -1,4 +1,3 @@
-import os
 import platform
 from tempfile import NamedTemporaryFile
 from typing import Union
@@ -57,7 +56,7 @@ class IndicatorType(JSONContentObject):
         # This section only runs if Windows is the detected operating system
         res = client.import_reputation_handler(file=filename)
         # Delete the NamedTemporaryFile object
-        os.remove(filename)
+        Path(filename).unlink()
         return res
 
     def type(self):

--- a/demisto_sdk/commands/content_graph/objects/incident_field.py
+++ b/demisto_sdk/commands/content_graph/objects/incident_field.py
@@ -1,11 +1,10 @@
-import json
-import os
 import platform
 from tempfile import NamedTemporaryFile
 from typing import Optional, Set
 
 import demisto_client
 from pydantic import Field
+from wcmatch.pathlib import Path
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.common.handlers import JSON_Handler
@@ -63,5 +62,5 @@ class IncidentField(ContentItem, content_type=ContentType.INCIDENT_FIELD):  # ty
         # This section only runs if Windows is the detected operating system
         res = client.import_incident_fields(file=filename)
         # Delete the NamedTemporaryFile object
-        os.remove(filename)
+        Path(filename).unlink()
         return res


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
No issue raised, but fixes upload of Incident Fields, Incident Types, Indicator Fields, and Indicator Types on Windows environments.

## Description
### Problem
When uploading Incident Fields, Incident Types, Indicator Fields, or Indicator Types, the following error is displayed in the FAILED UPLOADS summary table for each file of the affected content types:
```
[Errno 13] Permission denied: 'C:\\Users\\[USER]\\AppData\\Local\\Temp\\[TEMP_FILE].json'
```
### Root Cause
The error occurs because, on Windows environments, NamedTemporaryFile objects cannot be opened a second time while open in a context manager.

This is explained in the Python documentation for [NamedTemporaryFiles](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile) as well.

> Whether the name can be used to open the file a second time, while the named temporary file is still open, varies across platforms (it can be so used on Unix; **it cannot on Windows**).

### Replicating the bug
Run the following command in a Windows environment:
```
demisto-sdk upload --input Packs/CustomContent/<AFFECTED_CONTENT_TYPE>/
```

For example:
```
demisto-sdk upload --input Packs/CustomContent/IncidentFields/
```