### PR TITLE
[cirlce-ci] - update docker version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,7 @@ jobs:
         - <<: *install_neo4j
         - <<: *install_poetry
         - setup_remote_docker:
-            version: 20.10.12
+            version: default
         - python/install-packages:
             pkg-manager: "poetry"
             args: "-E generate-unit-tests"
@@ -360,7 +360,7 @@ jobs:
         - <<: *install_poetry
         - <<: *install_demisto_sdk
         - setup_remote_docker:
-            version: 20.10.12
+            version: default
         - attach_workspace:
             at: ~/project
         - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
         - checkout
         - <<: *install_poetry
         - setup_remote_docker:
-            version: 20.10.12
+             version: default
         - python/install-packages:
             pkg-manager: "poetry"
             args: "-E generate-unit-tests"


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-9876

## Description
Circle-CI do not support docker version `20.10.12` anymore, need to update it.
