### PR TITLE
Updated deprecated env vars 

### DIFF
--- a/demisto_sdk/commands/test_content/IntegrationsLock.py
+++ b/demisto_sdk/commands/test_content/IntegrationsLock.py
@@ -11,7 +11,7 @@ from google.resumable_media.common import InvalidResponse
 
 LOCKS_PATH = "content-locks"
 BUCKET_NAME = os.environ.get("GCS_ARTIFACTS_BUCKET")
-BUILD_NUM = os.environ.get("CI_BUILD_ID")
+BUILD_NUM = os.environ.get("CI_JOB_ID")
 WORKFLOW_ID = os.environ.get("CI_PIPELINE_ID")
 CIRCLE_STATUS_TOKEN = os.environ.get("CIRCLECI_STATUS_TOKEN")
 GITLAB_STATUS_TOKEN = os.environ.get("GITLAB_STATUS_TOKEN", "")


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Content PRs
https://github.com/demisto/content/pull/30983

## Description
Replaced CI_BUILD_ID with CI_JOB_ID, as the predefined CI/CD variables that start with CI_BUILD_* were deprecated in GitLab 9.0, and were removed in GitLab 16.0.
https://docs.gitlab.com/ee/update/deprecations.html?removal_milestone=16.0#ci_build_-predefined-variables
