### PR TITLE
use batches in docker hook multiprocessing

### DIFF
--- a/demisto_sdk/commands/pre_commit/hooks/docker.py
+++ b/demisto_sdk/commands/pre_commit/hooks/docker.py
@@ -300,6 +300,7 @@ class DockerHook(Hook):
         )
         docker_hook_ids = []
         with ThreadPoolExecutor(max_workers=cpu_count()) as executor:
+            # process images in batches to avoid memory issues
             results: List[List[Dict]] = []
             for chunk in more_itertools.chunked(
                 sorted(tag_to_files_objs.items()), IMAGES_BATCH

--- a/demisto_sdk/commands/pre_commit/hooks/docker.py
+++ b/demisto_sdk/commands/pre_commit/hooks/docker.py
@@ -40,6 +40,8 @@ from demisto_sdk.commands.pre_commit.hooks.hook import GeneratedHooks, Hook
 NO_SPLIT = None
 USER_DEMITSO = "demisto"
 
+IMAGES_BATCH = 100
+
 
 @lru_cache()
 def get_docker_python_path() -> str:
@@ -299,7 +301,9 @@ class DockerHook(Hook):
         docker_hook_ids = []
         with ThreadPoolExecutor(max_workers=cpu_count()) as executor:
             results: List[List[Dict]] = []
-            for chunk in more_itertools.chunked(sorted(tag_to_files_objs.items()), 10):
+            for chunk in more_itertools.chunked(
+                sorted(tag_to_files_objs.items()), IMAGES_BATCH
+            ):
                 results.extend(
                     executor.map(
                         lambda item: self.process_image(

--- a/demisto_sdk/commands/pre_commit/hooks/docker.py
+++ b/demisto_sdk/commands/pre_commit/hooks/docker.py
@@ -302,8 +302,8 @@ class DockerHook(Hook):
             for chunk in more_itertools.chunked(sorted(tag_to_files_objs.items()), 10):
                 results.extend(
                     executor.map(
-                        lambda image, files_with_obj: self.process_image(
-                            image, files_with_obj, config_arg, run_isolated
+                        lambda item: self.process_image(
+                            item[0], item[1], config_arg, run_isolated
                         ),
                         chunk,
                     )

--- a/demisto_sdk/commands/pre_commit/pre_commit_command.py
+++ b/demisto_sdk/commands/pre_commit/pre_commit_command.py
@@ -370,7 +370,7 @@ def group_by_language(
 
     language_to_files: Dict[str, Set] = defaultdict(set)
     integrations_scripts: Set[IntegrationScript] = set()
-    logger.debug("Pre-Commit: Starting parsing all integrations and scripts")
+    logger.debug("Pre-Commit: Starting to parse all integrations and scripts")
     for integration_script_paths in more_itertools.chunked_even(
         integrations_scripts_mapping.keys(), INTEGRATIONS_BATCH
     ):
@@ -390,7 +390,7 @@ def group_by_language(
             continue
 
     if api_modules:
-        logger.debug("Pre-Commit: Starting handling API Modules")
+        logger.debug("Pre-Commit: Starting to handle API Modules")
         with ContentGraphInterface() as graph:
             update_content_graph(graph)
             api_modules: List[Script] = graph.search(  # type: ignore[no-redef]

--- a/demisto_sdk/commands/pre_commit/pre_commit_command.py
+++ b/demisto_sdk/commands/pre_commit/pre_commit_command.py
@@ -51,7 +51,7 @@ from demisto_sdk.commands.pre_commit.pre_commit_context import (
 SKIPPED_HOOKS = {"format", "validate", "secrets"}
 
 INTEGRATION_SCRIPT_REGEX = re.compile(r"^Packs/.*/(?:Integrations|Scripts)/.*.yml$")
-INTEGRATIONS_BATCH = 100
+INTEGRATIONS_BATCH = 300
 
 
 class PreCommitRunner:
@@ -370,6 +370,7 @@ def group_by_language(
 
     language_to_files: Dict[str, Set] = defaultdict(set)
     integrations_scripts: Set[IntegrationScript] = set()
+    logger.debug("Pre-Commit: Starting parsing all integrations and scripts")
     for integration_script_paths in more_itertools.chunked_even(
         integrations_scripts_mapping.keys(), INTEGRATIONS_BATCH
     ):
@@ -380,13 +381,16 @@ def group_by_language(
                     continue
                 # content-item is a script/integration
                 integrations_scripts.add(content_item)
+    logger.debug("Pre-Commit: Finished parsing all integrations and scripts")
     exclude_integration_script = set()
     for integration_script in integrations_scripts:
         if (pack := integration_script.in_pack) and pack.object_id == API_MODULES_PACK:
             # add api modules to the api_modules list, we will handle them later
             api_modules.append(integration_script)
             continue
+
     if api_modules:
+        logger.debug("Pre-Commit: Starting handling API Modules")
         with ContentGraphInterface() as graph:
             update_content_graph(graph)
             api_modules: List[Script] = graph.search(  # type: ignore[no-redef]
@@ -409,7 +413,7 @@ def group_by_language(
                         else imported_by.path.relative_to(CONTENT_PATH)
                     )
                 )
-
+        logger.debug("Pre-Commit: Finished handling API Modules")
     for integration_script in integrations_scripts:
         if (pack := integration_script.in_pack) and pack.object_id == API_MODULES_PACK:
             # we dont need to lint them individually, they will be run with the integrations that uses them


### PR DESCRIPTION
When proccesing a large amount of images (in `docker` hook), in rare cases we get memory issues. This will use batches of the dictionary of images to proccess