### PR TITLE
Add `engineinfo` to script schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Fixed an issue where the **coverage-analyze** command was not parsing the logs correctly.
 * The content graph will now include the **python_version** field that each script/integration uses.
 * Updated the **update-release-notes** command message structure when is run with **--force** flag.
+* Fixed an issue where *engineinfo* was not in the script schema.
 
 ## 1.20.1
 * Added formatting for yml files when period is missing in the end of description field, in the **format** command.

--- a/demisto_sdk/commands/common/schemas/script.yml
+++ b/demisto_sdk/commands/common/schemas/script.yml
@@ -90,6 +90,8 @@ mapping:
   subtype:
     type: str
     enum: ['python2', 'python3']
+  engineinfo:
+    type: str
   contentitemexportablefields:
     type: map
     mapping:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-8291

## Description
Added the *engineinfo* key to the script schema.