### PR TITLE
free up resources when running pre-commit

### DIFF
--- a/.changelog/4196.yml
+++ b/.changelog/4196.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue in **pre-commit** when using `--all-files` it crashed with memory error.
+  type: fix
+pr_number: 4196

--- a/demisto_sdk/commands/pre_commit/pre_commit_command.py
+++ b/demisto_sdk/commands/pre_commit/pre_commit_command.py
@@ -205,7 +205,8 @@ class PreCommitRunner:
             logger.info(f"[yellow]Running hook {pre_commit_context.run_hook}[/yellow]")
 
         write_dict(PRECOMMIT_CONFIG_MAIN_PATH, pre_commit_context.precommit_template)
-
+        # we don't need the context anymore, we can clear it to free up memory for the pre-commit checks
+        del pre_commit_context
         # install dependencies of all hooks in advance
         PreCommitRunner._run_pre_commit_process(
             PRECOMMIT_CONFIG_MAIN_PATH,


### PR DESCRIPTION
The pre-commit context stores a bit amount of memory. Once we write it to a file, we don't need to store this object and we can simply delete it, so the pre-commit checks will run with more free memory

fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-10173