### PR TITLE
fixed regex for the wrong image url detection

### DIFF
--- a/demisto_sdk/commands/common/hook_validations/readme.py
+++ b/demisto_sdk/commands/common/hook_validations/readme.py
@@ -298,7 +298,7 @@ class ReadMeValidator(BaseValidator):
             bool: True If all links are valid else False.
         """
         invalid_paths = re.findall(
-            r"(\!\[.*?\]|src\=)(\(|\")(https://github.com/demisto/content/(?!raw).*?)(\)|\")",
+            r"(\!\[.*?\]|src\=)(\(|\")(https://github.com/demisto/content/blob/.*?)(\)|\")",
             self.readme_content,
             re.IGNORECASE,
         )

--- a/demisto_sdk/commands/common/tests/readme_test.py
+++ b/demisto_sdk/commands/common/tests/readme_test.py
@@ -209,6 +209,10 @@ def test_is_image_path_valid(mocker):
             str_in_call_args_list(logger_info.call_args_list, current_str)
             for current_str in raw_images_paths
         ]
+        + [
+            not str_in_call_args_list(logger_info.call_args_list, current_str)
+            for current_str in assets_images_paths
+        ]
     )
     assert not str_in_call_args_list(logger_info.call_args_list, raw_image_path)
 

--- a/demisto_sdk/commands/common/tests/readme_test.py
+++ b/demisto_sdk/commands/common/tests/readme_test.py
@@ -193,6 +193,9 @@ def test_is_image_path_valid(mocker):
         "https://github.com/demisto/content/raw/123/Packs/AutoFocus/doc_files/AutoFocusPolling.png",
         "https://github.com/demisto/content/raw/123/Packs/FeedOffice365/doc_files/test.png",
     ]
+    assets_images_paths = [
+        "https://github.com/demisto/content/assets/91506078/7915b150-bd26-4aed-b4ba-8820226dfe32",
+    ]
     readme_validator = ReadMeValidator(INVALID_MD)
     result = readme_validator.is_image_path_valid()
 

--- a/demisto_sdk/tests/test_files/README-invalid.md
+++ b/demisto_sdk/tests/test_files/README-invalid.md
@@ -361,3 +361,6 @@ accessdata-get-processing-case-id
 
 ##### Valid image path
 <img width="500" src="https://github.com/demisto/content/raw/123/Packs/valid/doc_files/test.png" />
+
+##### Valid image path
+<img width="500" src="https://github.com/demisto/content/assets/91506078/7915b150-bd26-4aed-b4ba-8820226dfe32" />


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-7325

## Description
Fixed the regex for the detection of wrong image URLs in README files (RM101 error).