### PR TITLE
demisto-sdk release 1.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 ## Unreleased
+
+## 1.18.1
 * Fixed an issue where the coloring directives where showing in log messages.
 * Fixed an issue where **create-content-graph** was not executed upon changes in the parser infra files.
 * Added a parameter `skip-packs-known-words` to the **doc-review** command, making sure that pack known words will not be added.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "demisto-sdk"
-version = "1.18.0"
+version = "1.18.1"
 description = "\"A Python library for the Demisto SDK\""
 authors = ["Demisto"]
 license = "MIT"


### PR DESCRIPTION
demisto-sdk release changes
* Fixed an issue where the coloring directives where showing in log messages.
* Fixed an issue where **create-content-graph** was not executed upon changes in the parser infra files.
* Added a parameter `skip-packs-known-words` to the **doc-review** command, making sure that pack known words will not be added.