### PR TITLE
Test Graph Commands Github Action

### DIFF
--- a/.github/actions/setup_environment/action.yml
+++ b/.github/actions/setup_environment/action.yml
@@ -1,5 +1,5 @@
-name: 'Setup python environment for demisto-sdk jobs'
-description: 'Setup python environment for demisto-sdk jobs'
+name: 'Setup testing environment for demisto-sdk jobs'
+description: 'Setup testing environment for demisto-sdk jobs - that includes adding python/create-artifacts/install dependencies'
 author: 'Demisto-SDK'
 
 inputs:
@@ -17,6 +17,11 @@ inputs:
     type: string
     default: "-E generate-unit-tests"
     description: "the arguments for the poetry install command"
+  artifacts-dir:
+    required: false
+    type: string
+    default: $GITHUB_JOB
+    description: "The name of the artifacts dir"
 
 runs:
   using: 'composite'
@@ -43,3 +48,8 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
         # cache: poetry
+
+    - name: Create Artifacts Dir
+      run: |
+        mkdir ${{ artifacts-dir }}
+      shell: bash

--- a/.github/actions/setup_environment/action.yml
+++ b/.github/actions/setup_environment/action.yml
@@ -48,9 +48,3 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
         # cache: poetry
-
-    - name: Create Artifacts Dir
-      run: |
-        mkdir -p ${{ inputs.artifacts-dir }}
-        echo "Created directory ${{ inputs.artifacts-dir }} successfully"
-      shell: bash

--- a/.github/actions/setup_environment/action.yml
+++ b/.github/actions/setup_environment/action.yml
@@ -51,5 +51,6 @@ runs:
 
     - name: Create Artifacts Dir
       run: |
-        mkdir ${{ artifacts-dir }}
+        mkdir -p ${{ inputs.artifacts-dir }}
+        echo "Created directory ${{ inputs.artifacts-dir }} successfully"
       shell: bash

--- a/.github/actions/setup_test_environment/action.yml
+++ b/.github/actions/setup_test_environment/action.yml
@@ -37,5 +37,5 @@ runs:
     - name: Install npm
       run: |
         npm install
-        echo $(echo '{"node_version": "'$(node --version)'","npm_list":'$(npm list --json)'}') > ${{ artifacts-dir }}/node_versions_info.json
+        echo $(echo '{"node_version": "'$(node --version)'","npm_list":'$(npm list --json)'}') > ${{ inputs.artifacts-dir }}/node_versions_info.json
       shell: bash

--- a/.github/actions/setup_test_environment/action.yml
+++ b/.github/actions/setup_test_environment/action.yml
@@ -18,6 +18,7 @@ inputs:
     default: $GITHUB_JOB
     description: "The name of the artifacts dir"
 
+
 runs:
   using: 'composite'
   steps:
@@ -36,5 +37,5 @@ runs:
     - name: Install npm
       run: |
         npm install
-        echo $(echo '{"node_version": "'$(node --version)'","npm_list":'$(npm list --json)'}') > node_versions_info.json
+        echo $(echo '{"node_version": "'$(node --version)'","npm_list":'$(npm list --json)'}') > ${{ artifacts-dir }}/node_versions_info.json
       shell: bash

--- a/.github/actions/setup_test_environment/action.yml
+++ b/.github/actions/setup_test_environment/action.yml
@@ -27,7 +27,7 @@ runs:
       uses: ./.github/actions/setup_environment
       with:
         python-version: ${{ inputs.python-version }}
-        artifacts-dir: ${{ artifacts-dir }}
+        artifacts-dir: ${{ inputs.artifacts-dir }}
 
     - name: Set up Node.js
       uses: actions/setup-node@v3

--- a/.github/actions/setup_test_environment/action.yml
+++ b/.github/actions/setup_test_environment/action.yml
@@ -15,7 +15,7 @@ inputs:
   artifacts-dir:
     required: false
     type: string
-    default: $GITHUB_JOB
+    default: "artifacts-dir"
     description: "The name of the artifacts dir"
 
 

--- a/.github/actions/setup_test_environment/action.yml
+++ b/.github/actions/setup_test_environment/action.yml
@@ -12,16 +12,21 @@ inputs:
     type: string
     default: "16"
     description: "The node version to install"
-
+  artifacts-dir:
+    required: false
+    type: string
+    default: $GITHUB_JOB
+    description: "The name of the artifacts dir"
 
 runs:
   using: 'composite'
   steps:
 
     - name: Python ${{ matrix.python-version }} - Setup Environment
-      uses: ./.github/actions/setup_poetry_python_environment
+      uses: ./.github/actions/setup_environment
       with:
         python-version: ${{ inputs.python-version }}
+        artifacts-dir: ${{ artifacts-dir }}
 
     - name: Set up Node.js
       uses: actions/setup-node@v3

--- a/.github/actions/setup_test_environment/action.yml
+++ b/.github/actions/setup_test_environment/action.yml
@@ -22,6 +22,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Create Artifacts Dir
+      run: |
+        mkdir -p ${{ inputs.artifacts-dir }}
+        echo "Created directory ${{ inputs.artifacts-dir }} successfully"
+      shell: bash
 
     - name: Python ${{ matrix.python-version }} - Setup Environment
       uses: ./.github/actions/setup_environment

--- a/.github/actions/test_summary/action.yml
+++ b/.github/actions/test_summary/action.yml
@@ -28,6 +28,13 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Combine Artifacts
+      if: always()
+      run: |
+        # move logs files created and .coverage to artifacts folder
+        mv .coverage ${{ inputs.artifacts-path-dir }}/.coverage | true
+        mv demisto_sdk_debug*.log ${{ inputs.artifacts-path-dir }} | true
+      shell: bash
     - name: Upload artifacts
       if: always()
       uses: ./.github/actions/upload_artifacts

--- a/.github/actions/test_summary/action.yml
+++ b/.github/actions/test_summary/action.yml
@@ -33,7 +33,7 @@ runs:
       run: |
         # move logs files created and .coverage to artifacts folder
         mv .coverage ${{ inputs.artifacts-path-dir }}/.coverage || true
-        mv demisto_sdk_debug*.log ${{ inputs.artifacts-path-dir }} || true
+        mv demisto_sdk_debug*.log ${{ inputs.artifacts-path-dir }}/logs || true
       shell: bash
     - name: Upload artifacts
       if: always()

--- a/.github/actions/test_summary/action.yml
+++ b/.github/actions/test_summary/action.yml
@@ -32,8 +32,8 @@ runs:
       if: always()
       run: |
         # move logs files created and .coverage to artifacts folder
-        mv .coverage ${{ inputs.artifacts-path-dir }}/.coverage | true
-        mv demisto_sdk_debug*.log ${{ inputs.artifacts-path-dir }} | true
+        mv .coverage ${{ inputs.artifacts-path-dir }}/.coverage || true
+        mv demisto_sdk_debug*.log ${{ inputs.artifacts-path-dir }} || true
       shell: bash
     - name: Upload artifacts
       if: always()

--- a/.github/actions/test_summary/action.yml
+++ b/.github/actions/test_summary/action.yml
@@ -3,14 +3,6 @@ description: 'Uploads artifacts, prints out a summary and check if there are any
 author: 'Demisto-SDK'
 
 inputs:
-  python-version:
-    required: true
-    type: string
-    description: "The python version"
-  artifacts-folder-name:
-    required: false
-    type: string
-    description: "The folder name to save artifacts"
   summary-display-options:
     required: false
     type: string
@@ -21,7 +13,16 @@ inputs:
     type: "string"
     description: "The junit-path file to post its summary in github workflow summary"
     default: ""
-
+  artifacts-path-dir:
+    required: false
+    type: string
+    default: $GITHUB_JOB
+    description: "The path to the artifacts dir"
+  artifact-name:
+    required: false
+    type: string
+    default: $GITHUB_JOB
+    description: "The name of of the artifact to upload"
 
 
 runs:
@@ -29,13 +30,10 @@ runs:
   steps:
     - name: Upload artifacts
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: ./.github/actions/upload_artifacts
       with:
-        name: ${{ inputs.artifacts-folder-name }}-artifacts-python-${{ inputs.python-version }}
-        path: |
-          ${{ inputs.artifacts-folder-name }}
-          node_versions_info.json
-          .coverage
+        artifacts-path-dir: ${{ inputs.artifacts-path-dir }}
+        artifact-name: ${{ inputs.artifact-name }}
     - name: Print Summary of pytest results in workflow summary
       if: ${{ inputs.junit-path != '' }}
       uses: pmeier/pytest-results-action@main
@@ -44,13 +42,13 @@ runs:
         summary: true
         display-options: ${{ inputs.summary-display-options }}
         fail-on-empty: false
-    - name: Check if ${{ inputs.artifacts-folder-name }} have passed
+    - name: Check if tests have have passed
       shell: bash
       if: always()
       run: |
         if [[ "$PYTEST_EXIT_CODE" -ne 0 ]]; then
-          echo "There are ${{ inputs.artifacts-folder-name }} that failed, pytest finished with exit code $PYTEST_EXIT_CODE, to see the ${{ inputs.artifacts-folder-name }} summary refer to https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}?pr=${{ github.event.pull_request.number }}"
+          echo "There are tests that failed, pytest finished with exit code $PYTEST_EXIT_CODE, to see the tests summary refer to https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}?pr=${{ github.event.pull_request.number }}"
         else
-          echo "All ${{ inputs.artifacts-folder-name }} have passed, congratulations!"
+          echo "All tests have passed, congratulations!"
         fi
         exit $PYTEST_EXIT_CODE

--- a/.github/actions/upload_artifacts/action.yml
+++ b/.github/actions/upload_artifacts/action.yml
@@ -15,7 +15,6 @@ inputs:
     description: "The name of of the artifact to upload"
 
 
-
 runs:
   using: 'composite'
   steps:

--- a/.github/actions/upload_artifacts/action.yml
+++ b/.github/actions/upload_artifacts/action.yml
@@ -4,9 +4,8 @@ author: 'Demisto-SDK'
 
 inputs:
   artifacts-path-dir:
-    required: false
+    required: true
     type: string
-    default: $GITHUB_JOB
     description: "The path to the artifacts dir"
 
   artifact-name:
@@ -25,6 +24,5 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}
-        # name: ${{ inputs.artifacts-folder-name }}-artifacts-python-${{ inputs.python-version }}
         path: |
           ${{ inputs.artifacts-path-dir }}

--- a/.github/actions/upload_artifacts/action.yml
+++ b/.github/actions/upload_artifacts/action.yml
@@ -1,0 +1,30 @@
+name: 'Upload artifacts to github summary'
+description: 'Uploads artifacts to the github summary of a workflow'
+author: 'Demisto-SDK'
+
+inputs:
+  artifacts-path-dir:
+    required: false
+    type: string
+    default: $GITHUB_JOB
+    description: "The path to the artifacts dir"
+
+  artifact-name:
+    required: false
+    type: string
+    default: $GITHUB_JOB
+    description: "The name of of the artifact to upload"
+
+
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Upload artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+        # name: ${{ inputs.artifacts-folder-name }}-artifacts-python-${{ inputs.python-version }}
+        path: |
+          ${{ inputs.artifacts-path-dir }}

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -89,9 +89,6 @@ jobs:
           poetry run pytest -v . --ignore={demisto_sdk/commands/init/templates,demisto_sdk/tests/integration_tests,demisto_sdk/commands/content_graph,tests_end_to_end} --cov=demisto_sdk --cov-report=html:unit-tests/coverage --junitxml=unit-tests/junit.xml || pytest_exit_code=$?
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
 
-          mv .coverage unit-tests/.coverage | true
-          mv demisto_sdk_debug*.log unit-tests | true
-
           kill $node_pid
           exit $pytest_exit_code
 
@@ -131,9 +128,6 @@ jobs:
           poetry run pytest -v demisto_sdk/tests/integration_tests --cov=demisto_sdk --cov-report=html:integration-tests/coverage --junitxml=integration-tests/junit.xml || pytest_exit_code=$?
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
 
-          mv .coverage integration-tests/.coverage | true
-          mv demisto_sdk_debug*.log integration-tests | true
-
           exit $pytest_exit_code
 
       - name: Python ${{ matrix.python-version }} - Test Summary Upload
@@ -171,9 +165,6 @@ jobs:
 
           poetry run pytest -v demisto_sdk/commands/content_graph --cov=demisto_sdk --cov-report=html:graph-tests/coverage --junitxml=graph-tests/junit.xml || pytest_exit_code=$?
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
-
-          mv .coverage graph-tests/.coverage | true
-          mv demisto_sdk_debug*.log graph-tests | true
 
           exit $pytest_exit_code
 

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -280,8 +280,9 @@ jobs:
       - name: run pre-commit on changed files
         run: |
           source $(poetry env info --path)/bin/activate
-          export DEMISTO_SDK_LOG_FILE_PATH=test-pre-commit-command/demisto_sdk_debug.log
+          mv test-pre-commit-command content
           cd content
+          export DEMISTO_SDK_LOG_FILE_PATH=test-pre-commit-command/demisto_sdk_debug.log
           echo "# test" >> Packs/HelloWorld/Integrations/HelloWorld/HelloWorld.yml
           echo "# test" >> Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR.yml
           echo "# test" >> Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.yml
@@ -295,7 +296,9 @@ jobs:
         continue-on-error: true
         run: |
           source $(poetry env info --path)/bin/activate
+          mv test-pre-commit-command content
           cd content
+          export DEMISTO_SDK_LOG_FILE_PATH=test-pre-commit-command/demisto_sdk_debug.log
           demisto-sdk pre-commit --validate --show-diff-on-failure --verbose -i Packs/HelloWorld -i Packs/QRadar/Integrations/QRadar_v3 --mode=nightly
 
       - name: Upload artifacts
@@ -327,8 +330,9 @@ jobs:
       - name: Run Graph
         run: |
           source $(poetry env info --path)/bin/activate
-          export DEMISTO_SDK_LOG_FILE_PATH=test-graph-commands/demisto_sdk_debug.log
+          mv test-pre-commit-command content
           cd content
+          export DEMISTO_SDK_LOG_FILE_PATH=test-pre-commit-command/demisto_sdk_debug.log
           # create content graph from scratch
           demisto-sdk create-content-graph
           # clean import folder

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Python Environment From Content Repository
+      - name: Setup Python Environment
         uses: ./.github/actions/setup_environment
         with:
           python-version: '3.10'

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -163,7 +163,7 @@ jobs:
 
           poetry run pytest -v demisto_sdk/commands/content_graph --cov=demisto_sdk --cov-report=html:graph-tests/coverage --junitxml=graph-tests/junit.xml || pytest_exit_code=$?
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
-          
+
           exit $pytest_exit_code
 
       - name: Python ${{ matrix.python-version }} - Test Summary Upload
@@ -271,7 +271,7 @@ jobs:
           path: ~/.cache/pre-commit
           key: ${{ runner.os }}-pre-commit
 
-      - name: Create SDK Config File - Ignore Docker and Release-Notes Validations
+      - name: Create SDK Config File - Ignore BA101
         run: |
           # Run only a specific validation to make sure validate is triggered successfully in demisto-sdk pre-commit
           cd content
@@ -296,16 +296,14 @@ jobs:
         continue-on-error: true
         run: |
           source $(poetry env info --path)/bin/activate
-          mv test-pre-commit-command content
           cd content
-          export DEMISTO_SDK_LOG_FILE_PATH=test-pre-commit-command/demisto_sdk_debug.log
           demisto-sdk pre-commit --validate --show-diff-on-failure --verbose -i Packs/HelloWorld -i Packs/QRadar/Integrations/QRadar_v3 --mode=nightly
 
       - name: Upload artifacts
         if: always()
         uses: ./.github/actions/upload_artifacts
         with:
-          artifacts-path-dir: test-pre-commit-command
+          artifacts-path-dir: content/test-pre-commit-command
           artifact-name: test-demisto-sdk-pre-commit-command-artifacts
 
   test-update-graph:
@@ -332,7 +330,7 @@ jobs:
           source $(poetry env info --path)/bin/activate
           mv test-pre-commit-command content
           cd content
-          export DEMISTO_SDK_LOG_FILE_PATH=test-pre-commit-command/demisto_sdk_debug.log
+          export DEMISTO_SDK_LOG_FILE_PATH=test-graph-commands/demisto_sdk_debug.log
           # create content graph from scratch
           demisto-sdk create-content-graph
           # clean import folder
@@ -347,5 +345,5 @@ jobs:
         if: always()
         uses: ./.github/actions/upload_artifacts
         with:
-          artifacts-path-dir: test-graph-commands
+          artifacts-path-dir: content/test-graph-commands
           artifact-name: test-graph-commands-artifacts

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -85,6 +85,8 @@ jobs:
           # For all the tests.
           node demisto_sdk/commands/common/markdown_server/mdx-parse-server.js &
           node_pid=$!
+          
+          export DEMISTO_SDK_LOG_FILE_PATH=./unit-tests/demisto_sdk_debug.log
 
           poetry run pytest -v . --ignore={demisto_sdk/commands/init/templates,demisto_sdk/tests/integration_tests,demisto_sdk/commands/content_graph,tests_end_to_end} --cov=demisto_sdk --cov-report=html:unit-tests/coverage --junitxml=unit-tests/junit.xml || pytest_exit_code=$?
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
@@ -125,7 +127,9 @@ jobs:
       - name: Run Integration Tests
         run: |
           source "$(poetry env info --path)/bin/activate"
-
+          
+          export DEMISTO_SDK_LOG_FILE_PATH=./integration-tests/demisto_sdk_debug.log
+          
           poetry run pytest -v demisto_sdk/tests/integration_tests --cov=demisto_sdk --cov-report=html:integration-tests/coverage --junitxml=integration-tests/junit.xml || pytest_exit_code=$?
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
           
@@ -164,7 +168,9 @@ jobs:
       - name: Run Graph Tests
         run: |
           source "$(poetry env info --path)/bin/activate"
-
+          
+          export DEMISTO_SDK_LOG_FILE_PATH=./graph-tests/demisto_sdk_debug.log
+          
           poetry run pytest -v demisto_sdk/commands/content_graph --cov=demisto_sdk --cov-report=html:graph-tests/coverage --junitxml=graph-tests/junit.xml || pytest_exit_code=$?
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
           
@@ -335,7 +341,7 @@ jobs:
           source $(poetry env info --path)/bin/activate
           cd content
           mkdir test-graph-commands
-          export DEMISTO_SDK_LOG_FILE_PATH=test-graph-commands/demisto_sdk_debug.log
+          export DEMISTO_SDK_LOG_FILE_PATH=./test-graph-commands/demisto_sdk_debug.log
           # create content graph from scratch
           demisto-sdk create-content-graph
           # clean import folder

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -173,7 +173,7 @@ jobs:
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
 
           mv .coverage graph-tests/.coverage | true
-          # mv demisto_sdk_debug*.log graph-tests | true
+          mv demisto_sdk_debug*.log graph-tests | true
 
           exit $pytest_exit_code
 

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -89,7 +89,7 @@ jobs:
           poetry run pytest -v . --ignore={demisto_sdk/commands/init/templates,demisto_sdk/tests/integration_tests,demisto_sdk/commands/content_graph,tests_end_to_end} --cov=demisto_sdk --cov-report=html:unit-tests/coverage --junitxml=unit-tests/junit.xml || pytest_exit_code=$?
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
 
-          mv .coverage unit-tests/coverage | true
+          mv .coverage unit-tests/.coverage | true
           mv demisto_sdk_debug*.log unit-tests | true
 
           kill $node_pid
@@ -130,7 +130,7 @@ jobs:
           poetry run pytest -v demisto_sdk/tests/integration_tests --cov=demisto_sdk --cov-report=html:integration-tests/coverage --junitxml=integration-tests/junit.xml || pytest_exit_code=$?
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
 
-          mv .coverage integration-tests/coverage | true
+          mv .coverage integration-tests/.coverage | true
           mv demisto_sdk_debug*.log integration-tests | true
 
           exit $pytest_exit_code
@@ -170,7 +170,7 @@ jobs:
           poetry run pytest -v demisto_sdk/commands/content_graph --cov=demisto_sdk --cov-report=html:graph-tests/coverage --junitxml=graph-tests/junit.xml || pytest_exit_code=$?
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
 
-          mv .coverage graph-tests/coverage | true
+          mv .coverage graph-tests/.coverage | true
           # mv demisto_sdk_debug*.log graph-tests | true
 
           exit $pytest_exit_code

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -124,7 +124,6 @@ jobs:
         run: |
           source "$(poetry env info --path)/bin/activate"
 
-          mkdir integration-tests
           poetry run pytest -v demisto_sdk/tests/integration_tests --cov=demisto_sdk --cov-report=html:integration-tests/coverage --junitxml=integration-tests/junit.xml || pytest_exit_code=$?
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
 
@@ -162,7 +161,6 @@ jobs:
         run: |
           source "$(poetry env info --path)/bin/activate"
 
-          mkdir graph-tests
           poetry run pytest -v demisto_sdk/commands/content_graph --cov=demisto_sdk --cov-report=html:graph-tests/coverage --junitxml=graph-tests/junit.xml || pytest_exit_code=$?
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
           

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -295,7 +295,7 @@ jobs:
 
   test-update-graph:
     runs-on: ubuntu-latest
-    name: Test Graph
+    name: Test Graph Commands
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Python ${{ matrix.python-version }} - Setup Environment
-        uses: ./.github/actions/setup_poetry_python_environment
+        uses: ./.github/actions/setup_environment
         with:
           python-version: '3.10'
 
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Python Environment From Content Repository
-        uses: ./.github/actions/setup_poetry_python_environment
+        uses: ./.github/actions/setup_environment
         with:
           python-version: '3.10'
 
@@ -75,6 +75,7 @@ jobs:
         uses: ./.github/actions/setup_test_environment
         with:
           python-version: ${{ matrix.python-version }}
+          artifacts-dir: unit-tests
 
       - name: Run Unit Tests
         run: |
@@ -85,7 +86,6 @@ jobs:
           node demisto_sdk/commands/common/markdown_server/mdx-parse-server.js &
           node_pid=$!
 
-          mkdir unit-tests
           poetry run pytest -v . --ignore={demisto_sdk/commands/init/templates,demisto_sdk/tests/integration_tests,demisto_sdk/commands/content_graph,tests_end_to_end} --cov=demisto_sdk --cov-report=html:unit-tests/coverage --junitxml=unit-tests/junit.xml || pytest_exit_code=$?
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
 
@@ -117,6 +117,7 @@ jobs:
         uses: ./.github/actions/setup_test_environment
         with:
           python-version: ${{ matrix.python-version }}
+          artifacts-dir: integration-tests
 
       - name: Run Integration Tests
         run: |
@@ -154,6 +155,7 @@ jobs:
         uses: ./.github/actions/setup_test_environment
         with:
           python-version: ${{ matrix.python-version }}
+          artifacts-dir: graph-tests
 
       - name: Run Graph Tests
         run: |
@@ -216,7 +218,7 @@ jobs:
         run: echo commit=$(git rev-parse HEAD) >> $GITHUB_OUTPUT
 
       - name: Python ${{ matrix.python-version }} - Setup Environment
-        uses: ./.github/actions/setup_poetry_python_environment
+        uses: ./.github/actions/setup_environment
         with:
           python-version: '3.10'
           working-dir: content
@@ -249,9 +251,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Python Environment
-        uses: ./.github/actions/setup_poetry_python_environment
+        uses: ./.github/actions/setup_environment
         with:
           python-version: '3.10'
+          artifacts-dir: test-pre-commit-command
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -276,6 +279,7 @@ jobs:
       - name: run pre-commit on changed files
         run: |
           source $(poetry env info --path)/bin/activate
+          export DEMISTO_SDK_LOG_FILE_PATH=test-pre-commit-command/demisto_sdk_debug.log
           cd content
           echo "# test" >> Packs/HelloWorld/Integrations/HelloWorld/HelloWorld.yml
           echo "# test" >> Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR.yml
@@ -301,9 +305,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Python Environment
-        uses: ./.github/actions/setup_poetry_python_environment
+        uses: ./.github/actions/setup_environment
         with:
           python-version: '3.10'
+          artifacts-dir: test-graph-commands
 
       - name: Checkout content
         uses: actions/checkout@v3
@@ -314,6 +319,7 @@ jobs:
       - name: Run Graph
         run: |
           source $(poetry env info --path)/bin/activate
+          export DEMISTO_SDK_LOG_FILE_PATH=test-graph-commands/demisto_sdk_debug.log
           cd content
           mkdir ./tmp
           # create content graph from scratch

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -97,6 +97,7 @@ jobs:
 
       - name: Python ${{ matrix.python-version }} - Test Summary Upload
         uses: ./.github/actions/test_summary
+        if: always()
         with:
           artifact-name: unit-tests-python-${{ matrix.python-version }}-artifacts
           artifacts-path-dir: unit-tests
@@ -137,6 +138,7 @@ jobs:
 
       - name: Python ${{ matrix.python-version }} - Test Summary Upload
         uses: ./.github/actions/test_summary
+        if: always()
         with:
           artifact-name: integration-tests-python-${{ matrix.python-version }}-artifacts
           artifacts-path-dir: integration-tests
@@ -177,6 +179,7 @@ jobs:
 
       - name: Python ${{ matrix.python-version }} - Test Summary Upload
         uses: ./.github/actions/test_summary
+        if: always()
         with:
           artifact-name: graph-tests-python-${{ matrix.python-version }}-artifacts
           artifacts-path-dir: graph-tests

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -90,12 +90,13 @@ jobs:
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
 
           kill $node_pid
+          exit $pytest_exit_code
 
       - name: Python ${{ matrix.python-version }} - Test Summary Upload
         uses: ./.github/actions/test_summary
         with:
-          python-version: ${{ matrix.python-version }}
-          artifacts-folder-name: unit-tests
+          artifact-name: unit-tests-python-${{ matrix.python-version }}-artifacts
+          artifacts-path-dir: unit-tests
           junit-path: unit-tests/junit.xml
 
   integration-tests:
@@ -132,8 +133,8 @@ jobs:
       - name: Python ${{ matrix.python-version }} - Test Summary Upload
         uses: ./.github/actions/test_summary
         with:
-          python-version: ${{ matrix.python-version }}
-          artifacts-folder-name: integration-tests
+          artifact-name: integration-tests-python-${{ matrix.python-version }}-artifacts
+          artifacts-path-dir: integration-tests
           junit-path: integration-tests/junit.xml
 
   graph-tests:
@@ -164,12 +165,14 @@ jobs:
           mkdir graph-tests
           poetry run pytest -v demisto_sdk/commands/content_graph --cov=demisto_sdk --cov-report=html:graph-tests/coverage --junitxml=graph-tests/junit.xml || pytest_exit_code=$?
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
+          
+          exit $pytest_exit_code
 
       - name: Python ${{ matrix.python-version }} - Test Summary Upload
         uses: ./.github/actions/test_summary
         with:
-          python-version: ${{ matrix.python-version }}
-          artifacts-folder-name: graph-tests
+          artifact-name: graph-tests-python-${{ matrix.python-version }}-artifacts
+          artifacts-path-dir: graph-tests
           junit-path: graph-tests/junit.xml
 
   coverage:
@@ -181,7 +184,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-      - name: Download all artifacts
+      - name: Download all artifacts  # TODO - download only the relevant artifacts
         uses: actions/download-artifact@v4
       - name: Run coverage
         run: |
@@ -297,6 +300,13 @@ jobs:
           cd content
           demisto-sdk pre-commit --validate --show-diff-on-failure --verbose -i Packs/HelloWorld -i Packs/QRadar/Integrations/QRadar_v3 --mode=nightly
 
+      - name: Upload artifacts
+        if: always()
+        uses: ./.github/actions/upload_artifacts
+        with:
+          artifacts-path-dir: test-pre-commit-command
+          artifact-name: test-demisto-sdk-pre-commit-command-artifacts
+
   test-update-graph:
     runs-on: ubuntu-latest
     name: Test Graph Commands
@@ -321,13 +331,19 @@ jobs:
           source $(poetry env info --path)/bin/activate
           export DEMISTO_SDK_LOG_FILE_PATH=test-graph-commands/demisto_sdk_debug.log
           cd content
-          mkdir ./tmp
           # create content graph from scratch
           demisto-sdk create-content-graph
           # clean import folder
           sudo rm -rf /var/lib/neo4j/import
           # Update content graph from the bucket
-          demisto-sdk update-content-graph -g -o ./tmp/content_graph
+          demisto-sdk update-content-graph -g -o ./test-graph-commands/content_graph
 
           # Update content graph from the the previous content graph that was created/built
-          demisto-sdk update-content-graph -i ./tmp/content_graph/xsoar.zip -o ./tmp/content_graph
+          demisto-sdk update-content-graph -i ./test-graph-commands/content_graph/xsoar.zip -o ./test-graph-commands/content_graph
+
+      - name: Upload artifacts
+        if: always()
+        uses: ./.github/actions/upload_artifacts
+        with:
+          artifacts-path-dir: test-graph-commands
+          artifact-name: test-graph-commands-artifacts

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -86,12 +86,11 @@ jobs:
           node demisto_sdk/commands/common/markdown_server/mdx-parse-server.js &
           node_pid=$!
           
-          export DEMISTO_SDK_LOG_FILE_PATH=./unit-tests/demisto_sdk_debug.log
-
           poetry run pytest -v . --ignore={demisto_sdk/commands/init/templates,demisto_sdk/tests/integration_tests,demisto_sdk/commands/content_graph,tests_end_to_end} --cov=demisto_sdk --cov-report=html:unit-tests/coverage --junitxml=unit-tests/junit.xml || pytest_exit_code=$?
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
           
           mv .coverage unit-tests/coverage
+          mv demisto_sdk_debug*.log unit-tests
           
           kill $node_pid
           exit $pytest_exit_code
@@ -127,13 +126,12 @@ jobs:
       - name: Run Integration Tests
         run: |
           source "$(poetry env info --path)/bin/activate"
-          
-          export DEMISTO_SDK_LOG_FILE_PATH=./integration-tests/demisto_sdk_debug.log
-          
+                    
           poetry run pytest -v demisto_sdk/tests/integration_tests --cov=demisto_sdk --cov-report=html:integration-tests/coverage --junitxml=integration-tests/junit.xml || pytest_exit_code=$?
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
           
           mv .coverage integration-tests/coverage
+          mv demisto_sdk_debug*.log integration-tests
 
           exit $pytest_exit_code
 
@@ -168,13 +166,12 @@ jobs:
       - name: Run Graph Tests
         run: |
           source "$(poetry env info --path)/bin/activate"
-          
-          export DEMISTO_SDK_LOG_FILE_PATH=./graph-tests/demisto_sdk_debug.log
-          
+                    
           poetry run pytest -v demisto_sdk/commands/content_graph --cov=demisto_sdk --cov-report=html:graph-tests/coverage --junitxml=graph-tests/junit.xml || pytest_exit_code=$?
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
           
           mv .coverage graph-tests/coverage
+          mv demisto_sdk_debug*.log graph-tests
           
           exit $pytest_exit_code
 

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -119,7 +119,7 @@ jobs:
         uses: ./.github/actions/setup_test_environment
         with:
           python-version: ${{ matrix.python-version }}
-          artifacts-dir: integration-tests
+          artifacts-dir: integration-tests/logs
 
       - name: Run Integration Tests
         run: |
@@ -135,7 +135,7 @@ jobs:
         if: always()
         with:
           artifact-name: integration-tests-python-${{ matrix.python-version }}-artifacts
-          artifacts-path-dir: integration-tests/logs
+          artifacts-path-dir: integration-tests
           junit-path: integration-tests/junit.xml
 
   graph-tests:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -322,6 +322,6 @@ jobs:
           sudo rm -rf /var/lib/neo4j/import
           # Update content graph from the bucket
           demisto-sdk update-content-graph -g -o ./tmp/content_graph
-          
+
           # Update content graph from the the previous content graph that was created/built
           demisto-sdk update-content-graph -i ./tmp/content_graph/xsoar.zip -o ./tmp/content_graph

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -292,3 +292,36 @@ jobs:
       - name: Run Pytest collection
         run: |
           poetry run pytest --collect-only .
+
+  test-update-graph:
+    runs-on: ubuntu-latest
+    name: Test Graph
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Python Environment
+        uses: ./.github/actions/setup_poetry_python_environment
+        with:
+          python-version: '3.10'
+
+      - name: Checkout content
+        uses: actions/checkout@v3
+        with:
+          repository: demisto/content
+          path: content
+
+      - name: Run Graph
+        run: |
+          source $(poetry env info --path)/bin/activate
+          cd content
+          mkdir ./tmp
+          # create content graph from scratch
+          demisto-sdk create-content-graph
+          # clean import folder
+          sudo rm -rf /var/lib/neo4j/import
+          # Update content graph from the bucket
+          demisto-sdk update-content-graph -g -o ./tmp/content_graph
+          
+          # Update content graph from the the previous content graph that was created/built
+          demisto-sdk update-content-graph -i ./tmp/content_graph/xsoar.zip -o ./tmp/content_graph

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -85,13 +85,13 @@ jobs:
           # For all the tests.
           node demisto_sdk/commands/common/markdown_server/mdx-parse-server.js &
           node_pid=$!
-          
+
           poetry run pytest -v . --ignore={demisto_sdk/commands/init/templates,demisto_sdk/tests/integration_tests,demisto_sdk/commands/content_graph,tests_end_to_end} --cov=demisto_sdk --cov-report=html:unit-tests/coverage --junitxml=unit-tests/junit.xml || pytest_exit_code=$?
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
-          
-          mv .coverage unit-tests/coverage
-          mv demisto_sdk_debug*.log unit-tests
-          
+
+          mv .coverage unit-tests/coverage 2>/dev/null
+          mv demisto_sdk_debug*.log unit-tests 2>/dev/null
+
           kill $node_pid
           exit $pytest_exit_code
 
@@ -126,12 +126,12 @@ jobs:
       - name: Run Integration Tests
         run: |
           source "$(poetry env info --path)/bin/activate"
-                    
+
           poetry run pytest -v demisto_sdk/tests/integration_tests --cov=demisto_sdk --cov-report=html:integration-tests/coverage --junitxml=integration-tests/junit.xml || pytest_exit_code=$?
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
-          
-          mv .coverage integration-tests/coverage
-          mv demisto_sdk_debug*.log integration-tests
+
+          mv .coverage integration-tests/coverage 2>/dev/null
+          mv demisto_sdk_debug*.log integration-tests 2>/dev/null
 
           exit $pytest_exit_code
 
@@ -166,13 +166,13 @@ jobs:
       - name: Run Graph Tests
         run: |
           source "$(poetry env info --path)/bin/activate"
-                    
+
           poetry run pytest -v demisto_sdk/commands/content_graph --cov=demisto_sdk --cov-report=html:graph-tests/coverage --junitxml=graph-tests/junit.xml || pytest_exit_code=$?
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
-          
-          mv .coverage graph-tests/coverage
-          mv demisto_sdk_debug*.log graph-tests
-          
+
+          mv .coverage graph-tests/coverage 2>/dev/null
+          mv demisto_sdk_debug*.log graph-tests 2>/dev/null
+
           exit $pytest_exit_code
 
       - name: Python ${{ matrix.python-version }} - Test Summary Upload

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -89,8 +89,8 @@ jobs:
           poetry run pytest -v . --ignore={demisto_sdk/commands/init/templates,demisto_sdk/tests/integration_tests,demisto_sdk/commands/content_graph,tests_end_to_end} --cov=demisto_sdk --cov-report=html:unit-tests/coverage --junitxml=unit-tests/junit.xml || pytest_exit_code=$?
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
 
-          mv .coverage unit-tests/coverage 2>/dev/null
-          mv demisto_sdk_debug*.log unit-tests 2>/dev/null
+          mv .coverage unit-tests/coverage | true
+          mv demisto_sdk_debug*.log unit-tests | true
 
           kill $node_pid
           exit $pytest_exit_code
@@ -130,8 +130,8 @@ jobs:
           poetry run pytest -v demisto_sdk/tests/integration_tests --cov=demisto_sdk --cov-report=html:integration-tests/coverage --junitxml=integration-tests/junit.xml || pytest_exit_code=$?
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
 
-          mv .coverage integration-tests/coverage 2>/dev/null
-          mv demisto_sdk_debug*.log integration-tests 2>/dev/null
+          mv .coverage integration-tests/coverage | true
+          mv demisto_sdk_debug*.log integration-tests | true
 
           exit $pytest_exit_code
 
@@ -170,8 +170,8 @@ jobs:
           poetry run pytest -v demisto_sdk/commands/content_graph --cov=demisto_sdk --cov-report=html:graph-tests/coverage --junitxml=graph-tests/junit.xml || pytest_exit_code=$?
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
 
-          mv .coverage graph-tests/coverage 2>/dev/null
-          mv demisto_sdk_debug*.log graph-tests 2>/dev/null
+          mv .coverage graph-tests/coverage | true
+          # mv demisto_sdk_debug*.log graph-tests | true
 
           exit $pytest_exit_code
 

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -75,7 +75,7 @@ jobs:
         uses: ./.github/actions/setup_test_environment
         with:
           python-version: ${{ matrix.python-version }}
-          artifacts-dir: unit-tests
+          artifacts-dir: unit-tests/logs
 
       - name: Run Unit Tests
         run: |
@@ -135,7 +135,7 @@ jobs:
         if: always()
         with:
           artifact-name: integration-tests-python-${{ matrix.python-version }}-artifacts
-          artifacts-path-dir: integration-tests
+          artifacts-path-dir: integration-tests/logs
           junit-path: integration-tests/junit.xml
 
   graph-tests:
@@ -157,7 +157,7 @@ jobs:
         uses: ./.github/actions/setup_test_environment
         with:
           python-version: ${{ matrix.python-version }}
-          artifacts-dir: graph-tests
+          artifacts-dir: graph-tests/logs
 
       - name: Run Graph Tests
         run: |
@@ -283,8 +283,8 @@ jobs:
         run: |
           source $(poetry env info --path)/bin/activate
           cd content
-          mkdir test-pre-commit-command
-          export DEMISTO_SDK_LOG_FILE_PATH=./test-pre-commit-command/demisto_sdk_debug.log
+          mkdir -p test-pre-commit-command/logs
+          export DEMISTO_SDK_LOG_FILE_PATH=./test-pre-commit-command/logs/demisto_sdk_debug.log
           echo "# test" >> Packs/HelloWorld/Integrations/HelloWorld/HelloWorld.yml
           echo "# test" >> Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR.yml
           echo "# test" >> Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.yml
@@ -331,8 +331,8 @@ jobs:
         run: |
           source $(poetry env info --path)/bin/activate
           cd content
-          mkdir test-graph-commands
-          export DEMISTO_SDK_LOG_FILE_PATH=./test-graph-commands/demisto_sdk_debug.log
+          mkdir -p test-graph-commands/logs
+          export DEMISTO_SDK_LOG_FILE_PATH=./test-graph-commands/logs/demisto_sdk_debug.log
           # create content graph from scratch
           demisto-sdk create-content-graph
           # clean import folder

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -88,7 +88,9 @@ jobs:
 
           poetry run pytest -v . --ignore={demisto_sdk/commands/init/templates,demisto_sdk/tests/integration_tests,demisto_sdk/commands/content_graph,tests_end_to_end} --cov=demisto_sdk --cov-report=html:unit-tests/coverage --junitxml=unit-tests/junit.xml || pytest_exit_code=$?
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
-
+          
+          mv .coverage unit-tests/coverage
+          
           kill $node_pid
           exit $pytest_exit_code
 
@@ -126,6 +128,8 @@ jobs:
 
           poetry run pytest -v demisto_sdk/tests/integration_tests --cov=demisto_sdk --cov-report=html:integration-tests/coverage --junitxml=integration-tests/junit.xml || pytest_exit_code=$?
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
+          
+          mv .coverage integration-tests/coverage
 
           exit $pytest_exit_code
 
@@ -163,7 +167,9 @@ jobs:
 
           poetry run pytest -v demisto_sdk/commands/content_graph --cov=demisto_sdk --cov-report=html:graph-tests/coverage --junitxml=graph-tests/junit.xml || pytest_exit_code=$?
           echo "PYTEST_EXIT_CODE=$pytest_exit_code" >> $GITHUB_ENV
-
+          
+          mv .coverage graph-tests/coverage
+          
           exit $pytest_exit_code
 
       - name: Python ${{ matrix.python-version }} - Test Summary Upload
@@ -244,7 +250,7 @@ jobs:
           poetry run pytest ./Tests/private_build/tests -v
           poetry run pytest Utils -v
 
-  test-demisto-sdk-pre-commit-command:
+  test-pre-commit-command:
     runs-on: ubuntu-latest
     name: Test Demisto-SDK Pre-Commit Command
     steps:
@@ -255,7 +261,6 @@ jobs:
         uses: ./.github/actions/setup_environment
         with:
           python-version: '3.10'
-          artifacts-dir: test-pre-commit-command
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -280,9 +285,9 @@ jobs:
       - name: run pre-commit on changed files
         run: |
           source $(poetry env info --path)/bin/activate
-          mv test-pre-commit-command content
           cd content
-          export DEMISTO_SDK_LOG_FILE_PATH=test-pre-commit-command/demisto_sdk_debug.log
+          mkdir test-pre-commit-command
+          export DEMISTO_SDK_LOG_FILE_PATH=./test-pre-commit-command/demisto_sdk_debug.log
           echo "# test" >> Packs/HelloWorld/Integrations/HelloWorld/HelloWorld.yml
           echo "# test" >> Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR.yml
           echo "# test" >> Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.yml
@@ -306,7 +311,7 @@ jobs:
           artifacts-path-dir: content/test-pre-commit-command
           artifact-name: test-demisto-sdk-pre-commit-command-artifacts
 
-  test-update-graph:
+  test-graph-commands:
     runs-on: ubuntu-latest
     name: Test Graph Commands
     steps:
@@ -328,8 +333,8 @@ jobs:
       - name: Run Graph
         run: |
           source $(poetry env info --path)/bin/activate
-          mv test-graph-commands content
           cd content
+          mkdir test-graph-commands
           export DEMISTO_SDK_LOG_FILE_PATH=test-graph-commands/demisto_sdk_debug.log
           # create content graph from scratch
           demisto-sdk create-content-graph

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -35,6 +35,27 @@ jobs:
           echo "Validating changelog for PR: $PR_NUMBER with Name: $PR_TITLE"
           poetry run python ./Utils/github_workflow_scripts/changelog_validation_scripts/validate_changelog.py -n "$PR_NUMBER" -t "$PR_TITLE"
 
+  pre-commit-checks:
+    runs-on: ubuntu-latest
+    name: Pre Commit Checks
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Python Environment From Content Repository
+        uses: ./.github/actions/setup_poetry_python_environment
+        with:
+          python-version: '3.10'
+
+      - name: Run Pre Commit
+        uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --all-files
+
+      - name: Run Pytest collection
+        run: |
+          poetry run pytest --collect-only .
+
   unit-tests:
     name: Unit Tests / Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
@@ -271,27 +292,6 @@ jobs:
           source $(poetry env info --path)/bin/activate
           cd content
           demisto-sdk pre-commit --validate --show-diff-on-failure --verbose -i Packs/HelloWorld -i Packs/QRadar/Integrations/QRadar_v3 --mode=nightly
-
-  pre-commit-checks:
-    runs-on: ubuntu-latest
-    name: Pre Commit Checks
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup Python Environment From Content Repository
-        uses: ./.github/actions/setup_poetry_python_environment
-        with:
-          python-version: '3.10'
-
-      - name: Run Pre Commit
-        uses: pre-commit/action@v3.0.0
-        with:
-          extra_args: --all-files
-
-      - name: Run Pytest collection
-        run: |
-          poetry run pytest --collect-only .
 
   test-update-graph:
     runs-on: ubuntu-latest

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -328,7 +328,7 @@ jobs:
       - name: Run Graph
         run: |
           source $(poetry env info --path)/bin/activate
-          mv test-pre-commit-command content
+          mv test-graph-commands content
           cd content
           export DEMISTO_SDK_LOG_FILE_PATH=test-graph-commands/demisto_sdk_debug.log
           # create content graph from scratch

--- a/demisto_sdk/commands/common/docker/tests/docker_image_test.py
+++ b/demisto_sdk/commands/common/docker/tests/docker_image_test.py
@@ -67,6 +67,5 @@ def test_docker_image_parse_invalid_docker_images(docker_image: str):
     Then:
     - make sure ValueError is raised
     """
-    assert False
     with pytest.raises(ValueError):
         DockerImage.parse(docker_image, raise_if_not_valid=True)

--- a/demisto_sdk/commands/common/docker/tests/docker_image_test.py
+++ b/demisto_sdk/commands/common/docker/tests/docker_image_test.py
@@ -67,5 +67,6 @@ def test_docker_image_parse_invalid_docker_images(docker_image: str):
     Then:
     - make sure ValueError is raised
     """
+    assert False
     with pytest.raises(ValueError):
         DockerImage.parse(docker_image, raise_if_not_valid=True)


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-9220
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-9466

## Description
* Move the `test-update-graph` to Github Actions
* Fail the step when unit-tests are running to make it red.
* Each job will upload its artifacts within a single directory
* jobs that tests commands will have logs inside the artifact folders too. (also unit/graph/integration jobs)
* Fixed an issue where the step of running the tests didn't fail when pytest failed.
