### PR TITLE
[upload, download] - fix bugs with lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 ## Unreleased
 * Fixed an issue where **validate** falsely failed with error `DS108` on descriptions ending with brackets that contains a dot at the end of them.
 * Fixed an issue where running **validate -g** failed reading a `.pack-ignore` file that contained only newlines and spaces.
-* Fixed an issue where the **upload** failed when trying to upload a list content item.
-* Fixed an issue where the **download** would skip downloading list content items assigned to specific user roles with no roles.
+* Fixed an issue where **upload** failed when trying to upload a list content item.
+* Fixed an issue where **download** would skip downloading list content items assigned to specific user roles with no roles.
 * Demisto-SDK will now exit gracefully with an appropriate error message when *git* is not installed.
 * Updated validation *RN116* to support the structure of **--force** flag in *update-release-notes* command.
 * Fixed an issue where the release notes file was not added automatically to git when using the *update-release-notes* command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 * Fixed an issue where **validate** falsely failed with error `DS108` on descriptions ending with brackets that contains a dot at the end of them.
 * Fixed an issue where the **upload** failed when trying to upload a `List`.
+* Fixed an issue where the **download** would skip downloading some `Lists` 
 * Demisto-SDK will now exit gracefully with an appropriate error message when *git* is not installed.
 
 ## 1.20.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 ## Unreleased
 * Fixed an issue where **validate** falsely failed with error `DS108` on descriptions ending with brackets that contains a dot at the end of them.
-* Fixed an issue where the **upload** failed when trying to upload a `List`.
-* Fixed an issue where the **download** would skip downloading `Lists` that are assigned to specific user roles with no roles.
+* Fixed an issue where the **upload** failed when trying to upload a list content item.
+* Fixed an issue where the **download** would skip downloading list content items assigned to specific user roles with no roles.
 * Fixed an issue where the **validate -g** failed reading a `.pack-ignore` file that contained only newlines and spaces.
 * Demisto-SDK will now exit gracefully with an appropriate error message when *git* is not installed.
 * Fixed the support in **validate** for `svg` images to have their theme suffix.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## Unreleased
 * Fixed an issue where **validate** falsely failed with error `DS108` on descriptions ending with brackets that contains a dot at the end of them.
 * Fixed an issue where the **upload** failed when trying to upload a `List`.
-* Fixed an issue where the **download** would skip downloading `Lists` that are assigned to specific user roles.
+* Fixed an issue where the **download** would skip downloading `Lists` that are assigned to specific user roles with no roles.
 * Demisto-SDK will now exit gracefully with an appropriate error message when *git* is not installed.
 
 ## 1.20.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## Unreleased
+* Fixed an issue where the **upload** failed when trying to upload a `List`.
 
 ## 1.20.2
 * Updated the **pre-commit** command to run on all python versions in one run.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## Unreleased
 * Fixed an issue where **validate** falsely failed with error `DS108` on descriptions ending with brackets that contains a dot at the end of them.
 * Fixed an issue where the **upload** failed when trying to upload a `List`.
-* Fixed an issue where the **download** would skip downloading some `Lists` 
+* Fixed an issue where the **download** would skip downloading some `Lists`
 * Demisto-SDK will now exit gracefully with an appropriate error message when *git* is not installed.
 
 ## 1.20.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## Unreleased
 * Fixed an issue where **validate** falsely failed with error `DS108` on descriptions ending with brackets that contains a dot at the end of them.
 * Fixed an issue where the **upload** failed when trying to upload a `List`.
-* Fixed an issue where the **download** would skip downloading some `Lists`
+* Fixed an issue where the **download** would skip downloading `Lists` that are assigned to specific user roles.
 * Demisto-SDK will now exit gracefully with an appropriate error message when *git* is not installed.
 
 ## 1.20.2

--- a/demisto_sdk/commands/common/schemas/list.yml
+++ b/demisto_sdk/commands/common/schemas/list.yml
@@ -2,10 +2,8 @@ type: map
 mapping:
   allRead:
     type: bool
-    required: True
   allReadWrite:
     type: bool
-    required: True
   data:
     type: str
   dbotCreatedBy:

--- a/demisto_sdk/commands/common/tests/tools_test.py
+++ b/demisto_sdk/commands/common/tests/tools_test.py
@@ -139,6 +139,7 @@ from demisto_sdk.tests.constants_test import (
     VALID_REPUTATION_FILE,
     VALID_SCRIPT_PATH,
     VALID_WIDGET_PATH,
+    VALID_LIST_PATH
 )
 from demisto_sdk.tests.test_files.validate_integration_test_valid_types import (
     LAYOUT,
@@ -334,6 +335,7 @@ class TestGenericFunctions:
         (VALID_GENERIC_FIELD_PATH, FileType.GENERIC_FIELD),
         (VALID_GENERIC_MODULE_PATH, FileType.GENERIC_MODULE),
         (VALID_GENERIC_DEFINITION_PATH, FileType.GENERIC_DEFINITION),
+        (VALID_LIST_PATH, FileType.LISTS),
         (IGNORED_PNG, None),
         ("Author_image.png", FileType.AUTHOR_IMAGE),
         (FileType.PACK_IGNORE.value, FileType.PACK_IGNORE),

--- a/demisto_sdk/commands/common/tests/tools_test.py
+++ b/demisto_sdk/commands/common/tests/tools_test.py
@@ -134,12 +134,12 @@ from demisto_sdk.tests.constants_test import (
     VALID_INCIDENT_TYPE_PATH,
     VALID_INTEGRATION_TEST_PATH,
     VALID_LAYOUT_PATH,
+    VALID_LIST_PATH,
     VALID_MD,
     VALID_PLAYBOOK_ID_PATH,
     VALID_REPUTATION_FILE,
     VALID_SCRIPT_PATH,
     VALID_WIDGET_PATH,
-    VALID_LIST_PATH
 )
 from demisto_sdk.tests.test_files.validate_integration_test_valid_types import (
     LAYOUT,

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -1903,7 +1903,7 @@ def find_type(
         if "rule_id" in _dict:
             return FileType.LAYOUT_RULE
 
-        if "data" in _dict or "allRead" in _dict or "truncated" in _dict:
+        if {"data", "allRead", "truncated"}.intersection(_dict.keys()):
             return FileType.LISTS
 
         # When using it for all files validation- sometimes 'id' can be integer

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -1869,9 +1869,6 @@ def find_type(
         ):
             return FileType.PRE_PROCESS_RULES
 
-        if "allRead" in _dict or "truncated" in _dict or "data" in _dict:
-            return FileType.LISTS
-
         if "definitionIds" in _dict and "views" in _dict:
             return FileType.GENERIC_MODULE
 
@@ -1902,6 +1899,9 @@ def find_type(
 
         if "rule_id" in _dict:
             return FileType.LAYOUT_RULE
+
+        if "allRead" in _dict or "truncated" in _dict or "data" in _dict:
+            return FileType.LISTS
 
         # When using it for all files validation- sometimes 'id' can be integer
         if "id" in _dict:

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -1903,7 +1903,7 @@ def find_type(
         if "rule_id" in _dict:
             return FileType.LAYOUT_RULE
 
-        if "allRead" in _dict or "truncated" in _dict or "data" in _dict:
+        if "data" in _dict or "allRead" in _dict or "truncated" in _dict:
             return FileType.LISTS
 
         # When using it for all files validation- sometimes 'id' can be integer

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -1903,7 +1903,9 @@ def find_type(
         if "rule_id" in _dict:
             return FileType.LAYOUT_RULE
 
-        if {"data", "allRead", "truncated"}.intersection(_dict.keys()):
+        if isinstance(_dict, dict) and {"data", "allRead", "truncated"}.intersection(
+            _dict.keys()
+        ):
             return FileType.LISTS
 
         # When using it for all files validation- sometimes 'id' can be integer

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -1869,7 +1869,7 @@ def find_type(
         ):
             return FileType.PRE_PROCESS_RULES
 
-        if "allRead" in _dict and "truncated" in _dict:
+        if "allRead" in _dict or "truncated" in _dict or "data" in _dict:
             return FileType.LISTS
 
         if "definitionIds" in _dict and "views" in _dict:

--- a/demisto_sdk/commands/content_graph/objects/list.py
+++ b/demisto_sdk/commands/content_graph/objects/list.py
@@ -26,4 +26,6 @@ class List(ContentItem, content_type=ContentType.LIST):  # type: ignore[call-arg
                 body=json.load(_list),
                 response_type="object",
             )
-            logger.debug(f'upload list {self.object_id} from path {self.path} successfully')
+            logger.debug(
+                f"upload list {self.object_id} from path {self.path} successfully"
+            )

--- a/demisto_sdk/commands/content_graph/objects/list.py
+++ b/demisto_sdk/commands/content_graph/objects/list.py
@@ -27,5 +27,5 @@ class List(ContentItem, content_type=ContentType.LIST):  # type: ignore[call-arg
                 response_type="object",
             )
             logger.debug(
-                f"upload list {self.object_id} from path {self.path} successfully"
+                f"Uploaded list {self.object_id} from path {self.path} successfully"
             )

--- a/demisto_sdk/commands/content_graph/objects/list.py
+++ b/demisto_sdk/commands/content_graph/objects/list.py
@@ -3,10 +3,9 @@ import logging
 import demisto_client
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
+from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.content_graph.common import ContentType
 from demisto_sdk.commands.content_graph.objects.content_item import ContentItem
-from demisto_sdk.commands.common.handlers import JSON_Handler
-
 
 json = JSON_Handler()
 logger = logging.getLogger("demisto-sdk")

--- a/demisto_sdk/commands/content_graph/objects/list.py
+++ b/demisto_sdk/commands/content_graph/objects/list.py
@@ -1,13 +1,14 @@
 import logging
-from pathlib import Path
-from tempfile import TemporaryDirectory
 
 import demisto_client
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.common import ContentType
 from demisto_sdk.commands.content_graph.objects.content_item import ContentItem
+from demisto_sdk.commands.common.handlers import JSON_Handler
 
+
+json = JSON_Handler()
 logger = logging.getLogger("demisto-sdk")
 
 
@@ -19,13 +20,10 @@ class List(ContentItem, content_type=ContentType.LIST):  # type: ignore[call-arg
         client: demisto_client,
         marketplace: MarketplaceVersions,
     ) -> None:
-        with TemporaryDirectory("w") as f:
-            dir_path = Path(f)
-            self.dump(dir_path, marketplace=marketplace)
-
+        with self.path.open("r") as _list:
             client.generic_request(
                 method="POST",
                 path="lists/save",
-                body=dir_path / self.normalize_name,
+                body=json.load(_list),
                 response_type="object",
             )

--- a/demisto_sdk/commands/content_graph/objects/list.py
+++ b/demisto_sdk/commands/content_graph/objects/list.py
@@ -26,3 +26,4 @@ class List(ContentItem, content_type=ContentType.LIST):  # type: ignore[call-arg
                 body=json.load(_list),
                 response_type="object",
             )
+            logger.debug(f'upload list {self.object_id} from path {self.path} successfully')

--- a/demisto_sdk/commands/content_graph/objects/list.py
+++ b/demisto_sdk/commands/content_graph/objects/list.py
@@ -25,10 +25,9 @@ class List(ContentItem, content_type=ContentType.LIST):  # type: ignore[call-arg
             dir_path = Path(f)
             self.dump(dir_path, marketplace=marketplace)
 
-            with (dir_path / self.normalize_name).open("r") as _list:
-                client.generic_request(
-                    method="POST",
-                    path="lists/save",
-                    body=json.load(_list),
-                    response_type="object",
-                )
+            client.generic_request(
+                method="POST",
+                path="lists/save",
+                body=json.loads((dir_path / self.normalize_name).read_text()),
+                response_type="object",
+            )

--- a/demisto_sdk/tests/constants_test.py
+++ b/demisto_sdk/tests/constants_test.py
@@ -120,9 +120,7 @@ VALID_DASHBOARD_PATH = f"{GIT_ROOT}/demisto_sdk/tests/test_files/dashboard-valid
 INVALID_DASHBOARD_PATH = (
     f"{GIT_ROOT}/demisto_sdk/tests/test_files/dashboard-invalid.json"
 )
-VALID_LIST_PATH = (
-    f"{GIT_ROOT}/demisto_sdk/tests/test_files/list-valid.json"
-)
+VALID_LIST_PATH = f"{GIT_ROOT}/demisto_sdk/tests/test_files/list-valid.json"
 VALID_INCIDENT_FIELD_PATH = (
     f"{GIT_ROOT}/demisto_sdk/tests/test_files/incidentfield-valid.json"
 )

--- a/demisto_sdk/tests/constants_test.py
+++ b/demisto_sdk/tests/constants_test.py
@@ -120,6 +120,9 @@ VALID_DASHBOARD_PATH = f"{GIT_ROOT}/demisto_sdk/tests/test_files/dashboard-valid
 INVALID_DASHBOARD_PATH = (
     f"{GIT_ROOT}/demisto_sdk/tests/test_files/dashboard-invalid.json"
 )
+VALID_LIST_PATH = (
+    f"{GIT_ROOT}/demisto_sdk/tests/test_files/list-valid.json"
+)
 VALID_INCIDENT_FIELD_PATH = (
     f"{GIT_ROOT}/demisto_sdk/tests/test_files/incidentfield-valid.json"
 )

--- a/demisto_sdk/tests/test_files/list-valid.json
+++ b/demisto_sdk/tests/test_files/list-valid.json
@@ -1,0 +1,15 @@
+{
+    "id": "test",
+    "itemVersion": "",
+    "data": "",
+    "locked": false,
+    "name": "test",
+    "nameLocked": false,
+    "packID": "",
+    "previousAllRead": true,
+    "system": false,
+    "truncated": false,
+    "type": "plain_text",
+    "version": -1,
+    "fromVersion": "6.5.0"
+}


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-27578, https://jira-hq.paloaltonetworks.local/browse/CIAC-8354

## Description

on this situation downloading lists would be skipped
![image](https://github.com/demisto/demisto-sdk/assets/53861351/949b84a7-a8a1-4c5e-a696-095fea4c7954)

1. it is not true that in order to identify list we should use `allRead` key, is is not always part of the `List` structure.
2. `data` key on the other hand **always appear at any list in any variation** and also the `truncated` key.