### PR TITLE
[TestSuite] - init git with master branch

### DIFF
--- a/TestSuite/repo.py
+++ b/TestSuite/repo.py
@@ -325,7 +325,7 @@ class Repo:
 
     def init_git(self):
         if not self.git_util:
-            GitUtil.REPO_CLS.init(self.path)
+            GitUtil.REPO_CLS.init(self.path, initial_branch=DEMISTO_GIT_PRIMARY_BRANCH)
             self.git_util = GitUtil(self.path)
             self.git_util.commit_files("Initial Commit")
             self.git_util.repo.create_head(DEMISTO_GIT_PRIMARY_BRANCH)


### PR DESCRIPTION
## Description
In new git versions, if not specifying initial branch when initializing git, it will create the repository with the `main` branch by default, we want the git to be created with `master` branch. 

when running tests that are based on `git` locally on new git versions, some of them fail as we commit all `TestSuite` changes into the `main` branch rather than the `master` branch. That doesn't fail in our CI because we use there a git version which by default initialize the git with the master branch even when not specifying it directly.