### PR TITLE
ST100 - Add strict mode to validations to load objects from path only

### DIFF
--- a/demisto_sdk/commands/content_graph/objects/base_content.py
+++ b/demisto_sdk/commands/content_graph/objects/base_content.py
@@ -274,6 +274,7 @@ class BaseContent(BaseNode):
         git_sha: Optional[str] = None,
         raise_on_exception: bool = False,
         metadata_only: bool = False,
+        strict: bool = False,
     ) -> Optional["BaseContent"]:
         logger.debug(f"Loading content item from path: {path}")
 
@@ -291,7 +292,9 @@ class BaseContent(BaseNode):
                 return None
         try:
             content_item.MARKETPLACE_MIN_VERSION = "0.0.0"
-            content_item_parser = ContentItemParser.from_path(path, git_sha=git_sha)
+            content_item_parser = ContentItemParser.from_path(
+                path, git_sha=git_sha, strict=strict
+            )
             content_item.MARKETPLACE_MIN_VERSION = MARKETPLACE_MIN_VERSION
 
         except NotAContentItemException:

--- a/demisto_sdk/commands/content_graph/objects/base_content.py
+++ b/demisto_sdk/commands/content_graph/objects/base_content.py
@@ -285,7 +285,12 @@ class BaseContent(BaseNode):
         ):  # if the path given is a pack
             try:
                 return CONTENT_TYPE_TO_MODEL[ContentType.PACK].from_orm(
-                    PackParser(path, git_sha=git_sha, metadata_only=metadata_only)
+                    PackParser(
+                        path,
+                        git_sha=git_sha,
+                        metadata_only=metadata_only,
+                        strict=strict,
+                    )
                 )
             except InvalidContentItemException:
                 logger.error(f"Could not parse content from {str(path)}")

--- a/demisto_sdk/commands/content_graph/parsers/content_item.py
+++ b/demisto_sdk/commands/content_graph/parsers/content_item.py
@@ -94,7 +94,7 @@ class ContentItemParser(BaseContentParser, metaclass=ParserMetaclass):
         path: Path,
         pack_marketplaces: List[MarketplaceVersions] = list(MarketplaceVersions),
         git_sha: Optional[str] = None,
-        strict: bool = False,
+        strict_path: bool = False,
     ) -> "ContentItemParser":
         """Tries to parse a content item by its path.
         If during the attempt we detected the file is not a content item, `None` is returned.
@@ -103,7 +103,7 @@ class ContentItemParser(BaseContentParser, metaclass=ParserMetaclass):
             path (Path): The path of the content item.
             pack_marketplaces (List[MarketplaceVersions], optional): The marketplaces of the pack.
             git_sha (Optional[str], optional): The git sha of the pack.
-            strict (bool, optional): Whether or not to raise an exception if the content item can't be determined by path. Defaults to False.
+            strict_path (bool, optional): Whether or not to raise an exception if the content item can't be determined by path. Defaults to False.
 
         Returns:
             Optional[ContentItemParser]: The parsed content item.
@@ -117,10 +117,8 @@ class ContentItemParser(BaseContentParser, metaclass=ParserMetaclass):
         try:
             content_type: ContentType = ContentType.by_path(path)
         except ValueError as e:
-            if strict:
-                logger.error(
-                    f"Could not determine content type for {path}. Using strict mode."
-                )
+            if strict_path:
+                logger.error(f"Could not determine content type for '{path}'.")
                 raise InvalidContentItemException from e
             try:
                 optional_content_type = ContentType.by_schema(path)

--- a/demisto_sdk/commands/content_graph/parsers/content_item.py
+++ b/demisto_sdk/commands/content_graph/parsers/content_item.py
@@ -94,9 +94,16 @@ class ContentItemParser(BaseContentParser, metaclass=ParserMetaclass):
         path: Path,
         pack_marketplaces: List[MarketplaceVersions] = list(MarketplaceVersions),
         git_sha: Optional[str] = None,
+        strict: bool = False,
     ) -> "ContentItemParser":
         """Tries to parse a content item by its path.
         If during the attempt we detected the file is not a content item, `None` is returned.
+
+        Args:
+            path (Path): The path of the content item.
+            pack_marketplaces (List[MarketplaceVersions], optional): The marketplaces of the pack.
+            git_sha (Optional[str], optional): The git sha of the pack.
+            strict (bool, optional): Whether or not to raise an exception if the content item can't be determined by path. Defaults to False.
 
         Returns:
             Optional[ContentItemParser]: The parsed content item.
@@ -109,7 +116,12 @@ class ContentItemParser(BaseContentParser, metaclass=ParserMetaclass):
                 path = path.parent
         try:
             content_type: ContentType = ContentType.by_path(path)
-        except ValueError:
+        except ValueError as e:
+            if strict:
+                logger.error(
+                    f"Could not determine content type for {path}. Using strict mode."
+                )
+                raise InvalidContentItemException from e
             try:
                 optional_content_type = ContentType.by_schema(path)
             except ValueError as e:

--- a/demisto_sdk/commands/validate/initializer.py
+++ b/demisto_sdk/commands/validate/initializer.py
@@ -443,7 +443,7 @@ class Initializer:
             path: Path = Path(file_path)
             try:
                 temp_obj = BaseContent.from_path(
-                    path, git_sha=None, raise_on_exception=True
+                    path, git_sha=None, raise_on_exception=True, strict=True
                 )
                 if temp_obj is None:
                     invalid_content_items.add(path)
@@ -478,11 +478,14 @@ class Initializer:
                 old_path = file_path
                 if isinstance(file_path, tuple):
                     file_path, old_path = file_path
-                obj = BaseContent.from_path(file_path, raise_on_exception=True)
+                obj = BaseContent.from_path(
+                    file_path, raise_on_exception=True, strict=True
+                )
                 if obj:
                     obj.git_status = git_status
                     # Check if the file exists
                     if git_status in (GitStatuses.MODIFIED, GitStatuses.RENAMED):
+                        # when loading the old content object, we need to load it from the git_sha and without strict mode
                         obj.old_base_content_object = BaseContent.from_path(
                             old_path, git_sha=git_sha, raise_on_exception=True
                         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ update-additional-dependencies = "demisto_sdk.scripts.update_additional_dependen
 sdk-changelog = "demisto_sdk.scripts.changelog.changelog:main"
 merge-coverage-report = "demisto_sdk.scripts.merge_coverage_report:main"
 merge-pytest-reports = "demisto_sdk.scripts.merge_pytest_reports:main"
+init-validation = "demisto_sdk.scripts.init_validation_script:main"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"


### PR DESCRIPTION
This will fail loading content objects if we cannot determine the content type by the path.

This replaces ST100 validation