### PR TITLE
fix: overwrite id problem in doc reviewer

### DIFF
--- a/demisto_sdk/commands/content_graph/objects/indicator_field.py
+++ b/demisto_sdk/commands/content_graph/objects/indicator_field.py
@@ -25,7 +25,7 @@ class IndicatorField(IndicatorIncidentField, content_type=ContentType.INDICATOR_
 
     @staticmethod
     def match(_dict: dict, path: Path) -> bool:
-        if "id" in _dict:
+        if "id" in _dict and isinstance(_dict["id"], str):
             _id = str(_dict["id"]).lower()
             if _id.startswith("indicator"):
                 return True


### PR DESCRIPTION
## Description
Hi! The reason why I opened this "pr" is due to the following scenario:

There is a field like this in the json file I uploaded for testing:
{"id": 1, ...}

I saw that the problem I was experiencing here was due to the fact that **_dict["id"]** in the IndicatorField.match function was overwritten and was an integer object, and I added an addition to the if statement.