### PR TITLE
Add id to schemas

### DIFF
--- a/demisto_sdk/commands/common/schemas/assetsmodelingrule.yml
+++ b/demisto_sdk/commands/common/schemas/assetsmodelingrule.yml
@@ -41,3 +41,13 @@ mapping:
     type: bool
   deprecated:xsoar_on_prem:
     type: bool
+  id:xsoar:
+    type: str
+  id:marketplacev2:
+    type: str
+  id:xpanse:
+    type: str
+  id:xsoar_saas:
+    type: str
+  id:xsoar_on_prem:
+    type: str

--- a/demisto_sdk/commands/common/schemas/classifier.yml
+++ b/demisto_sdk/commands/common/schemas/classifier.yml
@@ -79,3 +79,13 @@ mapping:
     type: str
   description:xsoar_on_prem:
     type: str
+  id:xsoar:
+    type: str
+  id:marketplacev2:
+    type: str
+  id:xpanse:
+    type: str
+  id:xsoar_saas:
+    type: str
+  id:xsoar_on_prem:
+    type: str

--- a/demisto_sdk/commands/common/schemas/classifier_5_9_9.yml
+++ b/demisto_sdk/commands/common/schemas/classifier_5_9_9.yml
@@ -47,3 +47,13 @@ mapping:
     allowempty: true
   custom:
     type: bool
+  id:xsoar:
+    type: str
+  id:marketplacev2:
+    type: str
+  id:xpanse:
+    type: str
+  id:xsoar_saas:
+    type: str
+  id:xsoar_on_prem:
+    type: str

--- a/demisto_sdk/commands/common/schemas/dashboard.yml
+++ b/demisto_sdk/commands/common/schemas/dashboard.yml
@@ -60,6 +60,16 @@ mapping:
     type: str
   description:xsoar_on_prem:
     type: str
+  id:xsoar:
+    type: str
+  id:marketplacev2:
+    type: str
+  id:xpanse:
+    type: str
+  id:xsoar_saas:
+    type: str
+  id:xsoar_on_prem:
+    type: str
 schema;layout_schema:
   type: map
   mapping:
@@ -90,3 +100,13 @@ schema;layout_schema:
       allowempty: true
     reflectDimensions:
       type: bool
+    id:xsoar:
+      type: str
+    id:marketplacev2:
+      type: str
+    id:xpanse:
+      type: str
+    id:xsoar_saas:
+      type: str
+    id:xsoar_on_prem:
+      type: str

--- a/demisto_sdk/commands/common/schemas/genericdefinition.yml
+++ b/demisto_sdk/commands/common/schemas/genericdefinition.yml
@@ -34,3 +34,13 @@ mapping:
     type: str
   name:xsoar_on_prem:
     type: str
+  id:xsoar:
+    type: str
+  id:marketplacev2:
+    type: str
+  id:xpanse:
+    type: str
+  id:xsoar_saas:
+    type: str
+  id:xsoar_on_prem:
+    type: str

--- a/demisto_sdk/commands/common/schemas/genericfield.yml
+++ b/demisto_sdk/commands/common/schemas/genericfield.yml
@@ -130,3 +130,13 @@ mapping:
     type: bool
   required:xsoar_on_prem:
     type: bool
+  id:xsoar:
+    type: str
+  id:marketplacev2:
+    type: str
+  id:xpanse:
+    type: str
+  id:xsoar_saas:
+    type: str
+  id:xsoar_on_prem:
+    type: str

--- a/demisto_sdk/commands/common/schemas/genericmodule.yml
+++ b/demisto_sdk/commands/common/schemas/genericmodule.yml
@@ -66,3 +66,13 @@ mapping:
     type: str
   name:xsoar_on_prem:
     type: str
+  id:xsoar:
+    type: str
+  id:marketplacev2:
+    type: str
+  id:xpanse:
+    type: str
+  id:xsoar_saas:
+    type: str
+  id:xsoar_on_prem:
+    type: str

--- a/demisto_sdk/commands/common/schemas/generictype.yml
+++ b/demisto_sdk/commands/common/schemas/generictype.yml
@@ -89,3 +89,13 @@ mapping:
     type: str
   name:xsoar_on_prem:
     type: str
+  id:xsoar:
+    type: str
+  id:marketplacev2:
+    type: str
+  id:xpanse:
+    type: str
+  id:xsoar_saas:
+    type: str
+  id:xsoar_on_prem:
+    type: str

--- a/demisto_sdk/commands/common/schemas/incidentfield.yml
+++ b/demisto_sdk/commands/common/schemas/incidentfield.yml
@@ -145,6 +145,16 @@ mapping:
     type: bool
   required:xsoar_on_prem:
     type: bool
+  id:xsoar:
+    type: str
+  id:marketplacev2:
+    type: str
+  id:xpanse:
+    type: str
+  id:xsoar_saas:
+    type: str
+  id:xsoar_on_prem:
+    type: str
 schema;aliases_schema:
   type: map
   mapping:

--- a/demisto_sdk/commands/common/schemas/incidentfields.yml
+++ b/demisto_sdk/commands/common/schemas/incidentfields.yml
@@ -133,6 +133,16 @@ schema;field_schema:
       type: bool
     required:xsoar_on_prem:
       type: bool
+    id:xsoar:
+      type: str
+    id:marketplacev2:
+      type: str
+    id:xpanse:
+      type: str
+    id:xsoar_saas:
+      type: str
+    id:xsoar_on_prem:
+      type: str
 schema;aliases_schema:
   type: map
   mapping:

--- a/demisto_sdk/commands/common/schemas/incidenttype.yml
+++ b/demisto_sdk/commands/common/schemas/incidenttype.yml
@@ -88,3 +88,13 @@ mapping:
     type: str
   name:xsoar_on_prem:
     type: str
+  id:xsoar:
+    type: str
+  id:marketplacev2:
+    type: str
+  id:xpanse:
+    type: str
+  id:xsoar_saas:
+    type: str
+  id:xsoar_on_prem:
+    type: str

--- a/demisto_sdk/commands/common/schemas/indicatorfield.yml
+++ b/demisto_sdk/commands/common/schemas/indicatorfield.yml
@@ -121,3 +121,13 @@ mapping:
     type: bool
   required:xsoar_on_prem:
     type: bool
+  id:xsoar:
+    type: str
+  id:marketplacev2:
+    type: str
+  id:xpanse:
+    type: str
+  id:xsoar_saas:
+    type: str
+  id:xsoar_on_prem:
+    type: str

--- a/demisto_sdk/commands/common/schemas/integration.yml
+++ b/demisto_sdk/commands/common/schemas/integration.yml
@@ -14,6 +14,16 @@ mapping:
         type: seq
         sequence:
         - type: str
+      id:xsoar:
+        type: str
+      id:marketplacev2:
+        type: str
+      id:xpanse:
+        type: str
+      id:xsoar_saas:
+        type: str
+      id:xsoar_on_prem:
+        type: str
   name:
     type: str
     required: true

--- a/demisto_sdk/commands/common/schemas/job.yml
+++ b/demisto_sdk/commands/common/schemas/job.yml
@@ -294,3 +294,13 @@ mapping:
     type: str
   description:xsoar_on_prem:
     type: str
+  id:xsoar:
+    type: str
+  id:marketplacev2:
+    type: str
+  id:xpanse:
+    type: str
+  id:xsoar_saas:
+    type: str
+  id:xsoar_on_prem:
+    type: str

--- a/demisto_sdk/commands/common/schemas/layout.yml
+++ b/demisto_sdk/commands/common/schemas/layout.yml
@@ -60,6 +60,16 @@ mapping:
         type: str
       name:xsoar_on_prem:
         type: str
+      id:xsoar:
+        type: str
+      id:marketplacev2:
+        type: str
+      id:xpanse:
+        type: str
+      id:xsoar_saas:
+        type: str
+      id:xsoar_on_prem:
+        type: str
   definitionId:
     type: str
 
@@ -72,6 +82,16 @@ mapping:
   description:xsoar_saas:
     type: str
   description:xsoar_on_prem:
+    type: str
+  id:xsoar:
+    type: str
+  id:marketplacev2:
+    type: str
+  id:xpanse:
+    type: str
+  id:xsoar_saas:
+    type: str
+  id:xsoar_on_prem:
     type: str
 schema;tabs_schema:
   type: any
@@ -126,6 +146,16 @@ schema;section_schema:
       type: str
     description:xsoar_on_prem:
       type: str
+    id:xsoar:
+      type: str
+    id:marketplacev2:
+      type: str
+    id:xpanse:
+      type: str
+    id:xsoar_saas:
+      type: str
+    id:xsoar_on_prem:
+      type: str
 schema;field_schema:
   type: map
   mapping:
@@ -140,4 +170,14 @@ schema;field_schema:
     isVisible:
       type: bool
     sortValues:
+      type: str
+    id:xsoar:
+      type: str
+    id:marketplacev2:
+      type: str
+    id:xpanse:
+      type: str
+    id:xsoar_saas:
+      type: str
+    id:xsoar_on_prem:
       type: str

--- a/demisto_sdk/commands/common/schemas/layoutscontainer.yml
+++ b/demisto_sdk/commands/common/schemas/layoutscontainer.yml
@@ -138,6 +138,16 @@ mapping:
     type: str
   description:xsoar_on_prem:
     type: str
+  id:xsoar:
+    type: str
+  id:marketplacev2:
+    type: str
+  id:xpanse:
+    type: str
+  id:xsoar_saas:
+    type: str
+  id:xsoar_on_prem:
+    type: str
 schema;tabs_schema:
   type: any
 
@@ -191,6 +201,16 @@ schema;section_schema:
       type: str
     description:xsoar_on_prem:
       type: str
+    id:xsoar:
+      type: str
+    id:marketplacev2:
+      type: str
+    id:xpanse:
+      type: str
+    id:xsoar_saas:
+      type: str
+    id:xsoar_on_prem:
+      type: str
 schema;field_schema:
   type: map
   mapping:
@@ -211,6 +231,16 @@ schema;field_schema:
       sequence:
       - include: arg_filters_schema
 
+    id:xsoar:
+      type: str
+    id:marketplacev2:
+      type: str
+    id:xpanse:
+      type: str
+    id:xsoar_saas:
+      type: str
+    id:xsoar_on_prem:
+      type: str
 schema;arg_filters_schema:
   type: seq
   sequence:

--- a/demisto_sdk/commands/common/schemas/list.yml
+++ b/demisto_sdk/commands/common/schemas/list.yml
@@ -83,6 +83,16 @@ mapping:
     type: str
   name:xsoar_on_prem:
     type: str
+  id:xsoar:
+    type: str
+  id:marketplacev2:
+    type: str
+  id:xpanse:
+    type: str
+  id:xsoar_saas:
+    type: str
+  id:xsoar_on_prem:
+    type: str
 schema;previousRoles_schema:
   type: any
 

--- a/demisto_sdk/commands/common/schemas/mapper.yml
+++ b/demisto_sdk/commands/common/schemas/mapper.yml
@@ -58,3 +58,13 @@ mapping:
     type: str
   description:xsoar_on_prem:
     type: str
+  id:xsoar:
+    type: str
+  id:marketplacev2:
+    type: str
+  id:xpanse:
+    type: str
+  id:xsoar_saas:
+    type: str
+  id:xsoar_on_prem:
+    type: str

--- a/demisto_sdk/commands/common/schemas/modelingrule.yml
+++ b/demisto_sdk/commands/common/schemas/modelingrule.yml
@@ -41,3 +41,13 @@ mapping:
     type: bool
   deprecated:xsoar_on_prem:
     type: bool
+  id:xsoar:
+    type: str
+  id:marketplacev2:
+    type: str
+  id:xpanse:
+    type: str
+  id:xsoar_saas:
+    type: str
+  id:xsoar_on_prem:
+    type: str

--- a/demisto_sdk/commands/common/schemas/parsingrule.yml
+++ b/demisto_sdk/commands/common/schemas/parsingrule.yml
@@ -46,3 +46,13 @@ mapping:
     type: bool
   deprecated:xsoar_on_prem:
     type: bool
+  id:xsoar:
+    type: str
+  id:marketplacev2:
+    type: str
+  id:xpanse:
+    type: str
+  id:xsoar_saas:
+    type: str
+  id:xsoar_on_prem:
+    type: str

--- a/demisto_sdk/commands/common/schemas/playbook.yml
+++ b/demisto_sdk/commands/common/schemas/playbook.yml
@@ -232,6 +232,16 @@ mapping:
                 type: str
               description:xsoar_on_prem:
                 type: str
+              id:xsoar:
+                type: text
+              id:marketplacev2:
+                type: text
+              id:xpanse:
+                type: text
+              id:xsoar_saas:
+                type: text
+              id:xsoar_on_prem:
+                type: text
           note:
             type: bool
           nexttasks:
@@ -291,6 +301,16 @@ mapping:
             - type: map
               allowempty: true
 
+          id:xsoar:
+            type: text
+          id:marketplacev2:
+            type: text
+          id:xpanse:
+            type: text
+          id:xsoar_saas:
+            type: text
+          id:xsoar_on_prem:
+            type: text
   system:
     type: bool
   fromversion:
@@ -346,6 +366,16 @@ mapping:
     type: bool
   deprecated:xsoar_on_prem:
     type: bool
+  id:xsoar:
+    type: str
+  id:marketplacev2:
+    type: str
+  id:xpanse:
+    type: str
+  id:xsoar_saas:
+    type: str
+  id:xsoar_on_prem:
+    type: str
 schema;task_schema:
   type: map
   allowempty: true

--- a/demisto_sdk/commands/common/schemas/pre-process-rule.yml
+++ b/demisto_sdk/commands/common/schemas/pre-process-rule.yml
@@ -92,6 +92,16 @@ mapping:
     type: str
   description:xsoar_on_prem:
     type: str
+  id:xsoar:
+    type: str
+  id:marketplacev2:
+    type: str
+  id:xpanse:
+    type: str
+  id:xsoar_saas:
+    type: str
+  id:xsoar_on_prem:
+    type: str
 schema;existingEventsFilters_schema:
   type: any
 

--- a/demisto_sdk/commands/common/schemas/report.yml
+++ b/demisto_sdk/commands/common/schemas/report.yml
@@ -123,6 +123,16 @@ mapping:
         type: str
       name:xsoar_on_prem:
         type: str
+      id:xsoar:
+        type: str
+      id:marketplacev2:
+        type: str
+      id:xpanse:
+        type: str
+      id:xsoar_saas:
+        type: str
+      id:xsoar_on_prem:
+        type: str
   decoder:
     type: map
     mapping:
@@ -170,6 +180,16 @@ mapping:
   description:xsoar_saas:
     type: str
   description:xsoar_on_prem:
+    type: str
+  id:xsoar:
+    type: str
+  id:marketplacev2:
+    type: str
+  id:xpanse:
+    type: str
+  id:xsoar_saas:
+    type: str
+  id:xsoar_on_prem:
     type: str
 schema;layout_schema:
   type: map
@@ -243,3 +263,23 @@ schema;layout_schema:
           type: str
         name:xsoar_on_prem:
           type: str
+        id:xsoar:
+          type: str
+        id:marketplacev2:
+          type: str
+        id:xpanse:
+          type: str
+        id:xsoar_saas:
+          type: str
+        id:xsoar_on_prem:
+          type: str
+    id:xsoar:
+      type: str
+    id:marketplacev2:
+      type: str
+    id:xpanse:
+      type: str
+    id:xsoar_saas:
+      type: str
+    id:xsoar_on_prem:
+      type: str

--- a/demisto_sdk/commands/common/schemas/reputation.yml
+++ b/demisto_sdk/commands/common/schemas/reputation.yml
@@ -73,3 +73,13 @@ mapping:
     sequence:
     - type: str
       enum: ['xsoar', 'marketplacev2', 'xpanse', 'xsoar_saas', 'xsoar_on_prem']
+  id:xsoar:
+    type: str
+  id:marketplacev2:
+    type: str
+  id:xpanse:
+    type: str
+  id:xsoar_saas:
+    type: str
+  id:xsoar_on_prem:
+    type: str

--- a/demisto_sdk/commands/common/schemas/script.yml
+++ b/demisto_sdk/commands/common/schemas/script.yml
@@ -12,6 +12,16 @@ mapping:
       version:
         type: int
         required: true
+      id:xsoar:
+        type: str
+      id:marketplacev2:
+        type: str
+      id:xpanse:
+        type: str
+      id:xsoar_saas:
+        type: str
+      id:xsoar_on_prem:
+        type: str
   name:
     type: str
     required: true

--- a/demisto_sdk/commands/common/schemas/widget.yml
+++ b/demisto_sdk/commands/common/schemas/widget.yml
@@ -63,3 +63,13 @@ mapping:
     type: str
   description:xsoar_on_prem:
     type: str
+  id:xsoar:
+    type: str
+  id:marketplacev2:
+    type: str
+  id:xpanse:
+    type: str
+  id:xsoar_saas:
+    type: str
+  id:xsoar_on_prem:
+    type: str

--- a/demisto_sdk/commands/common/schemas/wizard.yml
+++ b/demisto_sdk/commands/common/schemas/wizard.yml
@@ -98,6 +98,16 @@ mapping:
     type: bool
   deprecated:xsoar_on_prem:
     type: bool
+  id:xsoar:
+    type: str
+  id:marketplacev2:
+    type: str
+  id:xpanse:
+    type: str
+  id:xsoar_saas:
+    type: str
+  id:xsoar_on_prem:
+    type: str
 schema;integrations_schema:
   type: map
   mapping:

--- a/demisto_sdk/commands/common/schemas/xsiamdashboard.yml
+++ b/demisto_sdk/commands/common/schemas/xsiamdashboard.yml
@@ -85,6 +85,16 @@ schema;layout_schema:
       - include: layout_data_schema
 
 
+    id:xsoar:
+      type: str
+    id:marketplacev2:
+      type: str
+    id:xpanse:
+      type: str
+    id:xsoar_saas:
+      type: str
+    id:xsoar_on_prem:
+      type: str
 schema;layout_data_schema:
   type: map
   mapping:

--- a/demisto_sdk/commands/common/schemas/xsiamreport.yml
+++ b/demisto_sdk/commands/common/schemas/xsiamreport.yml
@@ -55,6 +55,16 @@ schema;layout_schema:
       sequence:
       - include: layout_data_schema
 
+    id:xsoar:
+      type: str
+    id:marketplacev2:
+      type: str
+    id:xpanse:
+      type: str
+    id:xsoar_saas:
+      type: str
+    id:xsoar_on_prem:
+      type: str
 schema;layout_data_schema:
   type: map
   mapping:

--- a/demisto_sdk/commands/common/tests/structure_test.py
+++ b/demisto_sdk/commands/common/tests/structure_test.py
@@ -548,12 +548,12 @@ class TestStructureValidator:
         structure = StructureValidator(str(tmp_path / "integration.yml"))
         assert structure.is_valid_scheme()
 
-        yml["commonfields"]["id:xsoar"] = "not-valid"  # can't edit the id
+        yml["commonfields"]["id:xsoar"] = "editid"  # edit id
 
-        write_dict(tmp_path / "integration-invalid.yml", yml)
+        write_dict(tmp_path / "integration-editid.yml", yml)
 
-        structure = StructureValidator(str(tmp_path / "integration-invalid.yml"))
-        assert not structure.is_valid_scheme()
+        structure = StructureValidator(str(tmp_path / "integration-editid.yml"))
+        assert structure.is_valid_scheme()
 
 
 class TestGetMatchingRegex:

--- a/demisto_sdk/scripts/add_marketplace_to_schemas.py
+++ b/demisto_sdk/scripts/add_marketplace_to_schemas.py
@@ -8,8 +8,9 @@ from demisto_sdk.commands.common.tools import get_file, write_dict
 
 GIT_ROOT = Path(git_path())
 SCHEMA_FOLDER = GIT_ROOT / "demisto_sdk" / "commands" / "common" / "schemas"
-NON_SUPPORTED_KEYS = ["id"]
+NON_SUPPORTED_KEYS = [""]
 SUPPORTED_KEYS = [
+    "id",
     "isfetch",
     "defaultValue",
     "defaultvalue",


### PR DESCRIPTION
Add id to validate schemas, enables the ability to have different ids in different marketplaces for the same content item in the repo.