### PR TITLE
remove `types-setuptools`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4,7 +4,7 @@
 name = "aiohttp"
 version = "3.9.4"
 description = "Async http client/server framework (asyncio)"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "aiohttp-3.9.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:76d32588ef7e4a3f3adff1956a0ba96faabbdee58f2407c122dd45aa6e34f372"},
@@ -100,7 +100,7 @@ speedups = ["Brotli", "aiodns", "brotlicffi"]
 name = "aiosignal"
 version = "1.3.1"
 description = "aiosignal: a list of registered asynchronous callbacks"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "aiosignal-1.3.1-py3-none-any.whl", hash = "sha256:f8376fb07dd1e86a584e4fcdec80b36b7f81aac666ebc724e2c090300dd83b17"},
@@ -198,7 +198,7 @@ test = ["astroid", "pytest"]
 name = "async-timeout"
 version = "4.0.2"
 description = "Timeout context manager for asyncio programs"
-optional = false
+optional = true
 python-versions = ">=3.6"
 files = [
     {file = "async-timeout-4.0.2.tar.gz", hash = "sha256:2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15"},
@@ -1206,7 +1206,7 @@ python-dateutil = ">=2.7"
 name = "frozenlist"
 version = "1.3.3"
 description = "A list-like structure which implements collections.abc.MutableSequence"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "frozenlist-1.3.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ff8bf625fe85e119553b5383ba0fb6aa3d0ec2ae980295aaefa552374926b3f4"},
@@ -2581,7 +2581,7 @@ files = [
 name = "multidict"
 version = "6.0.4"
 description = "multidict implementation"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "multidict-6.0.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0b1a97283e0c85772d613878028fec909f003993e1007eafa715b24b377cb9b8"},
@@ -4704,17 +4704,6 @@ files = [
 types-urllib3 = "<1.27"
 
 [[package]]
-name = "types-setuptools"
-version = "67.7.0.1"
-description = "Typing stubs for setuptools"
-optional = false
-python-versions = "*"
-files = [
-    {file = "types-setuptools-67.7.0.1.tar.gz", hash = "sha256:980a2651b2b019809817e1585071596b87fbafcb54433ff3b12445461db23790"},
-    {file = "types_setuptools-67.7.0.1-py3-none-any.whl", hash = "sha256:471a4ecf6984ffada63ffcfa884bfcb62718bd2d1a1acf8ee5513ec99789ed5e"},
-]
-
-[[package]]
 name = "types-six"
 version = "1.16.21.8"
 description = "Typing stubs for six"
@@ -5119,7 +5108,7 @@ pyyaml = "*"
 name = "yarl"
 version = "1.9.2"
 description = "Yet another URL library"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "yarl-1.9.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8c2ad583743d16ddbdf6bb14b5cd76bf43b0d0006e918809d5d4ddf7bde8dd82"},
@@ -5298,4 +5287,4 @@ generate-unit-tests = ["klara"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.11"
-content-hash = "32797812bce07e3687acaa1414fc694750fa350509757397592b97c22b8b3ec2"
+content-hash = "607aa70a4746214fcff02a451ad356b25520a17c7a87008aadb79616c08f98df"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ neo4j = "^5.14.0"
 pydantic = "^1.10"
 types-decorator = "^5.1.8"
 types-mock = "^4.0.15"
-types-setuptools = ">=65.6.0.1,<68.0.0.0"
 types-ujson = "^5.6.0.0"
 typer = {extras = ["all"], version = "^0.9.0"}
 types-pkg-resources = "^0.1.3"


### PR DESCRIPTION
Removed types-setuptools, for https://github.com/demisto/content/pull/33388 to pass (before merging https://github.com/demisto/demisto-sdk/pull/2801/) 