### PR TITLE
validate paths: don't check doc_files

### DIFF
--- a/demisto_sdk/scripts/validate_content_path.py
+++ b/demisto_sdk/scripts/validate_content_path.py
@@ -216,8 +216,8 @@ class PathIsUnified(ExemptedPath):
     message = "Paths of unified content items are not validated."
 
 
-class PathIsTestData(ExemptedPath):
-    message = "Paths under test_data are not validated."
+class PathIsTestdataOrDocfiles(ExemptedPath):
+    message = "Paths under test data or doc_files are not validated."
 
 
 def _validate(path: Path) -> None:
@@ -245,8 +245,8 @@ def _validate(path: Path) -> None:
         """
         raise PathUnderDeprecatedContent
 
-    if set(path.parts).intersection(TESTS_DIRECTORIES):
-        raise PathIsTestData
+    if set(path.parts).intersection(TESTS_AND_DOC_DIRECTORIES):
+        raise PathIsTestdataOrDocfiles
 
     parts_inside_pack = parts_after_packs[1:]  # everything after Packs/<pack name>
     depth = len(parts_inside_pack) - 1

--- a/demisto_sdk/tests/validate_content_path_test.py
+++ b/demisto_sdk/tests/validate_content_path_test.py
@@ -31,7 +31,7 @@ from demisto_sdk.scripts.validate_content_path import (
     InvalidXDRCTemplatesFileName,
     InvalidXSIAMReportFileName,
     PathIsFolder,
-    PathIsTestData,
+    PathIsTestdataOrDocfiles,
     PathIsUnified,
     PathUnderDeprecatedContent,
     SpacesInFileName,
@@ -166,7 +166,7 @@ def test_depth_one_pass(folder: str):
     try:
         _validate(Path(DUMMY_PACK_PATH, folder, "nested", "file"))
         _validate(Path(DUMMY_PACK_PATH, folder, "nested", "nested_deeper", "file"))
-    except PathIsTestData:
+    except PathIsTestdataOrDocfiles:
         pass
     except (
         InvalidIntegrationScriptFileType,


### PR DESCRIPTION
## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-10842

## Description
Ignore doc_files dirs when checking content paths