### PR TITLE
skip deleted packs when parsing packs in the graph

### DIFF
--- a/.changelog/4205.yml
+++ b/.changelog/4205.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Added support to delete packs in **graph update**
+  type: fix
+pr_number: 4205

--- a/demisto_sdk/commands/content_graph/parsers/repository.py
+++ b/demisto_sdk/commands/content_graph/parsers/repository.py
@@ -60,8 +60,8 @@ class RepositoryParser:
     def parse_pack(pack_path: Path) -> Optional[PackParser]:
         try:
             return PackParser(pack_path)
-        except NotAContentItemException:
-            logger.error(f"Pack {pack_path.name} is not a valid pack. Skipping")
+        except (NotAContentItemException, FileNotFoundError):
+            logger.warning(f"Pack {pack_path.name} is not a valid pack. Skipping")
             return None
 
     @staticmethod


### PR DESCRIPTION
This fixes an issue where a pack was deleted and the SDK tried to parse the deleted pack when updating the graph

fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-10236