### PR TITLE
Fix Validate File Permissions

### DIFF
--- a/.changelog/4434.yml
+++ b/.changelog/4434.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Improved the implementation of the **pre-commit** hook ***validate-file-permission-changes**.
+  type: fix
+pr_number: 4434

--- a/.changelog/4434.yml
+++ b/.changelog/4434.yml
@@ -1,4 +1,4 @@
 changes:
-- description: Improved the implementation of the **pre-commit** hook ***validate-file-permission-changes**.
+- description: Improved the implementation of the **pre-commit** hook ***validate-file-permission-changes***.
   type: fix
 pr_number: 4434

--- a/demisto_sdk/scripts/tests/validate_file_permission_changes_test.py
+++ b/demisto_sdk/scripts/tests/validate_file_permission_changes_test.py
@@ -1,509 +1,127 @@
-import os
 import stat
 from pathlib import Path
 
-import pytest
-import typer
-from git import Blob, Remote
-from pytest_mock import MockerFixture
 from typer.testing import CliRunner
 
-from demisto_sdk.scripts.validate_file_permission_changes import (
-    CI_ENV_VAR,
-    ERROR_IS_CI_INVALID,
-    is_ci,
-)
-from TestSuite.repo import Repo
-from TestSuite.test_tools import ChangeCWD
 
-
-class TestBaseClass:
-    from demisto_sdk.scripts.validate_file_permission_changes import main as func
-
-    branch_non_permission = "add-integration-code"
-    branch_permission = "set-integration-executable"
-
-
-class TestValidateFileChangePermissionsLocal(TestBaseClass):
+class TestValidateFileChangePermissions:
 
     """
     Test class for validation running in a local environment
     """
 
-    @pytest.fixture(autouse=True)
-    def setup(self, git_repo: Repo, mocker: MockerFixture, tmp_path: Path):
+    from demisto_sdk.scripts.validate_file_permission_changes import main as func
 
-        from demisto_sdk.commands.common.git_util import Repo as GitRepo
-        from demisto_sdk.scripts.validate_deleted_files import GitUtil
+    # branch_non_permission = "add-integration-code"
+    # branch_permission = "set-integration-executable"
 
-        mocker.patch.dict(os.environ, {"DEMISTO_SDK_CONTENT_PATH": git_repo.path})
-        mocker.patch.object(GitRepo, "remote", return_value="")
-        mocker.patch.object(GitUtil, "fetch", return_value=None)
+    # @pytest.fixture(autouse=True)
+    # def setup(self, git_repo: Repo, mocker: MockerFixture, tmp_path: Path):
 
-        # Set up 'local' remote
-        GitUtil.REPO_CLS.init(str(tmp_path), bare=True)
-        git_repo.git_util.repo.delete_remote(Remote(git_repo.git_util.repo, "origin"))
-        git_repo.git_util.repo.create_remote("origin", str(tmp_path))
+    #     from demisto_sdk.commands.common.git_util import Repo as GitRepo
+    #     from demisto_sdk.scripts.validate_deleted_files import GitUtil
 
-        # Initialize Pack
-        git_repo.create_pack(name="TestPack").create_integration(name="TestIntegration")
-        git_repo.git_util.commit_files("Added a new Pack and Integration")
+    #     mocker.patch.dict(os.environ, {"DEMISTO_SDK_CONTENT_PATH": git_repo.path})
+    #     mocker.patch.object(GitRepo, "remote", return_value="")
+    #     mocker.patch.object(GitUtil, "fetch", return_value=None)
 
-    def test_unchanged_permissions(cls, git_repo: Repo):
+    #     # Set up 'local' remote
+    #     GitUtil.REPO_CLS.init(str(tmp_path), bare=True)
+    #     git_repo.git_util.repo.delete_remote(Remote(git_repo.git_util.repo, "origin"))
+    #     git_repo.git_util.repo.create_remote("origin", str(tmp_path))
+
+    #     # Initialize Pack
+    #     git_repo.create_pack(name="TestPack").create_integration(name="TestIntegration")
+    #     git_repo.git_util.commit_files("Added a new Pack and Integration")
+
+    def test_unchanged_permissions(cls, tmp_path: Path):
         """
         Test `validate_file_permission_changes` exit code when
-        no file permissions are modified.
+        no the executable bits aren't set.
 
         Given:
-        - A content repo with a pack and integration.
+        - A temporary directory.
 
         When:
-        - On another branch, we modify the integration by
-        adding a code.
+        - A new file is created.
 
         Then:
         - `validate_file_permission_changes` exit code is 0.
         """
 
-        git_repo.git_util.repo.git.checkout("-b", cls.branch_non_permission)
-
-        py_file_path = Path(git_repo.packs[0].integrations[0].code.path)
-        py_file_path.write_text("print('some added code')")
-
-        git_repo.git_util.stage_file(py_file_path)
+        file = tmp_path / "a"
+        file.write_text("print('some added code')")
 
         runner = CliRunner()
 
-        with ChangeCWD(git_repo.path):
-            result = runner.invoke(cls.func, [])
+        result = runner.invoke(cls.func, [str(file)])
 
         assert result.exit_code == 0
 
-    def test_set_executable(cls, git_repo: Repo):
+    def test_set_executable(cls, tmp_path: Path):
         """
         Test `validate_file_permission_changes` exit code when
-        file permissions are modified.
+        no the executable bits aren't set.
 
         Given:
-        - A content repo with a pack and integration.
+        - A temporary directory.
 
         When:
-        - On another branch, we modify the integration by
-        making the python script executable.
+        - A new file is created and executable bit is set.
 
         Then:
         - `validate_file_permission_changes` exit code is 1.
-        - The output includes the command how to revert the change.
         """
 
-        git_repo.git_util.repo.git.checkout("-b", cls.branch_permission)
-
-        py_file_path = Path(git_repo.packs[0].integrations[0].code.path)
-        py_file_path.chmod(py_file_path.stat().st_mode | stat.S_IEXEC)
-
-        git_repo.git_util.stage_file(py_file_path)
+        file = tmp_path / "a"
+        file.write_text("print('some added code')")
+        file.chmod(file.stat().st_mode | stat.S_IEXEC)
 
         runner = CliRunner()
 
-        with ChangeCWD(git_repo.path):
-            result = runner.invoke(cls.func, [])
+        result = runner.invoke(cls.func, [str(file)])
 
         assert result.exit_code == 1
         actual_output = result.stdout.splitlines()
         assert actual_output
         assert (
-            f"\x1b[91mFile '{py_file_path.relative_to(git_repo.path)}' permission was changed from {oct(Blob.file_mode)[2:]} to {oct(Blob.executable_mode)[2:]}\x1b[0m"
-            in actual_output
-        )
-        assert (
-            f"\x1b[37mPlease revert the file permissions using the command 'chmod -x {py_file_path}'\x1b[0m"
+            f"\x1b[91mFile '{file}' has executable bits set. Please revert using command 'chmod -x {file}'\x1b[0m"
             in actual_output
         )
 
-    def test_set_not_executable(cls, git_repo: Repo):
+    def test_one_executable_one_not(cls, tmp_path: Path):
         """
         Test `validate_file_permission_changes` exit code when
-        file permissions are modified.
+        two files are fed in.
 
         Given:
-        - A content repo with a pack and integration.
+        - A temporary directory.
 
         When:
-        - The repo includes an executable file. We modify the file to
-        be not executable.
+        - A new file is created.
+        - A new file is created and executable bit is set.
 
         Then:
         - `validate_file_permission_changes` exit code is 1.
-        - The output includes the command how to revert the change.
         """
 
-        # Set python file as executable
-        py_file_path = Path(git_repo.packs[0].integrations[0].code.path)
-        py_file_path.chmod(py_file_path.stat().st_mode | stat.S_IEXEC)
+        not_executable_file = tmp_path / "not_executable"
+        not_executable_file.write_text("print('some added code')")
 
-        git_repo.git_util.commit_files("Added a new Pack and Integration")
-        git_repo.git_util.repo.git.checkout("-b", cls.branch_permission)
-
-        # Unset python file as executable
-        py_file_path.chmod(
-            py_file_path.stat().st_mode & ~stat.S_IXUSR & ~stat.S_IXGRP & ~stat.S_IXOTH
-        )
-
-        git_repo.git_util.stage_file(py_file_path)
+        executable_file = tmp_path / "executable"
+        executable_file.write_text("print('some added code')")
+        executable_file.chmod(executable_file.stat().st_mode | stat.S_IEXEC)
 
         runner = CliRunner()
 
-        with ChangeCWD(git_repo.path):
-            result = runner.invoke(cls.func, [])
+        result = runner.invoke(
+            cls.func, [str(not_executable_file), str(executable_file)]
+        )
 
         assert result.exit_code == 1
         actual_output = result.stdout.splitlines()
         assert actual_output
         assert (
-            f"\x1b[91mFile '{py_file_path.relative_to(git_repo.path)}' permission was changed from {oct(Blob.executable_mode)[2:]} to {oct(Blob.file_mode)[2:]}\x1b[0m"
+            f"\x1b[91mFile '{executable_file}' has executable bits set. Please revert using command 'chmod -x {executable_file}'\x1b[0m"
             in actual_output
         )
-        assert (
-            f"\x1b[37mPlease revert the file permissions using the command 'chmod +x {py_file_path}'\x1b[0m"
-            in actual_output
-        )
-
-
-class TestValidateFileChangePermissionsCI(TestBaseClass):
-    """
-    Test class for validation running in a CI environment.
-    """
-
-    @pytest.fixture(autouse=True)
-    def setup(self, git_repo: Repo, mocker: MockerFixture, tmp_path: Path):
-        """
-        Setup method for the class tests.
-
-        - Set CI=true env var.
-        - Set content path.
-        - Create local remote git repo and add it as remote to content repo.
-        - Create a Pack and Integration.
-        - Push changes to remote.
-        """
-
-        from demisto_sdk.scripts.validate_deleted_files import GitUtil
-
-        mocker.patch.dict(os.environ, {"DEMISTO_SDK_CONTENT_PATH": git_repo.path})
-        mocker.patch.dict(os.environ, {CI_ENV_VAR: "true"})
-        mocker.patch.object(GitUtil, "fetch", return_value=None)
-
-        # Set up 'local' remote
-        GitUtil.REPO_CLS.init(str(tmp_path), bare=True)
-        git_repo.git_util.repo.delete_remote(Remote(git_repo.git_util.repo, "origin"))
-        git_repo.git_util.repo.create_remote("origin", str(tmp_path))
-
-        # Initialize Pack
-        git_repo.create_pack(name="TestPack").create_integration(name="TestIntegration")
-        git_repo.git_util.commit_files("Added a new Pack and Integration")
-        git_repo.git_util.repo.remote().push(refspec="master:master")
-
-    def test_unchanged_permission(cls, git_repo: Repo):
-        """
-        Test `validate_file_permission_changes` exit code when
-        no file permissions are modified.
-
-        Given:
-        - A content repo with a pack and integration.
-
-        When:
-        - The CI env var is set to 'true'.
-        - On another branch, we modify the integration by
-        adding a code.
-
-        Then:
-        - `validate_file_permission_changes` exit code is 0.
-        """
-
-        # Make changes, commit and push to remote
-        git_repo.git_util.repo.git.checkout("-b", cls.branch_non_permission)
-        py_file_str_path = git_repo.packs[0].integrations[0].code.path
-        py_file_path = Path(py_file_str_path)
-        py_file_path.write_text("print('some added code')")
-        git_repo.git_util.commit_files("Added some code")
-        git_repo.git_util.repo.remote().push(
-            refspec=f"{cls.branch_non_permission}:{cls.branch_non_permission}"
-        )
-
-        runner = CliRunner()
-
-        with ChangeCWD(git_repo.path):
-            result = runner.invoke(cls.func, [])
-
-        assert result.exit_code == 0
-
-    def test_unchanged_permission_input_files_supplied(cls, git_repo: Repo):
-        """
-        Test `validate_file_permission_changes` exit code when
-        no file permissions are modified.
-
-        Given:
-        - A content repo with a pack and integration.
-
-        When:
-        - The `--ci` flag is supplied.
-        - On another branch, we modify the integration by
-        adding a code.
-        - The changed files are supplied as input.
-
-        Then:
-        - `validate_file_permission_changes` exit code is 0.
-        """
-
-        # Make changes, commit and push to remote
-        git_repo.git_util.repo.git.checkout("-b", cls.branch_non_permission)
-        py_file_str_path = git_repo.packs[0].integrations[0].code.path
-        py_file_path = Path(py_file_str_path)
-        py_file_path.write_text("print('some added code')")
-        git_repo.git_util.commit_files("Added some code")
-        git_repo.git_util.repo.remote().push(
-            refspec=f"{cls.branch_non_permission}:{cls.branch_non_permission}"
-        )
-
-        runner = CliRunner()
-
-        with ChangeCWD(git_repo.path):
-            result = runner.invoke(cls.func, [py_file_str_path])
-
-        assert result.exit_code == 0
-
-    def test_set_executable(cls, git_repo: Repo):
-        """
-        Test `validate_file_permission_changes` exit code when
-        file permissions are modified.
-
-        Given:
-        - A content repo with a pack and integration.
-
-        When:
-        - On another branch, we modify the integration by
-        making the python script executable.
-
-        Then:
-        - `validate_file_permission_changes` exit code is 1.
-        - The output includes the command how to revert the change.
-        """
-
-        git_repo.git_util.repo.git.checkout("-b", cls.branch_permission)
-        py_file_str_path = git_repo.packs[0].integrations[0].code.path
-        py_file_path = Path(py_file_str_path)
-        py_file_path.chmod(py_file_path.stat().st_mode | stat.S_IEXEC)
-        git_repo.git_util.commit_files(f"Set {py_file_str_path} executable")
-        git_repo.git_util.repo.remote().push(
-            refspec=f"{cls.branch_permission}:{cls.branch_permission}"
-        )
-
-        runner = CliRunner()
-
-        with ChangeCWD(git_repo.path):
-            result = runner.invoke(cls.func, [])
-
-        assert result.exit_code == 1
-        actual_output = result.stdout.splitlines()
-        assert actual_output
-        assert (
-            f"\x1b[91mFile '{py_file_path.relative_to(git_repo.path)}' permission was changed from {oct(Blob.file_mode)[2:]} to {oct(Blob.executable_mode)[2:]}\x1b[0m"
-            in actual_output
-        )
-        assert (
-            f"\x1b[37mPlease revert the file permissions using the command 'chmod -x {py_file_path}'\x1b[0m"
-            in actual_output
-        )
-
-    def test_set_not_executable(cls, git_repo: Repo):
-        """
-        Test `validate_file_permission_changes` exit code when
-        file permissions are modified.
-
-        Given:
-        - A content repo with a pack and integration.
-
-        When:
-        - The repo includes an executable file. We modify the file to
-        be not executable.
-
-        Then:
-        - `validate_file_permission_changes` exit code is 1.
-        - The output includes the command how to revert the change.
-        """
-
-        # Set Python file as executable
-        py_file_str_path = git_repo.packs[0].integrations[0].code.path
-        py_file_path = Path(py_file_str_path)
-        py_file_path.chmod(py_file_path.stat().st_mode | stat.S_IEXEC)
-        git_repo.git_util.commit_files(f"Set {py_file_str_path} executable")
-        git_repo.git_util.repo.remote().push(refspec="master:master")
-
-        git_repo.git_util.repo.git.checkout("-b", cls.branch_permission)
-        # Unset Python file as executable
-        py_file_path.chmod(
-            py_file_path.stat().st_mode & ~stat.S_IXUSR & ~stat.S_IXGRP & ~stat.S_IXOTH
-        )
-        git_repo.git_util.commit_files(f"Set {py_file_str_path} not executable")
-        git_repo.git_util.repo.remote().push(
-            refspec=f"{cls.branch_permission}:{cls.branch_permission}"
-        )
-
-        runner = CliRunner()
-
-        with ChangeCWD(git_repo.path):
-            result = runner.invoke(cls.func, [])
-
-        assert result.exit_code == 1
-        actual_output = result.stdout.splitlines()
-        assert actual_output
-        assert (
-            f"\x1b[91mFile '{py_file_path.relative_to(git_repo.path)}' permission was changed from {oct(Blob.executable_mode)[2:]} to {oct(Blob.file_mode)[2:]}\x1b[0m"
-            in actual_output
-        )
-        assert (
-            f"\x1b[37mPlease revert the file permissions using the command 'chmod +x {py_file_path}'\x1b[0m"
-            in actual_output
-        )
-
-    def test_unchanged_permission_valid_input_file(cls, git_repo: Repo):
-        """
-        Test the behavior when we don't change a permission and supply the input file.
-
-        Given:
-        - A content repo with a pack and integration.
-
-        When:
-        - We add code to a Python file.
-        - The changed Python file is supplied as input.
-
-        Then:
-        - `validate_file_permission_changes` exit code is 0.
-        """
-
-        # Make changes, commit and push to remote
-        git_repo.git_util.repo.git.checkout("-b", cls.branch_non_permission)
-        py_file_str_path = git_repo.packs[0].integrations[0].code.path
-        py_file_path = Path(py_file_str_path)
-        py_file_path.write_text("print('some added code')")
-        git_repo.git_util.commit_files("Added some code")
-        git_repo.git_util.repo.remote().push(
-            refspec=f"{cls.branch_non_permission}:{cls.branch_non_permission}"
-        )
-
-        runner = CliRunner()
-
-        with ChangeCWD(git_repo.path):
-            result = runner.invoke(cls.func, [py_file_str_path])
-
-        assert result.exit_code == 0
-
-    def test_invalid_input_files(cls, git_repo: Repo):
-        """
-        Test the behavior when we don't change a permission and supply the input file.
-
-        Given:
-        - A content repo with a pack and integration.
-
-        When:
-        - We add code to a Python file.
-        - The changed Python file is supplied as invalid input (tuple).
-
-        Then:
-        - `validate_file_permission_changes` exit code is 0.
-        """
-
-        git_repo.git_util.repo.git.checkout("-b", cls.branch_non_permission)
-        py_file_str_path = git_repo.packs[0].integrations[0].code.path
-        py_file_path = Path(py_file_str_path)
-        py_file_path.write_text("print('some added code')")
-        git_repo.git_util.commit_files("Added some code")
-        git_repo.git_util.repo.remote().push(
-            refspec=f"{cls.branch_non_permission}:{cls.branch_non_permission}"
-        )
-
-        runner = CliRunner()
-
-        with ChangeCWD(git_repo.path):
-            result = runner.invoke(cls.func, [{"some_struct": py_file_str_path}])
-
-        assert result.exit_code == 1
-
-
-class TestIsCI:
-
-    valid_true = "true"
-    valid_false = "false"
-    invalid_false = "fale"
-
-    def test_valid_true_env_var_supplied(self, mocker: MockerFixture):
-        """
-        Given:
-        - The `CI` environmental variable.
-
-        When:
-        - The `CI` environmental variable is set to 'true'.
-
-        Then:
-        - `is_ci` returns `True`
-        """
-
-        mocker.patch.dict(os.environ, {CI_ENV_VAR: self.valid_true})
-
-        actual = is_ci()
-
-        assert actual
-
-    def test_valid_false_env_var_supplied(self, mocker: MockerFixture):
-        """
-        Given:
-        - `CI` environmental variable.
-
-        When:
-        - The `CI` environmental variable is set to 'false'.
-
-        Then:
-        - `is_ci` returns `False`
-        """
-
-        mocker.patch.dict(os.environ, {CI_ENV_VAR: self.valid_false})
-
-        actual = is_ci()
-
-        assert not actual
-
-    def test_invalid_env_var_supplied(self, mocker: MockerFixture):
-        """
-        Given:
-        - `CI` environmental variable.
-
-        When:
-        - The `CI` environmental variable is set to an invalid value 'fale'.
-
-        Then:
-        - `typer.BadParameter` is raised.
-        """
-
-        mocker.patch.dict(os.environ, {CI_ENV_VAR: self.invalid_false})
-
-        with pytest.raises(typer.BadParameter) as exception_info:
-            is_ci()
-
-        assert str(exception_info.value) == ERROR_IS_CI_INVALID.format(
-            env_var_str=self.invalid_false
-        )
-
-    def test_env_var_not_supplied(self):
-        """
-        Given:
-        - `CI` environmental variable.
-
-        When:
-        - The `CI` environmental variable is not set.
-
-        Then:
-        - `False` is returned.
-        """
-
-        actual = is_ci()
-
-        assert not actual

--- a/demisto_sdk/scripts/tests/validate_file_permission_changes_test.py
+++ b/demisto_sdk/scripts/tests/validate_file_permission_changes_test.py
@@ -12,28 +12,6 @@ class TestValidateFileChangePermissions:
 
     from demisto_sdk.scripts.validate_file_permission_changes import main as func
 
-    # branch_non_permission = "add-integration-code"
-    # branch_permission = "set-integration-executable"
-
-    # @pytest.fixture(autouse=True)
-    # def setup(self, git_repo: Repo, mocker: MockerFixture, tmp_path: Path):
-
-    #     from demisto_sdk.commands.common.git_util import Repo as GitRepo
-    #     from demisto_sdk.scripts.validate_deleted_files import GitUtil
-
-    #     mocker.patch.dict(os.environ, {"DEMISTO_SDK_CONTENT_PATH": git_repo.path})
-    #     mocker.patch.object(GitRepo, "remote", return_value="")
-    #     mocker.patch.object(GitUtil, "fetch", return_value=None)
-
-    #     # Set up 'local' remote
-    #     GitUtil.REPO_CLS.init(str(tmp_path), bare=True)
-    #     git_repo.git_util.repo.delete_remote(Remote(git_repo.git_util.repo, "origin"))
-    #     git_repo.git_util.repo.create_remote("origin", str(tmp_path))
-
-    #     # Initialize Pack
-    #     git_repo.create_pack(name="TestPack").create_integration(name="TestIntegration")
-    #     git_repo.git_util.commit_files("Added a new Pack and Integration")
-
     def test_unchanged_permissions(cls, tmp_path: Path):
         """
         Test `validate_file_permission_changes` exit code when

--- a/demisto_sdk/scripts/validate_file_permission_changes.py
+++ b/demisto_sdk/scripts/validate_file_permission_changes.py
@@ -1,63 +1,37 @@
 import os
-from pathlib import Path
-from typing import Any, Dict, List, Union
+import stat
+from typing import Dict, List
 
 import typer
-from git import Blob
 
-from demisto_sdk.commands.common.constants import DEMISTO_GIT_PRIMARY_BRANCH
-from demisto_sdk.commands.common.git_util import GitUtil
 from demisto_sdk.commands.common.logger import logger, logging_setup
 
 main = typer.Typer()
 
 HELP_CHANGED_FILES = "The files to check, e.g. dir/f1 f2 f3.py"
-ERROR_IS_CI_INVALID = (
-    "Invalid value for CI env var. Expected 'true' or 'false', actual '{env_var_str}'"
-)
-ERROR_INPUT_FILES_INVALID = "Invalid value for input files: {input}"
-CI_ENV_VAR = "CI"
 
 
-def split_files(files_str: Union[str, List[str]]) -> List[str]:
+def is_executable(file_path: str) -> bool:
     """
-    Helper function to return a `list` of `str`
-    from an input string.
+    Checks whether a file has executable bits set or not.
 
-    Args:
-    - `files_str` (``str | List[str]``): The input files.
-
-    Returns
-    - `List[str]` containing a list of strings.
-    """
-
-    if isinstance(files_str, list):
-        return files_str
-    elif isinstance(files_str, str):
-        return files_str.split() if files_str else []
-    else:
-        raise typer.BadParameter(ERROR_INPUT_FILES_INVALID.format(input=files_str))
-
-
-def is_ci() -> bool:
-    """
-    Helper function to detect whether we're running
-    in a CI environment. To detect this, we rely on the `CI` env var.
+    Arguments:
+    - `file_path` (``str``): The file path to check.
 
     Returns:
-    - `True` if we're in a CI environment, `False` otherwise.
+    - `True` if the file has executable bits set, `False` otherwise.
     """
 
-    if os.getenv(CI_ENV_VAR):
-        env_var_str = os.getenv(CI_ENV_VAR, "false").lower()
-        if env_var_str in {"true", "1", "yes"}:
-            return True
-        elif env_var_str in {"false", "0", "no"}:
-            return False
-        else:
-            raise typer.BadParameter(
-                ERROR_IS_CI_INVALID.format(env_var_str=env_var_str)
-            )
+    # Retrieve the file's status
+    file_stat = os.stat(file_path)
+
+    # Check if the file is executable by owner, group, or others
+    is_owner_executable = file_stat.st_mode & stat.S_IXUSR
+    is_group_executable = file_stat.st_mode & stat.S_IXGRP
+    is_other_executable = file_stat.st_mode & stat.S_IXOTH
+
+    if is_owner_executable or is_group_executable or is_other_executable:
+        return True
     else:
         return False
 
@@ -65,7 +39,11 @@ def is_ci() -> bool:
 @main.command(help="Validate that file modes were not changed")
 def validate_changed_files_permissions(
     changed_files: List[str] = typer.Argument(
-        default=None, help=HELP_CHANGED_FILES, callback=split_files
+        default=...,
+        help=HELP_CHANGED_FILES,
+        file_okay=True,
+        exists=True,
+        dir_okay=False,
     )
 ) -> None:
     """
@@ -79,75 +57,23 @@ def validate_changed_files_permissions(
     exit_code = 0
 
     logging_setup()
-    git_util = GitUtil.from_content_path()
-
-    ci = is_ci()
-
-    logger.debug(f"Running in CI environment: {ci}")
 
     if changed_files:
-        logger.debug(f"Got {','.join(changed_files)} as input...")
-    else:
-        logger.debug(
-            f"Getting changed files from git branch '{DEMISTO_GIT_PRIMARY_BRANCH}'..."
-        )
-        changed_files = [
-            str(path)
-            for path in git_util.get_all_changed_files(DEMISTO_GIT_PRIMARY_BRANCH)
-        ]
-
-    if changed_files:
-
-        logger.debug(
-            f"The following changed files were found comparing '{DEMISTO_GIT_PRIMARY_BRANCH}': {', '.join(changed_files)}"
-        )
 
         logger.debug(
             f"Iterating over {len(changed_files)} changed files to check if their permissions flags have changed..."
         )
 
-        result: Dict[str, Any] = {}
+        result: Dict[str, bool] = {}
 
         for changed_file in changed_files:
-            result[changed_file] = git_util.has_file_permissions_changed(
-                file_path=changed_file, ci=ci
-            )
+            result[changed_file] = is_executable(changed_file)
 
-        for filename, (is_changed, old_permission, new_permission) in result.items():
-            if is_changed:
+        for filename, executable in result.items():
+            if executable:
                 logger.error(
-                    f"File '{filename}' permission was changed from {old_permission} to {new_permission}"
+                    f"File '{filename}' has executable bits set. Please revert using command 'chmod -x {filename}'"
                 )
-                msg = get_revert_permission_message(Path(filename), new_permission)
-                logger.info(msg)
                 exit_code = 1
 
     raise typer.Exit(code=exit_code)
-
-
-def get_revert_permission_message(file_path: Path, new_permission: str) -> str:
-    """
-    Helper method that returns an output message explaining
-    to the user how to revert the file permissions.
-
-    Args:
-    - `file_path` (``Path``): The path to the file.
-    - `new_permission` ((`str``)): The new permission bits.
-
-    Returns:
-    - `str` with a message how to revert the permission changes.
-    """
-
-    try:
-        if new_permission == oct(Blob.file_mode)[2:]:
-            cmd = f"chmod +x {file_path.absolute()}"
-        elif new_permission == oct(Blob.executable_mode)[2:]:
-            cmd = f"chmod -x {file_path.absolute()}"
-        else:
-            cmd = f"chmod +||- {file_path.absolute()}"
-        message = f"Please revert the file permissions using the command '{cmd}'"
-    except IndexError as e:
-        logger.warning(f"Unable to get the blob file permissions: {e}")
-        message = f"Unable to get the blob file permissions for file '{file_path.absolute()}': {e}"
-    finally:
-        return message


### PR DESCRIPTION
## Related Issues
fixes:https://jira-dc.paloaltonetworks.com/browse/CIAC-11178

## Description
As seen in https://github.com/demisto/content/actions/runs/9960003744/job/27518173799?pr=35457#step:8:796, when attempting to find if a file permission has changed, we're unable to find the upstream branch in contribution/external PRs.

Since the `validate_changed_files_permissions` hook runs only on files inside the `Packs` directory, there's no reason ever to have an executable file there. Therefore, this PR introduces a few changes to how `validate_changed_files_permissions` works:

- We use `os.stat` to check for file permissions for owner, group and world scopes instead of relying on `git_util.has_file_permissions_changed` and `git diff --summary` output parsing.
- Removed check whether we're in a CI environment as it's unnecessary. It was used previously to help construct the refs to compare to find if the file permissions have changed.


## Tests
- [x] PR no file permission/mode changes ([PR](https://github.com/demisto/content/pull/35457), [job](https://github.com/demisto/content/actions/runs/9974257531/job/27561362940?pr=35457#step:8:185))
- [x] PR with file permission changes ([PR](https://github.com/demisto/content/pull/35477), [job](https://github.com/demisto/content/actions/runs/9974582390/job/27562362912?pr=35477#step:8:266)