### PR TITLE
Fix API Key Access 

### DIFF
--- a/.changelog/4480.yml
+++ b/.changelog/4480.yml
@@ -1,4 +1,4 @@
 changes:
-- description: Fixed an issue where an error was raised if the value in the "cloud_servers_api_keys" file provided was not a dict.
+- description: Started supporting only the a dict value for "cloud_servers_api_keys" file provided.
   type: internal
 pr_number: 4480

--- a/.changelog/4480.yml
+++ b/.changelog/4480.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where an error was raised if the value in the "cloud_servers_api_keys" file provided was not a dict.
+  type: internal
+pr_number: 4480

--- a/.changelog/4480.yml
+++ b/.changelog/4480.yml
@@ -1,4 +1,4 @@
 changes:
-- description: Started supporting only the a dict value for "cloud_servers_api_keys" file provided.
+- description: Started supporting only a dict value for the "cloud_servers_api_keys" file provided.
   type: internal
 pr_number: 4480

--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -1216,16 +1216,9 @@ class CloudServerContext(ServerContext):
         super().__init__(build_context, server_private_ip, use_retries_mechanism)
         self.machine = cloud_machine
         self.server_url = self.server_ip
-        cloud_machine_details = self.build_context.api_key.get(cloud_machine, {})
-        self.api_key = (
-            cloud_machine_details.get("api-key")
-            if isinstance(cloud_machine_details, dict)
-            else self.build_context.api_key.get(cloud_machine)
-        )
-        self.auth_id = (
-            cloud_machine_details.get("x-xdr-auth-id")
-            if isinstance(cloud_machine_details, dict)
-            else self.build_context.env_json.get(cloud_machine, {}).get("x-xdr-auth-id")
+        self.api_key = self.build_context.api_key.get(cloud_machine, {}).get("api-key")
+        self.auth_id = self.build_context.api_key.get(cloud_machine, {}).get(
+            "x-xdr-auth-id"
         )
         os.environ.pop(
             "DEMISTO_USERNAME", None

--- a/demisto_sdk/commands/test_content/TestContentClasses.py
+++ b/demisto_sdk/commands/test_content/TestContentClasses.py
@@ -1216,12 +1216,17 @@ class CloudServerContext(ServerContext):
         super().__init__(build_context, server_private_ip, use_retries_mechanism)
         self.machine = cloud_machine
         self.server_url = self.server_ip
-        self.api_key = self.build_context.api_key.get(cloud_machine, {}).get(
-            "api-key"
-        ) or self.build_context.api_key.get(cloud_machine)
-        self.auth_id = self.build_context.api_key.get(cloud_machine, {}).get(
-            "x-xdr-auth-id"
-        ) or self.build_context.env_json.get(cloud_machine, {}).get("x-xdr-auth-id")
+        cloud_machine_details = self.build_context.api_key.get(cloud_machine, {})
+        self.api_key = (
+            cloud_machine_details.get("api-key")
+            if isinstance(cloud_machine_details, dict)
+            else self.build_context.api_key.get(cloud_machine)
+        )
+        self.auth_id = (
+            cloud_machine_details.get("x-xdr-auth-id")
+            if isinstance(cloud_machine_details, dict)
+            else self.build_context.env_json.get(cloud_machine, {}).get("x-xdr-auth-id")
+        )
         os.environ.pop(
             "DEMISTO_USERNAME", None
         )  # we use client without demisto username

--- a/demisto_sdk/commands/test_content/tests/build_context_test.py
+++ b/demisto_sdk/commands/test_content/tests/build_context_test.py
@@ -144,7 +144,6 @@ def generate_xsiam_servers_data():
         "qa2-test-111111": {
             "ui_url": "https://xsiam1.paloaltonetworks.com/",
             "instance_name": "qa2-test-111111",
-            "x-xdr-auth-id": 1,
             "base_url": "https://api1.paloaltonetworks.com/",
             "xsiam_version": "3.2.0",
             "demisto_version": "99.99.98",
@@ -152,7 +151,6 @@ def generate_xsiam_servers_data():
         "qa2-test-222222": {
             "ui_url": "https://xsoar-content-2.xdr-qa2-uat.us.paloaltonetworks.com/",
             "instance_name": "qa2-test-222222",
-            "x-xdr-auth-id": 1,
             "base_url": "https://api-xsoar-content-2.xdr-qa2-uat.us.paloaltonetworks.com",
             "xsiam_version": "3.2.0",
             "demisto_version": "99.99.98",


### PR DESCRIPTION
## Related Issues
related: https://github.com/demisto/demisto-sdk/pull/4442

## Description
Started supporting only the a dict value for "cloud_servers_api_keys" file provided.