### PR TITLE
Move LINK_PR_TO_JIRA_ISSUE to Content Gold NG

### DIFF
--- a/.github/workflows/close_jira_issue_by_pr_merge.yml
+++ b/.github/workflows/close_jira_issue_by_pr_merge.yml
@@ -32,9 +32,9 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_LINK: ${{ github.event.pull_request.html_url }}
           PR_BODY: ${{ github.event.pull_request.body }}
-          USERNAME: ${{ secrets.LINK_PR_TO_JIRA_ISSUE_USER }}
-          PASSWORD: ${{ secrets.LINK_PR_TO_JIRA_ISSUE_PASSWORD }}
-          INSTANCE_URL: ${{ secrets.ENGINE_URL }}
+          USERNAME: ${{ secrets.GOLD_NG_LINK_PR_TO_JIRA_ISSUE_USER }}
+          PASSWORD: ${{ secrets.GOLD_NG_LINK_PR_TO_JIRA_ISSUE_PASSWORD }}
+          INSTANCE_URL: ${{ secrets.GOLD_NG_ENGINE_URL }}
         run: |
           echo "Checking for related Jira issues to PR: $PR_NUMBER"
           cd Utils/github_workflow_scripts/jira_integration_scripts

--- a/.github/workflows/link_edited_pr_to_jira_issue.yml
+++ b/.github/workflows/link_edited_pr_to_jira_issue.yml
@@ -32,9 +32,9 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_LINK: ${{ github.event.pull_request.html_url }}
           PR_BODY: ${{ github.event.pull_request.body }}
-          USERNAME: ${{ secrets.LINK_PR_TO_JIRA_ISSUE_USER }}
-          PASSWORD: ${{ secrets.LINK_PR_TO_JIRA_ISSUE_PASSWORD }}
-          INSTANCE_URL: ${{ secrets.ENGINE_URL }}
+          USERNAME: ${{ secrets.GOLD_NG_LINK_PR_TO_JIRA_ISSUE_USER }}
+          PASSWORD: ${{ secrets.GOLD_NG_LINK_PR_TO_JIRA_ISSUE_PASSWORD }}
+          INSTANCE_URL: ${{ secrets.GOLD_NG_ENGINE_URL }}
         run: |
           echo "Checking for related Jira issues to PR: $PR_NUMBER"
           cd Utils/github_workflow_scripts/jira_integration_scripts


### PR DESCRIPTION
## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-7269

## Description
We want to move the webhook that runs the script LINK_PR_TO_JIRA_ISSUE to Content Gold NG.