### PR TITLE
Collect the python file along with the yml file in demisto-sdk pre-commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   * Fixed an issue where integrations / automations with a dot in their name would be saved with an incorrect file name (For example: `Test v1.1.py` would be named `Test v1.py`)
 
 **Note:** Due to the optimization changes made to the **download** command, playbooks might be formatted a bit differently than before when downloaded from the server using the new version. The playbooks should however function and work the same.
+* Fixed an issue in the command demisto-sdk pre-commit, now when a yml file is given as input the matching python file will be checked in the pre-commit as well.
 
 ## 1.20.8
 * Internal: Fixed an issue where the `tools.get_id` function would not find the ID for layout content items in some cases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
   * Fixed an issue where integrations / automations with a dot in their name would be saved with an incorrect file name (For example: `Test v1.1.py` would be named `Test v1.py`)
 
 **Note:** Due to the optimization changes made to the **download** command, playbooks might be formatted a bit differently than before when downloaded from the server using the new version. The playbooks should however function and work the same.
-* Fixed an issue in the command demisto-sdk pre-commit, now when a yml file is given as input the matching python file will be checked in the pre-commit as well.
+* Fixed an issue where the **pre-commit** command, now correctly gathers the associated python file when a yml file is provided as input.
 
 ## 1.20.8
 * Internal: Fixed an issue where the `tools.get_id` function would not find the ID for layout content items in some cases.

--- a/demisto_sdk/commands/pre_commit/pre_commit_command.py
+++ b/demisto_sdk/commands/pre_commit/pre_commit_command.py
@@ -430,6 +430,10 @@ def preprocess_files(
             files_to_run.update({path for path in file.rglob("*") if path.is_file()})
         else:
             files_to_run.add(file)
+            # if the current file is a yml file, add the matching python file to files_to_run
+            if str(file).endswith("yml"):
+                str_py_file_path = str(file).replace("yml", "py")
+                files_to_run.add(Path(str_py_file_path))
 
     # convert to relative file to content path
     relative_paths = {

--- a/demisto_sdk/commands/pre_commit/tests/pre_commit_test.py
+++ b/demisto_sdk/commands/pre_commit/tests/pre_commit_test.py
@@ -250,6 +250,14 @@ class TestPreprocessFiles:
         assert output == expected_output
 
     def test_preprocess_files_with_input_yml_files(self, mocker):
+        """
+        Given:
+            - A yml file.
+        When:
+            - Running demisto-sdk pre-commit -i file1.yml.
+        Then:
+            - Check that the associated python file was gathered correctly.
+        """
         input_files = [Path("file1.yml")]
         expected_output = set([Path("file1.yml"), Path("file1.py")])
         mocker.patch.object(GitUtil, "get_all_files", return_value=expected_output)

--- a/demisto_sdk/commands/pre_commit/tests/pre_commit_test.py
+++ b/demisto_sdk/commands/pre_commit/tests/pre_commit_test.py
@@ -249,6 +249,13 @@ class TestPreprocessFiles:
         output = preprocess_files(input_files=input_files)
         assert output == expected_output
 
+    def test_preprocess_files_with_input_yml_files(self, mocker):
+        input_files = [Path("file1.yml")]
+        expected_output = set([Path("file1.yml"), Path("file1.py")])
+        mocker.patch.object(GitUtil, "get_all_files", return_value=expected_output)
+        output = preprocess_files(input_files=input_files)
+        assert output == expected_output
+
     def test_preprocess_files_with_staged_only(self, mocker):
         expected_output = set([Path("file1.txt"), Path("file2.txt")])
         mocker.patch.object(GitUtil, "_get_staged_files", return_value=expected_output)


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes:https://jira-dc.paloaltonetworks.com/browse/CIAC-8303

## Description: When a yml file is given to demisto-sdk pre-commit command, the pre-commit will also check the matching python file.
For example, when running `demisto-sdk pre-commit -i Packs/Discord/Integrations/Discord/Discord.yml`, pre-commit will run on the files Packs/Discord/Integrations/Discord/Discord.py and Packs/Discord/Integrations/Discord/Discord.yml.
