### PR TITLE
demisto-sdk release 1.19.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 ## Unreleased
+
+## 1.19.5
 * Fixed an issue where **update-release-notes** generated "available from Cortex XSOAR" instead of "from XSIAM" when run on XSIAM event collectors.
 * Added support for controlling the sleep interval and retry count for **modeling-rules test** command.
 * Added support for a new marketplace tag `xsoar_saas`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "demisto-sdk"
-version = "1.19.2"
+version = "1.19.5"
 description = "\"A Python library for the Demisto SDK\""
 authors = ["Demisto"]
 license = "MIT"


### PR DESCRIPTION
demisto-sdk release changes
* Fixed an issue where **update-release-notes** generated "available from Cortex XSOAR" instead of "from XSIAM" when run on XSIAM event collectors.
* Added support for controlling the sleep interval and retry count for **modeling-rules test** command.
* Added support for a new marketplace tag `xsoar_saas`.
* Added support for yml hidden parameters for `xsoar_saas` marketplace, as part of the **prepare_content** command.
* Added support for custom documentation that will appear only in `xsoar_saas` marketplace, as part of the **prepare_content** command.
* Modified **prepare_content** command to be platform specific. For xsoar-saas and XSIAM regarding pack readme and integration description images in markdown files.
* Fixed an issue where the **lint** command was parsing % that may exist in the log data.