### PR TITLE
fix validate failing on list data.json

### DIFF
--- a/.changelog/3971.yml
+++ b/.changelog/3971.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where validate command failed with Lists folder containing a data json file.
+  type: fix
+pr_number: 3971

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Fixed false positives in **validate** in `GR103` validations [#3873](https://github.com/demisto/demisto-sdk/pull/3873)
 * Add command `sdk-changelog` for creating a yml file to describe the development changes in the SDK [#3177](https://github.com/demisto/demisto-sdk/pull/3177)
 * Locking the `CHANGELOG.md` file for changes when the PR is not a release process [#3177](https://github.com/demisto/demisto-sdk/pull/3177)
+* Fixed an issue where **validate** command failed with Lists folder containing a data json file.
 
 ## 1.25.2
 * Fixed an issue in the **prepare-content** and the **upload** commands where the unified YAML/JSON file was parsed instead of the original file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 * Fixed false positives in **validate** in `GR103` validations [#3873](https://github.com/demisto/demisto-sdk/pull/3873)
 * Add command `sdk-changelog` for creating a yml file to describe the development changes in the SDK [#3177](https://github.com/demisto/demisto-sdk/pull/3177)
 * Locking the `CHANGELOG.md` file for changes when the PR is not a release process [#3177](https://github.com/demisto/demisto-sdk/pull/3177)
-* Fixed an issue where **validate** command failed with Lists folder containing a data json file.
 
 ## 1.25.2
 * Fixed an issue in the **prepare-content** and the **upload** commands where the unified YAML/JSON file was parsed instead of the original file.

--- a/demisto_sdk/commands/validate/old_validate_manager.py
+++ b/demisto_sdk/commands/validate/old_validate_manager.py
@@ -20,6 +20,7 @@ from demisto_sdk.commands.common.constants import (
     GENERIC_FIELDS_DIR,
     GENERIC_TYPES_DIR,
     IGNORED_PACK_NAMES,
+    LISTS_DIR,
     OLDEST_SUPPORTED_VERSION,
     PACKS_DIR,
     PACKS_PACK_META_FILE_NAME,
@@ -740,8 +741,13 @@ class OldValidateManager:
         path = Path(file_path)
         if get_log_file() == path:
             return True
-        return path.name in SKIPPED_FILES or (
-            path.name == "CommonServerPython.py" and path.parent.parent.name != "Base"
+        return (
+            path.name in SKIPPED_FILES
+            or (
+                path.name == "CommonServerPython.py"
+                and path.parent.parent.name != "Base"
+            )
+            or (path.parent.name == LISTS_DIR and path.name.endswith("_data.json"))
         )
 
     # flake8: noqa: C901

--- a/demisto_sdk/scripts/changelog/changelog.py
+++ b/demisto_sdk/scripts/changelog/changelog.py
@@ -237,13 +237,13 @@ def _validate_branch(pr_number: str) -> None:
     if is_changelog_modified():
         raise ValueError(
             "Do not modify changelog.md\n"
-            "Run `demisto-sdk changelog --init -n <pr number>`"
+            "Run `sdk-changelog  --init -n <pr number>`"
             " to create a changelog file instead."
         )
     if not is_log_yml_exist(pr_number):
         raise ValueError(
             "Missing changelog file.\n"
-            "Run `demisto-sdk changelog --init -n <pr number>` and fill it."
+            "Run `sdk-changelog  --init -n <pr number>` and fill it."
         )
     validate_log_yml(pr_number)
 


### PR DESCRIPTION

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-32391

## Description
Fixed a bug in validate command, where it failed with the data json list in Lists folder
fixed a bug with validating pack lists