### PR TITLE
Removed autocomplete from docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fixed an issue where **validate** falsely failed with error `RN115` on release notes with linefeed at the end of the file.
 * Fixed an issue where **validate** falsely failed with error `DS108` on descriptions ending with new lines followed by square/curly brackets.
 * Fixed an issue where **graph** commands would not clean their temporary files properly, causing successive commands to fail.
+* Fixed an issue where the documentation was out of date with the current structure of **demisto-sdk** which does not support command auto-completion.
 * Fixed an issue where an error log message changed the terminal color.
 
 ## 1.20.5

--- a/README.md
+++ b/README.md
@@ -156,23 +156,6 @@ update_type=minor
 
 ---
 
-### Autocomplete
-
-Our CLI supports autocomplete for Linux/MacOS machines, you can turn this feature on by running one of the following:
-for zsh users run in the terminal
-
-```bash
-eval "$(_DEMISTO_SDK_COMPLETE=source_zsh demisto-sdk)"
-```
-
-for regular bashrc users run in the terminal
-
-```bash
-eval "$(_DEMISTO_SDK_COMPLETE=source demisto-sdk)"
-```
-
----
-
 ## License
 
 MIT - See [LICENSE](LICENSE) for more information.


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-28552?filter=63809

## Description
demisto-sdk does not support autocompletion of commands, updated the docs to reflect that. 