### PR TITLE
[File] - fix issue where reading files from git failed when sending absolute paths

### DIFF
--- a/.changelog/4060.yml
+++ b/.changelog/4060.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where reading files from git failed when sending file paths as absolute.
+  type: fix
+pr_number: 4060

--- a/demisto_sdk/commands/common/files/file.py
+++ b/demisto_sdk/commands/common/files/file.py
@@ -39,7 +39,7 @@ class File(ABC):
     def git_util(cls) -> GitUtil:
         current_path = Path.cwd()
         if current_path != Path(cls._git_util.repo.working_dir):
-            cls._git_util = GitUtil(current_path)
+            cls._git_util = GitUtil.from_content_path(current_path)
         return cls._git_util
 
     @property

--- a/demisto_sdk/commands/common/files/file.py
+++ b/demisto_sdk/commands/common/files/file.py
@@ -266,12 +266,9 @@ class File(ABC):
         if clear_cache:
             cls.read_from_git_path.cache_clear()
 
-        if cls.git_util().is_file_exist_in_commit_or_branch(
+        if not cls.git_util().is_file_exist_in_commit_or_branch(
             path, commit_or_branch=tag, from_remote=from_remote
         ):
-            # when reading from git we need relative path from the repo root
-            path = cls.git_util().path_from_git_root(path)
-        else:
             raise FileNotFoundError(
                 f"File {path} does not exist in commit/branch {tag}"
             )

--- a/demisto_sdk/commands/common/git_util.py
+++ b/demisto_sdk/commands/common/git_util.py
@@ -174,7 +174,8 @@ class GitUtil:
     ) -> bytes:
 
         commit = self.get_commit(commit_or_branch, from_remote=from_remote)
-        path = str(self.path_from_git_root(path))
+        if path.is_absolute():
+            path = str(self.path_from_git_root(path))
 
         try:
             blob: Blob = commit.tree / path

--- a/demisto_sdk/commands/common/git_util.py
+++ b/demisto_sdk/commands/common/git_util.py
@@ -172,10 +172,12 @@ class GitUtil:
     def read_file_content(
         self, path: Union[Path, str], commit_or_branch: str, from_remote: bool = True
     ) -> bytes:
-
         commit = self.get_commit(commit_or_branch, from_remote=from_remote)
-        if path.is_absolute():
-            path = str(self.path_from_git_root(path))
+        path = (
+            str(self.path_from_git_root(path))
+            if Path(path).is_absolute()
+            else str(path)
+        )
 
         try:
             blob: Blob = commit.tree / path


### PR DESCRIPTION

## Description
When sending absolute files when reading from git in the `File` object, reading it fails as it concatenates the string twice by mistake messing up the path 