### PR TITLE
[pre-commit] do not delete properties which set to False

### DIFF
--- a/demisto_sdk/commands/pre_commit/hooks/hook.py
+++ b/demisto_sdk/commands/pre_commit/hooks/hook.py
@@ -104,7 +104,7 @@ class Hook:
             key = full_key.split(":")[0]
             if hook.get(key):
                 continue
-            if prop := self._get_property(key):
+            if (prop := self._get_property(key)) is not None:
                 hook[key] = prop
         self.base_hook = hook
 


### PR DESCRIPTION
Currently, we delete properties in the configuration which are set to False.
For instance, in the template we set sometimes the `pass_filenames` to False. Right now, we delete this flag which makes the default is True.