### PR TITLE
demisto-sdk release 1.19.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+
+## 1.19.5
 * Added formatting for yml files when period is missing in the end of description field, in the **format** command.
 * Fixed an issue where logging arguments were not in the standard kebab-case. The new arguments are: **console-log-threshold**, **file-log-threshold**, **log-file-path**.
 * Added a new validation (`DS108`) to ensure that each description in the yml of script/integration ends with a dot.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "demisto-sdk"
-version = "1.20.0"
+version = "1.19.5"
 description = "\"A Python library for the Demisto SDK\""
 authors = ["Demisto"]
 license = "MIT"


### PR DESCRIPTION
demisto-sdk release changes
* Added formatting for yml files when period is missing in the end of description field, in the **format** command.
* Fixed an issue where logging arguments were not in the standard kebab-case. The new arguments are: **console-log-threshold**, **file-log-threshold**, **log-file-path**.
* Added a new validation (`DS108`) to ensure that each description in the yml of script/integration ends with a dot.
* Fixed an issue where the **validate -g** failed reading a `.pack-ignore` file that was previously empty.
* Fixed an issue where the **update-release-notes** failed when changing the `.pack-ignore` file.
* Fixed an issue where the **GR103** validation output was malformed.
* Fixed an issue where the **upload** command failed for private repositories while trying to find the landing_page.json file.
* Added a log when a content item is missing from the repo, in **graph create** and **graph update**.
* Replaced logs with a progress bar in **graph create** and **graph update**.
* Updated the **update-release-notes** command message structure when is run with **--force** flag.