### PR TITLE
sdk release - use the tag instead of the branch

### DIFF
--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -24,9 +24,11 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ inputs.branch_name }}
+
+      - name: Fetch and checkout release tag $${{ inputs.branch_name }}
+        run: |
+            git fetch --tags
+            git checkout tags/v${{ inputs.branch_name }}
 
       - name: Setup python
         uses: actions/setup-python@v5


### PR DESCRIPTION
We should use the tag as base to release the changelog