### PR TITLE
Require JSON/YAML_Handlers

### DIFF
--- a/TestSuite/job.py
+++ b/TestSuite/job.py
@@ -1,4 +1,3 @@
-from json.decoder import JSONDecodeError
 from pathlib import Path
 from typing import List, Optional
 
@@ -6,7 +5,10 @@ from demisto_sdk.commands.common.constants import (
     FILETYPE_TO_DEFAULT_FROMVERSION,
     FileType,
 )
+from demisto_sdk.commands.common.handlers import JSON_Handler
 from TestSuite.json_based import JSONBased
+
+json = JSON_Handler()
 
 
 class Job(JSONBased):
@@ -45,5 +47,5 @@ class Job(JSONBased):
         try:
             return (self.read_json_as_dict() or {}).get("playbookId", default)
 
-        except JSONDecodeError:  # file not yet written
+        except json.JSONDecodeError:  # file not yet written
             return default

--- a/demisto_sdk/commands/common/content/objects/abstract_objects/yaml_object.py
+++ b/demisto_sdk/commands/common/content/objects/abstract_objects/yaml_object.py
@@ -1,6 +1,6 @@
 from typing import Optional, Union
 
-from ruamel.yaml.scanner import ScannerError
+from ruamel.yaml.scanner import ScannerError  # noqa:TID251 # only importing error is ok
 from wcmatch.pathlib import EXTGLOB, NEGATE, Path
 
 import demisto_sdk.commands.common.content.errors as exc

--- a/demisto_sdk/commands/common/content/objects/pack_objects/readme/readme.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/readme/readme.py
@@ -1,12 +1,14 @@
-import json
 from typing import List, Optional, Union
 
 from wcmatch.pathlib import Path
 
 from demisto_sdk.commands.common.constants import CONTRIBUTORS_README_TEMPLATE, FileType
 from demisto_sdk.commands.common.content.objects.abstract_objects import TextObject
+from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.logger import logger
 from demisto_sdk.commands.common.tools import get_mp_tag_parser
+
+json = JSON_Handler()
 
 
 class Readme(TextObject):

--- a/demisto_sdk/commands/common/handlers/json/orjson_handler.py
+++ b/demisto_sdk/commands/common/handlers/json/orjson_handler.py
@@ -1,6 +1,6 @@
 from typing import IO, Optional
 
-import orjson
+import orjson  # noqa: TID251 - this is the handler
 
 from demisto_sdk.commands.common.handlers.xsoar_handler import XSOAR_Handler
 

--- a/demisto_sdk/commands/common/handlers/json/ujson_handler.py
+++ b/demisto_sdk/commands/common/handlers/json/ujson_handler.py
@@ -24,7 +24,7 @@ class UJSON_Handler(XSOAR_Handler):
         try:
             return ujson.loads(s)
         except ValueError as e:
-            raise JSONDecodeError(f"input: {s}, error: {e}")  # type: ignore
+            raise JSONDecodeError(f"input: {s!r}, error: {e}") from e
 
     def load(self, fp: IO[str]):
         try:

--- a/demisto_sdk/commands/common/handlers/json/ujson_handler.py
+++ b/demisto_sdk/commands/common/handlers/json/ujson_handler.py
@@ -1,6 +1,6 @@
 from typing import IO, Any, AnyStr
 
-import ujson
+import ujson  # noqa: TID251 - this is the handler
 
 from demisto_sdk.commands.common.handlers.xsoar_handler import XSOAR_Handler
 

--- a/demisto_sdk/commands/common/handlers/yaml/ruamel_handler.py
+++ b/demisto_sdk/commands/common/handlers/yaml/ruamel_handler.py
@@ -1,6 +1,6 @@
 from io import StringIO
 
-from ruamel.yaml import YAML
+from ruamel.yaml import YAML  # noqa:TID251 - only allowed in the handler
 
 from demisto_sdk.commands.common.handlers.handlers_utils import order_dict
 from demisto_sdk.commands.common.handlers.xsoar_handler import XSOAR_Handler

--- a/demisto_sdk/commands/common/handlers/yaml/ruamel_handler.py
+++ b/demisto_sdk/commands/common/handlers/yaml/ruamel_handler.py
@@ -1,6 +1,6 @@
 from io import StringIO
 
-from ruamel.yaml import YAML  # noqa:TID251 - only allowed in the handler
+from ruamel.yaml import YAML  # noqa:TID251 - this is the handler
 
 from demisto_sdk.commands.common.handlers.handlers_utils import order_dict
 from demisto_sdk.commands.common.handlers.xsoar_handler import XSOAR_Handler

--- a/demisto_sdk/commands/common/hook_validations/base_validator.py
+++ b/demisto_sdk/commands/common/hook_validations/base_validator.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 from typing import Optional
 
-from ruamel.yaml.comments import CommentedSeq
+from ruamel.yaml.comments import CommentedSeq  # noqa:TID251 - only importing a type
 
 from demisto_sdk.commands.common.constants import (
     PACK_METADATA_SUPPORT,

--- a/demisto_sdk/commands/common/hook_validations/base_validator.py
+++ b/demisto_sdk/commands/common/hook_validations/base_validator.py
@@ -2,7 +2,9 @@ import os
 from pathlib import Path
 from typing import Optional
 
-from ruamel.yaml.comments import CommentedSeq  # noqa:TID251 - only importing a type
+from ruamel.yaml.comments import (  # noqa:TID251 - only importing CommentedSeq
+    CommentedSeq,
+)
 
 from demisto_sdk.commands.common.constants import (
     PACK_METADATA_SUPPORT,

--- a/demisto_sdk/commands/common/hook_validations/correlation_rule.py
+++ b/demisto_sdk/commands/common/hook_validations/correlation_rule.py
@@ -3,7 +3,7 @@ This module is designed to validate the correctness of generic definition entiti
 """
 
 
-from ruamel.yaml.comments import CommentedSeq
+from ruamel.yaml.comments import CommentedSeq  # noqa:TID251 # only importing as type
 
 from demisto_sdk.commands.common.constants import (
     FILETYPE_TO_DEFAULT_FROMVERSION,

--- a/demisto_sdk/commands/common/hook_validations/correlation_rule.py
+++ b/demisto_sdk/commands/common/hook_validations/correlation_rule.py
@@ -3,7 +3,9 @@ This module is designed to validate the correctness of generic definition entiti
 """
 
 
-from ruamel.yaml.comments import CommentedSeq  # noqa:TID251 # only importing as type
+from ruamel.yaml.comments import (  # noqa:TID251 # only importing CommentedSeq
+    CommentedSeq,
+)
 
 from demisto_sdk.commands.common.constants import (
     FILETYPE_TO_DEFAULT_FROMVERSION,

--- a/demisto_sdk/commands/common/hook_validations/modeling_rule.py
+++ b/demisto_sdk/commands/common/hook_validations/modeling_rule.py
@@ -1,7 +1,6 @@
 """
 This module is designed to validate the correctness of generic definition entities in content.
 """
-import json
 import os
 import re
 from pathlib import Path
@@ -11,7 +10,7 @@ from demisto_sdk.commands.common.constants import (
     MODELING_RULE,
 )
 from demisto_sdk.commands.common.errors import Errors
-from demisto_sdk.commands.common.handlers import YAML_Handler
+from demisto_sdk.commands.common.handlers import JSON_Handler, YAML_Handler
 from demisto_sdk.commands.common.hook_validations.base_validator import error_codes
 from demisto_sdk.commands.common.hook_validations.content_entity_validator import (
     ContentEntityValidator,
@@ -19,6 +18,7 @@ from demisto_sdk.commands.common.hook_validations.content_entity_validator impor
 from demisto_sdk.commands.common.tools import get_files_in_dir
 
 yaml = YAML_Handler()
+json = JSON_Handler()
 
 
 class ModelingRuleValidator(ContentEntityValidator):

--- a/demisto_sdk/commands/common/tests/release_notes_test.py
+++ b/demisto_sdk/commands/common/tests/release_notes_test.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 from demisto_sdk.commands.common.constants import FileType
+from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.hook_validations.release_notes import (
     ReleaseNotesValidator,
 )
@@ -11,6 +12,8 @@ from demisto_sdk.commands.common.legacy_git_tools import git_path
 from demisto_sdk.commands.common.tools import get_dict_from_file
 from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
 from TestSuite.pack import Pack
+
+json = JSON_Handler()
 
 
 def get_validator(
@@ -630,8 +633,6 @@ def test_get_categories_from_rn(
 
 
 def update_json(path, key, value):
-    import json
-
     js = get_dict_from_file(path=path)[0]
     js[key] = value
     with open(path, "w") as f:

--- a/demisto_sdk/commands/content_graph/interface/neo4j/queries/dependencies.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/queries/dependencies.py
@@ -1,4 +1,3 @@
-import json
 import os
 from pathlib import Path
 from typing import Dict, List
@@ -10,6 +9,7 @@ from demisto_sdk.commands.common.constants import (
     GENERIC_COMMANDS_NAMES,
     MarketplaceVersions,
 )
+from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.logger import logger
 from demisto_sdk.commands.content_graph.common import (
     ContentType,
@@ -22,6 +22,7 @@ from demisto_sdk.commands.content_graph.interface.neo4j.queries.common import (
     to_neo4j_map,
 )
 
+json = JSON_Handler()
 IGNORED_PACKS_IN_DEPENDENCY_CALC = ["NonSupported", "Base", "ApiModules"]
 
 MAX_DEPTH = 5

--- a/demisto_sdk/commands/content_graph/objects/base_content.py
+++ b/demisto_sdk/commands/content_graph/objects/base_content.py
@@ -1,4 +1,3 @@
-import json
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from functools import lru_cache
@@ -27,6 +26,7 @@ from demisto_sdk.commands.common.constants import (
     MarketplaceVersions,
 )
 from demisto_sdk.commands.common.content_constant_paths import CONTENT_PATH
+from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.logger import logger
 from demisto_sdk.commands.content_graph.common import ContentType, RelationshipType
 from demisto_sdk.commands.content_graph.parsers.content_item import (
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     from demisto_sdk.commands.content_graph.objects.relationship import RelationshipData
 
 content_type_to_model: Dict[ContentType, Type["BaseContent"]] = {}
+json = JSON_Handler()
 
 
 class BaseContentMetaclass(ModelMetaclass):

--- a/demisto_sdk/commands/content_graph/objects/incident_field.py
+++ b/demisto_sdk/commands/content_graph/objects/incident_field.py
@@ -1,4 +1,3 @@
-import json
 from tempfile import NamedTemporaryFile
 from typing import Set
 
@@ -6,8 +5,11 @@ import demisto_client
 from pydantic import Field
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
+from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.content_graph.common import ContentType
 from demisto_sdk.commands.content_graph.objects.content_item import ContentItem
+
+json = JSON_Handler()
 
 
 class IncidentField(ContentItem, content_type=ContentType.INCIDENT_FIELD):  # type: ignore[call-arg]

--- a/demisto_sdk/commands/content_graph/objects/indicator_type.py
+++ b/demisto_sdk/commands/content_graph/objects/indicator_type.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import List, Optional, Set
@@ -7,8 +6,11 @@ import demisto_client
 from pydantic import Field
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
+from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.content_graph.common import ContentType
 from demisto_sdk.commands.content_graph.objects.content_item import ContentItem
+
+json = JSON_Handler()
 
 
 class IndicatorType(ContentItem, content_type=ContentType.INDICATOR_TYPE):  # type: ignore[call-arg]

--- a/demisto_sdk/commands/generate_integration/XSOARIntegration.py
+++ b/demisto_sdk/commands/generate_integration/XSOARIntegration.py
@@ -1,6 +1,8 @@
 from typing import Optional, Union
 
-from ruamel.yaml.scalarstring import FoldedScalarString
+from ruamel.yaml.scalarstring import (  # noqa: TID251 - only importing FoldedScalarString is OK
+    FoldedScalarString,
+)
 
 import demisto_sdk.commands.common.tools as tools
 from demisto_sdk.commands.common.handlers import JSON_Handler

--- a/demisto_sdk/commands/prepare_content/integration_script_unifier.py
+++ b/demisto_sdk/commands/prepare_content/integration_script_unifier.py
@@ -7,7 +7,9 @@ from pathlib import Path
 from typing import Dict, List, Union
 
 from inflection import dasherize, underscore
-from ruamel.yaml.scalarstring import FoldedScalarString
+from ruamel.yaml.scalarstring import (  # noqa: TID251 - only importing FoldedScalarString is OK
+    FoldedScalarString,
+)
 
 from demisto_sdk.commands.common.constants import (
     API_MODULE_FILE_SUFFIX,

--- a/demisto_sdk/commands/prepare_content/rule_unifier.py
+++ b/demisto_sdk/commands/prepare_content/rule_unifier.py
@@ -1,13 +1,17 @@
-import json
 import os
 from collections import defaultdict
 from pathlib import Path
 
-from ruamel.yaml.scalarstring import FoldedScalarString
+from ruamel.yaml.scalarstring import (  # noqa: TID251 - only importing FoldedScalarString is OK
+    FoldedScalarString,
+)
 
 from demisto_sdk.commands.common.constants import SAMPLES_DIR, MarketplaceVersions
+from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.logger import logger
 from demisto_sdk.commands.prepare_content.unifier import Unifier
+
+json = JSON_Handler()
 
 
 class RuleUnifier(Unifier):

--- a/demisto_sdk/commands/prepare_content/tests/xdrc_template_unifier_test.py
+++ b/demisto_sdk/commands/prepare_content/tests/xdrc_template_unifier_test.py
@@ -1,8 +1,8 @@
-import json
 import os
 from pathlib import Path
 
 from demisto_sdk.commands.common.legacy_git_tools import git_path
+from demisto_sdk.commands.common.tools import get_file
 from demisto_sdk.commands.prepare_content.prepare_upload_manager import (
     PrepareUploadManager,
 )
@@ -44,7 +44,6 @@ def test_unify_xdrc_template():
         "profile_type": "STANDARD",
         "yaml_template": "dGVzdDogZHVtbXlfdGVzdA==",
     }
-    with open(expected_json_path) as real_file:
-        assert expected_json_file == json.load(real_file)
+    assert get_file(expected_json_path) == expected_json_file
 
     os.remove(export_json_path)

--- a/demisto_sdk/commands/split/ymlsplitter.py
+++ b/demisto_sdk/commands/split/ymlsplitter.py
@@ -5,7 +5,10 @@ import shutil
 from pathlib import Path
 from typing import Optional
 
-from ruamel.yaml.scalarstring import PlainScalarString, SingleQuotedScalarString
+from ruamel.yaml.scalarstring import (  # noqa: TID251
+    PlainScalarString,
+    SingleQuotedScalarString,
+)
 
 from demisto_sdk.commands.common.configuration import Configuration
 from demisto_sdk.commands.common.constants import (

--- a/demisto_sdk/commands/test_content/timestamp_replacer.py
+++ b/demisto_sdk/commands/test_content/timestamp_replacer.py
@@ -1,11 +1,4 @@
-"""BEWARE:
-
-This file is used outside of the demisto-sdk.
-DO NOT import anything from custom packages, only use builtins.
-"""
-
 import functools
-import json
 import logging
 import urllib.parse
 from ast import literal_eval
@@ -21,6 +14,10 @@ from mitmproxy.addonmanager import Loader
 from mitmproxy.addons.serverplayback import ServerPlayback
 from mitmproxy.http import HTTPFlow, Request
 from mitmproxy.script import concurrent
+
+from demisto_sdk.commands.common.handlers import JSON_Handler
+
+json = JSON_Handler()
 
 logging.basicConfig(
     level=logging.DEBUG, format="[%(asctime)s] - [%(funcName)s] - %(message)s"

--- a/demisto_sdk/commands/test_content/xsiam_tools/xsiam_client.py
+++ b/demisto_sdk/commands/test_content/xsiam_tools/xsiam_client.py
@@ -1,5 +1,4 @@
 import gzip
-import json
 import os
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -11,7 +10,10 @@ import requests
 from pydantic import BaseModel, Field, HttpUrl, SecretStr, validator
 from pydantic.fields import ModelField
 
+from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.logger import logger
+
+json = JSON_Handler()
 
 
 class XsiamApiClientConfig(BaseModel):

--- a/demisto_sdk/utils/circle-ci/circle_ci_client.py
+++ b/demisto_sdk/utils/circle-ci/circle_ci_client.py
@@ -1,5 +1,5 @@
 import os
-from json.decoder import JSONDecodeError
+from json.decoder import JSONDecodeError  # noqa: TID251 - importing JSON in CI is OK
 from types import SimpleNamespace
 from typing import Dict, Optional
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,9 +163,10 @@ select = [
     "I",
     "PLE",
     "RUF100",
-    "T20",
-    "W",
     "T10",
+    "T20",
+    "TID251",
+    "W",
 ]
 
 target-version = "py38"
@@ -175,4 +176,6 @@ max-complexity = 30
 
 [tool.ruff.flake8-tidy-imports]
 [tool.ruff.flake8-tidy-imports.banned-api]
-"logging".msg = "The logging framework is banned. Please use demisto_sdk.commands.common.logger."
+# "logging".msg = "The logging framework is banned. Please use demisto_sdk.commands.common.logger."
+"json".msg = "use JSON_Handler instead"
+"ruamel.yaml".msg = "use YAML_Handler instead"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,4 +178,6 @@ max-complexity = 30
 [tool.ruff.flake8-tidy-imports.banned-api]
 # "logging".msg = "The logging framework is banned. Please use demisto_sdk.commands.common.logger."
 "json".msg = "use JSON_Handler instead"
+"ujson".msg = "use JSON_Handler instead"
+"orjson".msg = "use JSON_Handler instead"
 "ruamel.yaml".msg = "use YAML_Handler instead"


### PR DESCRIPTION
* Added Ruff `TID251`, preventing import of `json` and `ruamel.yaml` directly (configured in `pyproject.toml`)
* Replaced all direct imports with handler imports (or, rarely, `noqa`s)