### PR TITLE
[pre-commit] Fix validate hook will run before run-unit-tests hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## Unreleased
-* updated the **run-unit-tests** command to not fail on JavaScript items, but skip them instead.
+* Updated the **run-unit-tests** command to not fail on JavaScript items, but skip them instead.
+* Updated the `validate` pre-commit hook to run before the `run-unit-tests` hook. This will prevent `validate` from falling on errors about temporary files that are sometimes created when running unit-tests.
 * Added the *auto-replace-uuids* flag to the **download** command. set this flag to False to avoid UUID replacements when downloading using download command.
 * **format** command will run without the content graph if graph creation fails.
 * Internal: Replaced the `tools._read_file` function with a more generic `tools.safe_read_unicode` function.

--- a/demisto_sdk/commands/pre_commit/hooks/hook.py
+++ b/demisto_sdk/commands/pre_commit/hooks/hook.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, Optional, Set
+from typing import Any, Dict, List, Optional, Set
 
 from demisto_sdk.commands.common.constants import PreCommitModes
 
@@ -15,8 +15,9 @@ class Hook(ABC):
         all_files: bool = False,
         input_mode: bool = False,
     ) -> None:
-        self.hooks = repo["hooks"]
+        self.hooks: List[dict] = repo["hooks"]
         self.base_hook = deepcopy(hook)
+        self.hook_index = self.hooks.index(self.base_hook)
         self.hooks.remove(self.base_hook)
         self.mode = mode
         self.all_files = all_files

--- a/demisto_sdk/commands/pre_commit/hooks/validate_format.py
+++ b/demisto_sdk/commands/pre_commit/hooks/validate_format.py
@@ -23,4 +23,4 @@ class ValidateFormatHook(Hook):
         else:
             self.base_hook["args"].append("-g")
 
-        self.hooks.append(self.base_hook)
+        self.hooks.insert(self.hook_index, self.base_hook)


### PR DESCRIPTION
## Description
Because `run-unit-tests` hook sometimes generates temporary files, and currently they are not deleted, then `validate` hook fails because it does not recognize these files, so `validate` needs to run before `run-unit-tests`.