### PR TITLE
several validate infra failures fixes

### DIFF
--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -4189,7 +4189,7 @@ def get_file_by_status(
             )
 
         # handle renamed files which are in tuples
-        elif file_path in file:
+        elif isinstance(file, tuple) and file_path in file:
             filtered_modified_files.add(file)
             return (
                 filtered_modified_files,

--- a/demisto_sdk/commands/validate/initializer.py
+++ b/demisto_sdk/commands/validate/initializer.py
@@ -488,7 +488,7 @@ class Initializer:
                             )
                         except (NotAContentItemException, InvalidContentItemException):
                             logger.debug(
-                                f"Could not parse the old_base_content_object for {str(obj.path)}, setting a copy of the object as the old_base_content_object."
+                                f"Could not parse the old_base_content_object for {obj.path}, setting a copy of the object as the old_base_content_object."
                             )
                             obj.old_base_content_object = obj.copy(deep=True)
                     else:

--- a/demisto_sdk/commands/validate/initializer.py
+++ b/demisto_sdk/commands/validate/initializer.py
@@ -482,9 +482,15 @@ class Initializer:
                     obj.git_status = git_status
                     # Check if the file exists
                     if git_status in (GitStatuses.MODIFIED, GitStatuses.RENAMED):
-                        obj.old_base_content_object = BaseContent.from_path(
-                            old_path, git_sha=git_sha, raise_on_exception=True
-                        )
+                        try:
+                            obj.old_base_content_object = BaseContent.from_path(
+                                old_path, git_sha=git_sha, raise_on_exception=True
+                            )
+                        except (NotAContentItemException, InvalidContentItemException):
+                            logger.debug(
+                                f"Could not parse the old_base_content_object for {str(obj.path)}, setting a copy of the object as the old_base_content_object."
+                            )
+                            obj.old_base_content_object = obj.copy(deep=True)
                     else:
                         obj.old_base_content_object = obj.copy(deep=True)
                     if obj.old_base_content_object:

--- a/demisto_sdk/commands/validate/validators/base_validator.py
+++ b/demisto_sdk/commands/validate/validators/base_validator.py
@@ -205,7 +205,6 @@ class InvalidContentItemResult(BaseResult, BaseModel):
 
     @property
     def format_readable_message(self):
-        # return f"{str(self.path.relative_to(CONTENT_PATH))}: [{self.error_code}] - {self.message}"
         path: Path = self.path
         if path.is_absolute():
             path = path.relative_to(CONTENT_PATH)

--- a/demisto_sdk/commands/validate/validators/base_validator.py
+++ b/demisto_sdk/commands/validate/validators/base_validator.py
@@ -205,7 +205,11 @@ class InvalidContentItemResult(BaseResult, BaseModel):
 
     @property
     def format_readable_message(self):
-        return f"{str(self.path.relative_to(CONTENT_PATH))}: [{self.error_code}] - {self.message}"
+        # return f"{str(self.path.relative_to(CONTENT_PATH))}: [{self.error_code}] - {self.message}"
+        path: Path = self.path
+        if path.is_absolute():
+            path = path.relative_to(CONTENT_PATH)
+        return f"{str(path)}: [{self.error_code}] - {self.message}"
 
     @property
     def format_json_message(self):

--- a/demisto_sdk/commands/validate/validators/base_validator.py
+++ b/demisto_sdk/commands/validate/validators/base_validator.py
@@ -208,7 +208,7 @@ class InvalidContentItemResult(BaseResult, BaseModel):
         path: Path = self.path
         if path.is_absolute():
             path = path.relative_to(CONTENT_PATH)
-        return f"{str(path)}: [{self.error_code}] - {self.message}"
+        return f"{path}: [{self.error_code}] - {self.message}"
 
     @property
     def format_json_message(self):


### PR DESCRIPTION
## Description
- Fixed an issue where validate failed due to failure with relative and abs paths formatting.
- Fixed an issue where validate failed when didn't manage to create a reference to old content object.
- Fixed an issue where validate failed when receiving both -g & -i flags.