### PR TITLE
remove are_mock_calls_supported_in_python_version fixture

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -115,23 +115,6 @@ def malformed_incident_field(pack) -> JSONBased:
     return incident_field
 
 
-@pytest.fixture(scope="class")
-def are_mock_calls_supported_in_python_version():
-    """
-    Validates whether the mock calls feature is supported by the python version running.
-    mock calls feature is supported only in python 3.8+.
-    Skip the tests using the mock calls in case the python version < 3.8
-
-    secho_mocker = mocker.patch.object(click, 'secho')
-    secho_mocker.mock_calls (not supported in python < 3.8)
-    """
-    python_version = sys.version_info
-    if python_version.major == 2 or (
-        python_version.major == 3 and python_version.minor < 8
-    ):
-        pytest.skip('The current mock "calls" is supported only in python 3.8+')
-
-
 @pytest.fixture(scope="session", autouse=True)
 def mock_update_id_set_cpu_count() -> Generator:
     """

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,5 @@
 """Configuring tests for the content suite
 """
-import sys
 from typing import Generator
 from unittest import mock
 

--- a/demisto_sdk/commands/doc_reviewer/tests/doc_reviewer_test.py
+++ b/demisto_sdk/commands/doc_reviewer/tests/doc_reviewer_test.py
@@ -486,7 +486,6 @@ class TestDocReviewXSOAROnly:
         assert result.exit_code == self.CommandResultCode.FAIL.value
 
 
-@pytest.mark.usefixtures("are_mock_calls_supported_in_python_version")
 class TestDocReviewPrinting:
     """
     Test scenarios of doc-review printing.


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->


## Description
Remove the fixture as we do not support any python versions which are below python 3.8.