### PR TITLE
demisto-sdk release 1.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 * Added the *--xsiam* flag to the **init** command in order to create XSIAM content.
 * Fixed an issue where the `update-additional-dependencies` **pre-commit** step failed when not running in a content-like repo.
 * Removed the format execution step from the `contribution_converter` since it can be executed separately during the contribution process.
-* Added a new validation (`GR108`) to **validate** command that assures hidden packs do not have mandatory dependant packs.
-* Added a validation that check that non ignorable errors are not used.
+* Added a new validation (`GR108`) to **validate**, that assures hidden packs do not have mandatory dependant packs.
+Added a new validation (`PA137`) to **validate**, ensuring the absence of non-ignorable errors in `.pack-ignore`.
 * Running **validate** in a GitHub Action will now show errors as annotations, visible in the `Files Changed` tab of the pull request.
 * **lint** will now fail on `demisto.results` and `return_outputs` usage, when a pack is `xsoar` or `partner` supported.
 * **lint** will now fail on `LOG` usage in python files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 ## Unreleased
+
+## 1.19.0
 * Added the **graph** command group. The **create-content-graph** and **update-content-graph** commands were migrated to this command group, and named **graph create** and **graph update** respectively.
 * Added the **graph get-relationships** command.
 * The **graph create** command will now use a list of known content items from content-private, to avoid false-positives in validation `GR103`. Additionally, `GR103` was added to the **ALLOWED_IGNORE_ERRORS** list.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "demisto-sdk"
-version = "1.18.1"
+version = "1.19.0"
 description = "\"A Python library for the Demisto SDK\""
 authors = ["Demisto"]
 license = "MIT"


### PR DESCRIPTION
demisto-sdk release changes
* Added the **graph** command group. The **create-content-graph** and **update-content-graph** commands were migrated to this command group, and named **graph create** and **graph update** respectively.
* Added the **graph get-relationships** command.
* The **graph create** command will now use a list of known content items from content-private, to avoid false-positives in validation `GR103`. Additionally, `GR103` was added to the **ALLOWED_IGNORE_ERRORS** list.
* The **modeling-rules test** command will now validate that the modeling rules schema mappings are aligned with the test-data mappings.
* Added the *--xsiam* flag to the **init** command in order to create XSIAM content.
* Fixed an issue where the `update-additional-dependencies` **pre-commit** step failed when not running in a content-like repo.
* Removed the format execution step from the `contribution_converter` since it can be executed separately during the contribution process.
* Added a new validation (`GR108`) to **validate**, that assures hidden packs do not have mandatory dependant packs.
Added a new validation (`PA137`) to **validate**, ensuring the absence of non-ignorable errors in `.pack-ignore`.
* Running **validate** in a GitHub Action will now show errors as annotations, visible in the `Files Changed` tab of the pull request.
* **lint** will now fail on `demisto.results` and `return_outputs` usage, when a pack is `xsoar` or `partner` supported.
* **lint** will now fail on `LOG` usage in python files.
* Updated the **format** command to use the content graph instead of the id_set file.
* Updated **format** command not to fail on unexpected values that returns from the graph, and just add it to the log.
* Removed a redundant debug log on the `tools.get_file` function.