### PR TITLE
fix bug incident to alert playbook intended only xsiam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added support to check the version of the modeling rule against the demisto version of the XSIAM tenant when running the **modeling-rule test** command, and skip incompatible modeling rules.
 * Internal: Fixed an issue where `nativeimage` tags were not uploaded to buckets.
 * Fixed an issue where **lint -g** crashed when comparing changes against branches which are not `master`.
+* Fixed an issue in **prepare-content** command where the `incident to alert` process was not triggered when the playbook is set to only XSIAM.
 
 ## 1.25.1
 * Added the `clean` flag to **setup-env** to delete temp files that were created by `lint` from the repo.

--- a/demisto_sdk/commands/prepare_content/preparers/marketplace_incident_to_alert_playbooks_prepare.py
+++ b/demisto_sdk/commands/prepare_content/preparers/marketplace_incident_to_alert_playbooks_prepare.py
@@ -42,7 +42,6 @@ class MarketplaceIncidentToAlertPlaybooksPreparer:
         if (
             current_marketplace == MarketplaceVersions.MarketplaceV2
             and MarketplaceVersions.MarketplaceV2 in supported_marketplaces
-            and len(supported_marketplaces) > 1
         ):
             data = prepare_playbook_access_fields(data, playbook)
 

--- a/demisto_sdk/commands/prepare_content/tests/marketplace_incident_to_alert_playbooks_prepare_test.py
+++ b/demisto_sdk/commands/prepare_content/tests/marketplace_incident_to_alert_playbooks_prepare_test.py
@@ -100,7 +100,7 @@ def test_marketplace_version_is_xsiam_2():
     Then:
         - Ensure incident is converted to alert when needed.
         - Ensure the wrapper is removed.
-        - Ensure the access fields did change even as the playbook is supported only in MarketplaceVersions.MarketplaceV2.
+        - Ensure the access fields have changed even when the playbook is only supported in MarketplaceVersions.MarketplaceV2.
     """
 
     data = get_yaml(
@@ -126,7 +126,7 @@ def test_marketplace_version_is_xsiam_2():
         " while investigating the alert itself. Alerts incidents"
     )
 
-    # assert access fields did change even as this playbook is supported only in XSAIM and not both marketplaces
+    # assert access fields have changed even as this playbook is supported only in XSAIM and not both marketplaces
     assert data["tasks"]["3"]["task"]["script"] == "Builtin|||setAlert"
     assert (
         data["tasks"]["3"]["task"]["scriptarguments"]["id"]["complex"]["root"]

--- a/demisto_sdk/commands/prepare_content/tests/marketplace_incident_to_alert_playbooks_prepare_test.py
+++ b/demisto_sdk/commands/prepare_content/tests/marketplace_incident_to_alert_playbooks_prepare_test.py
@@ -100,7 +100,7 @@ def test_marketplace_version_is_xsiam_2():
     Then:
         - Ensure incident is converted to alert when needed.
         - Ensure the wrapper is removed.
-        - Ensure the access fields did NOT change as the playbook is supported only in MarketplaceVersions.MarketplaceV2.
+        - Ensure the access fields did change even as the playbook is supported only in MarketplaceVersions.MarketplaceV2.
     """
 
     data = get_yaml(
@@ -126,11 +126,11 @@ def test_marketplace_version_is_xsiam_2():
         " while investigating the alert itself. Alerts incidents"
     )
 
-    # assert access fields did NOT change as this playbook is supported only in XSAIM and not both marketplaces
-    assert data["tasks"]["3"]["task"]["script"] == "Builtin|||setIncident"
+    # assert access fields did change even as this playbook is supported only in XSAIM and not both marketplaces
+    assert data["tasks"]["3"]["task"]["script"] == "Builtin|||setAlert"
     assert (
         data["tasks"]["3"]["task"]["scriptarguments"]["id"]["complex"]["root"]
-        == "incident"
+        == "alert"
     )
 
 


### PR DESCRIPTION
## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-9419

## Description
Fix a bug where 'incident to Alert' doesn't run for an xsiam-only Playbook