### PR TITLE
Old validate PB103 fix

### DIFF
--- a/.changelog/4432.yml
+++ b/.changelog/4432.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where old validate failed without listing the invalid content items.
+  type: fix
+pr_number: 4432

--- a/demisto_sdk/commands/common/hook_validations/playbook.py
+++ b/demisto_sdk/commands/common/hook_validations/playbook.py
@@ -480,12 +480,11 @@ class PlaybookValidator(ContentEntityValidator):
         orphan_tasks = tasks_bucket.difference(next_tasks_bucket)
         if orphan_tasks:
             error_message, error_code = Errors.playbook_unconnected_tasks(orphan_tasks)
-            if not self.handle_error(
+            return self.handle_error(
                 error_message, error_code, file_path=self.file_path
-            ):
-                return False
+            ) is None
 
-        return tasks_bucket.issubset(next_tasks_bucket)
+        return True
 
     @error_codes("PB104")
     def is_valid_as_deprecated(self) -> bool:

--- a/demisto_sdk/commands/common/hook_validations/playbook.py
+++ b/demisto_sdk/commands/common/hook_validations/playbook.py
@@ -480,9 +480,7 @@ class PlaybookValidator(ContentEntityValidator):
         orphan_tasks = tasks_bucket.difference(next_tasks_bucket)
         if orphan_tasks:
             error_message, error_code = Errors.playbook_unconnected_tasks(orphan_tasks)
-            if self.handle_error(
-                error_message, error_code, file_path=self.file_path
-            ):
+            if self.handle_error(error_message, error_code, file_path=self.file_path):
                 return False
 
         return True

--- a/demisto_sdk/commands/common/hook_validations/playbook.py
+++ b/demisto_sdk/commands/common/hook_validations/playbook.py
@@ -480,9 +480,10 @@ class PlaybookValidator(ContentEntityValidator):
         orphan_tasks = tasks_bucket.difference(next_tasks_bucket)
         if orphan_tasks:
             error_message, error_code = Errors.playbook_unconnected_tasks(orphan_tasks)
-            return self.handle_error(
-                error_message, error_code, file_path=self.file_path
-            ) is None
+            return (
+                self.handle_error(error_message, error_code, file_path=self.file_path)
+                is None
+            )
 
         return True
 

--- a/demisto_sdk/commands/common/hook_validations/playbook.py
+++ b/demisto_sdk/commands/common/hook_validations/playbook.py
@@ -480,10 +480,10 @@ class PlaybookValidator(ContentEntityValidator):
         orphan_tasks = tasks_bucket.difference(next_tasks_bucket)
         if orphan_tasks:
             error_message, error_code = Errors.playbook_unconnected_tasks(orphan_tasks)
-            return (
-                self.handle_error(error_message, error_code, file_path=self.file_path)
-                is None
-            )
+            if self.handle_error(
+                error_message, error_code, file_path=self.file_path
+            ):
+                return False
 
         return True
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -4491,19 +4491,18 @@ files = [
 
 [[package]]
 name = "setuptools"
-version = "69.5.1"
+version = "70.0.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-69.5.1-py3-none-any.whl", hash = "sha256:c636ac361bc47580504644275c9ad802c50415c7522212252c033bd15f301f32"},
-    {file = "setuptools-69.5.1.tar.gz", hash = "sha256:6c1fccdac05a97e598fb0ae3bbed5904ccb317337a51139dcd51453611bbb987"},
+    {file = "setuptools-70.0.0-py3-none-any.whl", hash = "sha256:54faa7f2e8d2d11bcd2c07bed282eef1046b5c080d1c32add737d7b5817b1ad4"},
+    {file = "setuptools-70.0.0.tar.gz", hash = "sha256:f211a66637b8fa059bb28183da127d4e86396c991a942b028c6650d4319c3fd0"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mypy (==1.9)", "packaging (>=23.2)", "pip (>=19.1)", "pytest (>=6,!=8.1.1)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.2)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mypy (==1.9)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.1)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "shellingham"


### PR DESCRIPTION
## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-39367

## Description
currently, when running in a private repo we allow to ignore errors which aren't allowed to be ignored in `content` repo
`PB103` as example
`demisto-sdk validate --skip-new-validate --run-old-validate -i THE_PACK`

but, in case of ignored `PB103` in a private repo, due to a bug - the the error message not display but the result are invalid.

**_before fix:_**
<img width="1075" alt="image" src="https://github.com/user-attachments/assets/2cc51d89-233f-48c2-8060-c5b8f317f989">

**_after fix:_**
<img width="1349" alt="image" src="https://github.com/user-attachments/assets/bb957c7b-54f6-4edb-8aa1-6f5a6d67916e">

