### PR TITLE
install specific version of neo4j in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,7 @@ references:
           echo 'deb https://debian.neo4j.com stable 5' | sudo tee /etc/apt/sources.list.d/neo4j.list
           sudo apt-get update
           apt list -a neo4j
+          # The neo4j version should be consistent with APOC version below!
           sudo apt-get install neo4j==5.13.0
           sudo chown -R circleci /var/log/neo4j
           sudo chown -R circleci /var/lib/neo4j

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ references:
           echo 'deb https://debian.neo4j.com stable 5' | sudo tee /etc/apt/sources.list.d/neo4j.list
           sudo apt-get update
           apt list -a neo4j
-          sudo apt-get install neo4j
+          sudo apt-get install neo4j==5.13.0
           sudo chown -R circleci /var/log/neo4j
           sudo chown -R circleci /var/lib/neo4j
           sudo chown -R circleci /etc/neo4j

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ references:
           sudo apt-get update
           apt list -a neo4j
           # The neo4j version should be consistent with APOC version below!
-          sudo apt-get install neo4j=5.13.0
+          sudo apt-get install neo4j=1:5.15.0
           sudo chown -R circleci /var/log/neo4j
           sudo chown -R circleci /var/lib/neo4j
           sudo chown -R circleci /etc/neo4j

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ references:
           sudo apt-get update
           apt list -a neo4j
           # The neo4j version should be consistent with APOC version below!
-          sudo apt-get install neo4j==5.13.0
+          sudo apt-get install neo4j=5.13.0
           sudo chown -R circleci /var/log/neo4j
           sudo chown -R circleci /var/lib/neo4j
           sudo chown -R circleci /etc/neo4j

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ references:
           sudo apt-get update
           apt list -a neo4j
           # The neo4j version should be consistent with APOC version below!
-          sudo apt-get install neo4j=1:5.15.0
+          sudo apt-get install neo4j=1:5.13.0
           sudo chown -R circleci /var/log/neo4j
           sudo chown -R circleci /var/lib/neo4j
           sudo chown -R circleci /etc/neo4j


### PR DESCRIPTION
Install specific version of neo4j which consists the APOC version

fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-9209