### PR TITLE
change to months

### DIFF
--- a/.changelog/4119.yml
+++ b/.changelog/4119.yml
@@ -1,4 +1,4 @@
 changes:
-- description: Updated the **validate** command to not fail when an image is younger than 3 months instead of 3 days.
+- description: Updated the *DO106* error code in the **validate** command to not fail when a docker image is younger than 3 months instead of 3 days.
   type: feature
 pr_number: 4119

--- a/.changelog/4119.yml
+++ b/.changelog/4119.yml
@@ -1,4 +1,4 @@
 changes:
 - description: Updated the **validate** command to not fail when an image is younger than 3 months instead of 3 days.
-  type: breaking
+  type: feature
 pr_number: 4119

--- a/.changelog/4119.yml
+++ b/.changelog/4119.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Updated the **validate** command to not fail when an image is younger than 3 months instead of 3 days.
+  type: breaking
+pr_number: 4119

--- a/demisto_sdk/commands/common/hook_validations/docker.py
+++ b/demisto_sdk/commands/common/hook_validations/docker.py
@@ -153,7 +153,7 @@ class DockerImageValidator(BaseValidator):
             suggested_fix = Errors.suggest_docker_fix(
                 self.docker_image_name, self.file_path, self.is_iron_bank
             )
-            if self.is_docker_older_than_three_days():
+            if self.is_docker_older_than_three_months():
                 if self.handle_error(
                     error_message,
                     error_code,
@@ -182,14 +182,14 @@ class DockerImageValidator(BaseValidator):
 
         return is_latest_tag
 
-    def is_docker_older_than_three_days(self):
+    def is_docker_older_than_three_months(self):
         """
         Return True if the docker is more than 3 days old.
 
         Returns:
             bool: True if the docker is more than 3 days old.
         """
-        three_days_ago: Optional[datetime] = parse("3 days ago")
+        three_days_ago: Optional[datetime] = parse("3 months ago")
         last_updated = self.get_docker_image_creation_date(
             self.docker_image_name, self.docker_image_tag
         )

--- a/demisto_sdk/commands/validate/tests/DO_validators_test.py
+++ b/demisto_sdk/commands/validate/tests/DO_validators_test.py
@@ -213,7 +213,7 @@ def test_DockerImageTagIsLatestNumericVersionValidator_is_valid(mocker, requests
      - make sure that javascripts integrations/scripts are ignored
     """
     from demisto_sdk.commands.validate.validators.DO_validators.DO106_docker_image_is_latest_tag import (
-        DockerImageTagIsLatestNumericVersionValidator,
+        DockerImageTagIsNotOutdated,
     )
 
     content_items = [
@@ -264,12 +264,12 @@ def test_DockerImageTagIsLatestNumericVersionValidator_is_valid(mocker, requests
         json={"tags": ["1.0.0.11111", "1.0.0.99999"]},
     )
     mocker.patch.object(
-        DockerImageTagIsLatestNumericVersionValidator,
-        "is_docker_image_older_than_three_days",
+        DockerImageTagIsNotOutdated,
+        "is_docker_image_older_than_three_months",
         return_value=True,
     )
 
-    results = DockerImageTagIsLatestNumericVersionValidator().is_valid(content_items)
+    results = DockerImageTagIsNotOutdated().is_valid(content_items)
     assert len(results) == 2
     for result in results:
         content_item: IntegrationScript = result.content_object
@@ -289,7 +289,7 @@ def test_DockerImageTagIsLatestNumericVersionValidator_fix(requests_mock):
      - make sure docker-image is getting updated to the latest docker tag
     """
     from demisto_sdk.commands.validate.validators.DO_validators.DO106_docker_image_is_latest_tag import (
-        DockerImageTagIsLatestNumericVersionValidator,
+        DockerImageTagIsNotOutdated,
     )
 
     integration = create_integration_object(
@@ -310,7 +310,7 @@ def test_DockerImageTagIsLatestNumericVersionValidator_fix(requests_mock):
         json={"tags": ["3.10.13.88888", "3.10.13.99999"]},
     )
 
-    fix_result = DockerImageTagIsLatestNumericVersionValidator().fix(integration)
+    fix_result = DockerImageTagIsNotOutdated().fix(integration)
     assert fix_result.content_object.docker_image == "demisto/python3:3.10.13.99999"
 
 

--- a/demisto_sdk/commands/validate/validators/DO_validators/DO106_docker_image_is_latest_tag.py
+++ b/demisto_sdk/commands/validate/validators/DO_validators/DO106_docker_image_is_latest_tag.py
@@ -22,11 +22,9 @@ from demisto_sdk.commands.validate.validators.base_validator import (
 ContentTypes = Union[Integration, Script]
 
 
-class DockerImageTagIsLatestNumericVersionValidator(BaseValidator[ContentTypes]):
+class DockerImageTagIsNotOutdated(BaseValidator[ContentTypes]):
     error_code = "DO106"
-    description = (
-        "Validate that the given content-item uses the latest tag of a docker image"
-    )
+    description = "Validate that the given content-item's docker image isnt outdated'"
     error_message = (
         "docker image {0}'s tag {1} is not the latest tag, the latest tag is {2}"
     )
@@ -35,17 +33,17 @@ class DockerImageTagIsLatestNumericVersionValidator(BaseValidator[ContentTypes])
     is_auto_fixable = True
 
     @staticmethod
-    def is_docker_image_older_than_three_days(docker_image: DockerImage) -> bool:
+    def is_docker_image_older_than_three_months(docker_image: DockerImage) -> bool:
         """
-        Return True if the docker image is more than 3 days old.
+        Return True if the docker image is more than 3 months old.
 
         Args:
             docker_image: the docker image object.
         """
-        three_days_ago: datetime = parse("3 days ago")  # type: ignore[assignment]
+        three_months_ago: datetime = parse("3 months ago")  # type: ignore[assignment]
         try:
             last_updated = docker_image.creation_date
-            return not last_updated or three_days_ago > last_updated
+            return not last_updated or three_months_ago > last_updated
         except DockerHubRequestException as error:
             if error.exception.response.status_code == requests.codes.not_found:
                 logger.debug(
@@ -91,7 +89,7 @@ class DockerImageTagIsLatestNumericVersionValidator(BaseValidator[ContentTypes])
                     continue
                 if (
                     docker_image.tag != docker_image_latest_tag
-                    and self.is_docker_image_older_than_three_days(docker_image)
+                    and self.is_docker_image_older_than_three_months(docker_image)
                 ):
                     invalid_content_items.append(
                         ValidationResult(

--- a/demisto_sdk/commands/validate/validators/DO_validators/DO106_docker_image_is_latest_tag.py
+++ b/demisto_sdk/commands/validate/validators/DO_validators/DO106_docker_image_is_latest_tag.py
@@ -25,9 +25,7 @@ ContentTypes = Union[Integration, Script]
 class DockerImageTagIsNotOutdated(BaseValidator[ContentTypes]):
     error_code = "DO106"
     description = "Validate that the given content-item's docker image isnt outdated'"
-    error_message = (
-        "docker image {0}'s tag {1} is not the latest tag, the latest tag is {2}"
-    )
+    error_message = "docker image {0}'s tag {1} is outdated. The latest tag is {2}"
     fix_message = "docker image {0} has been updated to {1}"
     related_field = "Docker image"
     is_auto_fixable = True


### PR DESCRIPTION
primary focus on this validation should no longer be that the image youre using is the latest, it should be that your image isnt outdated. Outdated is > 3 months 
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-9920