### PR TITLE
demisto-sdk release 1.19.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 ## Unreleased
+
+## 1.19.5
 * Fixed an issue where the **coverage-analyze** command was not parsing the logs correctly.
 * The content graph will now include the **python_version** field that each script/integration uses.
 * Updated the **update-release-notes** command message structure when is run with **--force** flag.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "demisto-sdk"
-version = "1.20.1"
+version = "1.19.5"
 description = "\"A Python library for the Demisto SDK\""
 authors = ["Demisto"]
 license = "MIT"


### PR DESCRIPTION
demisto-sdk release changes
* Fixed an issue where the **coverage-analyze** command was not parsing the logs correctly.
* The content graph will now include the **python_version** field that each script/integration uses.
* Updated the **update-release-notes** command message structure when is run with **--force** flag.