### PR TITLE
Fix issues with .env file support

### DIFF
--- a/.changelog/4029.yml
+++ b/.changelog/4029.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue in **setup-environment** command where `.env` files were not loaded correctly.
+  type: fix
+pr_number: 4029

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -20,6 +20,7 @@ import os
 from pathlib import Path
 from typing import IO, Any, Dict, List, Optional, Tuple, Union
 
+import dotenv
 import typer
 from pkg_resources import DistributionNotFound, get_distribution
 
@@ -73,6 +74,8 @@ SDK_OFFLINE_ERROR_MESSAGE = (
     "[red]An internet connection is required for this command. If connected to the "
     "internet, un-set the DEMISTO_SDK_OFFLINE_ENV environment variable.[/red]"
 )
+
+dotenv.load_dotenv(CONTENT_PATH / ".env", override=True)  # type: ignore # load .env file from the cwd
 
 
 # Third party packages
@@ -209,9 +212,6 @@ def main(ctx, config, version, release_notes, **kwargs):
     handle_deprecated_args(ctx.args)
 
     config.configuration = Configuration()
-    import dotenv
-
-    dotenv.load_dotenv(CONTENT_PATH / ".env", override=True)  # type: ignore # load .env file from the cwd
 
     if platform.system() == "Windows":
         logger.warning(

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -20,7 +20,6 @@ import os
 from pathlib import Path
 from typing import IO, Any, Dict, List, Optional, Tuple, Union
 
-import dotenv
 import typer
 from pkg_resources import DistributionNotFound, get_distribution
 
@@ -74,8 +73,6 @@ SDK_OFFLINE_ERROR_MESSAGE = (
     "[red]An internet connection is required for this command. If connected to the "
     "internet, un-set the DEMISTO_SDK_OFFLINE_ENV environment variable.[/red]"
 )
-
-dotenv.load_dotenv(CONTENT_PATH / ".env", override=True)  # type: ignore # load .env file from the cwd
 
 
 # Third party packages
@@ -212,6 +209,9 @@ def main(ctx, config, version, release_notes, **kwargs):
     handle_deprecated_args(ctx.args)
 
     config.configuration = Configuration()
+    import dotenv
+
+    dotenv.load_dotenv(CONTENT_PATH / ".env", override=True)  # type: ignore # load .env file from the cwd
 
     if platform.system() == "Windows":
         logger.warning(

--- a/demisto_sdk/commands/setup_env/setup_environment.py
+++ b/demisto_sdk/commands/setup_env/setup_environment.py
@@ -95,7 +95,9 @@ def get_docker_python_path(docker_prefix: str) -> List[str]:
     return docker_python_path
 
 
-def update_dotenv(file_path: Path, values: Dict[str, str], quote_mode="never"):
+def update_dotenv(
+    file_path: Path, values: Dict[str, Optional[str]], quote_mode="never"
+):
     """
     Configure the .env file with the given values. Generates the file if it doesn't exist.
 
@@ -243,21 +245,16 @@ def configure_module_discovery(ide_type: IDEType):
         ide_type (IDEType): The IDE type to configure
     """
     if ide_type == IDEType.VSCODE:
-        update_dotenv(
-            file_path=DOTENV_PATH,
-            values={
-                "PYTHONPATH": ":".join([str(path) for path in PYTHONPATH]),
-                "MYPYPATH": ":".join(
-                    [
-                        str(path)
-                        for path in PYTHONPATH
-                        if "site-packages" not in str(path)
-                    ]
-                ),
-            },
-        )
+        ide_folder = CONTENT_PATH / ".vscode"
+        configure_vscode_settings(ide_folder=ide_folder)
+        # Delete PYTHONPATH and MYPYPATH from env file because they are not needed
+        env_file = CONTENT_PATH / ".env"
+        env_vars = dotenv.dotenv_values(env_file)
+        env_vars.pop("PYTHONPATH", None)
+        env_vars.pop("MYPYPATH", None)
+        update_dotenv(env_file, env_vars)
 
-    elif ide_type == IDEType.PYCHARM:
+    if ide_type == IDEType.PYCHARM:
         python_discovery_paths = PYTHONPATH.copy()
 
         # Remove 'CONTENT_PATH' from the python discovery paths as it is already configured by default,
@@ -298,7 +295,6 @@ def configure_vscode_tasks(
                         "env": {
                             "PYTHONPATH": ":".join(docker_python_path),
                         },
-                        "envFiles": [str(DOTENV_PATH)],
                     },
                 },
                 {

--- a/demisto_sdk/commands/setup_env/setup_environment.py
+++ b/demisto_sdk/commands/setup_env/setup_environment.py
@@ -246,6 +246,7 @@ def configure_module_discovery(ide_type: IDEType):
     """
     if ide_type == IDEType.VSCODE:
         ide_folder = CONTENT_PATH / ".vscode"
+        ide_folder.mkdir(exist_ok=True, parents=True)
         configure_vscode_settings(ide_folder=ide_folder)
         # Delete PYTHONPATH and MYPYPATH from env file because they are not needed
         env_file = CONTENT_PATH / ".env"

--- a/demisto_sdk/commands/setup_env/tests/setup_environment_test.py
+++ b/demisto_sdk/commands/setup_env/tests/setup_environment_test.py
@@ -73,10 +73,8 @@ def test_setup_env_vscode(mocker, monkeypatch, pack, create_virtualenv):
         create_virtualenv=create_virtualenv,
     )
     dotenv_text = (repo_path / ".env").read_text()
-    assert "PYTHONPATH" in dotenv_text
-    assert "MYPYPATH" in dotenv_text
-    assert "CommonServerPython" in dotenv_text
-
+    assert "DEMISTO_PARAMS" in dotenv_text
+    assert "PYTHONPATH" not in dotenv_text
     vscode_folder = (
         repo_path / ".vscode" if not create_virtualenv else Path(pack.path) / ".vscode"
     )


### PR DESCRIPTION
fixes:
1. loads the env in the module scope, as the clients are loaded before the `main` function starts.
2. Removes PYTHONPATH and MYPYPATH from the .env since the VSCode Docker extension now loads the dotenv file into the docker debugging, and it contradicts the file system in the container (and we don't need it since we configure it in VSCode settings) 