### PR TITLE
remove `poetry-export`, replace `poetry-lock` hook with `poetry-check --lock`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,18 +9,11 @@ repos:
     - --exit-non-zero-on-fix
     - --show-fixes
 - repo: https://github.com/python-poetry/poetry
-  rev: 1.6.1
+  rev: 1.8.2
   hooks:
   - id: poetry-check
-  - id: poetry-lock
     args:
-    - --check
-    files: ^pyproject.toml$
-  - id: poetry-export
-    args:
-    - --without-hashes
-    - -o
-    - requirements.txt
+    - --lock
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v0.982
   hooks:


### PR DESCRIPTION
- following https://github.com/demisto/demisto-sdk/pull/4225, `poetry-export` is no longer necessary.
- `poetry-check` hook with with `--lock` has been deprecated. Replacing with `poetry-lock --check`


related (similar): https://github.com/demisto/content/pull/34092