### PR TITLE
Add validation for non stash in demisto-sdk update script

### DIFF
--- a/demisto_sdk/scripts/update_demisto_sdk_version.sh
+++ b/demisto_sdk/scripts/update_demisto_sdk_version.sh
@@ -38,12 +38,16 @@ do
 
   # Do git commands...
   current_content_branch=$(git branch --show-current)
+  old_sha=$(git rev-parse -q --verify refs/stash)                                                                                                                                                                               ─╯
   git stash
+  new_sha=$(git rev-parse -q --verify refs/stash)
   git checkout master
   git pull
   poetry install
   git checkout "$current_content_branch"
-  git stash pop
+  if [ "$old_sha" != "$new_sha" ]; then
+    git stash pop
+  fi
 done
 
 # Move back to original path

--- a/demisto_sdk/scripts/update_demisto_sdk_version.sh
+++ b/demisto_sdk/scripts/update_demisto_sdk_version.sh
@@ -38,7 +38,7 @@ do
 
   # Do git commands...
   current_content_branch=$(git branch --show-current)
-  old_sha=$(git rev-parse -q --verify refs/stash)                                                                                                                                                                               ─╯
+  old_sha=$(git rev-parse -q --verify refs/stash)
   git stash
   new_sha=$(git rev-parse -q --verify refs/stash)
   git checkout master


### PR DESCRIPTION
## Related Issues
fixes:

## Description
run `git stash pop` only if we stash something in the begging of the script.
