### PR TITLE
Update additional dependencies: use files in pre-commit instead of code

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -53,5 +53,6 @@
   name: update-additional-dependencies
   entry: update-additional-dependencies
   language: python
+  files: poetry.lock
   require_serial: true
   pass_filenames: false

--- a/demisto_sdk/scripts/update_additional_dependencies.py
+++ b/demisto_sdk/scripts/update_additional_dependencies.py
@@ -30,6 +30,7 @@ def update_additional_dependencies(
             )
             return 0
         requirements = requirements_path.read_text().splitlines()
+        logger.info(f"Updating additional dependencies of {hooks} to {requirements}")
         pre_commit = get_file(pre_commit_config_path)
         for repo in pre_commit["repos"]:
             for hook in repo["hooks"]:

--- a/demisto_sdk/scripts/update_additional_dependencies.py
+++ b/demisto_sdk/scripts/update_additional_dependencies.py
@@ -2,7 +2,6 @@ import argparse
 from pathlib import Path
 from typing import Optional, Sequence
 
-from demisto_sdk.commands.common.git_util import GitUtil
 from demisto_sdk.commands.common.handlers import DEFAULT_YAML_HANDLER as yaml
 from demisto_sdk.commands.common.logger import logger
 from demisto_sdk.commands.common.tools import get_file, is_external_repository
@@ -25,14 +24,6 @@ def update_additional_dependencies(
         logger.warning("Cannot detect repo, skipping update_additional_dependencies")
         return 0
     try:
-        if (
-            Path("poetry.lock")
-            not in GitUtil()._get_all_changed_files() | GitUtil()._get_staged_files()
-        ):
-            logger.info(
-                "Skipping update of additional dependencies since poetry.lock was not changed"
-            )
-            return 0
         if not requirements_path.exists():
             logger.info(
                 "Skipping update of additional dependencies since requirements.txt was not found"


### PR DESCRIPTION

## Related Issues
fixes:

## Description
Instead of checking if `poetry.lock` has changed in the code, we can provide `files` argument in the hook itself. This simplifies things.