### PR TITLE
Add timeout to `run_query` in neo4j

### DIFF
--- a/demisto_sdk/commands/content_graph/interface/neo4j/neo4j_graph.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/neo4j_graph.py
@@ -568,7 +568,7 @@ class Neo4jContentGraphInterface(ContentGraphInterface):
     ) -> None:
         logger.info("Creating graph relationships...")
         with self.driver.session() as session:
-            session.execute_write(create_relationships, relationships)
+            session.execute_write(create_relationships, relationships, timeout=120)
             if self._rels_to_preserve:
                 session.execute_write(
                     return_preserved_relationships, self._rels_to_preserve

--- a/demisto_sdk/commands/content_graph/interface/neo4j/queries/common.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/queries/common.py
@@ -1,7 +1,7 @@
 import traceback
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from neo4j import Result, Transaction
 from packaging.version import Version
@@ -53,11 +53,13 @@ def to_neo4j_map(properties: dict) -> str:
     return params_str
 
 
-def run_query(tx: Transaction, query: str, **kwargs) -> Result:
+def run_query(
+    tx: Transaction, query: str, timeout: Optional[int] = None, **kwargs
+) -> Result:
     try:
         start_time: datetime = datetime.now()
         logger.debug(f"Running query:\n{query}")
-        result = tx.run(query, **kwargs)
+        result = tx.run(query, **kwargs, timeout=timeout)
         logger.debug(f"Took {(datetime.now() - start_time).total_seconds()} seconds")
         return result
     except Exception as e:

--- a/demisto_sdk/commands/content_graph/interface/neo4j/queries/relationships.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/queries/relationships.py
@@ -93,9 +93,9 @@ ON CREATE
 
 // Get or create the relationship and set its "mandatorily" field based on relationship data
 WITH source, target, rel_data
-CALL apoc.merge.relationship(source, "{RelationshipType.USES}", {{mandatorily: rel_data.mandatorily}}, {{}}, target) YIELD r
-SET r.mandatorily = coalesce(r.mandatorily, false) OR rel_data.mandatorily
-RETURN count(r) AS relationships_merged"""
+CALL apoc.merge.relationship(source, "{RelationshipType.USES}", {{mandatorily: rel_data.mandatorily}}, {{}}, target) YIELD rel
+SET rel.mandatorily = coalesce(r.mandatorily, false) OR rel_data.mandatorily
+RETURN count(rel) AS relationships_merged"""
 
 
 def build_in_pack_relationships_query() -> str:

--- a/demisto_sdk/commands/content_graph/interface/neo4j/queries/relationships.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/queries/relationships.py
@@ -92,6 +92,7 @@ ON CREATE
     SET target.not_in_repository = true
 
 // Get or create the relationship and set its "mandatorily" field based on relationship data
+WITH source, target, rel_data
 CALL apoc.merge.relationship(source, "{RelationshipType.USES}", {{mandatorily: rel_data.mandatorily}}, {{}}, target) YIELD r
 SET r.mandatorily = coalesce(r.mandatorily, false) OR rel_data.mandatorily
 RETURN count(r) AS relationships_merged"""

--- a/demisto_sdk/commands/content_graph/interface/neo4j/queries/relationships.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/queries/relationships.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from neo4j import Transaction
 
@@ -162,6 +162,7 @@ RETURN count(r) AS relationships_merged"""
 def create_relationships(
     tx: Transaction,
     relationships: Dict[RelationshipType, List[Dict[str, Any]]],
+    timeout: Optional[int] = None,
 ) -> None:
     if relationships.get(RelationshipType.HAS_COMMAND):
         data = relationships.pop(RelationshipType.HAS_COMMAND)

--- a/demisto_sdk/commands/content_graph/interface/neo4j/queries/relationships.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/queries/relationships.py
@@ -92,7 +92,7 @@ ON CREATE
     SET target.not_in_repository = true
 
 // Get or create the relationship and set its "mandatorily" field based on relationship data
-CALL apoc.merge.relationship(source, {RelationshipType.USES}, {{mandatorily: rel_data.mandatorily}}, {{}}, target) YIELD rel
+CALL apoc.merge.relationship(source, "{RelationshipType.USES}", {{mandatorily: rel_data.mandatorily}}, {{}}, target) YIELD rel
 SET rel.mandatorily = coalesce(rel.mandatorily, false) OR rel_data.mandatorily
 RETURN count(r) AS relationships_merged"""
 

--- a/demisto_sdk/commands/content_graph/interface/neo4j/queries/relationships.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/queries/relationships.py
@@ -92,10 +92,13 @@ ON CREATE
     SET target.not_in_repository = true
 
 // Get or create the relationship and set its "mandatorily" field based on relationship data
-WITH source, target, rel_data
-CALL apoc.merge.relationship(source, "{RelationshipType.USES}", {{}}, target) YIELD rel
-SET rel.mandatorily = coalesce(rel.mandatorily, false) OR rel_data.mandatorily
-RETURN count(rel) AS relationships_merged"""
+MERGE (source)-[r:{RelationshipType.USES}]->(target)
+ON CREATE
+    SET r.mandatorily = rel_data.mandatorily
+ON MATCH
+    SET r.mandatorily = r.mandatorily OR rel_data.mandatorily
+
+RETURN count(r) AS relationships_merged"""
 
 
 def build_in_pack_relationships_query() -> str:

--- a/demisto_sdk/commands/content_graph/interface/neo4j/queries/relationships.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/queries/relationships.py
@@ -169,16 +169,17 @@ def create_relationships(
 ) -> None:
     if relationships.get(RelationshipType.HAS_COMMAND):
         data = relationships.pop(RelationshipType.HAS_COMMAND)
-        create_relationships_by_type(tx, RelationshipType.HAS_COMMAND, data)
+        create_relationships_by_type(tx, RelationshipType.HAS_COMMAND, data, timeout)
 
     for relationship, data in relationships.items():
-        create_relationships_by_type(tx, relationship, data)
+        create_relationships_by_type(tx, relationship, data, timeout)
 
 
 def create_relationships_by_type(
     tx: Transaction,
     relationship: RelationshipType,
     data: List[Dict[str, Any]],
+    timeout: Optional[int] = None,
 ) -> None:
     if relationship == RelationshipType.HAS_COMMAND:
         query = build_has_command_relationships_query()
@@ -210,7 +211,7 @@ def create_relationships_by_type(
         query = build_depends_on_relationships_query()
     else:
         query = build_default_relationships_query(relationship)
-    run_query(tx, query, data=data)
+    run_query(tx, query, data=data, timeout=timeout)
     logger.debug(f"Merged relationships of type {relationship}.")
 
 

--- a/demisto_sdk/commands/content_graph/interface/neo4j/queries/relationships.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/queries/relationships.py
@@ -16,8 +16,6 @@ from demisto_sdk.commands.content_graph.interface.neo4j.queries.common import (
     run_query,
 )
 
-CHUNK_SIZE = 500
-
 
 def build_source_properties() -> str:
     return node_map(
@@ -94,12 +92,8 @@ ON CREATE
     SET target.not_in_repository = true
 
 // Get or create the relationship and set its "mandatorily" field based on relationship data
-MERGE (source)-[r:{RelationshipType.USES}]->(target)
-ON CREATE
-    SET r.mandatorily = rel_data.mandatorily
-ON MATCH
-    SET r.mandatorily = r.mandatorily OR rel_data.mandatorily
-
+CALL apoc.merge.relationship(source, {RelationshipType.USES}, {{mandatorily: rel_data.mandatorily}}, {{}}, target) YIELD rel
+SET rel.mandatorily = coalesce(rel.mandatorily, false) OR rel_data.mandatorily
 RETURN count(r) AS relationships_merged"""
 
 

--- a/demisto_sdk/commands/content_graph/interface/neo4j/queries/relationships.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/queries/relationships.py
@@ -92,8 +92,8 @@ ON CREATE
     SET target.not_in_repository = true
 
 // Get or create the relationship and set its "mandatorily" field based on relationship data
-CALL apoc.merge.relationship(source, "{RelationshipType.USES}", {{mandatorily: rel_data.mandatorily}}, {{}}, target) YIELD rel
-SET rel.mandatorily = coalesce(rel.mandatorily, false) OR rel_data.mandatorily
+CALL apoc.merge.relationship(source, "{RelationshipType.USES}", {{mandatorily: rel_data.mandatorily}}, {{}}, target) YIELD r
+SET r.mandatorily = coalesce(r.mandatorily, false) OR rel_data.mandatorily
 RETURN count(r) AS relationships_merged"""
 
 

--- a/demisto_sdk/commands/content_graph/interface/neo4j/queries/relationships.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/queries/relationships.py
@@ -94,7 +94,7 @@ ON CREATE
 // Get or create the relationship and set its "mandatorily" field based on relationship data
 WITH source, target, rel_data
 CALL apoc.merge.relationship(source, "{RelationshipType.USES}", {{mandatorily: rel_data.mandatorily}}, {{}}, target) YIELD rel
-SET rel.mandatorily = coalesce(r.mandatorily, false) OR rel_data.mandatorily
+SET rel.mandatorily = coalesce(rel.mandatorily, false) OR rel_data.mandatorily
 RETURN count(rel) AS relationships_merged"""
 
 

--- a/demisto_sdk/commands/content_graph/interface/neo4j/queries/relationships.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/queries/relationships.py
@@ -93,7 +93,7 @@ ON CREATE
 
 // Get or create the relationship and set its "mandatorily" field based on relationship data
 WITH source, target, rel_data
-CALL apoc.merge.relationship(source, "{RelationshipType.USES}", {{mandatorily: rel_data.mandatorily}}, {{}}, target) YIELD rel
+CALL apoc.merge.relationship(source, "{RelationshipType.USES}", {{}}, target) YIELD rel
 SET rel.mandatorily = coalesce(rel.mandatorily, false) OR rel_data.mandatorily
 RETURN count(rel) AS relationships_merged"""
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes:

## Description

This adds timeout to `run_query` as well to the transaction itself.
