### PR TITLE
Updated the call rule regex to require a space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## Unreleased
 * Fixed an issue where using **prepare-content**, **upload**, **zip-packs** and **download** on machines with default encoding other than unicode caused errors.
+* Fixed an issue where **modeling-rules init-test-data** command failed on modeling rules that contain the text `call` even not as a separate word.
 
 ## 1.20.3
 * Added the `FileType.VULTURE_WHITELIST` to the `FileType` enum for `.vulture_whitelist.py` files.

--- a/demisto_sdk/commands/common/content/objects/pack_objects/modeling_rule/modeling_rule.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/modeling_rule/modeling_rule.py
@@ -200,7 +200,7 @@ class ModelingRule(YAMLContentUnifiedObject):
         flags=re.M,
     )
     CALL_RULE_REGEX = re.compile(
-        r"call\s*(?P<rule_name>\w+)",
+        r"call\s+(?P<rule_name>\w+)",
         flags=re.IGNORECASE,
     )
     TESTDATA_FILE_SUFFIX = "_testdata.json"

--- a/demisto_sdk/commands/test_content/test_modeling_rule/tests/test_modeling_rule_test.py
+++ b/demisto_sdk/commands/test_content/test_modeling_rule/tests/test_modeling_rule_test.py
@@ -1695,6 +1695,19 @@ def test_day_suffix(day, suffix):
     ('call a', True),
 ])
 def test_call_rule_regex(mr_text, expected_result):
+    """
+    Test the CALL_RULE_REGEX regex matches text containing 'call'.
+
+    Given:
+        - mr_text: Text to search for 'call'
+        - expected_result: Whether we expect mr_text to match
+
+    When:
+        - Search mr_text with ModelingRule.CALL_RULE_REGEX
+
+    Then:
+        - The search result should match expected_result
+    """
     from demisto_sdk.commands.common.content.objects.pack_objects.modeling_rule.modeling_rule import ModelingRule
     mr = ModelingRule
     assert bool(mr.CALL_RULE_REGEX.search(mr_text)) == expected_result

--- a/demisto_sdk/commands/test_content/test_modeling_rule/tests/test_modeling_rule_test.py
+++ b/demisto_sdk/commands/test_content/test_modeling_rule/tests/test_modeling_rule_test.py
@@ -1565,6 +1565,16 @@ def test_day_suffix(day, suffix):
     assert day_suffix(day) == suffix
 
 
+@pytest.mark.parametrize('mr_text, expected_result', [
+    ('historically', False),
+    ('call a', True),
+])
+def test_call_rule_regex(mr_text, expected_result):
+    from demisto_sdk.commands.common.content.objects.pack_objects.modeling_rule.modeling_rule import ModelingRule
+    mr = ModelingRule
+    assert bool(mr.CALL_RULE_REGEX.search(mr_text)) == expected_result
+
+
 class TestValidateSchemaAlignedWithTestData:
     @pytest.mark.parametrize(
         "event_data, schema_file",

--- a/demisto_sdk/commands/test_content/test_modeling_rule/tests/test_modeling_rule_test.py
+++ b/demisto_sdk/commands/test_content/test_modeling_rule/tests/test_modeling_rule_test.py
@@ -1690,10 +1690,13 @@ def test_day_suffix(day, suffix):
     assert day_suffix(day) == suffix
 
 
-@pytest.mark.parametrize('mr_text, expected_result', [
-    ('historically', False),
-    ('call a', True),
-])
+@pytest.mark.parametrize(
+    "mr_text, expected_result",
+    [
+        ("historically", False),
+        ("call a", True),
+    ],
+)
 def test_call_rule_regex(mr_text, expected_result):
     """
     Test the CALL_RULE_REGEX regex matches text containing 'call'.
@@ -1708,7 +1711,10 @@ def test_call_rule_regex(mr_text, expected_result):
     Then:
         - The search result should match expected_result
     """
-    from demisto_sdk.commands.common.content.objects.pack_objects.modeling_rule.modeling_rule import ModelingRule
+    from demisto_sdk.commands.common.content.objects.pack_objects.modeling_rule.modeling_rule import (
+        ModelingRule,
+    )
+
     mr = ModelingRule
     assert bool(mr.CALL_RULE_REGEX.search(mr_text)) == expected_result
 


### PR DESCRIPTION

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-8443

## Description
Updated the call rule regex patern from `r"call\s*(?P<rule_name>\w+)"` to `r"call\s+(?P<rule_name>\w+)"` in order to avoid something like this `callblabla`