### PR TITLE
Fixed an issue where the **modeling-rules test** command failed report and error when test data didn't exist.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## Unreleased
 * Fixed an issue where **validate** falsely failed with error `PB101` and `PB123` due to condition names discrepancy
+* Fixed an issue where the **modeling-rules test** command failed report and error when test data didn't exist.
 * Updated the **prepare-content** to add contributor details to the `detaileddescription` field based on **supportlevelheader** key.
 * Added a new validation (`IN162`) to ensure that each event collector under partner supported packs have the *xsoar* value for the **supportlevelheader** key in its yml.
 * A rewrite for the **download** command, with many improvements and fixes, including:

--- a/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
+++ b/demisto_sdk/commands/test_content/test_modeling_rule/test_modeling_rule.py
@@ -1049,7 +1049,7 @@ def validate_modeling_rule(
                 )
             if delete_existing_dataset:
                 delete_existing_dataset_flow(xsiam_client, test_data, retrying_caller)
-            test_data_test_case = TestCase(
+            schema_test_case = TestCase(
                 "Validate Schema",
                 classname=f"Modeling Rule {get_relative_path_to_content(modeling_rule.schema_path)}",
             )
@@ -1062,14 +1062,14 @@ def validate_modeling_rule(
                         f"[red]{err}[/red]",
                         extra={"markup": True},
                     )
-                    test_data_test_case.system_err = str(ex)
+                    schema_test_case.system_err = str(ex)
                     return add_result_to_test_case(
-                        err, test_data_test_case, modeling_rule_test_suite
+                        err, schema_test_case, modeling_rule_test_suite
                     )
             else:
                 err = f"Schema file does not exist in path {get_relative_path_to_content(modeling_rule.schema_path)}"
                 return log_error_to_test_case(
-                    err, test_data_test_case, modeling_rule_test_suite
+                    err, schema_test_case, modeling_rule_test_suite
                 )
             if (
                 Validations.SCHEMA_TYPES_ALIGNED_WITH_TEST_DATA.value
@@ -1084,14 +1084,14 @@ def validate_modeling_rule(
                 success, results = validate_schema_aligned_with_test_data(
                     test_data=test_data, schema=schema
                 )
-                test_data_test_case.result += results
+                schema_test_case.result += results
                 if not success:
                     err = (
                         f"The schema {get_relative_path_to_content(schema_path)} is not aligned with the test data file "
                         f"{get_relative_path_to_content(modeling_rule.testdata_path)}"
                     )
                     return log_error_to_test_case(
-                        err, test_data_test_case, modeling_rule_test_suite
+                        err, schema_test_case, modeling_rule_test_suite
                     )
             else:
                 skipped = (
@@ -1099,8 +1099,8 @@ def validate_modeling_rule(
                     "is aligned with TestData file."
                 )
                 logger.info(f"[green]{skipped}[/green]", extra={"markup": True})
-                test_data_test_case.result += [Skipped(skipped)]
-                modeling_rule_test_suite.add_testcase(test_data_test_case)
+                schema_test_case.result += [Skipped(skipped)]
+                modeling_rule_test_suite.add_testcase(schema_test_case)
 
             if push:
                 event_id_exists_test_case = verify_event_id_does_not_exist_on_tenant(


### PR DESCRIPTION
## Description
Fixed an issue where the **modeling-rules test** command failed report and error when test data didn't exist.
