### PR TITLE
Add support for all xsoar mps in IN121 validation

### DIFF
--- a/.changelog/4398.yml
+++ b/.changelog/4398.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where IN121 in the new validate flow and IN148 in the old validate flow failed when running on content items with XSOAR on prem and XSOAR SAAS Marketplaces.
+  type: fix
+pr_number: 4398

--- a/demisto_sdk/commands/common/hook_validations/integration.py
+++ b/demisto_sdk/commands/common/hook_validations/integration.py
@@ -1308,8 +1308,12 @@ class IntegrationValidator(ContentEntityValidator):
             marketplaces = get_item_marketplaces(
                 item_path=self.file_path, item_data=self.current_file
             )
-            is_xsoar_marketplace = (
-                not marketplaces or MarketplaceVersions.XSOAR.value in marketplaces
+            is_xsoar_marketplace = not marketplaces or any(
+                [
+                    MarketplaceVersions.XSOAR.value in marketplaces,
+                    MarketplaceVersions.XSOAR_SAAS.value in marketplaces,
+                    MarketplaceVersions.XSOAR_ON_PREM.value in marketplaces,
+                ]
             )
             fetch_required_params = (
                 INCIDENT_FETCH_REQUIRED_PARAMS

--- a/demisto_sdk/commands/validate/validators/IN_validators/IN121_is_valid_fetch.py
+++ b/demisto_sdk/commands/validate/validators/IN_validators/IN121_is_valid_fetch.py
@@ -74,7 +74,13 @@ class IsValidFetchValidator(BaseValidator[ContentTypes]):
         """
         fetch_required_params = (
             INCIDENT_FETCH_REQUIRED_PARAMS
-            if MarketplaceVersions.XSOAR in marketplaces
+            if any(
+                [
+                    MarketplaceVersions.XSOAR in marketplaces,
+                    MarketplaceVersions.XSOAR_SAAS in marketplaces,
+                    MarketplaceVersions.XSOAR_ON_PREM in marketplaces,
+                ]
+            )
             else ALERT_FETCH_REQUIRED_PARAMS
         )
         current_integration = {}


### PR DESCRIPTION
## Related Issues
fixes: [CIAC-11031](https://jira-dc.paloaltonetworks.com/browse/CIAC-11031)

## Description
Fixed an issue where IN121 in the new validate flow and IN148 in the old validate flow failed when running on content items with XSOAR on prem and XSOAR SAAS Marketplaces.