### PR TITLE
bump SDK repo mypy hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     args:
     - --lock
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.982
+  rev: v1.10.1
   hooks:
   - id: mypy
     exclude: tests/.*|demisto_sdk/commands/init/templates/.*


### PR DESCRIPTION
bump mypy 0.982 to 1.10.1 (latest), no other changes are required.