### PR TITLE
fix flaky validation tests

### DIFF
--- a/.changelog/4023.yml
+++ b/.changelog/4023.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where some unit-tests failed in github-actions CI.
+  type: internal
+pr_number: 4023

--- a/demisto_sdk/commands/common/tests/readme_test.py
+++ b/demisto_sdk/commands/common/tests/readme_test.py
@@ -44,14 +44,16 @@ def test_is_file_valid(mocker, current, answer):
         "demisto_sdk.commands.common.hook_validations.readme.get_pack_name",
         return_value="PackName",
     )
-    integration_yml = f'{git_path()}/demisto_sdk/tests/test_files/integration-EDL.yml'
-    mocker.patch("demisto_sdk.commands.common.hook_validations.readme.get_yml_paths_in_dir",
-                 return_value=([integration_yml], integration_yml))
+    integration_yml = f"{git_path()}/demisto_sdk/tests/test_files/integration-EDL.yml"
+    mocker.patch(
+        "demisto_sdk.commands.common.hook_validations.readme.get_yml_paths_in_dir",
+        return_value=([integration_yml], integration_yml),
+    )
 
     mocker.patch.object(Path, "is_file", return_value=answer)
     mocker.patch.object(os.path, "isfile", return_value=answer)
     readme_validator = ReadMeValidator(current)
-    integration_yml = f'{git_path()}/demisto_sdk/tests/test_files/integration-EDL.yml'
+    integration_yml = f"{git_path()}/demisto_sdk/tests/test_files/integration-EDL.yml"
     valid = ReadMeValidator.are_modules_installed_for_verify(
         readme_validator.content_path
     )
@@ -89,9 +91,11 @@ def test_is_file_valid_mdx_server(mocker, current, answer):
         "demisto_sdk.commands.common.hook_validations.readme.get_pack_name",
         return_value="PackName",
     )
-    integration_yml = f'{git_path()}/demisto_sdk/tests/test_files/integration-EDL.yml'
-    mocker.patch("demisto_sdk.commands.common.hook_validations.readme.get_yml_paths_in_dir",
-                 return_value=([integration_yml], integration_yml))
+    integration_yml = f"{git_path()}/demisto_sdk/tests/test_files/integration-EDL.yml"
+    mocker.patch(
+        "demisto_sdk.commands.common.hook_validations.readme.get_yml_paths_in_dir",
+        return_value=([integration_yml], integration_yml),
+    )
     mocker.patch("demisto_sdk.commands.common.tools.sleep")
     mocker.patch.object(Path, "is_file", return_value=answer)
     mocker.patch.object(os.path, "isfile", return_value=answer)

--- a/demisto_sdk/commands/common/tests/readme_test.py
+++ b/demisto_sdk/commands/common/tests/readme_test.py
@@ -44,10 +44,14 @@ def test_is_file_valid(mocker, current, answer):
         "demisto_sdk.commands.common.hook_validations.readme.get_pack_name",
         return_value="PackName",
     )
+    integration_yml = f'{git_path()}/demisto_sdk/tests/test_files/integration-EDL.yml'
+    mocker.patch("demisto_sdk.commands.common.hook_validations.readme.get_yml_paths_in_dir",
+                 return_value=([integration_yml], integration_yml))
+
     mocker.patch.object(Path, "is_file", return_value=answer)
     mocker.patch.object(os.path, "isfile", return_value=answer)
-
     readme_validator = ReadMeValidator(current)
+    integration_yml = f'{git_path()}/demisto_sdk/tests/test_files/integration-EDL.yml'
     valid = ReadMeValidator.are_modules_installed_for_verify(
         readme_validator.content_path
     )
@@ -85,6 +89,9 @@ def test_is_file_valid_mdx_server(mocker, current, answer):
         "demisto_sdk.commands.common.hook_validations.readme.get_pack_name",
         return_value="PackName",
     )
+    integration_yml = f'{git_path()}/demisto_sdk/tests/test_files/integration-EDL.yml'
+    mocker.patch("demisto_sdk.commands.common.hook_validations.readme.get_yml_paths_in_dir",
+                 return_value=([integration_yml], integration_yml))
     mocker.patch("demisto_sdk.commands.common.tools.sleep")
     mocker.patch.object(Path, "is_file", return_value=answer)
     mocker.patch.object(os.path, "isfile", return_value=answer)

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -2809,7 +2809,7 @@ def compare_context_path_in_yml_and_readme(yml_dict, readme_content):
     readme_content += (
         "### "  # mark end of file so last pattern of regex will be recognized.
     )
-    commands = yml_dict.get("script", {})
+    commands = yml_dict.get("script") or {}
 
     # handles scripts
     if not commands:

--- a/demisto_sdk/commands/validate/tests/old_validators_test.py
+++ b/demisto_sdk/commands/validate/tests/old_validators_test.py
@@ -676,9 +676,13 @@ class TestValidators:
         )
         mocker.patch.object(OldValidateManager, "is_node_exist", return_value=True)
         validate_manager = OldValidateManager(file_path=file_path, skip_conf_json=True)
-        integration_yml = f'{git_path()}/demisto_sdk/tests/test_files/integration-EDL.yml'
-        mocker.patch("demisto_sdk.commands.common.hook_validations.readme.get_yml_paths_in_dir",
-                     return_value=([integration_yml], integration_yml))
+        integration_yml = (
+            f"{git_path()}/demisto_sdk/tests/test_files/integration-EDL.yml"
+        )
+        mocker.patch(
+            "demisto_sdk.commands.common.hook_validations.readme.get_yml_paths_in_dir",
+            return_value=([integration_yml], integration_yml),
+        )
         assert validate_manager.run_validation_on_specific_files()
 
     INVALID_FILES_PATHS_FOR_ALL_VALIDATIONS = [

--- a/demisto_sdk/commands/validate/tests/old_validators_test.py
+++ b/demisto_sdk/commands/validate/tests/old_validators_test.py
@@ -676,6 +676,9 @@ class TestValidators:
         )
         mocker.patch.object(OldValidateManager, "is_node_exist", return_value=True)
         validate_manager = OldValidateManager(file_path=file_path, skip_conf_json=True)
+        integration_yml = f'{git_path()}/demisto_sdk/tests/test_files/integration-EDL.yml'
+        mocker.patch("demisto_sdk.commands.common.hook_validations.readme.get_yml_paths_in_dir",
+                     return_value=([integration_yml], integration_yml))
         assert validate_manager.run_validation_on_specific_files()
 
     INVALID_FILES_PATHS_FOR_ALL_VALIDATIONS = [

--- a/demisto_sdk/tests/test_files/valid-beta-integration.yml
+++ b/demisto_sdk/tests/test_files/valid-beta-integration.yml
@@ -42,7 +42,7 @@ script:
   dockerimage: demisto/python3:3.8.2.6981
   isfetch: false
   runonce: false
-  script: ''
+  script: '-'
   type: python
   subtype: python3
 beta: true

--- a/demisto_sdk/tests/test_files/valid-beta-integration.yml
+++ b/demisto_sdk/tests/test_files/valid-beta-integration.yml
@@ -42,7 +42,7 @@ script:
   dockerimage: demisto/python3:3.8.2.6981
   isfetch: false
   runonce: false
-  script: '-'
+  script: ''
   type: python
   subtype: python3
 beta: true


### PR DESCRIPTION
## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-9681


## Description
Fixes an issue where we have flaky validation unit-tests.

We have a few tests failing: 

https://github.com/demisto/demisto-sdk/actions/runs/7812214569?pr=3945

That happens because we query all the yml files that are in the `demisto_sdk/tests/test_files/` dir. 
Some of the yml actually have the `script: ''` key in the schema, leading to this error. 
Those yml files are being collected differently each time making those tests flaky.