### PR TITLE
[clients] - validate that base-api-url is indeed the api-url

### DIFF
--- a/demisto_sdk/commands/common/clients/tests/get_client_test.py
+++ b/demisto_sdk/commands/common/clients/tests/get_client_test.py
@@ -208,3 +208,34 @@ def test_get_client_from_server_type_unauthorized_exception(api_requests_mocker)
     )
     with pytest.raises(UnAuthorized):
         get_client_from_server_type(base_url="https://test4.com")
+
+
+def test_get_client_from_server_type_base_url_is_not_api_url(mocker):
+    """
+    Given:
+     - /ioc-rules endpoint that is not valid
+     - /about that returns content-type of text/html
+
+    When:
+     - running get_client_from_server_type function
+
+    Then:
+     - make sure an exception of ValueError is raised
+    """
+    from demisto_sdk.commands.common.clients import get_client_from_server_type
+
+    def _generic_request_side_effect(
+        path: str, method: str, response_type: str = "object"
+    ):
+        if path == "/ioc-rules" and method == "GET":
+            raise ApiException(status=500, reason="error")
+        if path == "/about" and method == "GET" and response_type == "object":
+            return {}, 200, {"Content-Type": "text/html"}
+
+    mocker.patch.object(os, "getenv", side_effect=getenv_side_effect)
+
+    mocker.patch.object(
+        DefaultApi, "generic_request", side_effect=_generic_request_side_effect
+    )
+    with pytest.raises(ValueError):
+        get_client_from_server_type(base_url="https://test5.com")

--- a/demisto_sdk/commands/common/clients/tests/get_client_test.py
+++ b/demisto_sdk/commands/common/clients/tests/get_client_test.py
@@ -69,7 +69,7 @@ def test_get_client_from_config(
      - running get_client_from_config function
 
     Then:
-     - Case A: make sure XsoarOnPremClient is returned
+     - Case A: make sure Xsoarclient is returned
      - Case B: make sure XsoarSaasClient is returned
      - Case C: make sure XsiamClient is returned
     """

--- a/demisto_sdk/commands/common/clients/xsoar/xsoar_api_client.py
+++ b/demisto_sdk/commands/common/clients/xsoar/xsoar_api_client.py
@@ -1,7 +1,6 @@
 import contextlib
 import re
 import urllib.parse
-from abc import ABC
 from typing import Any, Dict, List, Optional, Union
 
 import dateparser
@@ -23,7 +22,7 @@ from demisto_sdk.commands.common.logger import logger
 from demisto_sdk.commands.common.tools import retry
 
 
-class XsoarClient(BaseModel, ABC):
+class XsoarClient(BaseModel):
     """
     api client for xsoar-on-prem
     """

--- a/demisto_sdk/commands/common/clients/xsoar/xsoar_api_client.py
+++ b/demisto_sdk/commands/common/clients/xsoar/xsoar_api_client.py
@@ -44,9 +44,14 @@ class XsoarClient(BaseModel, ABC):
         Get basic information about XSOAR server.
         """
         try:
-            raw_response, _, _ = client.generic_request(
+            raw_response, _, response_headers = client.generic_request(
                 "/about", "GET", response_type="object"
             )
+            if "text/html" in response_headers.get("Content-Type"):
+                raise ValueError(
+                    f"the {client.api_client.configuration.host} URL is not the api-url",
+                )
+
             return raw_response
         except ApiException as err:
             if err.status == requests.codes.unauthorized:


### PR DESCRIPTION


## Description
Validates that the `DEMISTO_BASE_URL` is indeed a valid api url and its not by mistake a reference for the base URL.