### PR TITLE
Fix Pycln in repos with hypen in their name

### DIFF
--- a/.changelog/3998.yml
+++ b/.changelog/3998.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where the **pre-commit** pycln hook won't work in a repo when the repo name contains a hypen.
+  type: fix
+pr_number: 3998

--- a/.changelog/3998.yml
+++ b/.changelog/3998.yml
@@ -1,4 +1,4 @@
 changes:
-- description: Fixed an issue where the **pre-commit** pycln hook won't work in a repo when the repo name contains a hypen.
+- description: Fixed an issue where the **pre-commit** pycln hook failed when the repo name contained hypens.
   type: fix
 pr_number: 3998

--- a/demisto_sdk/commands/pre_commit/hooks/pycln.py
+++ b/demisto_sdk/commands/pre_commit/hooks/pycln.py
@@ -20,7 +20,7 @@ class PyclnHook(Hook):
             for path in PYTHONPATH
             if path.absolute() != CONTENT_PATH.absolute()
         )
-        builtins_to_skip = ("demisto", "ComonServerUserPython")
+        builtins_to_skip = ("demisto", "CommonServerUserPython")
 
         skip_imports = f"--skip-imports={','.join(paths_to_skip + builtins_to_skip)}"
         safe_update_hook_args(self.base_hook, skip_imports)

--- a/demisto_sdk/commands/pre_commit/hooks/pycln.py
+++ b/demisto_sdk/commands/pre_commit/hooks/pycln.py
@@ -1,4 +1,4 @@
-from demisto_sdk.commands.common.content_constant_paths import PYTHONPATH
+from demisto_sdk.commands.common.content_constant_paths import CONTENT_PATH, PYTHONPATH
 from demisto_sdk.commands.pre_commit.hooks.hook import (
     Hook,
     safe_update_hook_args,
@@ -15,7 +15,14 @@ class PyclnHook(Hook):
         Returns:
             None
         """
-        skip_imports = f"--skip-imports={','.join(path.name for path in PYTHONPATH)},demisto,CommonServerUserPython"
+        paths_to_skip = tuple(
+            path.name
+            for path in PYTHONPATH
+            if path.absolute() != CONTENT_PATH.absolute()
+        )
+        builtins_to_skip = ("demisto", "ComonServerUserPython")
+
+        skip_imports = f"--skip-imports={','.join(paths_to_skip + builtins_to_skip)}"
         safe_update_hook_args(self.base_hook, skip_imports)
 
         self.hooks.append(self.base_hook)


### PR DESCRIPTION
Fixing an issue where the pycln hook won't work in a repo when the repo name contains a hypen (`-`)

fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-9601