### PR TITLE
address all warnings as errors.

### DIFF
--- a/demisto_sdk/Warnings_Summary.ini
+++ b/demisto_sdk/Warnings_Summary.ini
@@ -1,0 +1,23 @@
+; Warnings Summary:
+
+; deprecation warnings:
+
+;ignore added:
+ignore::DeprecationWarning:pytest_freezegun
+; count 7950
+;error msg ; warnings pytest_freezegun.py:17: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead. if LooseVersion(pytest.__version__) < LooseVersion('3.6.0'):
+
+;ignore added:
+ignore::DeprecationWarning:pkg_resources
+; count: 1
+;error msg ;demisto-sdk-b-AJAQhz-py3.10/lib/python3.10/site-packages/pkg_resources/__init__.py:121: DeprecationWarning: pkg_resources is deprecated as an API warnings.warn("pkg_resources is deprecated as an API", DeprecationWarning)
+
+;ignore added:
+ignore:.*pkg_resources.declare_namespace('google.rpc')*:DeprecationWarning
+; count: 1
+;error msg
+; python3.10/site-packages/google/rpc/__init__.py:20: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('google.rpc')`.
+;  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
+    ;pkg_resources.declare_namespace(__name__)
+
+; pytest failing to collect classes / methods names test with init method

--- a/demisto_sdk/commands/common/hook_validations/content_entity_validator.py
+++ b/demisto_sdk/commands/common/hook_validations/content_entity_validator.py
@@ -54,6 +54,7 @@ from demisto_sdk.commands.format.format_constants import OLD_FILE_DEFAULT_1_FROM
 
 
 class ContentEntityValidator(BaseValidator):
+    __test__ = False  # for pytest not a test class.
     DEFAULT_VERSION = -1
 
     def __init__(

--- a/demisto_sdk/commands/content_graph/objects/test_playbook.py
+++ b/demisto_sdk/commands/content_graph/objects/test_playbook.py
@@ -5,6 +5,8 @@ from demisto_sdk.commands.content_graph.objects.playbook import Playbook
 
 
 class TestPlaybook(Playbook, content_type=ContentType.TEST_PLAYBOOK):  # type: ignore[call-arg]
+    __test__ = False  # for pytest not a test class.
+
     is_test: bool = True
 
     def metadata_fields(self) -> Set[str]:

--- a/demisto_sdk/commands/content_graph/parsers/test_playbook.py
+++ b/demisto_sdk/commands/content_graph/parsers/test_playbook.py
@@ -14,6 +14,8 @@ NON_CIRCLE_TESTS_DIRECTORY = "NonCircleTests"
 
 
 class TestPlaybookParser(PlaybookParser, content_type=ContentType.TEST_PLAYBOOK):
+    __test__ = False  # for pytest not a test class.
+
     def __init__(
         self, path: Path, pack_marketplaces: List[MarketplaceVersions]
     ) -> None:

--- a/demisto_sdk/commands/format/update_playbook.py
+++ b/demisto_sdk/commands/format/update_playbook.py
@@ -291,6 +291,8 @@ class TestPlaybookYMLFormat(BasePlaybookYMLFormat):
         output (str): the desired file name to save the updated version of the YML to.
     """
 
+    __test__ = False  # for pytest not a test class.
+
     def __init__(self, *args, **kwargs):
         kwargs["path"] = os.path.normpath(
             os.path.join(__file__, "..", "..", "common", SCHEMAS_PATH, "playbook.yml")

--- a/demisto_sdk/commands/generate_unit_tests/test_case_builder.py
+++ b/demisto_sdk/commands/generate_unit_tests/test_case_builder.py
@@ -110,6 +110,8 @@ class ArgsBuilder:
 
 
 class TestCase:
+    __test__ = False  # for pytest not a test class.
+
     def __init__(
         self,
         func: ast_mod.FunctionDef,

--- a/demisto_sdk/commands/generate_unit_tests/test_module_builder.py
+++ b/demisto_sdk/commands/generate_unit_tests/test_module_builder.py
@@ -5,6 +5,8 @@ from demisto_sdk.commands.generate_unit_tests.common import ast_name
 
 
 class TestModule:
+    __test__ = False  # for pytest not a test class.
+
     def __init__(
         self,
         tree: ast_mod.Module,

--- a/demisto_sdk/commands/run_test_playbook/test_playbook_runner.py
+++ b/demisto_sdk/commands/run_test_playbook/test_playbook_runner.py
@@ -27,6 +27,8 @@ class TestPlaybookRunner:
         base_link_to_workplan (str): the base link to see the full test playbook run in your xsoar instance.
     """
 
+    __test__ = False  # for pytest not a test class.
+
     def __init__(
         self,
         test_playbook_path: str = "",

--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -114,6 +114,8 @@ class SecretConf:
 
 
 class TestConfiguration:
+    __test__ = False  # for pytest not a test class.
+
     def __init__(self, test_configuration: dict, default_test_timeout: int):
         """
         Args:
@@ -194,6 +196,8 @@ class Conf:
 
 
 class TestPlaybook:
+    __test__ = False  # for pytest not a test class.
+
     def __init__(self, build_context, test_configuration: TestConfiguration):
         """
         This class has all the info related to a test playbook during test execution
@@ -1722,6 +1726,8 @@ class Integration:
 
 
 class TestContext:
+    __test__ = False  # for pytest not a test class.
+
     def __init__(
         self,
         build_context: BuildContext,

--- a/demisto_sdk/commands/test_content/xsiam_tools/test_data.py
+++ b/demisto_sdk/commands/test_content/xsiam_tools/test_data.py
@@ -24,6 +24,7 @@ class EventLog(BaseModel):
 
 
 class TestData(BaseModel):
+    __test__ = False  # for pytest not a test class.
     data: List[EventLog] = Field(default_factory=lambda: [EventLog()])
     ignored_validations: List[str] = []
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,7 @@
 addopts = --ignore=demisto_sdk/commands/init/templates --ignore=demisto_sdk/commands/generate_unit_tests/tests/test_files/outputs --ignore=demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py --ignore=demisto_sdk/commands/test_content/xsiam_tools/test_data.py
 testpaths = demisto_sdk
 filterwarnings =
-        error
+        error  ; address pytest warnings as errors.
         ignore::DeprecationWarning:pytest_freezegun
         ignore::DeprecationWarning:pkg_resources
         ignore:.*pkg_resources.declare_namespace('google.rpc')*:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,8 @@
 [pytest]
 addopts = --ignore=demisto_sdk/commands/init/templates --ignore=demisto_sdk/commands/generate_unit_tests/tests/test_files/outputs --ignore=demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py --ignore=demisto_sdk/commands/test_content/xsiam_tools/test_data.py
 testpaths = demisto_sdk
+filterwarnings =
+        error
+        ignore::DeprecationWarning:pytest_freezegun
+        ignore::DeprecationWarning:pkg_resources
+        ignore:.*pkg_resources.declare_namespace('google.rpc')*:DeprecationWarning


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-2332

## Description
ignore 3 specific deprecation warning from specific sources.
prevent pytest from throwing a warning when collecting none
test classes BUT with test in name and with init method.