### PR TITLE
[prepare-content] - fix issue with partner collectors

### DIFF
--- a/.changelog/4021.yml
+++ b/.changelog/4021.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue with **prepare-content** where partner event collectors which are supported by PANW add irrelevant suffixes to their display names.
+  type: fix
+pr_number: 4021

--- a/demisto_sdk/commands/prepare_content/integration_script_unifier.py
+++ b/demisto_sdk/commands/prepare_content/integration_script_unifier.py
@@ -590,7 +590,10 @@ class IntegrationScriptUnifier(Unifier):
         if support_level_header := unified_yml.get(SUPPORT_LEVEL_HEADER):
             contributor_type = support_level_header
 
-        if " Contribution)" not in unified_yml["display"] and contributor_type != "xsoar":
+        if (
+            " Contribution)" not in unified_yml["display"]
+            and contributor_type != "xsoar"
+        ):
             unified_yml["display"] += CONTRIBUTOR_DISPLAY_NAME.format(
                 contributor_type.capitalize()
             )

--- a/demisto_sdk/commands/prepare_content/integration_script_unifier.py
+++ b/demisto_sdk/commands/prepare_content/integration_script_unifier.py
@@ -587,14 +587,14 @@ class IntegrationScriptUnifier(Unifier):
         Returns:
             The unified yaml file (dict).
         """
-        if " Contribution)" not in unified_yml["display"]:
+        if support_level_header := unified_yml.get(SUPPORT_LEVEL_HEADER):
+            contributor_type = support_level_header
+
+        if " Contribution)" not in unified_yml["display"] and contributor_type != "xsoar":
             unified_yml["display"] += CONTRIBUTOR_DISPLAY_NAME.format(
                 contributor_type.capitalize()
             )
         existing_detailed_description = unified_yml.get("detaileddescription", "")
-
-        if support_level_header := unified_yml.get(SUPPORT_LEVEL_HEADER):
-            contributor_type = support_level_header
 
         if contributor_type == COMMUNITY_SUPPORT:
             contributor_description = CONTRIBUTOR_COMMUNITY_DETAILED_DESC.format(author)


### PR DESCRIPTION
## Description
Fixed an issue where partner collectors that are supported by PANW show in their display a suffix of (Partner Contribution).
In that PR we remove the (Partner Contribution) addition to those kinds