### PR TITLE
add `metadata` field to XSIAM report schema

### DIFF
--- a/.changelog/4472.yml
+++ b/.changelog/4472.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where `XSIAM Report` objects would fail structure **validate** checks, for having the `metadata` field. It's now added as optional
+  type: fix
+pr_number: 4472

--- a/demisto_sdk/commands/common/schemas/xsiamreport.yml
+++ b/demisto_sdk/commands/common/schemas/xsiamreport.yml
@@ -17,6 +17,8 @@ mapping:
 schema;templates_data_schema:
   type: map
   mapping:
+    metadata:
+      type: str
     global_id:
       type: str
       required: true


### PR DESCRIPTION
## Related Issues
related: https://jira-dc.paloaltonetworks.com/browse/CIAC-10677

## Description
Add a missing key (as optional) in the schema.