### PR TITLE
Fix Generate Docs for new Integration in Existing Pack

### DIFF
--- a/.changelog/4162.yml
+++ b/.changelog/4162.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fix a bug in `generate-docs` for new integrations in existing Packs.
+  type: fix
+pr_number: 4162

--- a/.changelog/4162.yml
+++ b/.changelog/4162.yml
@@ -1,4 +1,4 @@
 changes:
-- description: Fix a bug in `generate-docs` for new integrations in existing Packs.
+- description: Fixed an issue where **generate-docs** command didn't work on newly-created integrations in existing Packs.
   type: fix
 pr_number: 4162

--- a/demisto_sdk/commands/generate_docs/generate_integration_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_integration_doc.py
@@ -136,13 +136,12 @@ class IntegrationDocUpdateManager:
             # so there's no need to get the file from remote.
             # We therefore set the output path to the relative path from
             # the content path of the resource.
-            if self.is_ui_contribution or not remote:
+            if self.is_ui_contribution:
                 relative_resource_path = os.path.join(
                     INTEGRATIONS_DIR, self.integration_name, resource_path.name
                 )
                 path = list(get_content_path().glob(f"**/{relative_resource_path}"))[0]
-            elif remote:
-
+            else:
                 if not resource_path.is_absolute():
                     resource_path = resource_path.absolute()
 
@@ -158,7 +157,7 @@ class IntegrationDocUpdateManager:
             KeyError,
             IndexError,
         ) as e:
-            msg = f"{e.__class__.__name__}: Could not find file '{str(resource_path)}' in {'remote' if remote else 'local'}. Please specify the full path to the integration YAML file, e.g. `demisto-sdk generate-docs -i $(realpath {resource_path})`"
+            msg = f"{e.__class__.__name__}: Could not find file '{str(resource_path)}' in {'remote' if remote else 'local'}."
             logger.error(msg)
             self.update_errors.append(msg)
             path = None

--- a/demisto_sdk/commands/generate_docs/generate_integration_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_integration_doc.py
@@ -157,7 +157,7 @@ class IntegrationDocUpdateManager:
             KeyError,
             IndexError,
         ) as e:
-            msg = f"{e.__class__.__name__}: Could not find file '{str(resource_path)}' in {'remote' if remote else 'local'}."
+            msg = f"{e.__class__.__name__}: Could not find file '{resource_path}' in {'remote' if remote else 'local'}."
             self.update_errors.append(msg)
             path = None
         except InvalidGitRepositoryError as err:

--- a/demisto_sdk/commands/generate_docs/generate_integration_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_integration_doc.py
@@ -158,7 +158,6 @@ class IntegrationDocUpdateManager:
             IndexError,
         ) as e:
             msg = f"{e.__class__.__name__}: Could not find file '{str(resource_path)}' in {'remote' if remote else 'local'}."
-            logger.error(msg)
             self.update_errors.append(msg)
             path = None
         except InvalidGitRepositoryError as err:

--- a/demisto_sdk/commands/generate_docs/generate_integration_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_integration_doc.py
@@ -158,6 +158,7 @@ class IntegrationDocUpdateManager:
             IndexError,
         ) as e:
             msg = f"{e.__class__.__name__}: Could not find file '{resource_path}' in {'remote' if remote else 'local'}."
+            logger.debug(msg)
             self.update_errors.append(msg)
             path = None
         except InvalidGitRepositoryError as err:


### PR DESCRIPTION
## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-10048

## Description

Fixes an issue when a new integration exists in the local filesystem is considered an existing integration.