### PR TITLE
[setup-env] - fix an issue with the client

### DIFF
--- a/.changelog/4044.yml
+++ b/.changelog/4044.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where **setup-env** crashed when trying to upload an instance of an integration into xsoar.
+  type: fix
+pr_number: 4044

--- a/demisto_sdk/commands/common/clients/xsoar/xsoar_api_client.py
+++ b/demisto_sdk/commands/common/clients/xsoar/xsoar_api_client.py
@@ -78,6 +78,10 @@ class XsoarClient:
         if should_validate_server_type and not self.is_server_type:
             raise InvalidServerType(str(self), server_type=self.server_type)
 
+    @property
+    def xsoar_client(self) -> DefaultApi:
+        return self._xsoar_client
+
     def __str__(self) -> str:
         try:
             about: Union[ServerAbout, None] = self.about

--- a/demisto_sdk/commands/setup_env/setup_environment.py
+++ b/demisto_sdk/commands/setup_env/setup_environment.py
@@ -567,7 +567,7 @@ def upload_and_create_instance(
     assert isinstance(pack, Pack)
     with tempfile.TemporaryDirectory() as temp_dir:
         pack.upload(
-            client=client.client,
+            client=client.xsoar_client,
             marketplace=client.marketplace,
             target_demisto_version=client.version,
             zip=True,


### PR DESCRIPTION

## Description
* Fixed an issue where **setup-env** crashed when trying to upload an instance of an integration into xsoar.