### PR TITLE
removing the maxcolwidths from tabulate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## Unreleased
 * Fixed an issue where **validate** falsely failed with error `DS108` on descriptions ending with brackets that contains a dot at the end of them.
+* Fixed an issue where **modeling-rule test** command failed to properly render the comparison table when boolean value were printed.
 * Fixed an issue were format added a dot at end of the description that already ends with question mark and exclamation mark.
 * Fixed an issue where **upload** failed when trying to upload an indicator field.
 

--- a/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
+++ b/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
@@ -93,7 +93,6 @@ def create_table(expected: Dict[str, Any], received: Dict[str, Any]) -> str:
         data,
         tablefmt="fancy_grid",
         headers=["Model Field", "Expected Value", "Received Value"],
-        maxcolwidths=[60, 40, 40],
     )
 
 


### PR DESCRIPTION

## Description
Fixed an issue where **modeling-rule test** command failed to properly render the comparison table when boolean value were printed.


related to bug in tabulate: https://github.com/astanin/python-tabulate/issues/189