### PR TITLE
[dockerhub-client] - handle 429 errors with username:password

### DIFF
--- a/.changelog/4227.yml
+++ b/.changelog/4227.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where requests to dockerhub failed on rate-limits when authenticating with username and password.
+  type: fix
+pr_number: 4227

--- a/demisto_sdk/commands/common/docker/dockerhub_client.py
+++ b/demisto_sdk/commands/common/docker/dockerhub_client.py
@@ -105,9 +105,11 @@ class DockerHubClient:
             logger.warning(
                 f"Error when trying to get dockerhub token, error\n:{_error}"
             )
-            if _error.response.status_code in (
-                requests.codes.unauthorized, requests.codes.too_many_requests
-            ) and self.auth:
+            if (
+                _error.response.status_code
+                in (requests.codes.unauthorized, requests.codes.too_many_requests)
+                and self.auth
+            ):
                 # in case of rate-limits with a username:password, retrieve the token without username:password
                 logger.debug("Trying to get dockerhub token without username:password")
                 try:

--- a/demisto_sdk/commands/common/docker/dockerhub_client.py
+++ b/demisto_sdk/commands/common/docker/dockerhub_client.py
@@ -105,7 +105,10 @@ class DockerHubClient:
             logger.warning(
                 f"Error when trying to get dockerhub token, error\n:{_error}"
             )
-            if _error.response.status_code == requests.codes.unauthorized and self.auth:
+            if _error.response.status_code in (
+                requests.codes.unauthorized, requests.codes.too_many_requests
+            ) and self.auth:
+                # in case of rate-limits with a username:password, retrieve the token without username:password
                 logger.debug("Trying to get dockerhub token without username:password")
                 try:
                     response = self._session.get(

--- a/demisto_sdk/commands/common/docker/tests/dockerhub_client_test.py
+++ b/demisto_sdk/commands/common/docker/tests/dockerhub_client_test.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, List
 
 import pytest
-import requests
 from freezegun import freeze_time
 from packaging.version import Version
 from requests import Response, Session
@@ -73,7 +72,9 @@ def test_get_token_with_existing_not_expired_token(
     assert not requests_mock.called
 
 
-def test_get_token_ratelimit_with_username_password(mocker, dockerhub_client: DockerHubClient):
+def test_get_token_ratelimit_with_username_password(
+    mocker, dockerhub_client: DockerHubClient
+):
     """
     Given:
         - no token from at the cache
@@ -88,11 +89,15 @@ def test_get_token_ratelimit_with_username_password(mocker, dockerhub_client: Do
     """
     rate_limit_response = Response()
     rate_limit_response.status_code = 429
-    rate_limit_response._content = b''
+    rate_limit_response._content = b""
     valid_response = Response()
     valid_response.status_code = 200
-    valid_response._content = json.dumps({"token": "token_from_api", "issued_at": "1234", "expires_in": 300}).encode("utf-8")
-    mocker.patch.object(Session, "get", side_effect=[rate_limit_response, valid_response])
+    valid_response._content = json.dumps(
+        {"token": "token_from_api", "issued_at": "1234", "expires_in": 300}
+    ).encode("utf-8")
+    mocker.patch.object(
+        Session, "get", side_effect=[rate_limit_response, valid_response]
+    )
     assert dockerhub_client.get_token(repo="test") == "token_from_api"
 
 


### PR DESCRIPTION

## Description
Fixes and issue where dockerhub client failed when receiving errors of rate-limits when authenticating with username:password.