### PR TITLE
Update Docker Error Message To Reflect Different Issues

### DIFF
--- a/demisto_sdk/commands/common/docker_helper.py
+++ b/demisto_sdk/commands/common/docker_helper.py
@@ -64,10 +64,12 @@ def init_global_docker_client(timeout: int = 60, log_prompt: str = ""):
         logger.debug(f"{log_prompt} - Using docker mounting: {CAN_MOUNT_FILES}")
         try:
             DOCKER_CLIENT = docker.from_env(timeout=timeout, use_ssh_client=ssh_client)  # type: ignore
-        except docker.errors.DockerException as e:
-            logger.warning(f"{log_prompt} - Failed to init docker client. "
-                           "This might indicate that your docker daemon is not running.")
-            raise e
+        except docker.errors.DockerException:
+            logger.warning(
+                f"{log_prompt} - Failed to init docker client. "
+                "This might indicate that your docker daemon is not running."
+            )
+            raise
         docker_user = os.getenv("DOCKERHUB_USER")
         docker_pass = os.getenv("DOCKERHUB_PASSWORD")
         if docker_user and docker_pass:

--- a/demisto_sdk/commands/common/docker_helper.py
+++ b/demisto_sdk/commands/common/docker_helper.py
@@ -64,10 +64,10 @@ def init_global_docker_client(timeout: int = 60, log_prompt: str = ""):
         logger.debug(f"{log_prompt} - Using docker mounting: {CAN_MOUNT_FILES}")
         try:
             DOCKER_CLIENT = docker.from_env(timeout=timeout, use_ssh_client=ssh_client)  # type: ignore
-        except docker.errors.DockerException:
-            msg = "Failed to init docker client. Please check that your docker daemon is running."
-            logger.error(f"{log_prompt} - {msg}")
-            raise DockerException(msg)
+        except docker.errors.DockerException as e:
+            logger.warning(f"{log_prompt} - Failed to init docker client. "
+                           "This might indicate that your docker daemon is not running.")
+            raise e
         docker_user = os.getenv("DOCKERHUB_USER")
         docker_pass = os.getenv("DOCKERHUB_PASSWORD")
         if docker_user and docker_pass:


### PR DESCRIPTION
## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-9851

## Description
We currently print the same error for all Docker exceptions, even though there can be different errors.
This causes a lot of confusion when debugging errors.
This PR resolves it by raising the original error.