### PR TITLE
Support Breaking Changes Marketplace

### DIFF
--- a/.changelog/4483.yml
+++ b/.changelog/4483.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Introduces the `marketplaces` new field in the breaking changes release notes ".json" file. This supports choosing on which marketplace the braking changes message will appear.
+  type: feature
+pr_number: 4483

--- a/.changelog/4483.yml
+++ b/.changelog/4483.yml
@@ -1,4 +1,4 @@
 changes:
-- description: Introduces the `marketplaces` new field in the breaking changes release notes ".json" file. This supports choosing on which marketplace the braking changes message will appear.
+- description: Introduces the `marketplaces` new optional field in the breaking changes release notes ".json" file. This supports choosing on which marketplace the braking changes message will appear. The field is a list, when not provided its default value is all marketplaces. It supports aggregated release notes and editing release notes backwards.
   type: feature
 pr_number: 4483

--- a/demisto_sdk/commands/common/schemas/releasenotesconfig.yml
+++ b/demisto_sdk/commands/common/schemas/releasenotesconfig.yml
@@ -6,3 +6,9 @@ mapping:
   breakingChangesNotes:
     type: str
     required: false
+  marketplaces:
+    type: seq
+    required: false
+    sequence:
+    - type: str
+      enum: ['xsoar', 'marketplacev2', 'xpanse', 'xsoar_saas', 'xsoar_on_prem']

--- a/demisto_sdk/commands/update_release_notes/update_rn.py
+++ b/demisto_sdk/commands/update_release_notes/update_rn.py
@@ -360,6 +360,7 @@ class UpdateRN:
             f.write(json.dumps(bc_file_data, indent=4))
         logger.info(
             f"[green]Finished creating config file for RN version {new_version}.\n"
+            "If the breaking changes apply only for specific marketplaces, add those values under the `marketplaces` field.\n"
             "If you wish only specific text to be shown as breaking changes, please fill the "
             "`breakingChangesNotes` field with the appropriate breaking changes text.[/green]"
         )


### PR DESCRIPTION
## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-11021

## Description
Braking changes release notes message on items related to specific marketplace, will not appear in other marketplaces.
This introduces the marketplaces new field in the BC RN JSON file.
The field is a list, its default value is all marketplaces. It supports aggregated RN and editing RN backwards.