### PR TITLE
clean graph with cleaning data folder

### DIFF
--- a/.changelog/4215.yml
+++ b/.changelog/4215.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where the graph was not fully cleaned before import in **graph update**
+  type: fix
+pr_number: 4215

--- a/demisto_sdk/commands/content_graph/interface/neo4j/neo4j_graph.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/neo4j_graph.py
@@ -43,7 +43,6 @@ from demisto_sdk.commands.content_graph.interface.neo4j.queries.indexes import (
 from demisto_sdk.commands.content_graph.interface.neo4j.queries.nodes import (
     _match,
     create_nodes,
-    delete_all_graph_nodes,
     get_relationships_to_preserve,
     get_schema,
     remove_content_private_nodes,
@@ -662,8 +661,7 @@ class Neo4jContentGraphInterface(ContentGraphInterface):
             self.zip_import_dir(output_path)
 
     def clean_graph(self):
-        with self.driver.session() as session:
-            session.execute_write(delete_all_graph_nodes)
+        neo4j_service.clean()
         self._id_to_obj = {}
 
     def search(

--- a/demisto_sdk/commands/content_graph/interface/neo4j/neo4j_graph.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/neo4j_graph.py
@@ -43,6 +43,7 @@ from demisto_sdk.commands.content_graph.interface.neo4j.queries.indexes import (
 from demisto_sdk.commands.content_graph.interface.neo4j.queries.nodes import (
     _match,
     create_nodes,
+    delete_all_graph_nodes,
     get_relationships_to_preserve,
     get_schema,
     remove_content_private_nodes,
@@ -661,6 +662,8 @@ class Neo4jContentGraphInterface(ContentGraphInterface):
             self.zip_import_dir(output_path)
 
     def clean_graph(self):
+        with self.driver.session() as session:
+            session.execute_write(delete_all_graph_nodes)
         neo4j_service.clean()
         self._id_to_obj = {}
 

--- a/demisto_sdk/commands/content_graph/interface/neo4j/neo4j_graph.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/neo4j_graph.py
@@ -55,6 +55,7 @@ from demisto_sdk.commands.content_graph.interface.neo4j.queries.nodes import (
 from demisto_sdk.commands.content_graph.interface.neo4j.queries.relationships import (
     _match_relationships,
     create_relationships,
+    delete_all_graph_relationships,
     get_sources_by_path,
     get_targets_by_path,
 )
@@ -663,8 +664,8 @@ class Neo4jContentGraphInterface(ContentGraphInterface):
 
     def clean_graph(self):
         with self.driver.session() as session:
+            session.execute_write(delete_all_graph_relationships)
             session.execute_write(delete_all_graph_nodes)
-        neo4j_service.clean()
         self._id_to_obj = {}
 
     def search(

--- a/demisto_sdk/commands/content_graph/interface/neo4j/queries/nodes.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/queries/nodes.py
@@ -260,7 +260,7 @@ def delete_all_graph_nodes(tx: Transaction) -> None:
         CALL { WITH n
         DETACH DELETE n
         };
-"""
+    """
     run_query(tx, query)
 
 

--- a/demisto_sdk/commands/content_graph/interface/neo4j/queries/nodes.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/queries/nodes.py
@@ -255,9 +255,12 @@ def get_list_properties(tx: Transaction) -> List[str]:
 
 
 def delete_all_graph_nodes(tx: Transaction) -> None:
-    query = """// Deletes all graph nodes and relationships
-MATCH (n)
-DETACH DELETE n"""
+    query = """// Deletes all graph nodes
+        MATCH (n)
+        CALL { WITH n
+        DETACH DELETE n
+        };
+"""
     run_query(tx, query)
 
 

--- a/demisto_sdk/commands/content_graph/interface/neo4j/queries/relationships.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/queries/relationships.py
@@ -421,3 +421,13 @@ RETURN
     minDepth
 ORDER BY content_type, object_id"""
     return run_query(tx, query).data()
+
+
+def delete_all_graph_relationships(tx: Transaction) -> None:
+    query = """// Deletes all graph relationships
+        MATCH ()-[r]->()
+        CALL { WITH r
+        DELETE r
+        };
+    """
+    run_query(tx, query)

--- a/demisto_sdk/commands/content_graph/neo4j_service.py
+++ b/demisto_sdk/commands/content_graph/neo4j_service.py
@@ -184,18 +184,3 @@ def get_neo4j_import_path() -> Path:
     if not is_running_on_docker():
         return LOCAL_NEO4J_PATH / NEO4J_IMPORT_FOLDER
     return NEO4J_DIR / NEO4J_IMPORT_FOLDER
-
-
-def clean():
-    """Clean the neo4j data folder"""
-    if is_running_on_docker():
-        data_folder = NEO4J_DIR / NEO4J_DATA_FOLDER
-    else:
-        data_folder = LOCAL_NEO4J_PATH / NEO4J_DATA_FOLDER
-    if not data_folder.exists():
-        return
-    for file in data_folder.iterdir():
-        if file.is_dir():
-            shutil.rmtree(file, ignore_errors=True)
-        else:
-            file.unlink()

--- a/demisto_sdk/commands/content_graph/neo4j_service.py
+++ b/demisto_sdk/commands/content_graph/neo4j_service.py
@@ -184,3 +184,11 @@ def get_neo4j_import_path() -> Path:
     if not is_running_on_docker():
         return LOCAL_NEO4J_PATH / NEO4J_IMPORT_FOLDER
     return NEO4J_DIR / NEO4J_IMPORT_FOLDER
+
+
+def clean():
+    """Clean the neo4j data folder"""
+    if is_running_on_docker():
+        shutil.rmtree(NEO4J_DIR / NEO4J_DATA_FOLDER, ignore_errors=True)
+    else:
+        shutil.rmtree(LOCAL_NEO4J_PATH / NEO4J_DATA_FOLDER, ignore_errors=True)

--- a/demisto_sdk/commands/content_graph/neo4j_service.py
+++ b/demisto_sdk/commands/content_graph/neo4j_service.py
@@ -189,6 +189,11 @@ def get_neo4j_import_path() -> Path:
 def clean():
     """Clean the neo4j data folder"""
     if is_running_on_docker():
-        shutil.rmtree(NEO4J_DIR / NEO4J_DATA_FOLDER, ignore_errors=True)
+        data_folder = NEO4J_DIR / NEO4J_DATA_FOLDER
     else:
-        shutil.rmtree(LOCAL_NEO4J_PATH / NEO4J_DATA_FOLDER, ignore_errors=True)
+        data_folder = LOCAL_NEO4J_PATH / NEO4J_DATA_FOLDER
+    for file in data_folder.iterdir():
+        if file.is_dir():
+            shutil.rmtree(file, ignore_errors=True)
+        else:
+            file.unlink()

--- a/demisto_sdk/commands/content_graph/neo4j_service.py
+++ b/demisto_sdk/commands/content_graph/neo4j_service.py
@@ -192,6 +192,8 @@ def clean():
         data_folder = NEO4J_DIR / NEO4J_DATA_FOLDER
     else:
         data_folder = LOCAL_NEO4J_PATH / NEO4J_DATA_FOLDER
+    if not data_folder.exists():
+        return
     for file in data_folder.iterdir():
         if file.is_dir():
             shutil.rmtree(file, ignore_errors=True)


### PR DESCRIPTION
Sometimes cleaning the graph with a query doesn't clean all the data and it fails to create a graph after it.
Instead, we can delete the neo4j data folder