### PR TITLE
[Format] Continue formatting if graph creation fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fixed an issue where the documentation was out of date with the current structure of **demisto-sdk** which does not support command auto-completion.
 * Improved logging for **lint** and **prepare-content** commands.
 * Internal: Added the `CI_SERVER_HOST`, `CI_PROJECT_ID` environment variables.
+* **format** command will run without the content graph if graph creation fails.
 
 ## 1.20.6
 * Added the *--mode* argument to the **pre-commit** command, to run pre-commit with special mode (to run with different settings), supported mode are: 'nightly'.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 ## Unreleased
 * Added the *auto-replace-uuids* flag to the **download** command. set this flag to False to avoid UUID replacements when downloading using download command.
+* **format** command will run without the content graph if graph creation fails.
 
 ## 1.20.7
 * Fixed an issue where unified integrations / scripts with a period in their name would not split properly.
 * Fixed an issue where the documentation was out of date with the current structure of **demisto-sdk** which does not support command auto-completion.
 * Improved logging for **lint** and **prepare-content** commands.
 * Internal: Added the `CI_SERVER_HOST`, `CI_PROJECT_ID` environment variables.
-* **format** command will run without the content graph if graph creation fails.
 
 ## 1.20.6
 * Added the *--mode* argument to the **pre-commit** command, to run pre-commit with special mode (to run with different settings), supported mode are: 'nightly'.

--- a/demisto_sdk/commands/format/README.md
+++ b/demisto_sdk/commands/format/README.md
@@ -31,6 +31,10 @@ When done formatting, the **validate** command will run, to let you know of thin
 
    Set if you want to update the docker image of the integration/script to the newest available tag.
 
+* **-ng ,--no-graph**
+
+  Skip formatting using graph.
+
 * **-v, --verbose**
 
    Verbose output

--- a/demisto_sdk/commands/format/format_module.py
+++ b/demisto_sdk/commands/format/format_module.py
@@ -204,11 +204,18 @@ def format_manager(
             else None
         )
         if graph:
-            update_content_graph(
-                graph,
-                use_git=True,
-                output_path=graph.output_path,
-            )
+            try:
+                update_content_graph(
+                    graph,
+                    use_git=True,
+                    output_path=graph.output_path,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Error updating content graph. Will not format using the graph."
+                )
+                logger.debug(f"Error encountered when updating content graph: {e}")
+                graph = False
         for file in files:
             file_path = str(Path(file))
             file_type = find_type(file_path, clear_cache=clear_cache)


### PR DESCRIPTION
This will contiinue the formatting of the files even if graph can not be created.
This is necessary as the format fixes the files so they will be able to be parsed using the graph.

fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-8621


