### PR TITLE
[Coverage report] Create the report dir if not exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Fixed an issue where **run-playbook** command did not work.
 * Fixed an issue in **setup-env** command where the virtual environment failed to set up.
 * Fixed an issue in **pre-commit** command where `False` properties were deleted.
-
+* Fixed an issue in **coverage-analyze** command where the `report_dir` does not exist.
 
 ## 1.23.0
 * Added support for inputs sections and outputs sections in a playbook.

--- a/demisto_sdk/commands/coverage_analyze/coverage_report.py
+++ b/demisto_sdk/commands/coverage_analyze/coverage_report.py
@@ -32,6 +32,7 @@ class CoverageReport:
             str
         ] = f"https://storage.googleapis.com/{DEMISTO_SDK_MARKETPLACE_XSOAR_DIST_DEV}/code-coverage-reports/coverage-min.json",
     ):
+        Path(report_dir).mkdir(parents=True, exist_ok=True)
         self.report_dir = report_dir
         self._cov: Optional[coverage.Coverage] = None
         self._report_str: Optional[str] = None


### PR DESCRIPTION
If running coverage-analyze to a report dir which doesn't exist locally it fails.

This PR creates the report dir if it doesn't exists.

