### PR TITLE
New Validation Correlation rules - Missing search window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added support for yml hidden parameters for `xsoar_saas` marketplace, as part of the **prepare_content** command.
 * Added support for custom documentation that will appear only in `xsoar_saas` marketplace, as part of the **prepare_content** command.
 * Modified **prepare_content** command to be platform specific. For xsoar-saas and XSIAM regarding pack readme and integration description images in markdown files.
+* Added a **validate** step in correlation rule files to ensure that if `execution_mode` is set to `SCHEDULED`, `search_window` cannot be empty.
 
 ## 1.19.2
 * Added a period at the end of lines produced by the **generate-docs** command that state the tested version of the product.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Fixed an issue where the (`GR108`) validation did not fail in the validate command with the `-a` flag.
 * Modified **prepare_content** command to be platform specific. For xsoar-saas and XSIAM regarding pack readme and integration description images in markdown files.
 * Fixed an issue where the **lint** command was parsing % that may exist in the log data.
-* Added a **validate** check in correlation rule files making sure that if `execution_mode` is set to `SCHEDULED`, `search_window` cannot be empty.
+* Added a **validate** check for correlation rules, making sure that `search_window` cannot be empty when `execution_mode` is set to `SCHEDULED`.
 
 ## 1.19.2
 * Added a period at the end of lines produced by the **generate-docs** command that state the tested version of the product.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fixed an issue where the (`GR108`) validation did not fail in the validate command with the `-a` flag.
 * Modified **prepare_content** command to be platform specific. For xsoar-saas and XSIAM regarding pack readme and integration description images in markdown files.
 * Fixed an issue where the **lint** command was parsing % that may exist in the log data.
+* Added a **validate** check in correlation rule files making sure that if `execution_mode` is set to `SCHEDULED`, `search_window` cannot be empty.
 
 ## 1.19.2
 * Added a period at the end of lines produced by the **generate-docs** command that state the tested version of the product.

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -1404,7 +1404,7 @@ ERROR_CODE: Dict = {
         "code": "CR101",
         "related_field": "",
     },
-    "correlation_rules_execution_mode_error": {
+    "correlation_rules_missing_search_window": {
         "code": "CR102",
         "related_field": "",
     },
@@ -4380,5 +4380,5 @@ class Errors:
 
     @staticmethod
     @error_code_decorator
-    def correlation_rules_execution_mode_error():
+    def correlation_rules_missing_search_window():
         return "The 'search_window' key must exist and cannot be empty when the 'execution_mode' is set to 'SCHEDULED'."

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -1404,6 +1404,10 @@ ERROR_CODE: Dict = {
         "code": "CR101",
         "related_field": "",
     },
+    "correlation_rules_execution_mode_error": {
+        "code": "CR102",
+        "related_field": "",
+    },
     # XR - XSIAM Reports
     "xsiam_report_files_naming_error": {
         "code": "XR100",
@@ -4373,3 +4377,9 @@ class Errors:
     @error_code_decorator
     def pack_have_nonignorable_error(nonignorable_errors: List[str]):
         return f"The following errors can not be ignored: {', '.join(nonignorable_errors)}, remove them from .pack-ignore files"
+
+    @staticmethod
+    @error_code_decorator
+    def correlation_rules_execution_mode_error():
+        return "The 'search_window' key must exist and cannot be empty when the 'execution_mode' is set to 'SCHEDULED'."
+

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -4382,4 +4382,3 @@ class Errors:
     @error_code_decorator
     def correlation_rules_execution_mode_error():
         return "The 'search_window' key must exist and cannot be empty when the 'execution_mode' is set to 'SCHEDULED'."
-

--- a/demisto_sdk/commands/common/hook_validations/correlation_rule.py
+++ b/demisto_sdk/commands/common/hook_validations/correlation_rule.py
@@ -47,6 +47,7 @@ class CorrelationRuleValidator(ContentEntityValidator):
         answers = [
             self.no_leading_hyphen(),
             self.is_files_naming_correct(),
+            self.validate_execution_mode_search_window(),
             super().is_valid_fromversion(),
         ]
         return all(answers)
@@ -83,4 +84,17 @@ class CorrelationRuleValidator(ContentEntityValidator):
             if self.handle_error(error_message, error_code, file_path=self.file_path):
                 self._is_valid = False
                 return False
+        return True
+
+    @error_codes("CR102")
+    def validate_execution_mode_search_window(self):
+        """
+        Validates 'search_window' existence and non-emptiness for 'execution_mode' = 'SCHEDULED'.
+        """
+        if (not 'search_window' in self.current_file or
+                self.current_file['execution_mode'] == 'SCHEDULED' and not self.current_file['search_window']):
+                error_message, error_code = Errors.correlation_rules_execution_mode_error()
+                if self.handle_error(error_message, error_code, file_path=self.file_path):
+                    self._is_valid = False
+                    return False
         return True

--- a/demisto_sdk/commands/common/hook_validations/correlation_rule.py
+++ b/demisto_sdk/commands/common/hook_validations/correlation_rule.py
@@ -91,9 +91,8 @@ class CorrelationRuleValidator(ContentEntityValidator):
         """
         Validates 'search_window' existence and non-emptiness for 'execution_mode' = 'SCHEDULED'.
         """
-        if (
-            "search_window" not in self.current_file
-            or self.current_file["execution_mode"] == "SCHEDULED"
+        if ("search_window" not in self.current_file) or (
+            self.current_file["execution_mode"] == "SCHEDULED"
             and not self.current_file["search_window"]
         ):
             error_message, error_code = Errors.correlation_rules_execution_mode_error()

--- a/demisto_sdk/commands/common/hook_validations/correlation_rule.py
+++ b/demisto_sdk/commands/common/hook_validations/correlation_rule.py
@@ -91,10 +91,13 @@ class CorrelationRuleValidator(ContentEntityValidator):
         """
         Validates 'search_window' existence and non-emptiness for 'execution_mode' = 'SCHEDULED'.
         """
-        if (not 'search_window' in self.current_file or
-                self.current_file['execution_mode'] == 'SCHEDULED' and not self.current_file['search_window']):
-                error_message, error_code = Errors.correlation_rules_execution_mode_error()
-                if self.handle_error(error_message, error_code, file_path=self.file_path):
-                    self._is_valid = False
-                    return False
+        if (
+            "search_window" not in self.current_file
+            or self.current_file["execution_mode"] == "SCHEDULED"
+            and not self.current_file["search_window"]
+        ):
+            error_message, error_code = Errors.correlation_rules_execution_mode_error()
+            if self.handle_error(error_message, error_code, file_path=self.file_path):
+                self._is_valid = False
+                return False
         return True

--- a/demisto_sdk/commands/common/hook_validations/correlation_rule.py
+++ b/demisto_sdk/commands/common/hook_validations/correlation_rule.py
@@ -34,7 +34,6 @@ class CorrelationRuleValidator(ContentEntityValidator):
                 FileType.CORRELATION_RULE
             ],
         )
-        self._is_valid = True
 
     def is_valid_file(self, validate_rn=True, is_new_file=False, use_git=False):
         """
@@ -68,7 +67,6 @@ class CorrelationRuleValidator(ContentEntityValidator):
         if isinstance(self.current_file, list):
             error_message, error_code = Errors.correlation_rule_starts_with_hyphen()
             if self.handle_error(error_message, error_code, file_path=self.file_path):
-                self.is_valid = False
                 return False
         return True
 
@@ -82,7 +80,6 @@ class CorrelationRuleValidator(ContentEntityValidator):
                 [self.file_path]
             )
             if self.handle_error(error_message, error_code, file_path=self.file_path):
-                self._is_valid = False
                 return False
         return True
 
@@ -95,8 +92,7 @@ class CorrelationRuleValidator(ContentEntityValidator):
             self.current_file["execution_mode"] == "SCHEDULED"
             and not self.current_file["search_window"]
         ):
-            error_message, error_code = Errors.correlation_rules_execution_mode_error()
+            error_message, error_code = Errors.correlation_rules_missing_search_window()
             if self.handle_error(error_message, error_code, file_path=self.file_path):
-                self._is_valid = False
                 return False
         return True

--- a/demisto_sdk/commands/common/schemas/correlationrule.yml
+++ b/demisto_sdk/commands/common/schemas/correlationrule.yml
@@ -32,12 +32,12 @@ mapping:
   execution_mode:
     type: str
     required: true
+    enum: ['REAL_TIME', 'SCHEDULED']
   mitre_defs:
     type: map
     allowempty: true
   search_window:
     type: str
-    required: true
   severity:
     type: str
     required: true

--- a/demisto_sdk/commands/common/tests/correlation_rules_test.py
+++ b/demisto_sdk/commands/common/tests/correlation_rules_test.py
@@ -29,17 +29,20 @@ def test_no_leading_hyphen():
     assert not correlation_rule_validator.no_leading_hyphen()
 
 
-@pytest.mark.parametrize("execution_mode, search_window, expected_result", [
-    # Test case 1: Missing 'search_window' when execution_mode is 'SCHEDULED'
-    ('SCHEDULED', None, False),
-
-    # Test case 2: Missing 'search_window' when execution_mode is 'REAL_TIME'
-    ('REAL_TIME', None, True),
-
-    # Test case 3: Valid 'search_window' when execution_mode is 'SCHEDULED'
-    ('SCHEDULED', 'valid_window', True)
-])
-def test_validate_execution_mode_search_window(execution_mode, search_window, expected_result):
+@pytest.mark.parametrize(
+    "execution_mode, search_window, expected_result",
+    [
+        # Test case 1: Missing 'search_window' when execution_mode is 'SCHEDULED'
+        ("SCHEDULED", None, False),
+        # Test case 2: Missing 'search_window' when execution_mode is 'REAL_TIME'
+        ("REAL_TIME", None, True),
+        # Test case 3: Valid 'search_window' when execution_mode is 'SCHEDULED'
+        ("SCHEDULED", "valid_window", True),
+    ],
+)
+def test_validate_execution_mode_search_window(
+    execution_mode, search_window, expected_result
+):
     """
     Given: A correlation rule with execution_mode and search_window.
     When: running validate_execution_mode_search_window.
@@ -53,8 +56,8 @@ def test_validate_execution_mode_search_window(execution_mode, search_window, ex
     correlation_rule_validator = CorrelationRuleValidator(content_validator)
 
     # Set the execution_mode and search_window in the current_file
-    correlation_rule_validator.current_file['execution_mode'] = execution_mode
-    correlation_rule_validator.current_file['search_window'] = search_window
+    correlation_rule_validator.current_file["execution_mode"] = execution_mode
+    correlation_rule_validator.current_file["search_window"] = search_window
 
     result = correlation_rule_validator.validate_execution_mode_search_window()
     assert result == expected_result

--- a/demisto_sdk/commands/common/tests/correlation_rules_test.py
+++ b/demisto_sdk/commands/common/tests/correlation_rules_test.py
@@ -1,3 +1,5 @@
+import pytest
+
 from demisto_sdk.commands.common.hook_validations.content_entity_validator import (
     ContentEntityValidator,
 )
@@ -14,7 +16,7 @@ GIT_ROOT = git_path()
 def test_no_leading_hyphen():
     """
     Given: A correlation rule with leading hyphen is given.
-    When: running dataset_name_matches_in_xif_and_schema.
+    When: running no_leading_hyphen.
     Then: Validate that the correlation rule is invalid.
     """
     invalid_correlation_file = f"{GIT_ROOT}/demisto_sdk/commands/common/tests/test_files/invalid_correlation_rule.yml"
@@ -25,3 +27,34 @@ def test_no_leading_hyphen():
     correlation_rule_validator = CorrelationRuleValidator(content_validator)
 
     assert not correlation_rule_validator.no_leading_hyphen()
+
+
+@pytest.mark.parametrize("execution_mode, search_window, expected_result", [
+    # Test case 1: Missing 'search_window' when execution_mode is 'SCHEDULED'
+    ('SCHEDULED', None, False),
+
+    # Test case 2: Missing 'search_window' when execution_mode is 'REAL_TIME'
+    ('REAL_TIME', None, True),
+
+    # Test case 3: Valid 'search_window' when execution_mode is 'SCHEDULED'
+    ('SCHEDULED', 'valid_window', True)
+])
+def test_validate_execution_mode_search_window(execution_mode, search_window, expected_result):
+    """
+    Given: A correlation rule with execution_mode and search_window.
+    When: running validate_execution_mode_search_window.
+    Then: Validate the result based on the provided execution_mode and search_window.
+    """
+    invalid_correlation_file = f"{GIT_ROOT}/demisto_sdk/commands/common/tests/test_files/invalid_correlation_rule_execution_mode.yml"
+    invalid_correlation_yaml = get_yaml(invalid_correlation_file)
+    structure_validator = StructureValidator(invalid_correlation_file)
+    structure_validator.current_file = invalid_correlation_yaml
+    content_validator = ContentEntityValidator(structure_validator)
+    correlation_rule_validator = CorrelationRuleValidator(content_validator)
+
+    # Set the execution_mode and search_window in the current_file
+    correlation_rule_validator.current_file['execution_mode'] = execution_mode
+    correlation_rule_validator.current_file['search_window'] = search_window
+
+    result = correlation_rule_validator.validate_execution_mode_search_window()
+    assert result == expected_result

--- a/demisto_sdk/commands/common/tests/test_files/invalid_correlation_rule_execution_mode.yml
+++ b/demisto_sdk/commands/common/tests/test_files/invalid_correlation_rule_execution_mode.yml
@@ -1,0 +1,33 @@
+alert_category: EXECUTION
+alert_description: This alert will trigger in an event where multiple attempts of
+  unauthorized actions were detected
+alert_fields:
+  actor_image: null
+  actor_path: xdm.source.user.user_type
+  cmd: null
+  domain: null
+  hash: null
+  hostname: null
+  local_ip: null
+  remote_ip: xdm.source.ipv4
+  remote_port: null
+  username: xdm.source.user.username
+alert_name: Test
+crontab: '* * * * *'
+dataset: alerts
+description: Test
+drilldown_query_timeframe: ALERT
+execution_mode: SCHEDULED
+global_rule_id: 1234
+investigation_query_link: null
+mapping_strategy: CUSTOM
+mitre_defs: {}
+name: Test
+search_window: null
+severity: SEV_030_MEDIUM
+suppression_duration: null
+suppression_enabled: false
+suppression_fields: null
+user_defined_category: null
+user_defined_severity: null
+xql_query: null


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes:https://jira-hq.paloaltonetworks.local/browse/CIAC-7254

## Description
Added a **validate** check in correlation rule files making sure that if `execution_mode` is set to `SCHEDULED`, `search_window` cannot be empty.
On the other hand, when `execution_mode` is set to `REAL_TIME`, `search_window` can be empty.