### PR TITLE
Add pre-loaded data support for `YmlSplitter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Internal: Added `pathlib.Path` support to the `tools.get_yml_paths_in_dir` and `tools.get_child_directories` functions.
 * Fixed an issue in the **test-modeling-rule** command, where possible exceptions were not caught.
 * Added the *--delete_existing_dataset/-dd* flag to the **modeling-rules test** command to delete an existing dataset in the tenant.
+* Internal: Added a `loaded_data` parameter to `YmlSplitter` to allow passing preloaded YAML data.
 
 ## 1.20.7
 * Fixed an issue where unified integrations / scripts with a period in their name would not split properly.

--- a/demisto_sdk/commands/split/ymlsplitter.py
+++ b/demisto_sdk/commands/split/ymlsplitter.py
@@ -76,7 +76,9 @@ class YmlSplitter:
         self.lines_inserted_at_code_start = 0
         self.config = configuration or Configuration()
         self.auto_create_dir = not no_auto_create_dir
-        self.yml_data = input_file_data if input_file_data is not None else get_yaml(self.input)
+        self.yml_data = (
+            input_file_data if input_file_data is not None else get_yaml(self.input)
+        )
         self.api_module_path: Optional[str] = None
 
     def get_output_path(self):

--- a/demisto_sdk/commands/split/ymlsplitter.py
+++ b/demisto_sdk/commands/split/ymlsplitter.py
@@ -41,7 +41,7 @@ class YmlSplitter:
     Attributes:
         input (str): input yml file path
         output (str): output path
-        loaded_data (dict | None): preloaded YAML data. if not provided, data will be loaded from input
+        input_file_data (dict | None): preloaded YAML data. if not provided, data will be loaded from input
         no_demisto_mock (bool): whether to add an import for demistomock
         no_common_server (bool): whether to add an import for common server
         no_auto_create_dir (bool): whether to create a dir
@@ -57,7 +57,7 @@ class YmlSplitter:
         input: str,
         output: str = "",
         file_type: str = "",
-        loaded_data: dict | None = None,
+        input_file_data: dict | None = None,
         no_demisto_mock: bool = False,
         no_common_server: bool = False,
         no_auto_create_dir: bool = False,
@@ -76,7 +76,7 @@ class YmlSplitter:
         self.lines_inserted_at_code_start = 0
         self.config = configuration or Configuration()
         self.auto_create_dir = not no_auto_create_dir
-        self.yml_data = loaded_data if loaded_data is not None else get_yaml(self.input)
+        self.yml_data = input_file_data if input_file_data is not None else get_yaml(self.input)
         self.api_module_path: Optional[str] = None
 
     def get_output_path(self):

--- a/demisto_sdk/commands/split/ymlsplitter.py
+++ b/demisto_sdk/commands/split/ymlsplitter.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import base64
 import os
 import re

--- a/demisto_sdk/commands/split/ymlsplitter.py
+++ b/demisto_sdk/commands/split/ymlsplitter.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import base64
 import os
 import re
@@ -39,6 +40,7 @@ class YmlSplitter:
     Attributes:
         input (str): input yml file path
         output (str): output path
+        loaded_data (dict | None): preloaded YAML data. if not provided, data will be loaded from input
         no_demisto_mock (bool): whether to add an import for demistomock
         no_common_server (bool): whether to add an import for common server
         no_auto_create_dir (bool): whether to create a dir
@@ -54,6 +56,7 @@ class YmlSplitter:
         input: str,
         output: str = "",
         file_type: str = "",
+        loaded_data: dict | None = None,
         no_demisto_mock: bool = False,
         no_common_server: bool = False,
         no_auto_create_dir: bool = False,
@@ -72,7 +75,7 @@ class YmlSplitter:
         self.lines_inserted_at_code_start = 0
         self.config = configuration or Configuration()
         self.auto_create_dir = not no_auto_create_dir
-        self.yml_data = get_yaml(self.input)
+        self.yml_data = loaded_data if loaded_data is not None else get_yaml(self.input)
         self.api_module_path: Optional[str] = None
 
     def get_output_path(self):
@@ -122,7 +125,11 @@ class YmlSplitter:
         self.extract_long_description(f"{output_path}/{base_name}_description.md")
         yaml_out = f"{output_path}/{base_name}.yml"
         logger.debug(f"Creating yml file: {yaml_out} ...")
-        yaml_obj = get_file(self.input, raise_on_error=True)
+        if self.yml_data:
+            yaml_obj = self.yml_data
+        else:
+            yaml_obj = get_file(self.input, raise_on_error=True)
+
         script_obj = yaml_obj
 
         if self.file_type in ("modelingrule", "parsingrule"):


### PR DESCRIPTION
## Description
Added support for using preloaded data when using the `YmlSplitter`, to avoid having to re-parse the file for no reason.
Used by the WIP download command rewrite.