### PR TITLE
force flag update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * Fixed an issue where the **upload** command failed for private repositories while trying to find the landing_page.json file.
 * Added a log when a content item is missing from the repo, in **graph create** and **graph update**.
 * Replaced logs with a progress bar in **graph create** and **graph update**.
+* Updated the **update-release-notes --force** flag to support general messages with the right template.
+
 
 ## 1.20.0
 * Fixed an issue where **update-release-notes** generated "available from Cortex XSOAR" instead of "from XSIAM" when run on XSIAM event collectors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Fixed an issue where logging arguments were not in the standard kebab-case. The new arguments are: **console-log-threshold**, **file-log-threshold**, **log-file-path**.
    Added a validation to ensure there's a '.' in the end of each description field in integration and script yml files.
 * Fixed an issue where the **upload** command failed for private repositories while trying to find the landing_page.json file.
+* Updated the **update-release-notes --force** flag to support general messages with the right template.
 
 ## 1.20.0
 * Fixed an issue where **update-release-notes** generated "available from Cortex XSOAR" instead of "from XSIAM" when run on XSIAM event collectors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Fixed an issue where the **upload** command failed for private repositories while trying to find the landing_page.json file.
 * Added a log when a content item is missing from the repo, in **graph create** and **graph update**.
 * Replaced logs with a progress bar in **graph create** and **graph update**.
-* Updated the **update-release-notes --force** flag to support general messages with the right template.
+* Updated the **update-release-notes** command message structure when is ran with **--force** flag. 
 
 
 ## 1.20.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Fixed an issue where the **upload** command failed for private repositories while trying to find the landing_page.json file.
 * Added a log when a content item is missing from the repo, in **graph create** and **graph update**.
 * Replaced logs with a progress bar in **graph create** and **graph update**.
-* Updated the **update-release-notes** command message structure when is ran with **--force** flag. 
+* Updated the **update-release-notes** command message structure when is run with **--force** flag.
 
 
 ## 1.20.0

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -2590,7 +2590,7 @@ def test_handle_existing_rn_with_docker_image(
 
 @pytest.mark.parametrize(
     "text, expected_rn_string",
-    [("Testing the upload", "##### PackName\n\n- Testing the upload\n")],
+    [("Testing the upload", "## PackName\n\n- Testing the upload\n")],
 )
 def test_force_and_text_update_rn(repo, text, expected_rn_string):
     """

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -2605,7 +2605,8 @@ def test_force_and_text_update_rn(repo, text, expected_rn_string):
     - Updating release notes with *--force* and without the *--text* flag
 
     Then:
-    - Ensure the release note includes the right text
+    - Ensure the release note includes the "Testing the upload" text
+    - Ensure the release note includes the "%%UPDATE_RN%%" text
     """
     pack = repo.create_pack("PackName")
     client = UpdateRN(

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -2590,7 +2590,10 @@ def test_handle_existing_rn_with_docker_image(
 
 @pytest.mark.parametrize(
     "text, expected_rn_string",
-    [("Testing the upload", "## PackName\n\n- Testing the upload\n")],
+    [
+        ("Testing the upload", "## PackName\n\n- Testing the upload\n"),
+        ("", "## PackName\n\n- %%UPDATE_RN%%\n"),
+    ],
 )
 def test_force_and_text_update_rn(repo, text, expected_rn_string):
     """
@@ -2599,9 +2602,10 @@ def test_force_and_text_update_rn(repo, text, expected_rn_string):
 
     When:
     - Updating release notes with *--force* and *--text* flags
+    - Updating release notes with *--force* and without the *--text* flag
 
     Then:
-    - Ensure the release note includes the given text
+    - Ensure the release note includes the right text
     """
     pack = repo.create_pack("PackName")
     client = UpdateRN(

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -5,7 +5,6 @@ import copy
 import errno
 import os
 import re
-import sys
 from pathlib import Path
 from typing import Any, Iterable, Optional, Tuple, Union
 
@@ -746,8 +745,7 @@ class UpdateRN:
 
         elif self.is_force:
             rn_desc = f"## {content_name}\n\n"
-            if text:
-                rn_desc += f'- {text}'
+            rn_desc += f'- {text or "%%UPDATE_RN%%"}\n'
         else:
             if is_new_file:
                 rn_desc = f"##### New: {content_name}\n\n"

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -5,6 +5,7 @@ import copy
 import errno
 import os
 import re
+import sys
 from pathlib import Path
 from typing import Any, Iterable, Optional, Tuple, Union
 
@@ -742,6 +743,11 @@ class UpdateRN:
                 rn_desc = f"- New: **{content_name}**\n"
             else:
                 rn_desc = f"- **{content_name}**\n"
+
+        elif self.is_force:
+            rn_desc = f"## {content_name}\n\n"
+            if text:
+                rn_desc += f'- {text}'
         else:
             if is_new_file:
                 rn_desc = f"##### New: {content_name}\n\n"

--- a/demisto_sdk/tests/integration_tests/update_release_notes_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/update_release_notes_integration_test.py
@@ -865,7 +865,7 @@ def test_force_update_release(demisto_client, mocker, repo):
 
     with open(rn_path) as f:
         rn = f.read()
-    assert "##### ThinkCanary\n\n- %%UPDATE_RN%%\n" == rn
+    assert "## ThinkCanary\n\n- %%UPDATE_RN%%\n" == rn
 
 
 def test_update_release_notes_only_pack_ignore_changed(mocker, pack):


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-5152

## Description
Updated the use of the `force` flag. 
Now when running the following command: `demisto-sdk update-release-notes -i Packs/PackName --force --text "testing"
The results will look like the following:
```
## PackName

- testing
```