### PR TITLE
return the docker image when pulling from remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## Unreleased
+* Fixed an issue where the docker image was not returned when pulling from the remote Docker Hub.
 * Added the ability to ignore any validation in the **validate** command when running in an external (non-demisto/content) repo, by placing a `.private-repo-settings` file at its root.
 * Fixed an issue where **validate** falsely detected backwards-compatibility issues, and prevented adding the `marketplaces` key to content items.
 * Calling **format** with the `-d` flag now removes test playbooks testing the deprecated content from conf.json.

--- a/demisto_sdk/commands/common/docker_helper.py
+++ b/demisto_sdk/commands/common/docker_helper.py
@@ -138,9 +138,9 @@ class DockerBase:
             return docker_client.images.get(image)
         except docker.errors.ImageNotFound:
             logger.debug(f"docker image {image} not found, pulling")
-            docker_client.images.pull(image)
+            docker_image = docker_client.images.pull(image)
             logger.debug(f"docker image {image} finished pulling")
-            return docker_client
+            return docker_image
 
     @staticmethod
     def copy_files_container(


### PR DESCRIPTION

## Related Issues
fixes: 

## Description
Return the docker image instead of the docker client when pulling form the remote Docker Hub.