### PR TITLE
ignore non error outputs

### DIFF
--- a/demisto_sdk/commands/lint/commands_builder.py
+++ b/demisto_sdk/commands/lint/commands_builder.py
@@ -314,6 +314,8 @@ def build_pwsh_analyze_command(file: Path) -> str:
     command = "Invoke-ScriptAnalyzer"
     # Return exit code when finished
     command += " -EnableExit"
+    # Don't fail on warnings and information
+    command += " -Severity Error"
     # Lint Files paths
     command += f" -Path {file.name}"
 

--- a/demisto_sdk/commands/lint/tests/command_builder_test.py
+++ b/demisto_sdk/commands/lint/tests/command_builder_test.py
@@ -194,7 +194,7 @@ def test_build_pwsh_analyze():
     from demisto_sdk.commands.lint.commands_builder import build_pwsh_analyze_command
 
     file = MagicMock()
-    command = f"pwsh -Command Invoke-ScriptAnalyzer -EnableExit -Path {file.name}"
+    command = f"pwsh -Command Invoke-ScriptAnalyzer -EnableExit -Severity Error -Path {file.name}"
     assert command == build_pwsh_analyze_command(file)
 
 


### PR DESCRIPTION

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-7415

## Description
Added severity rule to the pwsh analyzer to return only errors, not warnings.
