### PR TITLE
[File Management] - fix an issue with git_util in tests 

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -97,8 +97,10 @@ def graph_repo(request: FixtureRequest, tmp_path_factory: TempPathFactory) -> Ge
     """
     import demisto_sdk.commands.content_graph.neo4j_service as neo4j_service
     import demisto_sdk.commands.content_graph.objects.base_content as bc
+    from demisto_sdk.commands.common.files.file import File
 
     repo = get_repo(request, tmp_path_factory)
+    File.git_util = repo.git_util
 
     bc.CONTENT_PATH = Path(repo.path)
     neo4j_path = bc.CONTENT_PATH.parent.parent / "neo4j"

--- a/conftest.py
+++ b/conftest.py
@@ -97,11 +97,8 @@ def graph_repo(request: FixtureRequest, tmp_path_factory: TempPathFactory) -> Ge
     """
     import demisto_sdk.commands.content_graph.neo4j_service as neo4j_service
     import demisto_sdk.commands.content_graph.objects.base_content as bc
-    from demisto_sdk.commands.common.files.file import File
 
     repo = get_repo(request, tmp_path_factory)
-    if git_util := repo.git_util:
-        File.git_util = git_util
 
     bc.CONTENT_PATH = Path(repo.path)
     neo4j_path = bc.CONTENT_PATH.parent.parent / "neo4j"
@@ -115,16 +112,11 @@ def graph_repo(request: FixtureRequest, tmp_path_factory: TempPathFactory) -> Ge
 
 
 @pytest.fixture
-def git_repo(request: FixtureRequest, tmp_path_factory: TempPathFactory) -> Repo:
+def git_repo(request: FixtureRequest, tmp_path_factory: TempPathFactory):
     """
     Initializes a repo with git.
     """
-    from demisto_sdk.commands.common.files.file import File
-
-    repo = get_git_repo(request, tmp_path_factory)
-    if git_util := repo.git_util:
-        File.git_util = git_util
-    return repo
+    return get_git_repo(request, tmp_path_factory)
 
 
 @pytest.fixture(scope="module")

--- a/conftest.py
+++ b/conftest.py
@@ -100,7 +100,8 @@ def graph_repo(request: FixtureRequest, tmp_path_factory: TempPathFactory) -> Ge
     from demisto_sdk.commands.common.files.file import File
 
     repo = get_repo(request, tmp_path_factory)
-    File.git_util = repo.git_util
+    if git_util := repo.git_util:
+        File.git_util = git_util
 
     bc.CONTENT_PATH = Path(repo.path)
     neo4j_path = bc.CONTENT_PATH.parent.parent / "neo4j"
@@ -114,11 +115,16 @@ def graph_repo(request: FixtureRequest, tmp_path_factory: TempPathFactory) -> Ge
 
 
 @pytest.fixture
-def git_repo(request: FixtureRequest, tmp_path_factory: TempPathFactory):
+def git_repo(request: FixtureRequest, tmp_path_factory: TempPathFactory) -> Repo:
     """
     Initializes a repo with git.
     """
-    return get_git_repo(request, tmp_path_factory)
+    from demisto_sdk.commands.common.files.file import File
+
+    repo = get_git_repo(request, tmp_path_factory)
+    if git_util := repo.git_util:
+        File.git_util = git_util
+    return repo
 
 
 @pytest.fixture(scope="module")

--- a/demisto_sdk/commands/common/files/file.py
+++ b/demisto_sdk/commands/common/files/file.py
@@ -33,7 +33,13 @@ from demisto_sdk.commands.common.tools import retry
 
 class File(ABC):
 
-    git_util = GitUtil.from_content_path()
+    _git_util = GitUtil.from_content_path()
+
+    @property
+    def git_util(self) -> GitUtil:
+        if Path.cwd() != File._git_util.repo.working_dir:
+            return GitUtil()
+        return File._git_util
 
     @property
     def path(self) -> Path:
@@ -208,9 +214,9 @@ class File(ABC):
 
         if not path.is_absolute():
             logger.debug(
-                f"path {path} is not absolute, trying to get full relative path from {cls.git_util.repo.working_dir}"
+                f"path {path} is not absolute, trying to get full relative path from {cls._git_util.repo.working_dir}"
             )
-            path = cls.git_util.repo.working_dir / path
+            path = cls._git_util.repo.working_dir / path
             if not path.exists():
                 raise FileNotFoundError(f"File {path} does not exist")
 
@@ -259,11 +265,11 @@ class File(ABC):
         if clear_cache:
             cls.read_from_git_path.cache_clear()
 
-        if cls.git_util.is_file_exist_in_commit_or_branch(
+        if cls._git_util.is_file_exist_in_commit_or_branch(
             path, commit_or_branch=tag, from_remote=from_remote
         ):
             # when reading from git we need relative path from the repo root
-            path = cls.git_util.path_from_git_root(path)
+            path = cls._git_util.path_from_git_root(path)
         else:
             raise FileNotFoundError(
                 f"File {path} does not exist in commit/branch {tag}"

--- a/demisto_sdk/commands/common/files/tests/binary_file_test.py
+++ b/demisto_sdk/commands/common/files/tests/binary_file_test.py
@@ -21,7 +21,6 @@ class TestBinaryFile(FileTesting):
         BinaryFile.write("test".encode(), output_path=_bin_file_path)
 
         if git_util := git_repo.git_util:
-            BinaryFile.git_util = git_util
             git_util.commit_files("commit all binary files")
 
         binary_file_paths = [integration.image.path, _bin_file_path]

--- a/demisto_sdk/commands/common/files/tests/ini_file_test.py
+++ b/demisto_sdk/commands/common/files/tests/ini_file_test.py
@@ -34,7 +34,6 @@ class TestIniFile(FileTesting):
         )
 
         if git_util := git_repo.git_util:
-            IniFile.git_util = git_util
             git_util.commit_files("commit all INI files")
 
         ini_file_paths = [pack.pack_ignore.path, _ini_file_path]

--- a/demisto_sdk/commands/common/files/tests/json5_file_test.py
+++ b/demisto_sdk/commands/common/files/tests/json5_file_test.py
@@ -20,7 +20,6 @@ class TestJson5File(FileTesting):
         Json5File.write({"test": "test"}, output_path=json5_file_path)
 
         if git_util := git_repo.git_util:
-            Json5File.git_util = git_util
             git_util.commit_files("commit all json5 files")
 
         return json5_file_path, git_repo.path

--- a/demisto_sdk/commands/common/files/tests/json_file_test.py
+++ b/demisto_sdk/commands/common/files/tests/json_file_test.py
@@ -26,7 +26,6 @@ class TestJsonFile(FileTesting):
         _list = pack.create_list("test", content=file_content)
 
         if git_util := git_repo.git_util:
-            JsonFile.git_util = git_util
             git_util.commit_files("commit all json files")
 
         json_file_paths = [

--- a/demisto_sdk/commands/common/files/tests/text_file_test.py
+++ b/demisto_sdk/commands/common/files/tests/text_file_test.py
@@ -27,7 +27,6 @@ class TestTextFile(FileTesting):
             version="1.1.1", content="\n#### Integrations\n##### test\n- added feature"
         )
         if git_util := git_repo.git_util:
-            TextFile.git_util = git_util
             git_util.commit_files("commit all text files")
 
         text_file_paths = [

--- a/demisto_sdk/commands/common/files/tests/yml_file_test.py
+++ b/demisto_sdk/commands/common/files/tests/yml_file_test.py
@@ -27,7 +27,6 @@ class TestYMLFile(FileTesting):
         )
 
         if git_util := git_repo.git_util:
-            YmlFile.git_util = git_util
             git_util.commit_files("commit all yml files")
 
         yml_file_paths = [


### PR DESCRIPTION
## Description
Because the `git_util` is a class member for `File` object it gets read during tests only once, and that causes bugs as the same `git_util` object is shared between all the tests which can work on different repos.

that happens **only** in tests because there are multiple repositories created for each test using `TestSuite`.
When running in production we only have a single repository.