### PR TITLE
[lint] Added support for sharing test_data folder for all automations in a pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fixed an issue where **modeling-rule test** command failed to properly render the comparison table when boolean value were printed.
 * Fixed an issue were format added a dot at end of the description that already ends with question mark and exclamation mark.
 * Fixed an issue where **upload** failed when trying to upload an indicator field.
+* Added support for sharing test_data folder in a content pack.
 
 ## 1.20.4
 * Fixed an issue where using **prepare-content**, **upload**, **zip-packs** and **download** on machines with default encoding other than unicode caused errors.

--- a/demisto_sdk/commands/lint/helpers.py
+++ b/demisto_sdk/commands/lint/helpers.py
@@ -24,6 +24,7 @@ from demisto_sdk.commands.common.constants import (
     TYPE_PWSH,
     TYPE_PYTHON,
     DemistoException,
+    PACKS_DIR,
 )
 from demisto_sdk.commands.common.logger import logger
 
@@ -236,6 +237,22 @@ def add_typing_module(lint_files: List[Path], python_version: str):
             if back_file.exists():
                 original_name = back_file.with_suffix(".py")
                 back_file.rename(original_name)
+
+
+def get_pack_test_data_dir(input):
+    if Path(input).parent.name == PACKS_DIR:
+        return Path(input) / 'test_data'
+    else:
+        for p in  Path(input).parents:
+            if Path(p).parent.name == PACKS_DIR:
+                    return Path(p / 'test_data')
+
+
+def add_pack_test_data(pack_path, pack_test_data_dir):
+    for f in pack_test_data_dir.iterdir():
+        copied_test_data_path = pack_path / 'test_data' / f.name
+        if not copied_test_data_path.exists():
+            copied_test_data_path.write_bytes(f.read_bytes())
 
 
 @contextmanager

--- a/demisto_sdk/commands/lint/helpers.py
+++ b/demisto_sdk/commands/lint/helpers.py
@@ -250,7 +250,9 @@ def get_pack_test_data_dir(input):
 
 def add_pack_test_data(pack_path, pack_test_data_dir):
     for f in pack_test_data_dir.iterdir():
-        copied_test_data_path = pack_path / 'test_data' / f.name
+        pack_dir = pack_path / 'test_data'
+        pack_dir.mkdir(exist_ok=True)
+        copied_test_data_path = pack_dir / f.name
         if not copied_test_data_path.exists():
             copied_test_data_path.write_bytes(f.read_bytes())
 

--- a/demisto_sdk/commands/lint/lint_manager.py
+++ b/demisto_sdk/commands/lint/lint_manager.py
@@ -53,6 +53,7 @@ from demisto_sdk.commands.lint.helpers import (
     build_skipped_exit_code,
     generate_coverage_report,
     get_test_modules,
+    get_pack_test_data_dir,
 )
 from demisto_sdk.commands.lint.linter import DockerImageFlagOption, Linter
 
@@ -90,6 +91,7 @@ class LintManager:
 
         # Gather facts for manager
         self._facts: dict = self._gather_facts()
+        self.pack_test_data_dir = get_pack_test_data_dir(input)
         self._prev_ver = prev_ver
         self._all_packs = all_packs
         # Set 'git' to true if no packs have been specified, 'lint' should operate as 'lint -g'
@@ -505,6 +507,7 @@ class LintManager:
                             no_pwsh_analyze=no_pwsh_analyze,
                             no_pwsh_test=no_pwsh_test,
                             modules=self._facts["test_modules"],
+                            pack_test_data_dir=self.pack_test_data_dir,
                             keep_container=keep_container,
                             test_xml=test_xml,
                             no_coverage=no_coverage,

--- a/demisto_sdk/commands/lint/linter.py
+++ b/demisto_sdk/commands/lint/linter.py
@@ -68,6 +68,7 @@ from demisto_sdk.commands.lint.helpers import (
     SUCCESS,
     WARNING,
     add_tmp_lint_files,
+    add_pack_test_data,
     add_typing_module,
     coverage_report_editor,
     get_file_from_container,
@@ -212,6 +213,7 @@ class Linter:
         no_pwsh_test: bool,
         no_test: bool,
         modules: dict,
+        pack_test_data_dir: dict,
         keep_container: bool,
         test_xml: str,
         no_coverage: bool,
@@ -247,6 +249,14 @@ class Linter:
             # If not python pack - skip pack
             if skip:
                 return self._pkg_lint_status
+
+            # Copy shared test_data files
+            if pack_test_data_dir.exists():
+                add_pack_test_data(
+                    pack_path=self._pack_abs_dir,
+                    pack_test_data_dir=pack_test_data_dir,
+                )
+
             # Locate mandatory files in pack path - for more info checkout the context manager LintFiles
             with add_tmp_lint_files(
                 content_repo=self._content_repo,


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: In cases where many automations are relying on the same set of test files, user has to copy and paste each test file into all the automations, this pr solves the issue by copying each test file into the automation's test_data folder

## Description
