### PR TITLE
fix run-unit-tests command

### DIFF
--- a/demisto_sdk/commands/run_unit_tests/unit_tests_runner.py
+++ b/demisto_sdk/commands/run_unit_tests/unit_tests_runner.py
@@ -162,7 +162,7 @@ def unit_test_runner(file_paths: List[Path], verbose: bool = False) -> int:
                     ],
                     command=PWSH_COMMAND
                     if integration_script.type == "powershell"
-                    else PYTEST_COMMAND,
+                    else [PYTEST_COMMAND],
                     user=f"{os.getuid()}:{os.getgid()}",
                     working_dir=working_dir,
                     detach=True,


### PR DESCRIPTION

## Related Issues
fixes:

## Description
Fix run-unit-test command:
When running pytest it should be in a list, when running powershell supposed to be a str