### PR TITLE
[Content graph] fix cleaning environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Fixed an issue where deprecating parsing rules or modeling rules using **format** failed due to schema discrepancies.
 * Fixed an issue where kebab-case arguments were not parsed correctly.
 * Fixed an issue where **validate** falsely failed with error `RN115` on release notes with linefeed at the end of the file.
-
+* Fixed an issue where **graph** commands failed on dirty environments.
 
 ## 1.20.5
 * Fixed an issue where **validate** falsely failed with error `DS108` on descriptions ending with brackets that contains a dot at the end of them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Fixed an issue where deprecating parsing rules or modeling rules using **format** failed due to schema discrepancies.
 * Fixed an issue where kebab-case arguments were not parsed correctly.
 * Fixed an issue where **validate** falsely failed with error `RN115` on release notes with linefeed at the end of the file.
-* Fixed an issue where **graph** commands failed on dirty environments.
+* Fixed an issue where **graph** commands would not clean their temporary files properly, causing successive commands to fail.
 
 ## 1.20.5
 * Fixed an issue where **validate** falsely failed with error `DS108` on descriptions ending with brackets that contains a dot at the end of them.

--- a/demisto_sdk/commands/content_graph/neo4j_service.py
+++ b/demisto_sdk/commands/content_graph/neo4j_service.py
@@ -160,6 +160,9 @@ def stop(force: bool = False, clean: bool = False):
     _stop_neo4j_service_docker(docker_client)
     if clean:
         shutil.rmtree(REPO_PATH / NEO4J_FOLDER / NEO4J_DATA_FOLDER, ignore_errors=True)
+        shutil.rmtree(
+            REPO_PATH / NEO4J_FOLDER / NEO4J_PLUGINS_FOLDER, ignore_errors=True
+        )
 
 
 def is_alive():


### PR DESCRIPTION
If the there connection issues with the graph, we stop the container and clean the data folder and try again. However, we should clean the plugins folder as well, as this folder in some cases should be recreated by the container.

fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-8539