### PR TITLE
prevent using deprecated distutils.version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,5 +181,5 @@ max-complexity = 30
 "ujson".msg = "use JSON_Handler instead"
 "orjson".msg = "use JSON_Handler instead"
 "ruamel.yaml".msg = "use YAML_Handler instead"
-"distutils.version".msg = "Use packaging.Version instead"
-"packaging.version.LooseVersion".msg = "Use packaging.Version instead"
+"distutils.version".msg = "Use packaging.version.Version instead"
+"packaging.version.LooseVersion".msg = "Use packaging.version.Version instead"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,3 +181,4 @@ max-complexity = 30
 "ujson".msg = "use JSON_Handler instead"
 "orjson".msg = "use JSON_Handler instead"
 "ruamel.yaml".msg = "use YAML_Handler instead"
+"distutils.version".msg = "Use packaging.Version instead"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,3 +182,4 @@ max-complexity = 30
 "orjson".msg = "use JSON_Handler instead"
 "ruamel.yaml".msg = "use YAML_Handler instead"
 "distutils.version".msg = "Use packaging.Version instead"
+"packaging.version.LooseVersion".msg = "Use packaging.Version instead"


### PR DESCRIPTION
Following https://github.com/demisto/demisto-sdk/pull/3394, https://github.com/demisto/demisto-sdk/pull/3410
making sure we don't go back to using `distutils.version` (which prevents supporting Python 3.11)