### PR TITLE
Docker Hook: lower images batch to 50

### DIFF
--- a/demisto_sdk/commands/pre_commit/hooks/docker.py
+++ b/demisto_sdk/commands/pre_commit/hooks/docker.py
@@ -299,12 +299,13 @@ class DockerHook(Hook):
             f'collected images: {" ".join(filter(None, tag_to_files_objs.keys()))}'
         )
         docker_hook_ids = []
-        with ThreadPoolExecutor(max_workers=cpu_count()) as executor:
-            # process images in batches to avoid memory issues
-            results: List[List[Dict]] = []
-            for chunk in more_itertools.chunked(
-                sorted(tag_to_files_objs.items()), IMAGES_BATCH
-            ):
+        results: List[List[Dict]] = []
+
+        for chunk in more_itertools.chunked(
+            sorted(tag_to_files_objs.items()), IMAGES_BATCH
+        ):
+            with ThreadPoolExecutor(max_workers=cpu_count()) as executor:
+                # process images in batches to avoid memory issues
                 results.extend(
                     executor.map(
                         lambda item: self.process_image(

--- a/demisto_sdk/commands/pre_commit/hooks/docker.py
+++ b/demisto_sdk/commands/pre_commit/hooks/docker.py
@@ -40,7 +40,7 @@ from demisto_sdk.commands.pre_commit.hooks.hook import GeneratedHooks, Hook
 NO_SPLIT = None
 USER_DEMITSO = "demisto"
 
-IMAGES_BATCH = 100
+IMAGES_BATCH = 50
 
 
 @lru_cache()


### PR DESCRIPTION
Due to memory issues, we sometimes have memory issues in GitLab when proccesing the docker images in pre commit.
Here is a try to lower the images batch and to create an seperate thread executor for each batch