### PR TITLE
Fix `tools.get_id` for layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## Unreleased
+* Internal: Fixed an issue where the `tools.get_id` function would not find the ID for layout content items in some cases.
 * Internal: Fixed an issue where the `tools.get_display_name` function would return incorrect values for "Indicator Type" content items.
 * Changed the error code of the **validate** check for deprecated display names from `IN157` (duplicated a code used by a `nativeimage` check) to `IN160` (new code).
 * Changed the error code of the **validate** check for invalid SIEM marketplace values from `IN151` (duplicated a code used by a check for empty command arguments) to `IN161` (new code).

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -3780,7 +3780,13 @@ def get_id(file_content: Dict) -> Union[str, None]:
     elif "templates_data" in file_content:
         return file_content["templates_data"][0].get("global_id")
 
-    for key in ("global_rule_id", "trigger_id", "content_global_id", "rule_id"):
+    for key in (
+        "global_rule_id",
+        "trigger_id",
+        "content_global_id",
+        "rule_id",
+        "typeId",
+    ):
         if key in file_content:
             return file_content[key]
 


### PR DESCRIPTION
## Description
For some layouts, the ID seems to be in a field called `typeId`, which the `tools.get_id` function doesn't currently check for, resulting in a `None` value being returned for such cases. This PR fixes that issue.

Some examples for such layouts:
https://github.com/demisto/content/blob/master/Packs/CortexXDR/Layouts/layout-details-Cortex_XDR_Incident.json
https://github.com/demisto/content/blob/master/Packs/NIST/Layouts/layout-details-NIST-V2.json
https://github.com/demisto/content/blob/master/Packs/Claroty/Layouts/layout-details-Claroty_Integrity_Incident.json
