### PR TITLE
fix graph dependencie does not have is_test set to False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## Unreleased
+* Fixed an issue where **validate** command did not catch dependencies of core packs.
 * Fixed an issue where **lint** and **validate** commands failed on integrations and scripts that use docker images that are not available in the Docker Hub but exist locally.
 * Added documentation for the flag **override-existing** used in upload.
 * Fixed an issue where **validate** failed on Incident Field items with a `template` value.

--- a/demisto_sdk/commands/content_graph/interface/neo4j/queries/relationships.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/queries/relationships.py
@@ -144,7 +144,8 @@ MATCH (p1:{ContentType.PACK}{{object_id: rel_data.source}}),
 // Create the relationship, and mark as "from_metadata"
 CREATE (p1)-[r:{RelationshipType.DEPENDS_ON}{{
     mandatorily: rel_data.mandatorily,
-    from_metadata: true
+    from_metadata: true,
+    is_test: false
 }}]->(p2)
 RETURN count(r) AS relationships_merged"""
 


### PR DESCRIPTION
Fixed an issue where the dependencies between core pack to other packs from metadata did not have is_test set to False which caused to the validation not to fail.

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-7450

