### PR TITLE
[Pre-Commit] Execute fixable hooks before rest of the hooks

### DIFF
--- a/demisto_sdk/commands/pre_commit/tests/pre_commit_test.py
+++ b/demisto_sdk/commands/pre_commit/tests/pre_commit_test.py
@@ -160,7 +160,9 @@ def test_config_files(mocker, repo: Repo):
     )
 
     pre_commit.prepare_and_run()
+
     assert (Path(repo.path) / ".pre-commit-config.yaml").exists()
+    assert (Path(repo.path) / ".pre-commit-config-fixable.yaml").exists()
     assert list((Path(repo.path) / "docker-config").iterdir())
     assert (Path(repo.path) / ".pre-commit-config-needs.yaml").exists()
 

--- a/demisto_sdk/commands/pre_commit/tests/test_data/.pre-commit-config_template-test.yaml
+++ b/demisto_sdk/commands/pre_commit/tests/test_data/.pre-commit-config_template-test.yaml
@@ -28,6 +28,7 @@ repos:
     rev: "v2.0.1"
     hooks:
       - id: autopep8
+        fixable: true
   - repo: local
     hooks:
 


### PR DESCRIPTION
This adds support for `fixable` property in pre-commit-config, so we will be able to add `fixable` on the property, and the fixable hooks will run before the rest of the hooks

fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-9269