### PR TITLE
[docker_pull] - return Image object instead of DockerClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Added the ability to ignore any validation in the **validate** command when running in an external (non-demisto/content) repo, by placing a `.private-repo-settings` file at its root.
 * Fixed an issue where **validate** falsely detected backwards-compatibility issues, and prevented adding the `marketplaces` key to content items.
 * Calling **format** with the `-d` flag now removes test playbooks testing the deprecated content from conf.json.
-* Fixed an issue where in some cases when trying to pull a non-existent docker image, the SDK would crash.
+* Fixed an issue where the SDK would fail pulling docker images.
 * Fixed an issue where in some cases the **split** command did not remove pack version note from the script.
 * Improved the content graph performance when calculating content relationships.
 * Fixed an issue where **validate** would not properly detect dependencies of core packs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Added the ability to ignore any validation in the **validate** command when running in an external (non-demisto/content) repo, by placing a `.private-repo-settings` file at its root.
 * Fixed an issue where **validate** falsely detected backwards-compatibility issues, and prevented adding the `marketplaces` key to content items.
 * Calling **format** with the `-d` flag now removes test playbooks testing the deprecated content from conf.json.
+* Fixed an issue where in some cases where a docker image could not be found locally, the SDK would crash.
 * Fixed an issue where in some cases the **split** command did not remove pack version note from the script.
 * Improved the content graph performance when calculating content relationships.
 * Fixed an issue where **validate** would not properly detect dependencies of core packs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Added the ability to ignore any validation in the **validate** command when running in an external (non-demisto/content) repo, by placing a `.private-repo-settings` file at its root.
 * Fixed an issue where **validate** falsely detected backwards-compatibility issues, and prevented adding the `marketplaces` key to content items.
 * Calling **format** with the `-d` flag now removes test playbooks testing the deprecated content from conf.json.
-* Fixed an issue where in some cases where a docker image could not be found locally, the SDK would crash.
+* Fixed an issue where in some cases when trying to pull a non-existent docker image, the SDK would crash.
 * Fixed an issue where in some cases the **split** command did not remove pack version note from the script.
 * Improved the content graph performance when calculating content relationships.
 * Fixed an issue where **validate** would not properly detect dependencies of core packs.

--- a/demisto_sdk/commands/common/docker_helper.py
+++ b/demisto_sdk/commands/common/docker_helper.py
@@ -131,7 +131,7 @@ class DockerBase:
     @staticmethod
     def pull_image(image: str) -> docker.models.images.Image:
         """
-        Get a docker image, in case not found, will pull it.
+        Get a local docker image, or pull it when unavailable.
         """
         docker_client = init_global_docker_client(log_prompt="pull_image")
 

--- a/demisto_sdk/commands/common/docker_helper.py
+++ b/demisto_sdk/commands/common/docker_helper.py
@@ -131,16 +131,17 @@ class DockerBase:
     @staticmethod
     def pull_image(image: str) -> docker.models.images.Image:
         """
-        Pulling an image if it dosnt exist localy.
+        Get a docker image, in case not found, will pull it.
         """
         docker_client = init_global_docker_client(log_prompt="pull_image")
+
         try:
             return docker_client.images.get(image)
         except docker.errors.ImageNotFound:
             logger.debug(f"docker image {image} not found, pulling")
             docker_client.images.pull(image)
             logger.debug(f"docker image {image} finished pulling")
-            return docker_client
+            return docker_client.images.get(image)
 
     @staticmethod
     def copy_files_container(

--- a/demisto_sdk/commands/common/docker_helper.py
+++ b/demisto_sdk/commands/common/docker_helper.py
@@ -138,7 +138,7 @@ class DockerBase:
         try:
             return docker_client.images.get(image)
         except docker.errors.ImageNotFound:
-            logger.debug(f"docker image {image} not found, pulling")
+            logger.debug(f"docker {=image} not found locally, pulling")
             docker_client.images.pull(image)
             logger.debug(f"docker image {image} finished pulling")
             return docker_client.images.get(image)

--- a/demisto_sdk/commands/common/docker_helper.py
+++ b/demisto_sdk/commands/common/docker_helper.py
@@ -138,7 +138,7 @@ class DockerBase:
         try:
             return docker_client.images.get(image)
         except docker.errors.ImageNotFound:
-            logger.debug(f"docker {=image} not found locally, pulling")
+            logger.debug(f"docker {image=} not found locally, pulling")
             docker_client.images.pull(image)
             logger.debug(f"pulled docker {image=} successfully")
             return docker_client.images.get(image)

--- a/demisto_sdk/commands/common/docker_helper.py
+++ b/demisto_sdk/commands/common/docker_helper.py
@@ -140,7 +140,7 @@ class DockerBase:
         except docker.errors.ImageNotFound:
             logger.debug(f"docker {=image} not found locally, pulling")
             docker_client.images.pull(image)
-            logger.debug(f"docker image {image} finished pulling")
+            logger.debug(f"pulled docker {image=} successfully")
             return docker_client.images.get(image)
 
     @staticmethod


### PR DESCRIPTION

## Description
* Fixed an issue where in case a docker image could not be found locally, we would return DockerClient image instead of an Image object leading to possible `AttributeError` in functions using the `pull_image` function.