### PR TITLE
Fix Generate Docs Missing Argument Descriptions

### DIFF
--- a/.changelog/4320.yml
+++ b/.changelog/4320.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fix an issue in `gen-docs` when integration commands arguments are missing descriptions.
+  type: fix
+pr_number: 4320

--- a/.changelog/4320.yml
+++ b/.changelog/4320.yml
@@ -1,4 +1,4 @@
 changes:
-- description: Fix an issue in `gen-docs` when integration commands arguments are missing descriptions.
+- description: Fix an issue in `generate-docs` when integration commands arguments are missing descriptions.
   type: fix
 pr_number: 4320

--- a/demisto_sdk/commands/generate_docs/common.py
+++ b/demisto_sdk/commands/generate_docs/common.py
@@ -10,6 +10,7 @@ from demisto_sdk.commands.common.tools import run_command
 from demisto_sdk.commands.run_cmd.runner import Runner
 
 STRING_TYPES = (str, bytes)  # type: ignore
+DEFAULT_ARG_DESCRIPTION = "Description not provided."
 
 
 class HEADER_TYPE:

--- a/demisto_sdk/commands/generate_docs/common.py
+++ b/demisto_sdk/commands/generate_docs/common.py
@@ -10,7 +10,7 @@ from demisto_sdk.commands.common.tools import run_command
 from demisto_sdk.commands.run_cmd.runner import Runner
 
 STRING_TYPES = (str, bytes)  # type: ignore
-DEFAULT_ARG_DESCRIPTION = "Description not provided."
+DEFAULT_ARG_DESCRIPTION = "No description provided."
 
 
 class HEADER_TYPE:

--- a/demisto_sdk/commands/generate_docs/generate_integration_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_integration_doc.py
@@ -936,7 +936,7 @@ def generate_single_command_section(
             ]
         )
         for arg in arguments:
-            description = arg.get("description")
+            description = arg.get("description", "")
             if not description:
                 errors.append(
                     "Error! You are missing description in input {} of command {}".format(

--- a/demisto_sdk/commands/generate_docs/generate_integration_doc.py
+++ b/demisto_sdk/commands/generate_docs/generate_integration_doc.py
@@ -29,6 +29,7 @@ from demisto_sdk.commands.common.tools import (
 )
 from demisto_sdk.commands.generate_docs.common import (
     CONFIGURATION_SECTION_STEPS,
+    DEFAULT_ARG_DESCRIPTION,
     add_lines,
     build_example_dict,
     generate_numbered_section,
@@ -936,7 +937,7 @@ def generate_single_command_section(
             ]
         )
         for arg in arguments:
-            description = arg.get("description", "")
+            description = arg.get("description", DEFAULT_ARG_DESCRIPTION)
             if not description:
                 errors.append(
                     "Error! You are missing description in input {} of command {}".format(

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -1137,10 +1137,22 @@ class TestGenerateIntegrationDoc:
         actual_text = (
             (tmp_path / INTEGRATIONS_README_FILE_NAME).read_text().splitlines()
         )
-        assert actual_text[54] == "| entry_id |  | Required | "
-        assert actual_text[55] == "| target |  | Required | "
-        assert actual_text[73] == "| file_path |  | Required | "
-        assert actual_text[74] == "| file_name |  | Required | "
+        assert (
+            actual_text[54]
+            == f"| entry_id | {common.DEFAULT_ARG_DESCRIPTION} | Required | "
+        )
+        assert (
+            actual_text[55]
+            == f"| target | {common.DEFAULT_ARG_DESCRIPTION} | Required | "
+        )
+        assert (
+            actual_text[73]
+            == f"| file_path | {common.DEFAULT_ARG_DESCRIPTION} | Required | "
+        )
+        assert (
+            actual_text[74]
+            == f"| file_name | {common.DEFAULT_ARG_DESCRIPTION} | Required | "
+        )
 
 
 class TestGetCommandExamples:

--- a/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
+++ b/demisto_sdk/commands/generate_docs/tests/generate_docs_test.py
@@ -1107,6 +1107,41 @@ class TestGenerateIntegrationDoc:
                     in readme_data
                 )
 
+    def test_missing_cmd_description(self, tmp_path: Path):
+        """
+        Test generation of an integration README when one of the
+        command arguments is missing a description field.
+
+        Given:
+        - An integration YML.
+
+        When:
+        - The integration YML has a command that is missing
+        an argument description.
+
+        Then:
+        - The integration README is generated.
+        """
+
+        yml_path = (
+            Path(__file__).parent
+            / "test_files"
+            / "test_missing_cmd_description"
+            / "FTP.yml"
+        )
+
+        generate_integration_doc(str(yml_path), output=str(tmp_path))
+
+        assert (tmp_path / INTEGRATIONS_README_FILE_NAME).exists()
+
+        actual_text = (
+            (tmp_path / INTEGRATIONS_README_FILE_NAME).read_text().splitlines()
+        )
+        assert actual_text[54] == "| entry_id |  | Required | "
+        assert actual_text[55] == "| target |  | Required | "
+        assert actual_text[73] == "| file_path |  | Required | "
+        assert actual_text[74] == "| file_name |  | Required | "
+
 
 class TestGetCommandExamples:
     @staticmethod

--- a/demisto_sdk/commands/generate_docs/tests/test_files/test_missing_cmd_description/FTP.yml
+++ b/demisto_sdk/commands/generate_docs/tests/test_files/test_missing_cmd_description/FTP.yml
@@ -1,0 +1,60 @@
+category: Utilities
+commonfields:
+  id: FTP
+  version: -1
+configuration:
+- display: ''
+  name: host
+  required: true
+  section: Connect
+  type: 0
+- display: ''
+  name: user
+  required: false
+  section: Collect
+  type: 0
+- display: ''
+  displaypassword: API Key
+  hiddenusername: true
+  name: passwd
+  required: true
+  section: Connect
+  type: 4
+- advanced: true
+  display: Use system proxy settings
+  name: proxy
+  required: false
+  section: Connect
+  type: 8
+description: 'FTP integration to download or upload file to remote ftp server. Please be noted that FTP transfer is insecure. Please use it with care. '
+display: FTP
+name: FTP
+script:
+  commands:
+  - arguments:
+    - description: The path to list.
+      name: path
+    description: List all the files under current folder.
+    name: ftp-ls
+  - arguments:
+    - name: entry_id
+      required: true
+    - name: target
+      required: true
+    description: Upload file to ftp server.
+    name: ftp-put
+  - arguments:
+    - name: file_path
+      required: true
+    - name: file_name
+      required: true
+    description: Download file from ftp server.
+    name: ftp-get
+  dockerimage: demisto/python3:3.10.14.96411
+  runonce: false
+  script: ''
+  subtype: python3
+  type: python
+fromversion: 6.0.0
+tests:
+- No tests (auto formatted)


### PR DESCRIPTION
## Related Issues
fixes:https://jira-dc.paloaltonetworks.com/browse/CIAC-10587

## Description
When generating an integration documentation where the integration YML had a command with missing argument descriptions, the SDK would crash:

```bash
INFO:demisto-sdk:[red]Error: 'NoneType' object has no attribute 'replace'[/red]
--- Logging error ---
Traceback (most recent call last):
  File "/home/runner/.local/share/virtualenvs/actions-adXIK6GM/lib/python3.8/site-packages/demisto_sdk/commands/init/contribution_converter.py", line 496, in convert_contribution_to_pack
    generated_readmes = self.generate_readmes_for_new_content_pack(
  File "/home/runner/.local/share/virtualenvs/actions-adXIK6GM/lib/python3.8/site-packages/demisto_sdk/commands/init/contribution_converter.py", line 401, in generate_readmes_for_new_content_pack
    readme = self.generate_readme_for_pack_content_item(
  File "/home/runner/.local/share/virtualenvs/actions-adXIK6GM/lib/python3.8/site-packages/demisto_sdk/commands/init/contribution_converter.py", line 362, in generate_readme_for_pack_content_item
    generate_integration_doc(
  File "/home/runner/.local/share/virtualenvs/actions-adXIK6GM/lib/python3.8/site-packages/demisto_sdk/commands/generate_docs/generate_integration_doc.py", line 585, in generate_integration_doc
    ) = generate_commands_section(
  File "/home/runner/.local/share/virtualenvs/actions-adXIK6GM/lib/python3.8/site-packages/demisto_sdk/commands/generate_docs/generate_integration_doc.py", line 858, in generate_commands_section
    cmd_section, cmd_errors = generate_single_command_section(
  File "/home/runner/.local/share/virtualenvs/actions-adXIK6GM/lib/python3.8/site-packages/demisto_sdk/commands/generate_docs/generate_integration_doc.py", line 952, in generate_single_command_section
    string_escape_md(argument_description, True, True),
  File "/home/runner/.local/share/virtualenvs/actions-adXIK6GM/lib/python3.8/site-packages/demisto_sdk/commands/generate_docs/common.py", line 214, in string_escape_md
    st = html.escape(st, quote=False)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/html/__init__.py", line 19, in escape
    s = s.replace("&", "&amp;") # Must be done first!
AttributeError: 'NoneType' object has no attribute 'replace'
```

Seen in https://github.com/demisto/content/pull/34659 and https://github.com/demisto/content/pull/34400.

This PR sets a default value (empty string) when the description field is missing.