### PR TITLE
CIAC-11145 - Split the testing of modeling rules on XSIAM to multiple machines fixing logger threading

### DIFF
--- a/.changelog/4487.yml
+++ b/.changelog/4487.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue with the parallel logger not showing the thread id.
+  type: fix
+pr_number: 4487

--- a/demisto_sdk/commands/test_content/ParallelLoggingManager.py
+++ b/demisto_sdk/commands/test_content/ParallelLoggingManager.py
@@ -7,7 +7,7 @@ from queue import Queue
 from threading import Lock, current_thread
 from typing import Any, Dict, Set
 
-from demisto_sdk.commands.common.logger import get_logging_color_formatter
+import coloredlogs
 
 ARTIFACTS_PATH = os.environ.get("ARTIFACTS_FOLDER", ".")
 LOGGING_FORMAT = "[%(asctime)s] - [%(threadName)s] - [%(levelname)s] - %(message)s"
@@ -124,7 +124,9 @@ class ParallelLoggingManager:
             _add_logging_level("SUCCESS", 25)
         self.real_time_logs_only = real_time_logs_only
         self.log_file_name = log_file_name
-        formatter = get_logging_color_formatter(LOGGING_FORMAT)
+        formatter = coloredlogs.ColoredFormatter(
+            fmt=LOGGING_FORMAT, level_styles=LEVEL_STYLES
+        )
         self.console_handler = logging.StreamHandler(sys.stdout)
         self.console_handler.setFormatter(formatter)
         log_file_path = (


### PR DESCRIPTION
Split the testing of modeling rules on XSIAM to multiple machines fixing logger threading

<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: [CIAC-11145](https://jira-dc.paloaltonetworks.com/browse/CIAC-11145)

## Description
fix parallel logger