### PR TITLE
Support svg images in validate command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 * Fixed an issue where the coloring directives where showing in log messages.
 * Fixed an issue where **create-content-graph** was not executed upon changes in the parser infra files.
+* Added support in **validate** command for `svg` images.
 
 ## 1.18.0
 * Added the ability to ignore any validation in the **validate** command when running in an external (non-demisto/content) repo, by placing a `.private-repo-settings` file at its root.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## Unreleased
 * Fixed an issue where the coloring directives where showing in log messages.
 * Fixed an issue where **create-content-graph** was not executed upon changes in the parser infra files.
-* Added support in **validate** command for `svg` images.
+* Added support for `svg` integration images in content repo in **validate** command.
 
 ## 1.18.0
 * Added the ability to ignore any validation in the **validate** command when running in an external (non-demisto/content) repo, by placing a `.private-repo-settings` file at its root.

--- a/demisto_sdk/commands/common/hook_validations/structure.py
+++ b/demisto_sdk/commands/common/hook_validations/structure.py
@@ -75,7 +75,7 @@ class StructureValidator(BaseValidator):
             specific_validations=specific_validations,
         )
         self.is_valid = True
-        self.valid_extensions = [".yml", ".json", ".md", ".png", ".py"]
+        self.valid_extensions = [".yml", ".json", ".md", ".png", ".py", ".svg"]
         self.file_path = file_path.replace("\\", "/")
         self.skip_schema_check = skip_schema_check
         self.pykwalify_logs = pykwalify_logs

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -1673,7 +1673,7 @@ def find_type_by_path(path: Union[str, Path] = "") -> Optional[FileType]:
         elif LAYOUT_RULES_DIR in path.parts:
             return FileType.LAYOUT_RULE
 
-    elif path.name.endswith("_image.png") or path.name.endswith("_image.svg"):
+    elif path.stem.endswith("_image") and path.suffix in (".png", ".svg"):
         if path.name.endswith("Author_image.png"):
             return FileType.AUTHOR_IMAGE
         elif XSIAM_DASHBOARDS_DIR in path.parts:

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -1673,7 +1673,7 @@ def find_type_by_path(path: Union[str, Path] = "") -> Optional[FileType]:
         elif LAYOUT_RULES_DIR in path.parts:
             return FileType.LAYOUT_RULE
 
-    elif path.name.endswith("_image.png"):
+    elif path.name.endswith("_image.png") or path.name.endswith("_image.svg"):
         if path.name.endswith("Author_image.png"):
             return FileType.AUTHOR_IMAGE
         elif XSIAM_DASHBOARDS_DIR in path.parts:


### PR DESCRIPTION
## Related Issues
related: https://jira-hq.paloaltonetworks.local/browse/CIAC-7590

## Description
Adds support in validate command for svg images that will be used in the dynamic dashboard.