### PR TITLE
Fixed Typos in log help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 ## Unreleased
 * Improved memory efficiency in **update-content-graph** and **create-content-graph** commands.
-* Fixed typos in the log flag help.
 
 ## 1.17.1
 * Added the `aliasTo` key to the Incident Field schema.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## Unreleased
 * Improved memory efficiency in **update-content-graph** and **create-content-graph** commands.
+* Fixed typos in the log flag help. 
 
 ## 1.17.1
 * Added the `aliasTo` key to the Incident Field schema.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 ## Unreleased
 * Improved memory efficiency in **update-content-graph** and **create-content-graph** commands.
-* Fixed typos in the log flag help. 
+* Fixed typos in the log flag help.
 
 ## 1.17.1
 * Added the `aliasTo` key to the Incident Field schema.

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -133,12 +133,12 @@ def logging_setup_decorator(func, *args, **kwargs):
     @click.option(
         "--console_log_threshold",
         help="Minimum logging threshold for the console logger."
-        " Pssible values: DEBUG, INFO, WARNING, ERROR.",
+        " Possible values: DEBUG, INFO, WARNING, ERROR.",
     )
     @click.option(
         "--file_log_threshold",
         help="Minimum logging threshold for the file logger."
-        " Pssible values: DEBUG, INFO, WARNING, ERROR.",
+        " Possible values: DEBUG, INFO, WARNING, ERROR.",
     )
     @click.option(
         "--log_file_path",


### PR DESCRIPTION
## Related Issues
fixes:

## Description

Fix typo in the log's flag help.