### PR TITLE
added sha1 validation for content graph parser

### DIFF
--- a/demisto_sdk/commands/common/tests/test_files/test_sha1/content/file.txt
+++ b/demisto_sdk/commands/common/tests/test_files/test_sha1/content/file.txt
@@ -1,0 +1,1 @@
+this is a file

--- a/demisto_sdk/commands/common/tests/test_files/test_sha1/content/file2.txt
+++ b/demisto_sdk/commands/common/tests/test_files/test_sha1/content/file2.txt
@@ -1,0 +1,1 @@
+this is a different file

--- a/demisto_sdk/commands/common/tests/tools_test.py
+++ b/demisto_sdk/commands/common/tests/tools_test.py
@@ -3,6 +3,7 @@ import os
 import shutil
 from configparser import ConfigParser
 from pathlib import Path
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import Callable, List, Optional, Tuple, Union
 
 import git
@@ -2983,3 +2984,48 @@ def test_get_pack_names_from_files(file_paths, skip_file_types, expected_packs):
     """
     packs_result = get_pack_names_from_files(file_paths, skip_file_types)
     assert packs_result == expected_packs
+
+
+@pytest.mark.parametrize(
+    "file_name, expected_hash",
+    [
+        ("file.txt", "c8c54e11b1cb27c3376fa82520d53ef9932a02c0"),
+        ("file2.txt", "f1e01f0882e1f08f00f38d0cd60a850dc9288188"),
+    ],
+)
+def test_sha1_file(file_name, expected_hash):
+    """
+    Given:
+        - A file path
+    When:
+        - Checking the hash
+    Then:
+        Validate that the hash is correct, even after moving to a different location
+    """
+    path_str = f"{GIT_ROOT}/demisto_sdk/commands/common/tests/test_files/test_sha1/content/{file_name}"
+    assert tools.sha1_file(path_str) == expected_hash
+    assert tools.sha1_file(Path(path_str)) == expected_hash
+    # move file to a different location and check that the hash is still the same
+    with NamedTemporaryFile() as temp_dir:
+        shutil.copy(path_str, temp_dir.name)
+        assert tools.sha1_file(temp_dir.name) == expected_hash
+
+
+def test_sha1_dir():
+    """
+    Given:
+        - A directory path
+    When:
+        - Checking the hash
+    Then:
+        Validate that the hash is correct, even after moving to a different location
+    """
+    path_str = f"{GIT_ROOT}/demisto_sdk/commands/common/tests/test_files/test_sha1"
+    expected_hash = "70feabcd73ccbcb14201453942edf4a5fb4c4aac"
+    assert tools.sha1_dir(path_str) == expected_hash
+    assert tools.sha1_dir(Path(path_str)) == expected_hash
+    # move dir to a different location and check that the hash is still the same
+    with TemporaryDirectory() as temp_dir:
+        dest = Path(temp_dir, "dest")
+        shutil.copytree(path_str, dest)
+        assert tools.sha1_dir(dest) == expected_hash

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -12,6 +12,7 @@ from configparser import ConfigParser, MissingSectionHeaderError
 from contextlib import contextmanager
 from enum import Enum
 from functools import lru_cache
+from hashlib import sha1
 from pathlib import Path, PosixPath
 from subprocess import DEVNULL, PIPE, Popen, check_output
 from time import sleep
@@ -3828,3 +3829,34 @@ def is_sdk_defined_working_offline() -> bool:
         bool: The value for DEMISTO_SDK_OFFLINE_ENV environment variable.
     """
     return str2bool(os.getenv(ENV_SDK_WORKING_OFFLINE))
+
+
+def sha1_update_from_file(filename: Union[str, Path], hash):
+    """This will iterate the file and update the hash object"""
+    assert Path(filename).is_file()
+    with open(str(filename), "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            hash.update(chunk)
+    return hash
+
+
+def sha1_file(filename: Union[str, Path]) -> str:
+    """Return the sha1 hash of a directory"""
+    return str(sha1_update_from_file(filename, sha1()).hexdigest())
+
+
+def sha1_update_from_dir(directory: Union[str, Path], hash_):
+    """This will recursivly iterate all the files in the directory and update the hash object"""
+    assert Path(directory).is_dir()
+    for path in sorted(Path(directory).iterdir(), key=lambda p: str(p).lower()):
+        hash_.update(path.name.encode())
+        if path.is_file():
+            hash_ = sha1_update_from_file(path, hash_)
+        elif path.is_dir():
+            hash_ = sha1_update_from_dir(path, hash_)
+    return hash_
+
+
+def sha1_dir(directory: Union[str, Path]) -> str:
+    """Return the sha1 hash of a directory"""
+    return str(sha1_update_from_dir(directory, sha1()).hexdigest())

--- a/demisto_sdk/commands/content_graph/interface/graph.py
+++ b/demisto_sdk/commands/content_graph/interface/graph.py
@@ -7,17 +7,18 @@ from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.common.content_constant_paths import CONTENT_PATH
 from demisto_sdk.commands.common.git_util import GitUtil
 from demisto_sdk.commands.common.handlers import DEFAULT_JSON_HANDLER as json
+from demisto_sdk.commands.common.logger import logger
+from demisto_sdk.commands.common.tools import get_file, sha1_dir
 from demisto_sdk.commands.content_graph.common import ContentType, RelationshipType
 from demisto_sdk.commands.content_graph.objects.base_content import BaseContent
 from demisto_sdk.commands.content_graph.objects.content_item import ContentItem
 from demisto_sdk.commands.content_graph.objects.pack import Pack
 from demisto_sdk.commands.content_graph.objects.repository import ContentDTO
 
-METADATA_FILE_NAME = "metadata.json"
-
 
 class ContentGraphInterface(ABC):
     repo_path = CONTENT_PATH  # type: ignore
+    METADATA_FILE_NAME = "metadata.json"
 
     @property
     @abstractmethod
@@ -35,8 +36,7 @@ class ContentGraphInterface(ABC):
     @property
     def metadata(self) -> Optional[dict]:
         try:
-            with (self.import_path / METADATA_FILE_NAME).open() as f:
-                return json.load(f)
+            return get_file(self.import_path / self.METADATA_FILE_NAME)
         except FileNotFoundError:
             return None
 
@@ -46,13 +46,39 @@ class ContentGraphInterface(ABC):
             return self.metadata.get("commit")
         return None
 
+    @property
+    def content_parser_latest_hash(self) -> Optional[str]:
+        if self.metadata:
+            return self.metadata.get("content_parser_latest_hash")
+        return None
+
     def dump_metadata(self) -> None:
         """Adds metadata to the graph."""
         metadata = {
             "commit": GitUtil().get_current_commit_hash(),
+            "content_parser_latest_hash": self._get_latest_content_parser_hash(),
         }
-        with open(self.import_path / METADATA_FILE_NAME, "w") as f:
+        with open(self.import_path / self.METADATA_FILE_NAME, "w") as f:
             json.dump(metadata, f)
+
+    def _get_latest_content_parser_hash(self) -> Optional[str]:
+        parsers_path = Path(__file__).parent.parent / "parsers"
+        return sha1_dir(parsers_path)
+
+    def _has_infra_graph_been_changed(self) -> bool:
+        if not self.content_parser_latest_hash:
+            logger.warning("The content parser hash is missing.")
+        elif self.content_parser_latest_hash != self._get_latest_content_parser_hash():
+            logger.warning("The content parser has been changed.")
+            return True
+        try:
+            self.marshal_graph(MarketplaceVersions.XSOAR)
+        except Exception as e:
+            logger.warning("Failed to load the content graph.")
+            logger.debug(f"Validation Error: {e}")
+            return True
+
+        return False
 
     def zip_import_dir(self, output_file: Path) -> None:
         shutil.make_archive(str(output_file), "zip", self.import_path)

--- a/demisto_sdk/commands/content_graph/tests/update_content_graph_test.py
+++ b/demisto_sdk/commands/content_graph/tests/update_content_graph_test.py
@@ -719,9 +719,7 @@ class TestUpdateContentGraph:
             )
 
             # perform the update on ContentDTO
-            pack_ids_to_update = content_graph_commands.update_repository(
-                repository, commit_func
-            )
+            pack_ids_to_update = update_repository(repository, commit_func)
 
             # update the graph accordingly
             content_graph_commands.update_content_graph(

--- a/demisto_sdk/commands/content_graph/tests/update_content_graph_test.py
+++ b/demisto_sdk/commands/content_graph/tests/update_content_graph_test.py
@@ -528,52 +528,50 @@ class TestUpdateContentGraph:
             assert get_nodes_count_by_type(interface, ContentType.COMMAND) == 1
             assert get_nodes_count_by_type(interface, ContentType.CLASSIFIER) == 1
 
-    data_test_update_content_graph = (
-        [
-            pytest.param(
-                _testcase1__pack3_pack4__script2_uses_script4,
-                [mock_dependency("SamplePack3", "SamplePack4")],
-                [],
-                id="New pack with USES relationship, causing adding a dependency",
-            ),
-            pytest.param(
-                _testcase2__pack3__remove_relationship,
-                [],
-                [mock_dependency("SamplePack2", "SamplePack3")],
-                id="Remove USES relationship, causing removing a dependency",
-            ),
-            pytest.param(
-                _testcase3__no_change,
-                [],
-                [],
-                id="No change in repository",
-            ),
-            pytest.param(
-                _testcase4__new_integration_with_existing_command,
-                [],
-                [],
-                id="New integration with existing command test-command",
-            ),
-            pytest.param(
-                _testcase5__move_script_from_pack3_to_pack1,
-                [mock_dependency("SamplePack2", "SamplePack")],
-                [mock_dependency("SamplePack2", "SamplePack3")],
-                id="Moved script - dependency pack2 -> pack3 changed to pack2 -> pack1",
-            ),
-            pytest.param(
-                _testcase6__move_script_from_pack3_to_pack2,
-                [],
-                [mock_dependency("SamplePack2", "SamplePack3")],
-                id="Moved script - removed dependency between pack2 and pack3",
-            ),
-            pytest.param(
-                _testcase7__changed_script2_fromversion,
-                [],
-                [],
-                id="Changed fromversion of script",
-            ),
-        ],
-    )
+    data_test_update_content_graph = [
+        pytest.param(
+            _testcase1__pack3_pack4__script2_uses_script4,
+            [mock_dependency("SamplePack3", "SamplePack4")],
+            [],
+            id="New pack with USES relationship, causing adding a dependency",
+        ),
+        pytest.param(
+            _testcase2__pack3__remove_relationship,
+            [],
+            [mock_dependency("SamplePack2", "SamplePack3")],
+            id="Remove USES relationship, causing removing a dependency",
+        ),
+        pytest.param(
+            _testcase3__no_change,
+            [],
+            [],
+            id="No change in repository",
+        ),
+        pytest.param(
+            _testcase4__new_integration_with_existing_command,
+            [],
+            [],
+            id="New integration with existing command test-command",
+        ),
+        pytest.param(
+            _testcase5__move_script_from_pack3_to_pack1,
+            [mock_dependency("SamplePack2", "SamplePack")],
+            [mock_dependency("SamplePack2", "SamplePack3")],
+            id="Moved script - dependency pack2 -> pack3 changed to pack2 -> pack1",
+        ),
+        pytest.param(
+            _testcase6__move_script_from_pack3_to_pack2,
+            [],
+            [mock_dependency("SamplePack2", "SamplePack3")],
+            id="Moved script - removed dependency between pack2 and pack3",
+        ),
+        pytest.param(
+            _testcase7__changed_script2_fromversion,
+            [],
+            [],
+            id="Changed fromversion of script",
+        ),
+    ]
 
     @pytest.mark.parametrize(
         "commit_func, expected_added_dependencies, expected_removed_dependencies",
@@ -664,10 +662,10 @@ class TestUpdateContentGraph:
         self,
         tmp_path,
         repository: ContentDTO,
+        mocker,
         commit_func: Callable[[ContentDTO], List[Pack]],
         expected_added_dependencies: List[Dict[str, Any]],
         expected_removed_dependencies: List[Dict[str, Any]],
-        mocker,
     ):
         """
         Given:
@@ -687,7 +685,10 @@ class TestUpdateContentGraph:
                 and don't exist after the update.
         """
 
-        create_content_graph_spy = mocker.spy(create_content_graph)
+        create_content_graph_spy = mocker.patch(
+            "demisto_sdk.commands.content_graph.content_graph_commands.create_content_graph",
+            new=None,
+        )
 
         with ContentGraphInterface() as interface:
             # create the graph with dependencies

--- a/demisto_sdk/commands/content_graph/tests/update_content_graph_test.py
+++ b/demisto_sdk/commands/content_graph/tests/update_content_graph_test.py
@@ -684,15 +684,17 @@ class TestUpdateContentGraph:
             - Make sure the expected removed dependencies actually exist before the update
                 and don't exist after the update.
         """
+        import demisto_sdk.commands.content_graph.content_graph_commands as content_graph_commands
 
-        create_content_graph_spy = mocker.patch(
-            "demisto_sdk.commands.content_graph.content_graph_commands.create_content_graph",
-            new=None,
+        create_content_graph_spy = mocker.spy(
+            content_graph_commands, "create_content_graph"
         )
 
         with ContentGraphInterface() as interface:
             # create the graph with dependencies
-            create_content_graph(interface, dependencies=True, output_path=tmp_path)
+            content_graph_commands.create_content_graph(
+                interface, dependencies=True, output_path=tmp_path
+            )
             packs_from_graph = interface.search(
                 marketplace=MarketplaceVersions.XSOAR,
                 content_type=ContentType.PACK,
@@ -717,10 +719,12 @@ class TestUpdateContentGraph:
             )
 
             # perform the update on ContentDTO
-            pack_ids_to_update = update_repository(repository, commit_func)
+            pack_ids_to_update = content_graph_commands.update_repository(
+                repository, commit_func
+            )
 
             # update the graph accordingly
-            update_content_graph(
+            content_graph_commands.update_content_graph(
                 interface,
                 packs_to_update=pack_ids_to_update,
                 dependencies=True,

--- a/demisto_sdk/commands/content_graph/tests/update_content_graph_test.py
+++ b/demisto_sdk/commands/content_graph/tests/update_content_graph_test.py
@@ -701,7 +701,7 @@ class TestUpdateContentGraph:
                 all_level_dependencies=True,
             )
 
-            file_added = parsers_path = (
+            file_added = (
                 Path(__file__).parent.parent / "parsers" / "content_graph_test.txt"
             )
             file_added.write_text(

--- a/demisto_sdk/commands/content_graph/tests/update_content_graph_test.py
+++ b/demisto_sdk/commands/content_graph/tests/update_content_graph_test.py
@@ -528,8 +528,7 @@ class TestUpdateContentGraph:
             assert get_nodes_count_by_type(interface, ContentType.COMMAND) == 1
             assert get_nodes_count_by_type(interface, ContentType.CLASSIFIER) == 1
 
-    @pytest.mark.parametrize(
-        "commit_func, expected_added_dependencies, expected_removed_dependencies",
+    data_test_update_content_graph = (
         [
             pytest.param(
                 _testcase1__pack3_pack4__script2_uses_script4,
@@ -574,6 +573,11 @@ class TestUpdateContentGraph:
                 id="Changed fromversion of script",
             ),
         ],
+    )
+
+    @pytest.mark.parametrize(
+        "commit_func, expected_added_dependencies, expected_removed_dependencies",
+        data_test_update_content_graph,
     )
     def test_update_content_graph(
         self,
@@ -652,6 +656,10 @@ class TestUpdateContentGraph:
                 for file in extracted_files
             )
 
+    @pytest.mark.parametrize(
+        "commit_func, expected_added_dependencies, expected_removed_dependencies",
+        data_test_update_content_graph,
+    )
     def test_create_content_graph_if_needed(
         self,
         tmp_path,


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-7520

## Description
Added a validation that content_graph was created with the current version of the parser.
if not it will create the graph from scratch.