### PR TITLE
[Download Command] Fix display name of custom indicator types when using list-files flag

### DIFF
--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -3491,17 +3491,19 @@ def get_display_name(file_path, file_data={}) -> str:
             file_data = get_file(file_path)
 
     if "display" in file_data:
-        name = file_data.get("display", None)
+        name = file_data.get("display")
     elif "layout" in file_data and isinstance(file_data["layout"], dict):
         name = file_data["layout"].get("id")
     elif "name" in file_data:
-        name = file_data.get("name", None)
+        name = file_data.get("name")
     elif "TypeName" in file_data:
-        name = file_data.get("TypeName", None)
+        name = file_data.get("TypeName")
     elif "brandName" in file_data:
-        name = file_data.get("brandName", None)
+        name = file_data.get("brandName")
+    elif "reputationCommand" in file_data:
+        name = file_data.get("details")
     elif "id" in file_data:
-        name = file_data.get("id", None)
+        name = file_data.get("id")
     elif "trigger_name" in file_data:
         name = file_data.get("trigger_name")
     elif "rule_name" in file_data:

--- a/demisto_sdk/commands/download/downloader.py
+++ b/demisto_sdk/commands/download/downloader.py
@@ -47,7 +47,6 @@ from demisto_sdk.commands.common.tools import (
     get_code_lang,
     get_dict_from_file,
     get_entity_id_by_entity_type,
-    get_entity_name_by_entity_type,
     get_file,
     get_files_in_dir,
     get_id,
@@ -57,6 +56,7 @@ from demisto_sdk.commands.common.tools import (
     is_sdk_defined_working_offline,
     retrieve_file_ending,
     safe_write_unicode,
+    get_display_name,
 )
 from demisto_sdk.commands.format.format_module import format_manager
 from demisto_sdk.commands.init.initiator import Initiator
@@ -789,7 +789,7 @@ class Downloader:
                 main_file_data = get_json(entity_instance_path)
 
         main_id = get_entity_id_by_entity_type(main_file_data, content_entity)
-        main_name = get_entity_name_by_entity_type(main_file_data, content_entity)
+        main_name = get_display_name(file_path="", file_data=main_file_data)
 
         return main_id, main_name
 
@@ -906,7 +906,7 @@ class Downloader:
             existing, file_type
         )  # For example: Integrations
         file_id: str = get_entity_id_by_entity_type(existing, file_entity)
-        file_name: str = get_entity_name_by_entity_type(existing, file_entity)
+        file_name: str = get_display_name(file_path="", file_data=existing)
 
         if not file_name:
             file_name = existing.get("id", "")
@@ -935,7 +935,7 @@ class Downloader:
         :return: The file entity, for example: Integrations
         """
         if file_type and file_type == "playbook":
-            name: str = get_entity_name_by_entity_type(existing, PLAYBOOKS_DIR)
+            name: str = get_display_name(file_path="", file_data=existing)
             if name.endswith(
                 ("Test", "_test", "_Test", "-test", "-Test")
             ) or name.lower().startswith("test"):


### PR DESCRIPTION
## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-3583

## Description
Fix display name of custom indicator types to show an appropriate name instead of a UUID ID.
This will also cause the UUID replacement the download command does to apply to indicator types (their UUID IDs will be replaced with the now-found display name).