### PR TITLE
Fixed FileNotFound: landing_page.json error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## Unreleased
 * Fixed an issue where logging arguments were not in the standard kebab-case. The new arguments are: **console-log-threshold**, **file-log-threshold**, **log-file-path**.
+* Fixed an issue where the **upload** command failed because it didn't found the landing_page.json file in content repo.
 
 ## 1.20.0
 * Fixed an issue where **update-release-notes** generated "available from Cortex XSOAR" instead of "from XSIAM" when run on XSIAM event collectors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 ## Unreleased
 * Fixed an issue where logging arguments were not in the standard kebab-case. The new arguments are: **console-log-threshold**, **file-log-threshold**, **log-file-path**.
-* Fixed an issue where the **upload** command failed because it didn't found the landing_page.json file in content repo.
+* Fixed an issue where the **upload** command failed for private repositories while trying to find the landing_page.json file.
 
 ## 1.20.0
 * Fixed an issue where **update-release-notes** generated "available from Cortex XSOAR" instead of "from XSIAM" when run on XSIAM event collectors.

--- a/demisto_sdk/commands/content_graph/objects/pack_metadata.py
+++ b/demisto_sdk/commands/content_graph/objects/pack_metadata.py
@@ -321,8 +321,16 @@ class PackMetadata(BaseModel):
         Returns:
             set: Pack's tags.
         """
-        tags = set()
-        landing_page_sections = get_json(LANDING_PAGE_SECTIONS_PATH)
+        tags: set = set()
+
+        try:
+            landing_page_sections = get_json(LANDING_PAGE_SECTIONS_PATH)
+        except FileNotFoundError as e:
+            logger.warning(
+                f"Couldn't find the landing_page file in path {LANDING_PAGE_SECTIONS_PATH}. Skipping collecting tags by landing page sections.\n{e}"
+            )
+            return tags
+
         sections = landing_page_sections.get("sections") or []
 
         for section in sections:


### PR DESCRIPTION
## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-27601

## Description
Fixed an issue where uploading private content the command `demisto-sdk upload` fails on fileNotFound on landing_page.json.