### PR TITLE
Fix setup env test collection

### DIFF
--- a/.changelog/4219.yml
+++ b/.changelog/4219.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where tests were not collected in VSCode after **setup-env**
+  type: fix
+pr_number: 4219

--- a/demisto_sdk/commands/setup_env/setup_environment.py
+++ b/demisto_sdk/commands/setup_env/setup_environment.py
@@ -44,6 +44,7 @@ from demisto_sdk.commands.content_graph.objects.pack import Pack
 
 BACKUP_FILES_SUFFIX = ".demisto_sdk_backup"
 DOTENV_PATH = CONTENT_PATH / ".env"
+DOTENV_DOCKER_PATH = CONTENT_PATH / ".env.docker"
 
 
 class IDEType(Enum):
@@ -281,10 +282,9 @@ def configure_module_discovery(ide_type: IDEType):
         env_file = CONTENT_PATH / ".env"
         env_vars = dotenv.dotenv_values(env_file)
         env_vars["PYTHONPATH"] = PYTHONPATH_STR
-        update_dotenv(env_file, env_vars)
-        env_file_docker = CONTENT_PATH / ".env.docker"
+        update_dotenv(DOTENV_PATH, env_vars)
         env_vars.pop("PYTHONPATH", None)
-        update_dotenv(env_file_docker, env_vars)
+        update_dotenv(DOTENV_DOCKER_PATH, env_vars)
 
     if ide_type == IDEType.PYCHARM:
         python_discovery_paths = PYTHONPATH.copy()
@@ -327,7 +327,7 @@ def configure_vscode_tasks(
                         "env": {
                             "PYTHONPATH": ":".join(docker_python_path),
                         },
-                        "envfiles": [str(CONTENT_PATH / ".env.docker")],
+                        "envfiles": [str(DOTENV_DOCKER_PATH)],
                     },
                 },
                 {
@@ -352,7 +352,7 @@ def configure_vscode_tasks(
                         ],
                         "customOptions": f"-w /app/{integration_script.path.parent.relative_to(CONTENT_PATH.absolute())}",
                         "env": {"PYTHONPATH": ":".join(docker_python_path)},
-                        "envfiles": [str(CONTENT_PATH / ".env.docker")],
+                        "envfiles": [str(DOTENV_DOCKER_PATH)],
                     },
                 },
             ],
@@ -640,6 +640,11 @@ def configure_params(
                     )
             update_dotenv(
                 file_path=DOTENV_PATH,
+                values={"DEMISTO_PARAMS": json.dumps(params)},
+                quote_mode="never",
+            )
+            update_dotenv(
+                file_path=DOTENV_DOCKER_PATH,
                 values={"DEMISTO_PARAMS": json.dumps(params)},
                 quote_mode="never",
             )

--- a/demisto_sdk/commands/setup_env/setup_environment.py
+++ b/demisto_sdk/commands/setup_env/setup_environment.py
@@ -761,6 +761,7 @@ def configure_integration(
         )
 
     if create_virtualenv and integration_script.type.startswith("python"):
+        (base_path / ".vscode" / "launch.json").unlink(missing_ok=True)
         pack = integration_script.in_pack
         assert isinstance(pack, Pack), "Expected pack"
         base_path = pack.path

--- a/demisto_sdk/commands/setup_env/setup_environment.py
+++ b/demisto_sdk/commands/setup_env/setup_environment.py
@@ -278,12 +278,13 @@ def configure_module_discovery(ide_type: IDEType):
         ide_folder = CONTENT_PATH / ".vscode"
         ide_folder.mkdir(exist_ok=True, parents=True)
         configure_vscode_settings(ide_folder=ide_folder)
-        # Delete PYTHONPATH and MYPYPATH from env file because they are not needed
         env_file = CONTENT_PATH / ".env"
         env_vars = dotenv.dotenv_values(env_file)
-        env_vars.pop("PYTHONPATH", None)
-        env_vars.pop("MYPYPATH", None)
+        env_vars["PYTHONPATH"] = PYTHONPATH_STR
         update_dotenv(env_file, env_vars)
+        env_file_docker = CONTENT_PATH / ".env.docker"
+        env_vars.pop("PYTHONPATH", None)
+        update_dotenv(env_file_docker, env_vars)
 
     if ide_type == IDEType.PYCHARM:
         python_discovery_paths = PYTHONPATH.copy()
@@ -326,6 +327,7 @@ def configure_vscode_tasks(
                         "env": {
                             "PYTHONPATH": ":".join(docker_python_path),
                         },
+                        "envfiles": [str(CONTENT_PATH / ".env.docker")],
                     },
                 },
                 {
@@ -350,6 +352,7 @@ def configure_vscode_tasks(
                         ],
                         "customOptions": f"-w /app/{integration_script.path.parent.relative_to(CONTENT_PATH.absolute())}",
                         "env": {"PYTHONPATH": ":".join(docker_python_path)},
+                        "envfiles": [str(CONTENT_PATH / ".env.docker")],
                     },
                 },
             ],

--- a/demisto_sdk/commands/setup_env/setup_environment.py
+++ b/demisto_sdk/commands/setup_env/setup_environment.py
@@ -413,7 +413,7 @@ def configure_vscode_launch(
                     },
                     {
                         "name": "Python: Debug Integration locally",
-                        "type": "python",
+                        "type": "debugpy",
                         "request": "launch",
                         "program": f"/workspaces/content/{integration_script.path.relative_to(CONTENT_PATH)}"
                         if devcontainer
@@ -425,7 +425,7 @@ def configure_vscode_launch(
                     },
                     {
                         "name": "Python: Debug Tests",
-                        "type": "python",
+                        "type": "debugpy",
                         "request": "launch",
                         "program": "${file}",
                         "purpose": ["debug-test"],

--- a/demisto_sdk/commands/setup_env/setup_environment.py
+++ b/demisto_sdk/commands/setup_env/setup_environment.py
@@ -791,7 +791,7 @@ def clean_repo():
     """
     for path in PYTHONPATH:
         for temp_file in CONTENT_PATH.rglob(f"{path.name}.py"):
-            if temp_file.parent != path:
+            if temp_file.parent != path and ".venv" not in temp_file.parts:
                 temp_file.unlink(missing_ok=True)
     for path in CONTENT_PATH.rglob("*.pyc"):
         path.unlink(missing_ok=True)

--- a/demisto_sdk/commands/setup_env/setup_environment.py
+++ b/demisto_sdk/commands/setup_env/setup_environment.py
@@ -327,7 +327,7 @@ def configure_vscode_tasks(
                         "env": {
                             "PYTHONPATH": ":".join(docker_python_path),
                         },
-                        "envfiles": [str(DOTENV_DOCKER_PATH)],
+                        "envFiles": [str(DOTENV_DOCKER_PATH)],
                     },
                 },
                 {
@@ -352,7 +352,7 @@ def configure_vscode_tasks(
                         ],
                         "customOptions": f"-w /app/{integration_script.path.parent.relative_to(CONTENT_PATH.absolute())}",
                         "env": {"PYTHONPATH": ":".join(docker_python_path)},
-                        "envfiles": [str(DOTENV_DOCKER_PATH)],
+                        "envFiles": [str(DOTENV_DOCKER_PATH)],
                     },
                 },
             ],

--- a/demisto_sdk/commands/setup_env/tests/setup_environment_test.py
+++ b/demisto_sdk/commands/setup_env/tests/setup_environment_test.py
@@ -96,13 +96,13 @@ def test_setup_env_vscode(mocker, monkeypatch, pack, create_virtualenv):
     tasks = tasks_json["tasks"]
     assert (
         tasks[0]["python"]["file"]
-        == f"/{str(repo_path)}/Packs/pack_0/Integrations/integration_0/integration_0.py"
+        == f"{str(repo_path)}/Packs/pack_0/Integrations/integration_0/integration_0.py"
     )
     assert tasks[0]["dockerRun"]["image"] == image
     assert tasks[1]["python"]["module"] == "pytest"
     assert (
         tasks[1]["python"]["args"][-1]
-        == f"/{str(repo_path)}/Packs/pack_0/Integrations/integration_0/integration_0_test.py"
+        == f"{str(repo_path)}/Packs/pack_0/Integrations/integration_0/integration_0_test.py"
     )
     assert tasks[1]["dockerRun"]["image"] == test_image
 

--- a/demisto_sdk/commands/setup_env/tests/setup_environment_test.py
+++ b/demisto_sdk/commands/setup_env/tests/setup_environment_test.py
@@ -74,7 +74,7 @@ def test_setup_env_vscode(mocker, monkeypatch, pack, create_virtualenv):
     )
     dotenv_text = (repo_path / ".env").read_text()
     assert "DEMISTO_PARAMS" in dotenv_text
-    assert "PYTHONPATH" not in dotenv_text
+    assert "PYTHONPATH" in dotenv_text
     vscode_folder = (
         repo_path / ".vscode" if not create_virtualenv else Path(pack.path) / ".vscode"
     )

--- a/demisto_sdk/commands/setup_env/tests/setup_environment_test.py
+++ b/demisto_sdk/commands/setup_env/tests/setup_environment_test.py
@@ -96,13 +96,13 @@ def test_setup_env_vscode(mocker, monkeypatch, pack, create_virtualenv):
     tasks = tasks_json["tasks"]
     assert (
         tasks[0]["python"]["file"]
-        == "/app/Packs/pack_0/Integrations/integration_0/integration_0.py"
+        == f"/{str(repo_path)}/Packs/pack_0/Integrations/integration_0/integration_0.py"
     )
     assert tasks[0]["dockerRun"]["image"] == image
     assert tasks[1]["python"]["module"] == "pytest"
     assert (
         tasks[1]["python"]["args"][-1]
-        == "/app/Packs/pack_0/Integrations/integration_0/integration_0_test.py"
+        == f"/{str(repo_path)}/Packs/pack_0/Integrations/integration_0/integration_0_test.py"
     )
     assert tasks[1]["dockerRun"]["image"] == test_image
 


### PR DESCRIPTION
fixes the following:
* This will create a seperate .env for the docker run. We have to use it because the path are different between the host and container
* Change to use `debugpy` in luanch since `python` debugging is deprecated.

fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-10277