### PR TITLE
Make lint container name unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 **Note:** Due to the optimization changes made to the **download** command, playbooks might be formatted a bit differently than before when downloaded from the server using the new version. The playbooks should however function and work the same.
 * Fixed an issue where the **pre-commit** command, now correctly gathers the associated python file when a yml file is provided as input.
+* Fixed an issue where the **lint** command with docker, would not give unique container names to different image runs.
 
 ## 1.20.8
 * Internal: Fixed an issue where the `tools.get_id` function would not find the ID for layout content items in some cases.

--- a/demisto_sdk/commands/lint/linter.py
+++ b/demisto_sdk/commands/lint/linter.py
@@ -2,6 +2,7 @@
 import copy
 import os
 import platform
+import re
 import traceback
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
@@ -991,7 +992,14 @@ class Linter:
     ) -> Tuple[int, str]:
         log_prompt = f"{self._pack_name} - {linter} - Image {test_image}"
         logger.info(f"{log_prompt} - Start")
-        container_name = f"{self._pack_name}-{linter}"
+
+        # Get rid of chars that are not suitable for container names
+        test_image_cont_name = re.sub(
+            r"[^a-zA-Z0-9_.-]", "_", test_image.split("/")[-1]
+        )
+        test_image_cont_name = re.sub(r"^[^a-zA-Z0-9]", "", test_image_cont_name)
+
+        container_name = f"{self._pack_name}-{linter}-{test_image_cont_name}"
         # Check if previous run left container a live if it do, we remove it
         self._docker_remove_container(container_name)
 

--- a/demisto_sdk/commands/lint/linter.py
+++ b/demisto_sdk/commands/lint/linter.py
@@ -2,7 +2,6 @@
 import copy
 import os
 import platform
-import re
 import traceback
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
@@ -992,14 +991,7 @@ class Linter:
     ) -> Tuple[int, str]:
         log_prompt = f"{self._pack_name} - {linter} - Image {test_image}"
         logger.info(f"{log_prompt} - Start")
-
-        # Get rid of chars that are not suitable for container names
-        test_image_cont_name = re.sub(
-            r"[^a-zA-Z0-9_.-]", "_", test_image.split("/")[-1]
-        )
-        test_image_cont_name = re.sub(r"^[^a-zA-Z0-9]", "", test_image_cont_name)
-
-        container_name = f"{self._pack_name}-{linter}-{test_image_cont_name}"
+        container_name = f"{self._pack_name}-{linter}"
         # Check if previous run left container a live if it do, we remove it
         self._docker_remove_container(container_name)
 

--- a/demisto_sdk/commands/lint/linter.py
+++ b/demisto_sdk/commands/lint/linter.py
@@ -2,6 +2,7 @@
 import copy
 import os
 import platform
+import re
 import traceback
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
@@ -986,12 +987,19 @@ class Linter:
             )
             raise
 
+    def get_container_name(self, run_type, image_name):
+        # Get rid of chars that are not suitable for container names
+        image_cont_name = re.sub(r"[^a-zA-Z0-9_.-]", "_", image_name.split("/")[-1])
+        image_cont_name = re.sub(r"^[^a-zA-Z0-9]", "", image_cont_name)
+        return f"{self._pack_name}-{run_type}-{image_cont_name}"
+
     def _docker_run_linter(
         self, linter: str, test_image: str, keep_container: bool
     ) -> Tuple[int, str]:
         log_prompt = f"{self._pack_name} - {linter} - Image {test_image}"
         logger.info(f"{log_prompt} - Start")
-        container_name = f"{self._pack_name}-{linter}"
+
+        container_name = self.get_container_name(linter, test_image)
         # Check if previous run left container a live if it do, we remove it
         self._docker_remove_container(container_name)
 
@@ -1084,7 +1092,7 @@ class Linter:
 
         log_prompt = f"{self._pack_name} - Pytest - Image {test_image}, network: {network_status}"
         logger.info(f"{log_prompt} - Start")
-        container_name = f"{self._pack_name}-pytest"
+        container_name = self.get_container_name("pytest", test_image)
         # Check if previous run left container a live if it does, Remove it
         self._docker_remove_container(container_name)
         # Collect tests
@@ -1213,7 +1221,7 @@ class Linter:
         """
         log_prompt = f"{self._pack_name} - Powershell analyze - Image {test_image}"
         logger.info(f"{log_prompt} - Start")
-        container_name = f"{self._pack_name}-pwsh-analyze"
+        container_name = self.get_container_name("pwsh-analyze", test_image)
         # Check if previous run left container a live if it do, we remove it
         container: docker.models.containers.Container
         try:
@@ -1307,7 +1315,7 @@ class Linter:
         """
         log_prompt = f"{self._pack_name} - Powershell test - Image {test_image}"
         logger.info(f"{log_prompt} - Start")
-        container_name = f"{self._pack_name}-pwsh-test"
+        container_name = self.get_container_name("pwsh-test", test_image)
         # Check if previous run left container a live if it do, we remove it
         self._docker_remove_container(container_name)
 

--- a/demisto_sdk/commands/lint/tests/test_linter/docker_runner_test.py
+++ b/demisto_sdk/commands/lint/tests/test_linter/docker_runner_test.py
@@ -216,6 +216,47 @@ class TestRunLintInContainer:
             linter_obj._docker_run_pwsh_test.assert_called_once()
 
     @pytest.mark.parametrize(
+        argnames="image_name, expected_container_name",
+        argvalues=[
+            # Full image path.
+            (
+                "docker-io.art.code.pan.run/devtestdemisto/py3-native:8.2.0.123-abcd12345",
+                "some_pack-pylint-py3-native_8.2.0.123-abcd12345",
+            ),
+            # Name and tag only.
+            (
+                "py3-native:8.2.0.123-abcd12345",
+                "some_pack-pylint-py3-native_8.2.0.123-abcd12345",
+            ),
+            # Starts with invalid character.
+            (
+                "_py3-native:8.2.0.123-abcd12345",
+                "some_pack-pylint-py3-native_8.2.0.123-abcd12345",
+            ),
+            # Name only.
+            ("py3-native-no-tag", "some_pack-pylint-py3-native-no-tag"),
+            # Name and tag using an invalid char.
+            ("py3-native@some-tag", "some_pack-pylint-py3-native_some-tag"),
+        ],
+    )
+    def test_container_names(
+        self, linter_obj: Linter, image_name: str, expected_container_name: str
+    ):
+        """
+        Given: A docker image name
+        When: Running lint using docker
+        Then: Ensure the container name is valid and as expected.
+        """
+        linter_obj._linter_to_commands()
+        linter_obj._pack_name = "some_pack"
+
+        container_name = linter_obj.get_container_name(
+            run_type="pylint", image_name=image_name
+        )
+
+        assert container_name == expected_container_name
+
+    @pytest.mark.parametrize(
         argnames="lint_check, lint_check_kwargs",
         argvalues=[
             ("_docker_run_linter", {"linter": "pylint", "keep_container": False}),


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-6015

## Description
Lint container names are not unique per image, this causes errors when running lint in parallel on a few different images (like we do with the native image and its candidates). In this PR I make the docker container name include the image name and therefore make it unique per image.