### PR TITLE
Add debug level log if version fetch failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## Unreleased
+* Added a debug-level log with more information in case connection to the server failed while trying to fetch its version.
 
 ## 1.23.0
 * Added support for inputs sections and outputs sections in a playbook.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ## Unreleased
-* Added a debug-level log with more information in case connection to the server failed while trying to fetch its version.
+* Fixed an issue where the error was not clear when trying to retrieve the server version.
 
 ## 1.23.0
 * Added support for inputs sections and outputs sections in a playbook.

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -2552,7 +2552,7 @@ def get_demisto_version(client: demisto_client) -> Version:
         about_data = json.loads(resp[0].replace("'", '"'))
         return Version(Version(about_data.get("demistoVersion")).base_version)
     except Exception as e:
-        logger.debug(f"Failed to get server version. Error: {e}")
+        logger.debug(f"Failed to fetch server version. Error: {e}")
         logger.warning(
             "Could not parse server version, please make sure the environment is properly configured."
         )

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -2551,7 +2551,8 @@ def get_demisto_version(client: demisto_client) -> Version:
         resp = client.generic_request("/about", "GET")
         about_data = json.loads(resp[0].replace("'", '"'))
         return Version(Version(about_data.get("demistoVersion")).base_version)
-    except Exception:
+    except Exception as e:
+        logger.debug(f"Failed to get server version. Error: {e}")
         logger.warning(
             "Could not parse server version, please make sure the environment is properly configured."
         )


### PR DESCRIPTION
## Description
Add a debug-level (will only appear in logfile) if there is an error fetching server's version (which is the first step for the `upload` command).
Makes it easier to debug issues which currently only log:
```
[INFO] You are using demisto-sdk 1.23.0.
Could not parse server version, please make sure the environment is properly configured.
[INFO] Could not connect to the server. Try checking your connection configurations.
```