### PR TITLE
[CI] - do not run coverage in master

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -183,6 +183,7 @@ jobs:
 
   coverage:
     needs: [unit-tests, integration-tests, graph-tests]
+    if: github.ref_name != 'master'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION

## Description
Do not run the `coverage` job in master, should be done only each on-push which isn't master