### PR TITLE
[Setup env] Fix issues with environment setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 ## Unreleased
+* Added the `clean` flag to **setup-env** to delete temp files that were created by `lint` from the repo.
+
 
 ## 1.25.0
 * Added support to detect automatically the playground-id when running cli commands in xsoar-6.

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -3494,7 +3494,7 @@ def update_content_graph(
     "--clean",
     is_flag=True,
     default=False,
-    help="Clean the repo out of the temp `CommonServerPython.py` files, `demistomock.py` and other files that were copied by `lint`",
+    help="Clean the repo out of the temp files that were created by `lint`",
 )
 @click.argument("file_paths", nargs=-1, type=click.Path(exists=True, resolve_path=True))
 def setup_env(
@@ -3521,7 +3521,7 @@ def setup_env(
         secret_id=secret_id,
         instance_name=instance_name,
         test_module=run_test_module,
-        clean=True,
+        clean=clean,
     )
 
 

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -3490,6 +3490,12 @@ def update_content_graph(
     default=False,
     help="Whether to run test-module on the configured XSOAR/XSIAM instance",
 )
+@click.option(
+    "--clean",
+    is_flag=True,
+    default=False,
+    help="Clean the repo out of the temp `CommonServerPython.py` files, `demistomock.py` and other files that were copied by `lint`",
+)
 @click.argument("file_paths", nargs=-1, type=click.Path(exists=True, resolve_path=True))
 def setup_env(
     input,
@@ -3499,6 +3505,7 @@ def setup_env(
     secret_id,
     instance_name,
     run_test_module,
+    clean,
 ):
     from demisto_sdk.commands.setup_env.setup_environment import (
         setup_env,
@@ -3514,6 +3521,7 @@ def setup_env(
         secret_id=secret_id,
         instance_name=instance_name,
         test_module=run_test_module,
+        clean=True,
     )
 
 

--- a/demisto_sdk/commands/setup_env/README.md
+++ b/demisto_sdk/commands/setup_env/README.md
@@ -32,3 +32,5 @@ Secret ID, to use with Google Secret Manager instance. If not provided, will use
 Instance name to configure in XSOAR/XSIAM.
 - **--run-test-module**
 Whether to run the test-module of the integration.
+- **--clean**
+Clean the repo out of the temp `CommonServerPython.py` files, `demistomock.py` and other files that were created by `lint`.

--- a/demisto_sdk/commands/setup_env/settings.json
+++ b/demisto_sdk/commands/setup_env/settings.json
@@ -5,6 +5,7 @@
         "-v"
     ],
     "python.analysis.typeCheckingMode": "basic",
+    "coverage-gutters.coverageBaseDir": "coverage_report",
     "python.testing.unittestEnabled": false,
     "mypy-type-checker.args": [
         "--follow-imports=silent",

--- a/demisto_sdk/commands/setup_env/setup_environment.py
+++ b/demisto_sdk/commands/setup_env/setup_environment.py
@@ -43,11 +43,6 @@ class IDE(Enum):
 IDE_TO_FOLDER = {IDE.VSCODE: ".vscode", IDE.PYCHARM: ".idea"}
 
 
-def add_init_file_in_test_data(integration_script: IntegrationScript):
-    if (test_data_dir := (integration_script.path.parent / "test_data")).exists():
-        (test_data_dir / "__init__.py").touch()
-
-
 def configure_vscode_settings(
     ide_folder: Path,
     integration_script: Optional[IntegrationScript] = None,
@@ -466,7 +461,6 @@ def configure_integration(
         integration_script, IntegrationScript
     ), "Expected Integration Script"
     add_demistomock_and_commonserveruser(integration_script)
-    add_init_file_in_test_data(integration_script)
     docker_image = integration_script.docker_image
     interpreter_path = CONTENT_PATH / ".venv" / "bin" / "python"
     configure_params(integration_script, secret_id, instance_name, test_module)

--- a/demisto_sdk/commands/setup_env/setup_environment.py
+++ b/demisto_sdk/commands/setup_env/setup_environment.py
@@ -67,7 +67,9 @@ def configure_vscode_settings(
     else:
         python_path = [str(path) for path in PYTHONPATH if str(path)]
 
-    settings["python.analysis.extraPaths"] = python_path
+    settings["python.analysis.extraPaths"] = [
+        path for path in python_path if "site-packages" not in path
+    ]
     with open(ide_folder / "settings.json", "w") as f:
         json5.dump(settings, f, indent=4)
 

--- a/demisto_sdk/commands/setup_env/setup_environment.py
+++ b/demisto_sdk/commands/setup_env/setup_environment.py
@@ -112,7 +112,10 @@ def configure_dotenv():
     """
     DOTENV_PATH.touch()
     python_path_values = ":".join((str(path) for path in PYTHONPATH))
-    update_dotenv({"PYTHONPATH": python_path_values, "MYPYPATH": python_path_values})
+    mypy_path_values = ":".join(
+        (str(path) for path in PYTHONPATH if "site-packages" not in str(path))
+    )
+    update_dotenv({"PYTHONPATH": python_path_values, "MYPYPATH": mypy_path_values})
 
 
 def configure_vscode_tasks(

--- a/demisto_sdk/commands/setup_env/setup_environment.py
+++ b/demisto_sdk/commands/setup_env/setup_environment.py
@@ -503,6 +503,16 @@ def configure_integration(
         )
 
 
+def clean_repo():
+    """
+    This functions clean the repo from the temp `CommonServerPython` and `APIModules` files and other files that were created by lint
+    """
+    for path in PYTHONPATH:
+        for temp_file in CONTENT_PATH.rglob(path.name):
+            if temp_file != path:
+                temp_file.unlink(missing_ok=True)
+
+
 def setup_env(
     file_paths: Tuple[Path, ...],
     ide: IDE = IDE.VSCODE,
@@ -511,6 +521,7 @@ def setup_env(
     secret_id: Optional[str] = None,
     instance_name: Optional[str] = None,
     test_module: bool = False,
+    clean: bool = False,
 ) -> None:
     """This function sets up the development environment for integration scripts
 
@@ -525,6 +536,8 @@ def setup_env(
     Raises:
         RuntimeError:
     """
+    if clean:
+        clean_repo()
     configure_dotenv()
     if not file_paths:
         (CONTENT_PATH / "CommonServerUserPython.py").touch()


### PR DESCRIPTION
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-9241

* fix MYPYPATH and `extrapath` not to include site packages to search dependencies which are installed in site-packages
* set the setting to search the coverage file to `coverage_report`.
* Don't create `__init__.py` files in the test_data, as it's not needed after we removed all of them from the repo
* add clean flag to delete temp files