### PR TITLE
Updated validation to support force flag + some fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Fixed an issue where the **validate -g** failed reading a `.pack-ignore` file that contained only newlines and spaces.
 * Demisto-SDK will now exit gracefully with an appropriate error message when *git* is not installed.
 * Updated validation *RN116* to support the structure of **--force** flag in *update-release-notes* command.
+* Fixed an issue where the release notes file was not added automatically to git when using the *update-release-notes* command.
+* Fixed the structure in *update-release-notes* command when used with the **--force** flag. Now the header will display the pack display name.
 * Fixed the support in **validate** for `svg` images to have their theme suffix.
 * Fixed an issue where **modeling-rule test** command failed to properly compare types of fields.
 * Updated the **engineinfo** type in the script schema.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## Unreleased
 * Demisto-SDK will now exit gracefully with an appropriate error message when *git* is not installed.
+* Updated validation *RN116* to support the structure of **--force** flag in *update-release-notes* command.
 
 ## 1.20.2
 * Updated the **pre-commit** command to run on all python versions in one run.

--- a/demisto_sdk/commands/common/hook_validations/release_notes.py
+++ b/demisto_sdk/commands/common/hook_validations/release_notes.py
@@ -1,6 +1,7 @@
 import itertools
 import os
 import re
+import sys
 from typing import Dict, List, Tuple, Union
 
 from demisto_sdk.commands.common.constants import (
@@ -180,9 +181,10 @@ class ReleaseNotesValidator(BaseValidator):
             True if the RN has a first level header, False otherwise.
         """
         first_level_header_index = re.search(
-            r"\s#{4}\B", f"\n{self.latest_release_notes}"
+            r"\s#{4}\s", f"\n{self.latest_release_notes}"
         )
-        if not first_level_header_index:
+        force_header_index = re.search(r"\s#{2}\s", f"\n{self.latest_release_notes}")
+        if not (first_level_header_index or force_header_index):
             (
                 error_message,
                 error_code,
@@ -452,12 +454,11 @@ class ReleaseNotesValidator(BaseValidator):
         Return:
             True if the release notes headers are valid, False otherwise.
         """
-
-        validations = []
-        validations.append(self.validate_first_level_header_exists())
         headers = self.extract_rn_headers()
+        validations = [self.validate_first_level_header_exists()]
         self.filter_rn_headers(headers=headers)
         for content_type, content_items in headers.items():
+
             validations.append(
                 self.rn_valid_header_format(
                     content_type=content_type, content_items=content_items

--- a/demisto_sdk/commands/common/hook_validations/release_notes.py
+++ b/demisto_sdk/commands/common/hook_validations/release_notes.py
@@ -1,7 +1,6 @@
 import itertools
 import os
 import re
-import sys
 from typing import Dict, List, Tuple, Union
 
 from demisto_sdk.commands.common.constants import (

--- a/demisto_sdk/commands/common/tests/release_notes_test.py
+++ b/demisto_sdk/commands/common/tests/release_notes_test.py
@@ -869,4 +869,4 @@ def test_validate_first_level_header_exists(mocker, rn_content, expected_result)
     mocker.patch.object(ReleaseNotesValidator, "__init__", lambda a, b: None)
     validator = get_validator(rn_content)
     results = validator.validate_first_level_header_exists()
-    assert  results == expected_result
+    assert results == expected_result

--- a/demisto_sdk/commands/common/tests/release_notes_test.py
+++ b/demisto_sdk/commands/common/tests/release_notes_test.py
@@ -844,6 +844,7 @@ def test_invalid_headers(mocker, repo, content, content_type, expected_result):
         ("#### Scripts\n- Some description.", True),
         ("##### script_name\n- Some description.", False),
         ("- Some description.", False),
+        ("## script_name\n- Some description.", True),
     ],
 )
 def test_validate_first_level_header_exists(mocker, rn_content, expected_result):
@@ -854,6 +855,7 @@ def test_validate_first_level_header_exists(mocker, rn_content, expected_result)
     - Case 2: Release notes with only first level header and description.
     - Case 3: Release notes with only second level header and description.
     - Case 4: Release notes only with description.
+    - Case 5: Release notes that was created with the --force flag
     When
     - Calling validate_first_level_header_exists.
     Then
@@ -862,8 +864,9 @@ def test_validate_first_level_header_exists(mocker, rn_content, expected_result)
     - Case 2: Should return True.
     - Case 3: Should return False.
     - Case 4: Should return False.
+    - Case 5: Should return True.
     """
     mocker.patch.object(ReleaseNotesValidator, "__init__", lambda a, b: None)
     validator = get_validator(rn_content)
     results = validator.validate_first_level_header_exists()
-    expected_result == results
+    assert  results == expected_result

--- a/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
+++ b/demisto_sdk/commands/update_release_notes/tests/update_rn_test.py
@@ -1716,8 +1716,8 @@ class TestRNUpdateUnit:
             modified_files_in_pack={"HelloWorld"},
             added_files=set(),
         )
-        filepath = os.path.join(TestRNUpdate.FILES_PATH, "ReleaseNotes/1_1_1.md")
-        md_string = "### Test"
+        filepath = os.path.join(TestRNUpdate.FILES_PATH, "ReleaseNotes/1_1_67.md")
+        md_string = "### Shelly"
         update_rn.create_markdown(
             release_notes_path=filepath, rn_string=md_string, changed_files={}
         )
@@ -2793,3 +2793,31 @@ def test_no_release_notes_for_first_version(mocker):
     with pytest.raises(ValueError) as e:
         update_rn.get_new_version_and_metadata()
         assert str(e) == "Release notes do not need to be updated for version '1.0.0'."
+
+
+def test_git_add_release_notes(mocker):
+    """
+    Given:
+        - a filepath for a release notes file and a markdown string
+    When:
+        - creating a new markdown file and adding it
+    Then:
+        - create the file and then remove it.
+    """
+    from demisto_sdk.commands.update_release_notes.update_rn import UpdateRN
+
+    mocker.patch.object(UpdateRN, "get_master_version", return_value="0.0.0")
+    update_rn = UpdateRN(
+        pack_path="Packs/VulnDB",
+        update_type="minor",
+        modified_files_in_pack={"HelloWorld"},
+        added_files=set(),
+    )
+    filepath = os.path.join(TestRNUpdate.FILES_PATH, "ReleaseNotes/1_1_2.md")
+    md_string = "### Test Release Notes"
+    update_rn.create_markdown(
+        release_notes_path=filepath, rn_string=md_string, changed_files={}
+    )
+    assert Path(filepath).exists()
+    Path(filepath).unlink()
+    assert not Path(filepath).exists()

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -429,28 +429,6 @@ class UpdateRN:
             master_current_version = master_metadata.get("currentVersion", "0.0.0")
         return master_current_version
 
-    def get_pack_display_name(self) -> str:
-        """
-        Gets the pack display name from the metadata file. If not found return the pack name.
-
-        :rtype: ``str``
-        :return
-            Pack display name
-
-        """
-        pack_display_name = self.pack
-        master_metadata = None
-        try:
-            master_metadata = get_remote_file(self.metadata_path)
-        except Exception:
-            logger.exception(
-                f"[red]Failed fetching {self.metadata_path} from remote master branch."
-                "Using the local version (if exists), instead[/red]",
-            )
-        if master_metadata:
-            pack_display_name = master_metadata.get("name")
-        return pack_display_name
-
     def is_bump_required(self) -> bool:
         """
         Checks if the currentVersion in the pack metadata has been changed or not. Additionally, it will verify
@@ -698,7 +676,7 @@ class UpdateRN:
             return rn_string
         rn_template_as_dict: dict = {}
         if self.is_force:
-            pack_display_name = self.get_pack_display_name()
+            pack_display_name = self.get_pack_metadata().get("name", self.pack)
             rn_string = self.build_rn_desc(
                 content_name=pack_display_name, text=self.text
             )

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -5,7 +5,6 @@ import copy
 import errno
 import os
 import re
-import sys
 from pathlib import Path
 from typing import Any, Iterable, Optional, Tuple, Union
 
@@ -701,7 +700,9 @@ class UpdateRN:
         rn_template_as_dict: dict = {}
         if self.is_force:
             pack_display_name = self.get_pack_display_name()
-            rn_string = self.build_rn_desc(content_name=pack_display_name, text=self.text)
+            rn_string = self.build_rn_desc(
+                content_name=pack_display_name, text=self.text
+            )
         # changed_items.items() looks like that: [((name, type), {...}), (name, type), {...}] and we want to sort
         # them by type (x[0][1])
 
@@ -951,9 +952,11 @@ class UpdateRN:
             with open(release_notes_path, "w") as fp:
                 fp.write(rn_string)
         try:
-            run_command(f'git add {release_notes_path}', exit_on_error=False)
+            run_command(f"git add {release_notes_path}", exit_on_error=False)
         except RuntimeError:
-            logger.warning(f'Could not add the release note files to git: {release_notes_path}')
+            logger.warning(
+                f"Could not add the release note files to git: {release_notes_path}"
+            )
 
     def rn_with_docker_image(self, rn_string: str, docker_image: Optional[str]) -> str:
         """


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-8262

## Description
1. Updated the release notes validation to support the new force flag template
2. Fixed an issue where the new force template showed the pack ID instead of the pack display name
3. Fixed an issue in regex that missed some wrong first-level header
4. When creating a new release notes file, it will be added to git automatically 