### PR TITLE
Fixing the way we try to remove old containers

### DIFF
--- a/.changelog/4495.yml
+++ b/.changelog/4495.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where reusing the Content-Graph after a long period of inactivity resulted in a 409 error.
+  type: fix
+pr_number: 4495

--- a/demisto_sdk/commands/content_graph/neo4j_service.py
+++ b/demisto_sdk/commands/content_graph/neo4j_service.py
@@ -41,7 +41,9 @@ def _stop_neo4j_service_docker(docker_client: docker.DockerClient):  # type: ign
         docker_client (docker.DockerClient): The docker client to use
     """
     try:
-        containers = docker_client.containers.list(all=True,filters={"name": "neo4j-content"})
+        containers = docker_client.containers.list(
+            all=True, filters={"name": "neo4j-content"}
+        )
         if containers:
             container = containers[0]
         else:

--- a/demisto_sdk/commands/content_graph/neo4j_service.py
+++ b/demisto_sdk/commands/content_graph/neo4j_service.py
@@ -41,7 +41,7 @@ def _stop_neo4j_service_docker(docker_client: docker.DockerClient):  # type: ign
         docker_client (docker.DockerClient): The docker client to use
     """
     try:
-        containers = docker_client.containers.list(filters={"name": "neo4j-content"})
+        containers = docker_client.containers.list(all=True,filters={"name": "neo4j-content"})
         if containers:
             container = containers[0]
         else:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-11519

## Description
fixing the way we try to remove old containers by adding "all=True" to when we search for the old container in order to remove him.
