### PR TITLE
Add a CLI command log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Added a new validation (`BA125`) to **validate** that assures internal function names aren't in use in customer-facing docs.
 * Fixed an issue in **update-content-graph** where the neo4j service was unaccessible for non-root users.
 * Added a Sourcery hook to **pre-commit**.
+* Added a log specifying the SDK command that's in use in log files.
 
 ## 1.17.2
 * Fixed an issue where **lint** and **validate** commands failed on integrations and scripts that use docker images that are not available in the Docker Hub but exist locally.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 * Added a new validation (`BA125`) to **validate** that assures internal function names aren't in use in customer-facing docs.
 * Fixed an issue in **update-content-graph** where the neo4j service was unaccessible for non-root users.
 * Added a Sourcery hook to **pre-commit**.
-* Added a log specifying the SDK command that's in use in log files.
+* Added a log of the CLI command used when running demisto-sdk.
 
 ## 1.17.2
 * Fixed an issue where **lint** and **validate** commands failed on integrations and scripts that use docker images that are not available in the Docker Hub but exist locally.

--- a/demisto_sdk/commands/common/logger.py
+++ b/demisto_sdk/commands/common/logger.py
@@ -328,7 +328,9 @@ def logging_setup(
 
     set_demisto_logger(demisto_logger)
 
-    cli_args = [f'"{arg}"' if " " in arg else arg for arg in sys.argv[1:]]  # Add quotes to spaced arguments
+    cli_args = [
+        f'"{arg}"' if " " in arg else arg for arg in sys.argv[1:]
+    ]  # Add quotes to spaced arguments
     demisto_logger.debug(f"CLI command: demisto-sdk {' '.join(cli_args)}")
     demisto_logger.debug(f"Python version: {sys.version}")
     demisto_logger.debug(f"Working dir: {os.getcwd()}")

--- a/demisto_sdk/commands/common/logger.py
+++ b/demisto_sdk/commands/common/logger.py
@@ -332,6 +332,7 @@ def logging_setup(
         f'"{arg}"' if " " in arg else arg for arg in sys.argv[1:]
     ]  # Add quotes to spaced arguments
     demisto_logger.debug(f"CLI command: demisto-sdk {' '.join(cli_args)}")
+    demisto_logger.debug(f"Executable location: {sys.argv[0]}")
     demisto_logger.debug(f"Python version: {sys.version}")
     demisto_logger.debug(f"Working dir: {os.getcwd()}")
     import platform

--- a/demisto_sdk/commands/common/logger.py
+++ b/demisto_sdk/commands/common/logger.py
@@ -328,6 +328,8 @@ def logging_setup(
 
     set_demisto_logger(demisto_logger)
 
+    cli_args = [f'"{arg}"' if " " in arg else arg for arg in sys.argv[1:]]  # Add quotes to spaced arguments
+    demisto_logger.debug(f"CLI command: demisto-sdk {' '.join(cli_args)}")
     demisto_logger.debug(f"Python version: {sys.version}")
     demisto_logger.debug(f"Working dir: {os.getcwd()}")
     import platform


### PR DESCRIPTION
## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-7586

## Description
Add a log (visible only in log files) that specifies what command was used, with the complete arguments.
Quotes are added to arguments that contain spaces to know that they're a single arguments and not multiple separate ones.

Example output:
```
[2023-07-27T11:47:26] - [MainThread] - [DEBUG] - logger.py:332 - CLI command: demisto-sdk download -i "Michael Test" -o Packs/MichaelTest
```