### PR TITLE
[Format] add period suffix to comment field and fix issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Added support for lazy loading the of widgets in XSIAM dashboards.
 
 ## 1.20.1
-* Added formatting for integration yml files when period is missing in the end of description field, in the **format** command.
+* Added formatting for yml files when period is missing in the end of description field, in the **format** command.
 * Fixed an issue where logging arguments were not in the standard kebab-case. The new arguments are: **console-log-threshold**, **file-log-threshold**, **log-file-path**.
 * Added a new validation (`DS108`) to ensure that each description in the yml of script/integration ends with a dot.
 * Fixed an issue where the **validate -g** failed reading a `.pack-ignore` file that was previously empty.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 ## Unreleased
 * Fixed an issue where the **coverage-analyze** command was not parsing the logs correctly.
 * Fixed an issue where **validate** falsly failed with error `DS108` on descriptions ending with a newline.
+* Added formatting for script yml files when period is missing in the end of comment field, in the **format** command.
+* Fixed an issue where **format**  add a newline with a period when the description field missing a period.
 * The content graph will now include the **python_version** field that each script/integration uses.
 * Updated the **update-release-notes** command message structure when is run with **--force** flag.
 
 ## 1.20.1
-* Added formatting for yml files when period is missing in the end of description field, in the **format** command.
+* Added formatting for integration yml files when period is missing in the end of description field, in the **format** command.
 * Fixed an issue where logging arguments were not in the standard kebab-case. The new arguments are: **console-log-threshold**, **file-log-threshold**, **log-file-path**.
 * Added a new validation (`DS108`) to ensure that each description in the yml of script/integration ends with a dot.
 * Fixed an issue where the **validate -g** failed reading a `.pack-ignore` file that was previously empty.

--- a/demisto_sdk/commands/common/tests/docker_test.py
+++ b/demisto_sdk/commands/common/tests/docker_test.py
@@ -12,6 +12,7 @@ from demisto_sdk.commands.common.tools import get_yaml
 from TestSuite.test_tools import ChangeCWD, str_in_call_args_list
 
 RETURN_ERROR_TARGET = "GetDockerImageLatestTag.return_error"
+DEPRECATED_IMAGES_URL = "https://raw.githubusercontent.com/demisto/dockerfiles/master/docker/deprecated_images.json"
 
 MOCK_TAG_LIST = [
     {
@@ -472,7 +473,7 @@ class TestDockerImage:
         )
         error, code = Errors.non_existing_docker(docker_image)
         requests_mock.get(
-            "https://raw.githubusercontent.com/demisto/dockerfiles/master/docker/deprecated_images.json",
+            DEPRECATED_IMAGES_URL,
             json=[
                 {
                     "image_name": "demisto/aiohttp",
@@ -501,7 +502,9 @@ class TestDockerImage:
         "native_image",
         ["demisto/py3-native:8.2.0.58349", "devdemisto/py3-native:8.2.0.58349"],
     )
-    def test_is_native_image_in_dockerimage_field(self, mocker, pack, native_image):
+    def test_is_native_image_in_dockerimage_field(
+        self, mocker, requests_mock, pack, native_image
+    ):
         """
         Given:
             native image that is configured into the yml for the dockerimage field
@@ -513,6 +516,11 @@ class TestDockerImage:
             make sure that validation for the integration/script with
             native image configured in the dockerimage field fails
         """
+        requests_mock.get(
+            DEPRECATED_IMAGES_URL,
+            json=[],
+        )
+
         integration = pack.create_integration(docker_image=native_image)
         script = pack.create_script(docker_image=native_image)
 
@@ -733,9 +741,8 @@ class TestDockerImage:
                 - Validates that the deprecated image is invalid
                 - Validates that the not deprecated image is valid
             """
-            api_url = "https://raw.githubusercontent.com/demisto/dockerfiles/master/docker/deprecated_images.json"
             requests_mock.get(
-                api_url,
+                DEPRECATED_IMAGES_URL,
                 json=[
                     {
                         "image_name": "demisto/aiohttp",
@@ -776,9 +783,8 @@ class TestDockerImage:
             Then:
                 - Validates that the image is deprecated and the command returns the right tuple response.
             """
-            api_url = "https://raw.githubusercontent.com/demisto/dockerfiles/master/docker/deprecated_images.json"
             requests_mock.get(
-                api_url,
+                DEPRECATED_IMAGES_URL,
                 json=[
                     {
                         "image_name": "demisto/aiohttp",

--- a/demisto_sdk/commands/format/tests/test_formatting_generic_test.py
+++ b/demisto_sdk/commands/format/tests/test_formatting_generic_test.py
@@ -274,41 +274,89 @@ def test_initiate_file_validator(mocker, is_old_file, function_validate):
 
 
 @pytest.mark.parametrize(
-    "description, expected_description",
+    "comment, expected_comment, description, expected_description",
     [
+        ("", "", "", ""),
         (
+            "comment without dot",
+            "comment without dot.",
             "description without dot",
             "description without dot.",
         ),
-        ("dot at the end.", "dot at the end."),
         (
-            "a yml with url and no dot at the end https://www.test.com",
-            "a yml with url and no dot at the end https://www.test.com",
+            "comment with dot.",
+            "comment with dot.",
+            "description with dot at the end.",
+            "description with dot at the end.",
         ),
         (
-            "a yml with a description that has https://www.test.com in the middle of the sentence",
-            "a yml with a description that has https://www.test.com in the middle of the sentence.",
+            "comment with url and no dot at the end https://www.test.com",
+            "comment with url and no dot at the end https://www.test.com",
+            "description with url and no dot at the end https://www.test.com",
+            "description with url and no dot at the end https://www.test.com",
         ),
         (
-            "a yml with a description that has an 'example without dot at the end of the string'",
-            "a yml with a description that has an 'example without dot at the end of the string'.",
+            "comment with url and dot at the end https://www.test.com.",
+            "comment with url and dot at the end https://www.test.com.",
+            "description that has https://www.test.com in the middle of the sentence",
+            "description that has https://www.test.com in the middle of the sentence.",
+        ),
+        (
+            "comment with url and dot at the end https://www.test.com.",
+            "comment with url and dot at the end https://www.test.com.",
+            "description that has an 'example without dot at the end of the string'",
+            "description that has an 'example without dot at the end of the string'.",
+        ),
+        (
+            "comment with dot and empty string in the end. ",
+            "comment with dot and empty string in the end.",
+            "description with dot and empty string in the end. ",
+            "description with dot and empty string in the end.",
+        ),
+        (
+            "comment without dot and empty string in the end ",
+            "comment without dot and empty string in the end.",
+            "description without dot and empty string in the end ",
+            "description without dot and empty string in the end.",
+        ),
+        (
+            "comment with dot and 'new_line' in the end. \n",
+            "comment with dot and 'new_line' in the end.",
+            "description with dot and 'new_line' in the end. \n",
+            "description with dot and 'new_line' in the end.",
+        ),
+        (
+            "comment without dot and 'new_line' in the end \n",
+            "comment without dot and 'new_line' in the end.",
+            "description without dot and 'new_line' in the end \n",
+            "description without dot and 'new_line' in the end.",
         ),
     ],
     ids=[
+        "empty string",
         "Without dot",
         "with dot",
         "url in the end",
         "url in the middle",
         "with single-quotes in double-quotes",
+        "with dot and empty string in the end",
+        "without dot and empty string in the end",
+        "with dot and new line in the end",
+        "without dot and new line in the end",
     ],
 )
 def test_adds_period_to_description(
-    mocker: MockerFixture, description: str, expected_description: str
+    mocker: MockerFixture,
+    comment: str,
+    expected_comment: str,
+    description: str,
+    expected_description: str,
 ) -> None:
     """
     Test case for the `adds_period_to_description`.
-
+    for integration, script yml files.
     Given:
+        a comment and its expected comment with a period,
         a description and its expected description with a period,
     When:
         the `adds_period_to_description` method is called,
@@ -316,6 +364,7 @@ def test_adds_period_to_description(
         the description in the YAML data should have a period added if is not end with url.
     """
     yml_data = {
+        "comment": comment,
         "description": description,
         "script": {
             "commands": [
@@ -338,6 +387,7 @@ def test_adds_period_to_description(
         },
     }
     expected__yml_data = {
+        "comment": expected_comment,
         "description": expected_description,
         "script": {
             "commands": [

--- a/demisto_sdk/commands/format/tests/test_formatting_generic_test.py
+++ b/demisto_sdk/commands/format/tests/test_formatting_generic_test.py
@@ -309,9 +309,9 @@ def test_initiate_file_validator(mocker, is_old_file, function_validate):
         ),
         (
             "comment with dot and empty string in the end. ",
-            "comment with dot and empty string in the end.",
+            "comment with dot and empty string in the end. ",
             "description with dot and empty string in the end. ",
-            "description with dot and empty string in the end.",
+            "description with dot and empty string in the end. ",
         ),
         (
             "comment without dot and empty string in the end ",
@@ -321,9 +321,9 @@ def test_initiate_file_validator(mocker, is_old_file, function_validate):
         ),
         (
             "comment with dot and 'new_line' in the end. \n",
-            "comment with dot and 'new_line' in the end.",
+            "comment with dot and 'new_line' in the end. \n",
             "description with dot and 'new_line' in the end. \n",
-            "description with dot and 'new_line' in the end.",
+            "description with dot and 'new_line' in the end. \n",
         ),
         (
             "comment without dot and 'new_line' in the end \n",

--- a/demisto_sdk/commands/format/tests/test_formatting_generic_test.py
+++ b/demisto_sdk/commands/format/tests/test_formatting_generic_test.py
@@ -329,7 +329,7 @@ def test_initiate_file_validator(mocker, is_old_file, function_validate):
             "comment without dot and 'new_line' in the end \n",
             "comment without dot and 'new_line' in the end.",
             "description without dot and 'new_line' in the end \n",
-            "description without dot and 'new_line' in the end.",
+            "description without dot and 'new_line' in the end.",  # Simulates a case when the description starts with pipe -|
         ),
     ],
     ids=[
@@ -341,8 +341,8 @@ def test_initiate_file_validator(mocker, is_old_file, function_validate):
         "with single-quotes in double-quotes",
         "with dot and empty string in the end",
         "without dot and empty string in the end",
-        "with dot and new line in the end",
-        "without dot and new line in the end",
+        "case when the description starts with pipe with dot",
+        "case when the description starts with pipe without dot",
     ],
 )
 def test_adds_period_to_description(

--- a/demisto_sdk/commands/format/update_generic.py
+++ b/demisto_sdk/commands/format/update_generic.py
@@ -477,7 +477,7 @@ class BaseUpdate:
                 if not strip_value.endswith(".") and not is_string_ends_with_url(
                     strip_value
                 ):
-                    return f"{value}."
+                    return f"{strip_value}."
             return value
 
         # script yml

--- a/demisto_sdk/commands/format/update_generic.py
+++ b/demisto_sdk/commands/format/update_generic.py
@@ -20,6 +20,7 @@ from demisto_sdk.commands.common.tools import (
     get_yaml,
     is_file_from_content_repo,
     is_string_ends_with_url,
+    strip_description,
 )
 from demisto_sdk.commands.format.format_constants import (
     DEFAULT_VERSION,
@@ -467,19 +468,21 @@ class BaseUpdate:
                     self.data.pop(self.json_from_server_version_key)
 
     def adds_period_to_description(self):
-        """Adds a period to the end of the descriptions
+        """Adds a period to the end of the descriptions or comments
         if it does not already end with a period."""
 
         def _add_period(value: Optional[str]) -> Optional[str]:
-            if (
-                value
-                and isinstance(value, str)
-                and not value.endswith(".")
-                and not is_string_ends_with_url(value)
-            ):
-                return f"{value}."
+            if value and isinstance(value, str):
+                value = strip_description(value)
+                if not value.endswith(".") and not is_string_ends_with_url(value):
+                    return f"{value}."
             return value
 
+        # script yml
+        if comment_script := self.data.get("comment", {}):
+            self.data["comment"] = _add_period(comment_script)
+
+        # integration yml
         if data_description := self.data.get("description", {}):
             self.data["description"] = _add_period(data_description)
 

--- a/demisto_sdk/commands/format/update_generic.py
+++ b/demisto_sdk/commands/format/update_generic.py
@@ -473,8 +473,10 @@ class BaseUpdate:
 
         def _add_period(value: Optional[str]) -> Optional[str]:
             if value and isinstance(value, str):
-                value = strip_description(value)
-                if not value.endswith(".") and not is_string_ends_with_url(value):
+                strip_value = strip_description(value)
+                if not strip_value.endswith(".") and not is_string_ends_with_url(
+                    strip_value
+                ):
                     return f"{value}."
             return value
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: [now support script yml](https://jira-hq.paloaltonetworks.local/browse/CIAC-8308)
fixed: [added a new line with a period](https://jira-hq.paloaltonetworks.local/browse/CIAC-8281)

## Description
fixed an issue where the format  added a new line with a period
when the description start with pipe `|`
```
comment: |-
  The test
 ```
