### PR TITLE
Add A Deprecation Notice To The `update-content-graph` Command

### DIFF
--- a/.changelog/4027.yml
+++ b/.changelog/4027.yml
@@ -1,6 +1,6 @@
 changes:
-- description: The `content-graph-create` command is now deprecated and will be removed in future releases. Use the `demisto-sdk graph create` command instead.
+- description: The `create-content-graph` command is now deprecated and will be removed in future releases. Use the `demisto-sdk graph create` command instead.
   type: feature
-- description: The `content-graph-update` command is now deprecated and will be removed in future releases. Use the `demisto-sdk graph update` command instead.
+- description: The `update-content-graph` command is now deprecated and will be removed in future releases. Use the `demisto-sdk graph update` command instead.
   type: feature
 pr_number: 4027

--- a/.changelog/4027.yml
+++ b/.changelog/4027.yml
@@ -1,0 +1,6 @@
+changes:
+- description: The `content-graph-create` command is now deprecated and will be removed in future releases. Use the `demisto-sdk graph create` command instead.
+  type: feature
+- description: The `content-graph-update` command is now deprecated and will be removed in future releases. Use the `demisto-sdk graph update` command instead.
+  type: feature
+pr_number: 4027

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -3363,6 +3363,10 @@ def create_content_graph(
     output_path: Path = None,
     **kwargs,
 ):
+    logger.warning(
+        "[WARNING] The 'create-content-graph' command is deprecated and will be removed "
+        "in upcoming versions. Use 'demisto-sdk graph create' instead."
+    )
     ctx.invoke(
         create,
         ctx,
@@ -3438,6 +3442,10 @@ def update_content_graph(
     output_path: Path = None,
     **kwargs,
 ):
+    logger.warning(
+        "[WARNING] The 'update-content-graph' command is deprecated and will be removed "
+        "in upcoming versions. Use 'demisto-sdk graph update' instead."
+    )
     ctx.invoke(
         update,
         ctx,


### PR DESCRIPTION
## Description
Add a deprecation note to the `update-content-graph` command, which is replaced by the `graph update` command.
<img width="1117" alt="Screenshot 2024-02-08 at 12 06 43" src="https://github.com/demisto/demisto-sdk/assets/8832013/af50ae19-798c-49c6-95c4-d425f07e9783">
