### PR TITLE
[demisto-sdk] Add skipped paths to old_validate_manager

### DIFF
--- a/demisto_sdk/commands/validate/old_validate_manager.py
+++ b/demisto_sdk/commands/validate/old_validate_manager.py
@@ -173,6 +173,9 @@ SKIPPED_FILES = [
     "DemistoClassApiModule.py",
 ]
 
+SKIPPED_PATHS = [
+    "Packs/myPack", "myPack"
+]
 
 class OldValidateManager:
     def __init__(
@@ -2493,6 +2496,8 @@ class OldValidateManager:
         old_format_files: set = set()
         valid_types: set = set()
         for path in file_set:
+            if self.include_untracked and any(skipped_path in str(path) for skipped_path in SKIPPED_PATHS):
+                continue
             old_path = None
             if isinstance(path, tuple):
                 file_path = str(path[1])


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
relates: [CIAC-10490](https://jira-dc.paloaltonetworks.com/browse/CIAC-10490)

## Description
Add SKIPPED_PATHS constant, which is used to exclude specific paths when using `--include-untracked` flag when running `demisto-sdk validate`.
