### PR TITLE
[slack-notifier] - avoid sending duplicated tests

### DIFF
--- a/Utils/github_workflow_scripts/slack_notifier_master/slack_notifier.py
+++ b/Utils/github_workflow_scripts/slack_notifier_master/slack_notifier.py
@@ -6,7 +6,7 @@ from github import Github, WorkflowRun
 from slack_sdk import WebClient
 
 from demisto_sdk.commands.common.logger import logger
-from Utils.pytest_junit_parser import JunitParser
+from Utils.pytest_junit_parser import JunitParser, TestResult
 
 DEFAULT_SLACK_CHANNEL = "dmst-build-test"
 
@@ -46,31 +46,26 @@ def get_failed_tests() -> Tuple[List[str], List[str], List[str]]:
     Returns:
         a list of failed unit-tests, a list of failed integration-tests, a list of failed graph-tests.
     """
-    failed_unit_tests: Set[str] = set()
-    failed_integration_tests: Set[str] = set()
-    failed_graph_tests: Set[str] = set()
+    failed_unit_tests: Set[TestResult] = set()
+    failed_integration_tests: Set[TestResult] = set()
+    failed_graph_tests: Set[TestResult] = set()
 
     for path in Path(".").glob("*/junit.xml"):
         for test_suite in JunitParser(path).test_suites:
-            failed_unit_tests = failed_unit_tests.union(
-                {str(failed_test) for failed_test in test_suite.failed_unit_tests}
-            )
+            failed_unit_tests = failed_unit_tests.union(set(test_suite.failed_tests))
             failed_integration_tests = failed_integration_tests.union(
-                {
-                    str(failed_test)
-                    for failed_test in test_suite.failed_integration_tests
-                }
+                set(test_suite.failed_integration_tests)
             )
             failed_graph_tests = failed_graph_tests.union(
-                {str(failed_test) for failed_test in test_suite.failed_graph_tests}
+                set(test_suite.failed_graph_tests)
             )
 
         logger.info(f"Finished processing junit-file {path}")
 
     return (
-        list(failed_unit_tests),
-        list(failed_integration_tests),
-        list(failed_graph_tests),
+        [str(test) for test in failed_unit_tests],
+        [str(test) for test in failed_integration_tests],
+        [str(test) for test in failed_graph_tests],
     )
 
 

--- a/Utils/pytest_junit_parser.py
+++ b/Utils/pytest_junit_parser.py
@@ -65,12 +65,11 @@ class TestResult:
         return (
             self.name == other.name
             and self.status == other.status
-            and self.time == other.status
             and self.message == other.message
         )
 
     def __hash__(self):
-        return hash((self.name, self.status, self.time, self.message))
+        return hash((self.name, self.status, self.message))
 
 
 class PytestTestSuite:


### PR DESCRIPTION

## Description
* Fixed an issue where slack-notifier sent duplicated tests in case the same tests failed on master for every python version.

If the same test failed for each python version, it will be reported into slack notifier just once.