### PR TITLE
Initialize lock_file with None value

### DIFF
--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -4571,6 +4571,7 @@ def run_sync(
         exclusive_function (Callable): The function we want to run exclusivly.
         exclusive_function_kwargs (dict, optional): The kwargs we wish to pass to the exclusive_function. Defaults to {}.
     """
+    lock_file = None
     try:
         # Open (or create) the lock file
         lock_file = open(lock_file_path, "w")


### PR DESCRIPTION
## Description

On one of the latest runs of our demisto pipeline I received the following error:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/demisto_sdk/commands/common/tools.py", line 4576, in run_sync
    lock_file = open(lock_file_path, "w")
                ^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'None/markdown_images.lock'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/demisto_sdk/commands/content_graph/objects/pack.py", line 365, in dump
    self.dump_readme(path / "README.md", marketplace)
  File "/usr/local/lib/python3.11/site-packages/demisto_sdk/commands/content_graph/objects/pack.py", line 317, in dump_readme
    update_markdown_images_with_urls_and_rel_paths(
  File "/usr/local/lib/python3.11/site-packages/demisto_sdk/commands/prepare_content/markdown_images_handler.py", line 35, in update_markdown_images_with_urls_and_rel_paths
    urls_dict = replace_markdown_urls_and_update_markdown_images(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/demisto_sdk/commands/prepare_content/markdown_images_handler.py", line 77, in replace_markdown_urls_and_update_markdown_images
    safe_init_json_file(MARKDOWN_IMAGES_ARTIFACT_FILE_NAME)
  File "/usr/local/lib/python3.11/site-packages/demisto_sdk/commands/prepare_content/markdown_images_handler.py", line 53, in safe_init_json_file
    run_sync(
  File "/usr/local/lib/python3.11/site-packages/demisto_sdk/commands/common/tools.py", line 4592, in run_sync
    if lock_file:
       ^^^^^^^^^
UnboundLocalError: cannot access local variable 'lock_file' where it is not associated with a value
```

I simply added a line which initializes the `lock_file` with `None`. This should fix the bug in my opinion.
Let me know what you think. 