### PR TITLE
Add `safe_write_unicode` function to tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ## Unreleased
 * Added the *auto-replace-uuids* flag to the **download** command. set this flag to False to avoid UUID replacements when downloading using download command.
 * **format** command will run without the content graph if graph creation fails.
+* Replaced the `tools._read_file` function with a more generic `tools.safe_read_unicode` function.
+* Added `pathlib.Path` support to the `tools.get_yml_paths_in_dir` and `tools.get_child_directories` functions.
 
 ## 1.20.7
 * Fixed an issue where unified integrations / scripts with a period in their name would not split properly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 ## Unreleased
 * Added the *auto-replace-uuids* flag to the **download** command. set this flag to False to avoid UUID replacements when downloading using download command.
 * **format** command will run without the content graph if graph creation fails.
-* Replaced the `tools._read_file` function with a more generic `tools.safe_read_unicode` function.
-* Added `pathlib.Path` support to the `tools.get_yml_paths_in_dir` and `tools.get_child_directories` functions.
+* Internal: Replaced the `tools._read_file` function with a more generic `tools.safe_read_unicode` function.
+* Internal: Added `pathlib.Path` support to the `tools.get_yml_paths_in_dir` and `tools.get_child_directories` functions.
 
 ## 1.20.7
 * Fixed an issue where unified integrations / scripts with a period in their name would not split properly.

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -264,19 +264,19 @@ def get_mp_tag_parser():
     return MARKETPLACE_TAG_PARSER
 
 
-def get_yml_paths_in_dir(project_dir: str, error_msg: str = "") -> Tuple[list, str]:
+def get_yml_paths_in_dir(project_dir: str | Path) -> Tuple[list, str]:
     """
     Gets the project directory and returns the path of the first yml file in that directory
-    :param project_dir: string path to the project_dir
-    :param error_msg: the error msg to show to the user in case not yml files found in the directory
+    :param project_dir: path to the project_dir
     :return: first returned argument is the list of all yml files paths in the directory, second returned argument is a
     string path to the first yml file in project_dir
     """
-    yml_files = glob.glob(os.path.join(project_dir, "*.yml"))
+    project_dir_path = Path(project_dir)
+    yml_files = [str(path) for path in project_dir_path.glob("*.yml")]
+
     if not yml_files:
-        if error_msg:
-            logger.info(error_msg)
         return [], ""
+
     return yml_files, yml_files[0]
 
 

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -3532,8 +3532,12 @@ def get_display_name(file_path: str, file_data: dict | None = None) -> str:
     """
     if not file_data:
         file_extension = Path(file_path).suffix
+
         if file_extension in [".yml", ".yaml", ".json"]:
             file_data = get_file(file_path)
+
+        else:
+            raise ValueError(f"Unsupported file extension: '{file_extension}'")
 
     if "display" in file_data:
         return file_data.get("display")

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -3521,7 +3521,7 @@ def remove_copy_and_dev_suffixes_from_str(field_name: str) -> str:
     return field_name
 
 
-def get_display_name(file_path: str, file_data: dict | None = None) -> str:
+def get_display_name(file_path, file_data={}) -> str:
     """Gets the entity display name from the file.
 
     :param file_path: The entity file path
@@ -3531,46 +3531,46 @@ def get_display_name(file_path: str, file_data: dict | None = None) -> str:
     :return The display name
     """
     if not file_data:
-        file_extension = Path(file_path).suffix
-
-        if file_extension in [".yml", ".yaml", ".json"]:
+        file_extension = os.path.splitext(file_path)[1]
+        if file_extension in [".yml", ".json"]:
             file_data = get_file(file_path)
 
-        else:
-            raise ValueError(f"Unsupported file extension: '{file_extension}'")
-
     if "display" in file_data:
-        return file_data.get("display")
+        name = file_data.get("display", None)
     elif "layout" in file_data and isinstance(file_data["layout"], dict):
-        return file_data["layout"].get("id")
+        name = file_data["layout"].get("id")
     elif "name" in file_data:
-        return file_data.get("name")
+        name = file_data.get("name", None)
     elif "TypeName" in file_data:
-        return file_data.get("TypeName")
+        name = file_data.get("TypeName", None)
     elif "brandName" in file_data:
-        return file_data.get("brandName")
+        name = file_data.get("brandName", None)
     elif "id" in file_data:
-        return file_data.get("id")
+        name = file_data.get("id", None)
     elif "trigger_name" in file_data:
-        return file_data.get("trigger_name")
+        name = file_data.get("trigger_name")
     elif "rule_name" in file_data:
-        return file_data.get("rule_name")
+        name = file_data.get("rule_name")
+
     elif (
         "dashboards_data" in file_data
         and file_data.get("dashboards_data")
         and isinstance(file_data["dashboards_data"], list)
     ):
         dashboard_data = file_data.get("dashboards_data", [{}])[0]
-        return dashboard_data.get("name")
+        name = dashboard_data.get("name")
+
     elif (
         "templates_data" in file_data
         and file_data.get("templates_data")
         and isinstance(file_data["templates_data"], list)
     ):
         r_name = file_data.get("templates_data", [{}])[0]
-        return r_name.get("report_name")
+        name = r_name.get("report_name")
 
-    return Path(file_path).name
+    else:
+        name = Path(file_path).name
+    return name
 
 
 def get_invalid_incident_fields_from_mapper(

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import glob
 import logging
@@ -700,9 +702,7 @@ def get_child_directories(directory: str | Path) -> list[str]:
     directory_path = Path(directory)
 
     if directory_path.is_dir():
-        return [
-            str(path) for path in directory_path.iterdir() if path.is_dir()
-        ]
+        return [str(path) for path in directory_path.iterdir() if path.is_dir()]
 
     return []
 
@@ -788,12 +788,12 @@ def safe_read_unicode(bytes_data: bytes) -> str:
     except UnicodeDecodeError:
         try:
             logger.debug(
-                f"Could not read data using UTF-8 encoding. Trying to auto-detect encoding..."
+                "Could not read data using UTF-8 encoding. Trying to auto-detect encoding..."
             )
             return UnicodeDammit(bytes_data).unicode_markup
 
         except UnicodeDecodeError:
-            logger.error(f"Could not auto-detect encoding.")
+            logger.error("Could not auto-detect encoding.")
             raise
 
 

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -1773,7 +1773,7 @@ def find_type(
     ignore_sub_categories: bool = False,
     ignore_invalid_schema_file: bool = False,
     clear_cache: bool = False,
-) -> FileType | None:
+):
     """
     returns the content file type
 
@@ -1789,9 +1789,9 @@ def find_type(
     Returns:
         FileType: Enum representation of the content file type, None otherwise.
     """
-    if type_by_path := find_type_by_path(path):
+    type_by_path = find_type_by_path(path)
+    if type_by_path:
         return type_by_path
-
     try:
         if not _dict and not file_type:
             _dict, file_type = get_dict_from_file(

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -687,16 +687,23 @@ def filter_packagify_changes(
     return modified_files, updated_added_files, removed_files
 
 
-def get_child_directories(directory):
-    """Return a list of paths of immediate child directories of the 'directory' argument"""
-    if not os.path.isdir(directory):
-        return []
-    child_directories = [
-        os.path.join(directory, path)
-        for path in os.listdir(directory)
-        if os.path.isdir(os.path.join(directory, path))
-    ]
-    return child_directories
+def get_child_directories(directory: str | Path) -> list[str]:
+    """
+    Get a list of all directories within a directory.
+    Does not search recursively.
+    Args:
+        directory (str | Path): The directory to search in
+    Returns:
+        list[str]: A list of paths (in string format) of immediate child directories of the 'directory' argument
+    """
+    directory_path = Path(directory)
+
+    if directory_path.is_dir():
+        return [
+            str(path) for path in directory_path.iterdir() if path.is_dir()
+        ]
+
+    return []
 
 
 def get_child_files(directory):


### PR DESCRIPTION
## Description
This PR adds a few changes to the `tools` module made originally in the [download-rewrite PR](https://github.com/demisto/demisto-sdk/pull/3295).
This PR adds the `safe_write_unicode` function, which is needed for the new `download` rewrite, since we open files in memory and can't use the previous `_read_file` function (which opens files from disk).
It also adds support for using `pathlib.Path` on the `get_yml_paths_in_dir` and `get_child_directories` functions, and a few other minor fixes & changes.
