### PR TITLE
demisto-sdk release 1.19.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 ## Unreleased
+
+## 1.19.5
 * Fixed an issue where logging arguments were not in the standard kebab-case. The new arguments are: **console-log-threshold**, **file-log-threshold**, **log-file-path**.
    Added a validation to ensure there's a '.' in the end of each description field in integration and script yml files.
 * Fixed an issue where the **upload** command failed for private repositories while trying to find the landing_page.json file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "demisto-sdk"
-version = "1.20.0"
+version = "1.19.5"
 description = "\"A Python library for the Demisto SDK\""
 authors = ["Demisto"]
 license = "MIT"


### PR DESCRIPTION
demisto-sdk release changes
* Fixed an issue where logging arguments were not in the standard kebab-case. The new arguments are: **console-log-threshold**, **file-log-threshold**, **log-file-path**.
   Added a validation to ensure there's a '.' in the end of each description field in integration and script yml files.
* Fixed an issue where the **upload** command failed for private repositories while trying to find the landing_page.json file.