### PR TITLE
Merge pytest and coverage reports script

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -65,9 +65,9 @@
   pass_filenames: false
   args: ["-i", ".coverage"]
 
-- id: merge-pytest-report
-  name: merge-pytest-report
-  entry: merge-pytest-report
+- id: merge-pytest-reports
+  name: merge-pytest-reports
+  entry: merge-pytest-reports
   language: python
   require_serial: true
   pass_filenames: false

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -65,9 +65,9 @@
   pass_filenames: false
   args: ["-i", ".coverage"]
 
-- id: merge-coverage-report
-  name: merge-coverage-report
-  entry: merge-coverage-report
+- id: merge-pytest-report
+  name: merge-pytest-report
+  entry: merge-pytest-report
   language: python
   require_serial: true
   pass_filenames: false

--- a/demisto_sdk/commands/pre_commit/pre_commit_command.py
+++ b/demisto_sdk/commands/pre_commit/pre_commit_command.py
@@ -230,7 +230,7 @@ class PreCommitRunner:
         if not unit_test:
             skipped_hooks.add("run-unit-tests")
             skipped_hooks.add("coverage-analyze")
-            skipped_hooks.add("merge-coverage-report")
+            skipped_hooks.add("merge-pytest-reports")
         if validate and "validate" in skipped_hooks:
             skipped_hooks.remove("validate")
         if format and "format" in skipped_hooks:

--- a/demisto_sdk/commands/pre_commit/pre_commit_command.py
+++ b/demisto_sdk/commands/pre_commit/pre_commit_command.py
@@ -238,7 +238,7 @@ class PreCommitRunner:
         if secrets and "secrets" in skipped_hooks:
             skipped_hooks.remove("secrets")
         precommit_env["SKIP"] = ",".join(sorted(skipped_hooks))
-        precommit_env["PYTHONPATH"] = ":".join(str(path) for path in sorted(PYTHONPATH))
+        precommit_env["PYTHONPATH"] = ":".join(str(path) for path in PYTHONPATH)
         # The PYTHONPATH should be the same as the PYTHONPATH, but without the site-packages because MYPY does not support it
         precommit_env["MYPYPATH"] = ":".join(
             str(path) for path in sorted(PYTHONPATH) if "site-packages" not in str(path)

--- a/demisto_sdk/commands/pre_commit/tests/pre_commit_test.py
+++ b/demisto_sdk/commands/pre_commit/tests/pre_commit_test.py
@@ -130,7 +130,7 @@ def test_config_files(mocker, repo: Repo, is_test: bool):
     if not is_test:
         tests_we_should_skip.add("run-unit-tests")
         tests_we_should_skip.add("coverage-analyze")
-        tests_we_should_skip.add("merge-coverage-report")
+        tests_we_should_skip.add("merge-pytest-reports")
     for m in mock_subprocess.call_args_list:
         assert set(m.kwargs["env"]["SKIP"].split(",")) == tests_we_should_skip
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ exclude = ["TestSuite/**", "*/tests/*", "tests"]
 [tool.poetry.scripts]
 demisto-sdk = "demisto_sdk.__main__:main"
 update-additional-dependencies = "demisto_sdk.scripts.update_additional_dependencies:main"
-merge-coverage-report = "demisto_sdk.scripts.merge_coverage_report:main"
+merge-pytest-report = "demisto_sdk.scripts.merge_pytest_report:main"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ exclude = ["TestSuite/**", "*/tests/*", "tests"]
 [tool.poetry.scripts]
 demisto-sdk = "demisto_sdk.__main__:main"
 update-additional-dependencies = "demisto_sdk.scripts.update_additional_dependencies:main"
-merge-pytest-report = "demisto_sdk.scripts.merge_pytest_report:main"
+merge-pytest-reports = "demisto_sdk.scripts.merge_pytest_reports:main"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"


### PR DESCRIPTION
We currently have a script to merge the coverge reports.
Changing the script to merge both pytest and coverage reports.

related: https://jira-dc.paloaltonetworks.com/browse/CIAC-7962