### PR TITLE
Fixed PA102 for modeling_rules

### DIFF
--- a/.changelog/4497.yml
+++ b/.changelog/4497.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where PA102 failed when there were valid modeling_rules in a pack.
+  type: fix
+pr_number: 4497

--- a/demisto_sdk/commands/common/content/objects/pack_objects/pack.py
+++ b/demisto_sdk/commands/common/content/objects/pack_objects/pack.py
@@ -341,6 +341,10 @@ class Pack:
         )
 
     @property
+    def modeling_rules_count(self) -> int:
+        return len(tuple(self.modeling_rules))
+
+    @property
     def correlation_rules(self) -> Iterator[CorrelationRule]:
         return self._content_files_list_generator_factory(
             dir_name=CORRELATION_RULES_DIR, suffix="yml"
@@ -488,12 +492,17 @@ class Pack:
 
     def _are_integrations_or_scripts_or_playbooks_exist(self) -> int:
         """
-        Checks whether an integration/script/playbook exist in the pack.
+        Checks whether an integration/script/playbook/modeling_rules exist in the pack.
 
         Returns:
             int: number > 0 if there is at least one integration/script/playbook in the pack, 0 if not.
         """
-        return self.integrations_count or self.scripts_count or self.playbooks_count
+        return (
+            self.integrations_count
+            or self.scripts_count
+            or self.playbooks_count
+            or self.modeling_rules_count
+        )
 
     def is_deprecated(self) -> bool:
         """
@@ -539,6 +548,10 @@ class Pack:
                 and (
                     self.scripts_count
                     == _get_deprecated_content_entities_count(self.scripts)
+                )
+                and (
+                    self.modeling_rules_count
+                    == _get_deprecated_content_entities_count(self.modeling_rules)
                 )
             )
         # if there aren't any playbooks/scripts/integrations -> no deprecated content -> pack shouldn't be deprecated.

--- a/demisto_sdk/commands/common/hook_validations/pack_unique_files.py
+++ b/demisto_sdk/commands/common/hook_validations/pack_unique_files.py
@@ -1060,7 +1060,7 @@ class PackUniqueFilesValidator(BaseValidator):
     def should_pack_be_deprecated(self) -> bool:
         """
         Validates whether a pack should be deprecated
-        if all its content items (playbooks/scripts/integrations) are deprecated.
+        if all its content items (playbooks/scripts/integrations/modeling_rules) are deprecated.
 
         Returns:
             bool: True if pack should be deprecated, False if it shouldn't.

--- a/demisto_sdk/commands/validate/tests/PA_validators_test.py
+++ b/demisto_sdk/commands/validate/tests/PA_validators_test.py
@@ -1525,16 +1525,17 @@ def test_IsValidUseCasesValidator_fix():
     "pack, is_deprecated_pack, integrations, playbooks, scripts, modeling_rules, expected_number_of_failures, "
     "expected_msgs",
     [
-        (create_pack_object(), False, [], [], [], 0, []),
+        (create_pack_object(), False, [], [], [], [], 0, []),
         (
             create_pack_object(),
             False,
             [create_integration_object(["deprecated"], [True])],
             [],
             [],
+            [],
             1,
             [
-                "The Pack HelloWorld should be deprecated, as all its integrations, playbooks and scripts are deprecated.\nThe name of the pack in the pack_metadata.json should end with (Deprecated).\nThe description of the pack in the pack_metadata.json should be one of the following formats:\n1. 'Deprecated. Use <PACK_NAME> instead.'\n2. 'Deprecated. <REASON> No available replacement.'"
+                "The Pack HelloWorld should be deprecated, as all its content items are deprecated.\nThe name of the pack in the pack_metadata.json should end with (Deprecated).\nThe description of the pack in the pack_metadata.json should be one of the following formats:\n1. 'Deprecated. Use <PACK_NAME> instead.'\n2. 'Deprecated. <REASON> No available replacement.'"
             ],
         ),
         (
@@ -1543,6 +1544,7 @@ def test_IsValidUseCasesValidator_fix():
             [],
             [create_playbook_object(["deprecated"], [True])],
             [create_script_object()],
+            [],
             0,
             [],
         ),
@@ -1552,14 +1554,16 @@ def test_IsValidUseCasesValidator_fix():
             [create_integration_object(["deprecated"], [True])],
             [],
             [],
+            [],
             0,
             [],
         ),
         (
             create_pack_object(),
             False,
-            [],
             [create_integration_object(["deprecated"], [True])],
+            [],
+            [],
             [create_modeling_rule_object()],
             0,
             [],

--- a/demisto_sdk/commands/validate/tests/PA_validators_test.py
+++ b/demisto_sdk/commands/validate/tests/PA_validators_test.py
@@ -1587,7 +1587,7 @@ def test_ShouldPackBeDeprecatedValidator_obtain_invalid_content_items(
         - Case 2: A non deprecated pack with a deprecated integration.
         - Case 3: A non deprecated pack with a deprecated integration and a non deprecated script
         - Case 4: A deprecated pack with a deprecated integration.
-        - Case 3: A non deprecated pack with a deprecated integration and a non deprecated modeling_rule
+        - Case 5: A non deprecated pack with a deprecated integration and a non deprecated modeling_rule
     When
     - Calling the ShouldPackBeDeprecatedValidator obtain_invalid_content_items function.
     Then

--- a/demisto_sdk/commands/validate/tests/PA_validators_test.py
+++ b/demisto_sdk/commands/validate/tests/PA_validators_test.py
@@ -19,6 +19,7 @@ from demisto_sdk.commands.common.constants import (
 from demisto_sdk.commands.content_graph.parsers.related_files import RelatedFile
 from demisto_sdk.commands.validate.tests.test_tools import (
     create_integration_object,
+    create_modeling_rule_object,
     create_old_file_pointers,
     create_pack_object,
     create_playbook_object,
@@ -1521,7 +1522,8 @@ def test_IsValidUseCasesValidator_fix():
 
 
 @pytest.mark.parametrize(
-    "pack, is_deprecated_pack, integrations, playbooks, scripts, expected_number_of_failures, expected_msgs",
+    "pack, is_deprecated_pack, integrations, playbooks, scripts, modeling_rules, expected_number_of_failures, "
+    "expected_msgs",
     [
         (create_pack_object(), False, [], [], [], 0, []),
         (
@@ -1553,6 +1555,15 @@ def test_IsValidUseCasesValidator_fix():
             0,
             [],
         ),
+        (
+            create_pack_object(),
+            False,
+            [],
+            [create_integration_object(["deprecated"], [True])],
+            [create_modeling_rule_object()],
+            0,
+            [],
+        ),
     ],
 )
 def test_ShouldPackBeDeprecatedValidator_obtain_invalid_content_items(
@@ -1561,6 +1572,7 @@ def test_ShouldPackBeDeprecatedValidator_obtain_invalid_content_items(
     integrations,
     playbooks,
     scripts,
+    modeling_rules,
     expected_number_of_failures,
     expected_msgs,
 ):
@@ -1571,6 +1583,7 @@ def test_ShouldPackBeDeprecatedValidator_obtain_invalid_content_items(
         - Case 2: A non deprecated pack with a deprecated integration.
         - Case 3: A non deprecated pack with a deprecated integration and a non deprecated script
         - Case 4: A deprecated pack with a deprecated integration.
+        - Case 3: A non deprecated pack with a deprecated integration and a non deprecated modeling_rule
     When
     - Calling the ShouldPackBeDeprecatedValidator obtain_invalid_content_items function.
     Then
@@ -1579,11 +1592,13 @@ def test_ShouldPackBeDeprecatedValidator_obtain_invalid_content_items(
         - Case 2: Should fail.
         - Case 3: Shouldn't fail.
         - Case 4: Shouldn't fail.
+        - Case 5: Shouldn't fail.
     """
     pack.deprecated = is_deprecated_pack
     pack.content_items.integration.extend(integrations)
     pack.content_items.playbook.extend(playbooks)
     pack.content_items.script.extend(scripts)
+    pack.content_items.modeling_rule.extend(modeling_rules)
     content_items = [pack]
     results = ShouldPackBeDeprecatedValidator().obtain_invalid_content_items(
         content_items

--- a/demisto_sdk/commands/validate/validators/PA_validators/PA102_should_pack_be_deprecated.py
+++ b/demisto_sdk/commands/validate/validators/PA_validators/PA102_should_pack_be_deprecated.py
@@ -18,10 +18,21 @@ class ShouldPackBeDeprecatedValidator(BaseValidator[ContentTypes]):
     description = "Validate that the pack is deprecated if it needs to."
     rationale = (
         "This ensures clarity for users and prevents potential confusion of deprecated content. "
-        "For more about deprecation see: https://xsoar.pan.dev/docs/reference/articles/deprecation-process-and-hidden-packs"
+        "For more about deprecation see: "
+        "https://xsoar.pan.dev/docs/reference/articles/deprecation-process-and-hidden-packs"
     )
-    error_message = "The Pack {0} should be deprecated, as all its integrations, playbooks and scripts are deprecated.\nThe name of the pack in the pack_metadata.json should end with (Deprecated).\nThe description of the pack in the pack_metadata.json should be one of the following formats:\n1. 'Deprecated. Use <PACK_NAME> instead.'\n2. 'Deprecated. <REASON> No available replacement.'"
-    fix_message = "Deprecated the pack {0}.\nPlease make sure to edit the description of the pack in the pack_metadata.json file if there's an existing pack to use instead or add the deprecation reason."
+    error_message = (
+        "The Pack {0} should be deprecated, as all its content items are deprecated.\n"
+        "The name of the pack in the pack_metadata.json should end with (Deprecated).\n"
+        "The description of the pack in the pack_metadata.json should be one of the following formats:\n"
+        "1. 'Deprecated. Use <PACK_NAME> instead.'\n"
+        "2. 'Deprecated. <REASON> No available replacement.'"
+    )
+    fix_message = (
+        "Deprecated the pack {0}.\n"
+        "Please make sure to edit the description of the pack in the pack_metadata.json file "
+        "if there's an existing pack to use instead or add the deprecation reason."
+    )
     related_field = "deprecated"
     is_auto_fixable = True
     expected_git_statuses = [GitStatuses.MODIFIED]
@@ -46,6 +57,7 @@ class ShouldPackBeDeprecatedValidator(BaseValidator[ContentTypes]):
                 content_item.content_items.integration,
                 content_item.content_items.script,
                 content_item.content_items.playbook,
+                content_item.content_items.modeling_rule,
             ]
         ):
             for integration in content_item.content_items.integration:
@@ -56,6 +68,9 @@ class ShouldPackBeDeprecatedValidator(BaseValidator[ContentTypes]):
                     return False
             for playbook in content_item.content_items.playbook:
                 if not playbook.deprecated:
+                    return False
+            for rule in content_item.content_items.modeling_rule:
+                if not rule.deprecated:
                     return False
             return True
         return False


### PR DESCRIPTION
## Related Issues
fixes: [CIAC-11542](https://jira-dc.paloaltonetworks.com/browse/CIAC-11542)

## Description
Fixed validation PA102 (and PA132 old validate) that failed when there were valid modeling rules in a pack, therefore the entire pack should not be deprecated. 
Example PR: https://github.com/demisto/content/pull/35922
