### PR TITLE
demisto-sdk release 1.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 ## Unreleased
+
+## 1.19.1
 * Improved **update-release-notes** logs when changes in dependent API modules are detected.
 * Reverted changes released in version 1.19.0 in lint, lint will not fail on `demisto.results`, `return_outputs` and `LOG`.
 * Updated the **generate-docs** command to use the content graph instead of the id_set file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "demisto-sdk"
-version = "1.19.0"
+version = "1.19.1"
 description = "\"A Python library for the Demisto SDK\""
 authors = ["Demisto"]
 license = "MIT"


### PR DESCRIPTION
demisto-sdk release changes
* Improved **update-release-notes** logs when changes in dependent API modules are detected.
* Reverted changes released in version 1.19.0 in lint, lint will not fail on `demisto.results`, `return_outputs` and `LOG`.
* Updated the **generate-docs** command to use the content graph instead of the id_set file.