### PR TITLE
Fixed wrong handling for event collector

### DIFF
--- a/.changelog/3995.yml
+++ b/.changelog/3995.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed the init command to successfully create event collector integration
+  type: fix
+pr_number: 3995

--- a/demisto_sdk/commands/init/initiator.py
+++ b/demisto_sdk/commands/init/initiator.py
@@ -202,7 +202,11 @@ class Initiator:
     DEFAULT_TEMPLATE_PACK_NAME = "StarterPack"
     HELLO_WORLD_PACK_NAME = "HelloWorld"
     DEFAULT_TEMPLATES = [DEFAULT_INTEGRATION_TEMPLATE, DEFAULT_SCRIPT_TEMPLATE]
-    HELLO_WORLD_BASE_TEMPLATES = [HELLO_WORLD_SCRIPT, HELLO_WORLD_INTEGRATION]
+    HELLO_WORLD_BASE_TEMPLATES = [
+        HELLO_WORLD_SCRIPT,
+        HELLO_WORLD_INTEGRATION,
+        HELLO_WORLD_EVENT_COLLECTOR_INTEGRATION,
+    ]
 
     DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
     PACK_INITIAL_VERSION = "1.0.0"
@@ -1406,10 +1410,6 @@ class Initiator:
                 template_files = template_files.union(
                     self.DEFAULT_INTEGRATION_TEST_DATA_FILES
                 )
-            elif self.template == self.HELLO_WORLD_EVENT_COLLECTOR_INTEGRATION:
-                template_files = template_files.union(
-                    self.DEFAULT_EVENT_COLLECTOR_TEST_DATA_FILES
-                )
         elif self.template == self.HELLO_WORLD_MODELING_RULES:
             template_files = set(self.TEMPLATE_MODELING_RULES_FILES)
         elif self.template == self.HELLO_WORLD_PARSING_RULES:
@@ -1449,13 +1449,9 @@ class Initiator:
             pack_name = self.DEFAULT_TEMPLATE_PACK_NAME
 
         elif self.template in self.HELLO_WORLD_BASE_TEMPLATES + [
-            self.HELLO_WORLD_FEED_INTEGRATION
-        ]:
-            pack_name = self.HELLO_WORLD_PACK_NAME
-        elif self.template in [
+            self.HELLO_WORLD_FEED_INTEGRATION,
             self.HELLO_WORLD_PARSING_RULES,
             self.HELLO_WORLD_MODELING_RULES,
-            self.HELLO_WORLD_EVENT_COLLECTOR_INTEGRATION,
         ]:
             pack_name = self.HELLO_WORLD_PACK_NAME
         else:

--- a/demisto_sdk/commands/init/initiator.py
+++ b/demisto_sdk/commands/init/initiator.py
@@ -138,10 +138,6 @@ class Initiator:
         os.path.join(TEST_DATA_DIR, "baseintegration-dummy.json")
     }
 
-    DEFAULT_EVENT_COLLECTOR_TEST_DATA_FILES = {
-        os.path.join(TEST_DATA_DIR, "baseintegrationEventCollector-dummy.json")
-    }
-
     TEMPLATE_MODELING_RULES_FILES = {
         "HelloWorldModelingRules_schema.json",
         "HelloWorldModelingRules.xif",

--- a/demisto_sdk/commands/init/tests/initiator_test.py
+++ b/demisto_sdk/commands/init/tests/initiator_test.py
@@ -866,7 +866,6 @@ def test_integration_init_xsiam_files_content(mocker, monkeypatch, initiator, tm
     res = initiator.integration_init()
     expected_files = {
         "command_examples",
-        "test_data",
         "README.md",
         f"{INTEGRATION_NAME}{EVENT_COLLECTOR}.py",
         f"{INTEGRATION_NAME}{EVENT_COLLECTOR}.yml",
@@ -931,7 +930,6 @@ def test_integration_init_xsiam_files_existence(mocker, monkeypatch, initiator, 
     integration_dir_files = set(listdir(integration_path))
     expected_files = {
         "command_examples",
-        "test_data",
         "README.md",
         f"{INTEGRATION_NAME}{EVENT_COLLECTOR}.py",
         f"{INTEGRATION_NAME}{EVENT_COLLECTOR}.yml",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-9391

## Description
Fixed the handling of event collectors in the init command. The command was looking for files in content master that do not exist and when did not find them it failed the entire pulling action.