### PR TITLE
Fix upload to handle approaching value in explicit way- e.g ${}

### DIFF
--- a/.changelog/3970.yml
+++ b/.changelog/3970.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue in **upload**  where customFields with explicitly defined values (e.g., ${}) were failing.
+  type: fix
+pr_number: 3970

--- a/demisto_sdk/commands/common/tests/update_id_set_test.py
+++ b/demisto_sdk/commands/common/tests/update_id_set_test.py
@@ -2880,16 +2880,16 @@ class TestGenericFunctions:
         },
     }
     @staticmethod
-    def test_get_fields_by_script_argument__explicit_method(task = custom_fields_with_explicit_method):
+    def test_get_fields_by_script_argument__explicit_method(custom_fields_with_explicit_method):
         """
         Given
             - A playbook task with custom fields that retrieves its values in an explicit way (using the ${} method instead of "get" method)
         When
-            -  'get_fields_by_script_argument' is called
+            -  Searching for dependent incident fields in the task script arguments
         Then
-            -  The function should return an empty set with no errors
+            -  The function should return an empty set with no errors, since a the custom field - ${} sould be ignored
         """
-        result = get_fields_by_script_argument(task)
+        result = get_fields_by_script_argument(custom_fields_with_explicit_method)
         assert result ==set()
         
 
@@ -2900,16 +2900,16 @@ class TestGenericFunctions:
         },
     }
     @staticmethod
-    def test_get_fields_by_script_argument__json(task = custom_fields_as_a_json):
+    def test_get_fields_by_script_argument__json(custom_fields_as_a_json):
         """
         Given
             - A playbook task with custom fields value is a json
         When
-            -  'get_fields_by_script_argument' is called
+            -  Searching for dependent incident fields in the task script arguments
         Then
-            -  The function should return a set with the json keys that are not in BUILT_IN_FIELDS
+            -  The function should return all dependent incident custom fields in the task
         """
-        result = get_fields_by_script_argument(task)
+        result = get_fields_by_script_argument(custom_fields_as_a_json)
         assert result =={'root', 'test_key'}
 
 

--- a/demisto_sdk/commands/common/tests/update_id_set_test.py
+++ b/demisto_sdk/commands/common/tests/update_id_set_test.py
@@ -2871,6 +2871,26 @@ class TestGenericFunctions:
 
         result = get_fields_by_script_argument(task)
         assert "field_name" in result
+    
+    
+    custom_fields_with_explicit_method ={
+        "id": "ID",
+        "scriptarguments": {
+            "customFields": {'simple': '${keys}'}
+        },
+    }
+    @staticmethod
+    def test(task = custom_fields_with_explicit_method):
+        """
+        Given
+            - A playbook task with custom fields that retrieves its values in an explicit way (using the ${} method instead of "get" method)
+        When
+            -  'get_fields_by_script_argument' is called
+        Then
+            -  The function should return an empty set with no errors
+        """
+        result = get_fields_by_script_argument(task)
+        assert result ==set()
 
 
 class TestFlow(unittest.TestCase):

--- a/demisto_sdk/commands/common/tests/update_id_set_test.py
+++ b/demisto_sdk/commands/common/tests/update_id_set_test.py
@@ -2873,14 +2873,8 @@ class TestGenericFunctions:
         assert "field_name" in result
     
     
-    custom_fields_with_explicit_method ={
-        "id": "ID",
-        "scriptarguments": {
-            "customFields": {'simple': '${keys}'}
-        },
-    }
     @staticmethod
-    def test_get_fields_by_script_argument__explicit_method(custom_fields_with_explicit_method):
+    def test_get_fields_by_script_argument__explicit_method():
         """
         Given
             - A playbook task with custom fields that retrieves its values in an explicit way (using the ${} method instead of "get" method)
@@ -2889,18 +2883,18 @@ class TestGenericFunctions:
         Then
             -  The function should return an empty set with no errors, since a the custom field - ${} sould be ignored
         """
-        result = get_fields_by_script_argument(custom_fields_with_explicit_method)
+        task ={
+        "id": "ID",
+        "scriptarguments": {
+            "customFields": {'simple': '${keys}'}
+        }}
+        result = get_fields_by_script_argument(task)
         assert result ==set()
         
 
-    custom_fields_as_a_json ={
-        "id": "ID",
-        "scriptarguments": {
-            "customFields": {'complex': {'root': 'keys', 'test_key': 'tets_value','id': 'ID'}}
-        },
-    }
+
     @staticmethod
-    def test_get_fields_by_script_argument__json(custom_fields_as_a_json):
+    def test_get_fields_by_script_argument__json():
         """
         Given
             - A playbook task with custom fields value is a json
@@ -2909,7 +2903,12 @@ class TestGenericFunctions:
         Then
             -  The function should return all dependent incident custom fields in the task
         """
-        result = get_fields_by_script_argument(custom_fields_as_a_json)
+        task ={
+        "id": "ID",
+        "scriptarguments": {
+            "customFields": {'complex': {'root': 'keys', 'test_key': 'tets_value','id': 'ID'}}
+        }}
+        result = get_fields_by_script_argument(task)
         assert result =={'root', 'test_key'}
 
 

--- a/demisto_sdk/commands/common/tests/update_id_set_test.py
+++ b/demisto_sdk/commands/common/tests/update_id_set_test.py
@@ -2871,8 +2871,7 @@ class TestGenericFunctions:
 
         result = get_fields_by_script_argument(task)
         assert "field_name" in result
-    
-    
+
     @staticmethod
     def test_get_fields_by_script_argument__explicit_method():
         """
@@ -2883,15 +2882,9 @@ class TestGenericFunctions:
         Then
             -  The function should return an empty set with no errors, since a the custom field - ${} sould be ignored
         """
-        task ={
-        "id": "ID",
-        "scriptarguments": {
-            "customFields": {'simple': '${keys}'}
-        }}
+        task = {"id": "ID", "scriptarguments": {"customFields": {"simple": "${keys}"}}}
         result = get_fields_by_script_argument(task)
-        assert result ==set()
-        
-
+        assert result == set()
 
     @staticmethod
     def test_get_fields_by_script_argument__json():
@@ -2903,13 +2896,16 @@ class TestGenericFunctions:
         Then
             -  The function should return all dependent incident custom fields in the task
         """
-        task ={
-        "id": "ID",
-        "scriptarguments": {
-            "customFields": {'complex': {'root': 'keys', 'test_key': 'tets_value','id': 'ID'}}
-        }}
+        task = {
+            "id": "ID",
+            "scriptarguments": {
+                "customFields": {
+                    "complex": {"root": "keys", "test_key": "tets_value", "id": "ID"}
+                }
+            },
+        }
         result = get_fields_by_script_argument(task)
-        assert result =={'root', 'test_key'}
+        assert result == {"root", "test_key"}
 
 
 class TestFlow(unittest.TestCase):

--- a/demisto_sdk/commands/common/tests/update_id_set_test.py
+++ b/demisto_sdk/commands/common/tests/update_id_set_test.py
@@ -2880,7 +2880,7 @@ class TestGenericFunctions:
         },
     }
     @staticmethod
-    def test(task = custom_fields_with_explicit_method):
+    def test_get_fields_by_script_argument__explicit_method(task = custom_fields_with_explicit_method):
         """
         Given
             - A playbook task with custom fields that retrieves its values in an explicit way (using the ${} method instead of "get" method)
@@ -2891,6 +2891,26 @@ class TestGenericFunctions:
         """
         result = get_fields_by_script_argument(task)
         assert result ==set()
+        
+
+    custom_fields_as_a_json ={
+        "id": "ID",
+        "scriptarguments": {
+            "customFields": {'complex': {'root': 'keys', 'test_key': 'tets_value','id': 'ID'}}
+        },
+    }
+    @staticmethod
+    def test_get_fields_by_script_argument__json(task = custom_fields_as_a_json):
+        """
+        Given
+            - A playbook task with custom fields value is a json
+        When
+            -  'get_fields_by_script_argument' is called
+        Then
+            -  The function should return a set with the json keys that are not in BUILT_IN_FIELDS
+        """
+        result = get_fields_by_script_argument(task)
+        assert result =={'root', 'test_key'}
 
 
 class TestFlow(unittest.TestCase):

--- a/demisto_sdk/commands/common/update_id_set.py
+++ b/demisto_sdk/commands/common/update_id_set.py
@@ -680,7 +680,7 @@ def get_fields_by_script_argument(task):
                 custom_field_value = list(field_value.values())[0]
                 if isinstance(custom_field_value, str):
                     if custom_field_value.startswith("$"):
-                        logger.info("You're using an unrecommended method - ${} - to retrieve values from the context data.")
+                        logger.warning("You're using an unrecommended method - ${} - to retrieve values from the context data.")
                         continue
                     else:
                         custom_fields_list = json.loads(custom_field_value)

--- a/demisto_sdk/commands/common/update_id_set.py
+++ b/demisto_sdk/commands/common/update_id_set.py
@@ -678,16 +678,17 @@ def get_fields_by_script_argument(task):
             else:
                 # the value should be a list of dicts in str format
                 custom_field_value = list(field_value.values())[0]
-                if "$" in custom_field_value and "{" in custom_field_value:
-                    logger.info("You're using an unrecommended method - ${} - to retrieve values from the context data.")
-                elif isinstance(custom_field_value, str):
-                    custom_fields_list = json.loads(custom_field_value)
-                    if not isinstance(custom_fields_list, list):
-                        custom_fields_list = [custom_fields_list]
-                    for custom_field in custom_fields_list:
-                        for field_name in custom_field.keys():
-                            if field_name not in BUILT_IN_FIELDS:
-                                dependent_incident_fields.add(field_name)
+                if isinstance(custom_field_value, str):
+                    if custom_field_value.startswith("$"):
+                        logger.info("You're using an unrecommended method - ${} - to retrieve values from the context data.")
+                    else:
+                        custom_fields_list = json.loads(custom_field_value)
+                        if not isinstance(custom_fields_list, list):
+                            custom_fields_list = [custom_fields_list]
+                        for custom_field in custom_fields_list:
+                            for field_name in custom_field.keys():
+                                if field_name not in BUILT_IN_FIELDS:
+                                    dependent_incident_fields.add(field_name)
     return dependent_incident_fields
 
 

--- a/demisto_sdk/commands/common/update_id_set.py
+++ b/demisto_sdk/commands/common/update_id_set.py
@@ -680,7 +680,9 @@ def get_fields_by_script_argument(task):
                 custom_field_value = list(field_value.values())[0]
                 if isinstance(custom_field_value, str):
                     if custom_field_value.startswith("$"):
-                        logger.warning("You're using an unrecommended method - ${} - to retrieve values from the context data.")
+                        logger.warning(
+                            "You're using an unrecommended method - ${} - to retrieve values from the context data."
+                        )
                         continue
                     else:
                         custom_fields_list = json.loads(custom_field_value)

--- a/demisto_sdk/commands/common/update_id_set.py
+++ b/demisto_sdk/commands/common/update_id_set.py
@@ -678,7 +678,9 @@ def get_fields_by_script_argument(task):
             else:
                 # the value should be a list of dicts in str format
                 custom_field_value = list(field_value.values())[0]
-                if isinstance(custom_field_value, str):
+                if "$" in custom_field_value and "{" in custom_field_value:
+                    logger.info("You're using an unrecommended method - ${} - to retrieve values from the context data.")
+                elif isinstance(custom_field_value, str):
                     custom_fields_list = json.loads(custom_field_value)
                     if not isinstance(custom_fields_list, list):
                         custom_fields_list = [custom_fields_list]

--- a/demisto_sdk/commands/common/update_id_set.py
+++ b/demisto_sdk/commands/common/update_id_set.py
@@ -681,6 +681,7 @@ def get_fields_by_script_argument(task):
                 if isinstance(custom_field_value, str):
                     if custom_field_value.startswith("$"):
                         logger.info("You're using an unrecommended method - ${} - to retrieve values from the context data.")
+                        continue
                     else:
                         custom_fields_list = json.loads(custom_field_value)
                 else:

--- a/demisto_sdk/commands/common/update_id_set.py
+++ b/demisto_sdk/commands/common/update_id_set.py
@@ -683,12 +683,14 @@ def get_fields_by_script_argument(task):
                         logger.info("You're using an unrecommended method - ${} - to retrieve values from the context data.")
                     else:
                         custom_fields_list = json.loads(custom_field_value)
-                        if not isinstance(custom_fields_list, list):
-                            custom_fields_list = [custom_fields_list]
-                        for custom_field in custom_fields_list:
-                            for field_name in custom_field.keys():
-                                if field_name not in BUILT_IN_FIELDS:
-                                    dependent_incident_fields.add(field_name)
+                else:
+                    custom_fields_list = custom_field_value
+                if not isinstance(custom_fields_list, list):
+                    custom_fields_list = [custom_fields_list]
+                for custom_field in custom_fields_list:
+                    for field_name in custom_field.keys():
+                        if field_name not in BUILT_IN_FIELDS:
+                            dependent_incident_fields.add(field_name)
     return dependent_incident_fields
 
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-31260

## Description

- When a user uses the upload command to upload a playbook that contains a task with a field name "CustomFields", if the value of that field has been retrieved from the context data using the explicit method - **${}**, the command will fail and raise an error. In this PR that will be fixed.
- Found a bug in the _get_fields_by_script_argument function regarding handling JSON input and fixed it.