### PR TITLE
[Pre-Commit] fix update additional dependencies to use a deep copy

### DIFF
--- a/demisto_sdk/scripts/update_additional_dependencies.py
+++ b/demisto_sdk/scripts/update_additional_dependencies.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Optional, Sequence
 
 from demisto_sdk.commands.common.handlers import DEFAULT_YAML_HANDLER as yaml
-from demisto_sdk.commands.common.logger import logger
+from demisto_sdk.commands.common.logger import logger, logging_setup
 from demisto_sdk.commands.common.tools import get_file, is_external_repository
 
 
@@ -21,6 +21,7 @@ def update_additional_dependencies(
     Returns:
         int: 1 if failed, 0 if succeeded (OR not in a content-likerepository)
     """
+    logging_setup()
     if is_external_repository():
         logger.warning("Cannot detect repo, skipping update_additional_dependencies")
         return 0


### PR DESCRIPTION
When comparing between the original pre-commit and the updated pre-commit, we should compare a deep copy of the original one.

## Related Issues
fixes:

## Description
