### PR TITLE
[tools] Add FileType - VULTURE_WHITELIST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Updated the **modeling-rules init & test** commands to support RULE section fields.
 * Stability improvements for **graph create** and **graph update** commands.
 * Fixed the *metadata* type in the XSIAM dashboard schema to *map*.
+* Added the `FileType.VULTURE_WHITELIST` to the `FileType` enum for `.vulture_whitelist.py` files.
 
 ## 1.20.2
 * Updated the **pre-commit** command to run on all python versions in one run.

--- a/demisto_sdk/commands/common/constants.py
+++ b/demisto_sdk/commands/common/constants.py
@@ -1136,7 +1136,6 @@ VALIDATION_USING_GIT_IGNORABLE_DATA = (
     "doc_files",
     "doc_imgs",
     ".secrets-ignore",
-    ".vulture_whitelist.py",
 )
 
 FILE_TYPES_FOR_TESTING = [".py", ".js", ".yml", ".ps1"]

--- a/demisto_sdk/commands/common/constants.py
+++ b/demisto_sdk/commands/common/constants.py
@@ -1136,6 +1136,7 @@ VALIDATION_USING_GIT_IGNORABLE_DATA = (
     "doc_files",
     "doc_imgs",
     ".secrets-ignore",
+    ".vulture_whitelist.py",
 )
 
 FILE_TYPES_FOR_TESTING = [".py", ".js", ".yml", ".ps1"]

--- a/demisto_sdk/commands/common/constants.py
+++ b/demisto_sdk/commands/common/constants.py
@@ -180,6 +180,7 @@ class FileType(str, Enum):
     UNIFIED_YML = "unified_yml"
     INI = "ini"
     PEM = "pem"
+    VULTURE_WHITELIST = "vulture_whitelist"
 
 
 RN_HEADER_BY_FILE_TYPE = {

--- a/demisto_sdk/commands/common/tests/tools_test.py
+++ b/demisto_sdk/commands/common/tests/tools_test.py
@@ -141,6 +141,7 @@ from demisto_sdk.tests.constants_test import (
     VALID_REPUTATION_FILE,
     VALID_SCRIPT_PATH,
     VALID_WIDGET_PATH,
+    VULTURE_WHITELIST_PATH,
 )
 from demisto_sdk.tests.test_files.validate_integration_test_valid_types import (
     LAYOUT,
@@ -344,6 +345,7 @@ class TestGenericFunctions:
         (Path(DOC_FILES_DIR) / "foo", FileType.DOC_FILE),
         (METADATA_FILE_NAME, FileType.METADATA),
         ("", None),
+        (VULTURE_WHITELIST_PATH, FileType.VULTURE_WHITELIST),
     ]
 
     @pytest.mark.parametrize("path, _type", data_test_find_type)

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -1661,6 +1661,9 @@ def find_type_by_path(path: Union[str, Path] = "") -> Optional[FileType]:
     elif path.suffix == ".ps1":
         return FileType.POWERSHELL_FILE
 
+    elif path.name == ".vulture_whitelist.py":
+        return FileType.VULTURE_WHITELIST
+
     elif path.suffix == ".py":
         return FileType.PYTHON_FILE
 
@@ -1728,6 +1731,7 @@ def find_type_by_path(path: Union[str, Path] = "") -> Optional[FileType]:
         or path.suffix.lower() == ".txt"
     ):
         return FileType.TXT
+
     elif path.name == ".pylintrc":
         return FileType.PYLINTRC
 

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -142,6 +142,7 @@ from demisto_sdk.tests.constants_test import (
     VALID_SCRIPT_PATH,
     VALID_TEST_PLAYBOOK_PATH,
     VALID_WIDGET_PATH,
+    VULTURE_WHITELIST_PATH,
     WIDGET_TARGET,
     XSIAM_CORRELATION_TARGET,
     XSIAM_DASHBOARD_TARGET,
@@ -1066,6 +1067,26 @@ class TestValidators:
         assert validate_manager.run_validations_on_file(
             INVALID_IGNORED_UNIFIED_INTEGRATION, None
         )
+
+    def test_skipped_file_types(self, mocker):
+        """
+        Given:
+            - A file of a type that should be skipped
+        When:
+            - Validating the file
+        Then:
+            - The file should be skipped
+        """
+
+        mocker.patch.object(
+            demisto_sdk.commands.common.tools,
+            "find_type",
+            return_value=FileType.VULTURE_WHITELIST,
+        )
+
+        validate_manager = ValidateManager()
+        assert validate_manager.run_validations_on_file(VULTURE_WHITELIST_PATH, None)
+        assert VULTURE_WHITELIST_PATH in validate_manager.ignored_files
 
     def test_non_integration_png_files_ignored(self, set_git_test_env):
         """
@@ -2278,6 +2299,7 @@ def test_check_file_relevance_and_format_path_non_formatted_relevant_file(mocker
         "Packs/pack_id/Scripts/script_id/test_data/file.json",
         "Packs/pack_id/TestPlaybooks/test_data/file.json",
         "Packs/pack_id/Integrations/integration_id/command_examples",
+        "Packs/pack_id/Integrations/integration_id/.vulture_whitelist.py",
     ],
 )
 def test_check_file_relevance_and_format_path_ignored_files(input_file_path):

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -2639,6 +2639,9 @@ class ValidateManager:
         if file_type == FileType.CONF_JSON:
             return file_path, "", True
 
+        if file_type == FileType.VULTURE_WHITELIST:
+            return irrelevant_file_output
+
         if self.ignore_files_irrelevant_for_validation(
             file_path, check_metadata_files=check_metadata_files
         ):

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -309,6 +309,7 @@ class ValidateManager:
             FileType.INI,
             FileType.PEM,
             FileType.METADATA,
+            FileType.VULTURE_WHITELIST,
         )
 
         self.is_external_repo = is_external_repo

--- a/demisto_sdk/tests/constants_test.py
+++ b/demisto_sdk/tests/constants_test.py
@@ -540,3 +540,7 @@ INVALID_XSIAM_CORRELATION_PATH = (
 )
 
 XSIAM_CORRELATION_TARGET = f"{PACK_TARGET}/CorrelationRules/correlationrule-mock.yml"
+
+VULTURE_WHITELIST_PATH = (
+    "Packs/TestPack/Integrations/TestIntegration/.vulture_whitelist.py"
+)


### PR DESCRIPTION
## Related Issues
fixes: [xsoar-prepare-testing-bucket](https://code.pan.run/xsoar/content/-/jobs/32846327) - collect_tests of vulture_whitelist file

## Description
For `collect_tests` to skip `.vulture_whitelist.py` files it is added to `FileType`.