### PR TITLE
Remove `validate-file-permission-changes` hook from Pre-Commit conf

### DIFF
--- a/.changelog/4436.yml
+++ b/.changelog/4436.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Remove the **validate-file-permissions-changes** pre-commit hook.
+  type: internal
+pr_number: 4436

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -82,4 +82,3 @@
   entry: validate-xsoar-config
   language: python
   pass_filenames: true
-

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -83,9 +83,3 @@
   language: python
   pass_filenames: true
 
-- id: validate-file-permission-changes
-  name: validate-file-permission-changes
-  description: Validate that file permissions haven't been changed.
-  entry: validate-file-permission-changes
-  language: python
-  files: ^Packs/


### PR DESCRIPTION
## Related Issues
fixes:https://jira-dc.paloaltonetworks.com/browse/CIAC-3448

## Description
Remove the `validate-file-permission-changes` from pre-commit conf. Will be readded once https://github.com/demisto/demisto-sdk/pull/4434 is released.