### PR TITLE
demisto-sdk release 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 ## Unreleased
+
+## 1.0.1
 * Added a period at the end of lines produced by the **generate-docs** command that state the tested version of the product.
 * Update `RN112` validation's docs reference link.
 * Fixed an issue in calculating content graph hash when creating or updating it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "demisto-sdk"
-version = "1.19.1"
+version = "1.0.1"
 description = "\"A Python library for the Demisto SDK\""
 authors = ["Demisto"]
 license = "MIT"


### PR DESCRIPTION
demisto-sdk release changes
* Added a period at the end of lines produced by the **generate-docs** command that state the tested version of the product.
* Update `RN112` validation's docs reference link.
* Fixed an issue in calculating content graph hash when creating or updating it.
* Calling **graph create** or **graph update** now run the commands with default arguments, instead of showing the command help.
* Removed the use of chunks when calculating content relationships.