### PR TITLE
fix get property in  pre-commit

### DIFF
--- a/.changelog/4238.yml
+++ b/.changelog/4238.yml
@@ -1,4 +1,4 @@
 changes:
-- description: fixed an issue where reading **pre-commit** config templates would not handle cases with key=false and key:mode=true. 
+- description: fixed an issue where reading **pre-commit** config templates would not handle cases with key=false and key:mode=true.
   type: fix
 pr_number: 4238

--- a/.changelog/4238.yml
+++ b/.changelog/4238.yml
@@ -1,0 +1,4 @@
+changes:
+- description: fixed an issue where reading **pre-commit** config templates would not handle cases with key=false and key:mode=true. 
+  type: fix
+pr_number: 4238

--- a/demisto_sdk/commands/pre_commit/hooks/utils.py
+++ b/demisto_sdk/commands/pre_commit/hooks/utils.py
@@ -11,4 +11,6 @@ def get_property(hook: dict, mode: str, name: str, default=None):
     ret = None
     if mode:
         ret = hook.get(f"{name}:{mode}")
-    return ret or hook.get(name, default)
+    if ret is None:
+        return hook.get(name, default)
+    return ret


### PR DESCRIPTION
The `get_property` didn't work corrrectly in this use case:

`property`: true
`property:<mode>`: false