### PR TITLE
[GR106] reputation_tests

### DIFF
--- a/.changelog/4549.yml
+++ b/.changelog/4549.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where the GR106 validation rule incorrectly flagged reputation tests as unused test playbooks.
+  type: fix
+pr_number: 4549

--- a/.changelog/4549.yml
+++ b/.changelog/4549.yml
@@ -1,4 +1,4 @@
 changes:
-- description: Fixed an issue where the GR106 validation rule incorrectly flagged reputation tests as unused test playbooks.
+- description: Fixed an issue where the GR106 validation would fail on test playbooks that are marked as reputation tests.
   type: fix
 pr_number: 4549

--- a/demisto_sdk/commands/content_graph/interface/neo4j/neo4j_graph.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/neo4j_graph.py
@@ -568,7 +568,7 @@ class Neo4jContentGraphInterface(ContentGraphInterface):
             return [self._id_to_obj[result] for result in results]
 
     def find_unused_test_playbook(
-        self, test_playbook_ids: List[str], skipped_tests_keys: List[str]
+        self, test_playbook_ids: List[str], test_playbooks_ids_to_skip: List[str]
     ) -> List[BaseNode]:
         """
         Finds unused test playbooks.
@@ -585,7 +585,9 @@ class Neo4jContentGraphInterface(ContentGraphInterface):
         """
         with self.driver.session() as session:
             results = session.execute_read(
-                validate_test_playbook_in_use, test_playbook_ids, skipped_tests_keys
+                validate_test_playbook_in_use,
+                test_playbook_ids,
+                test_playbooks_ids_to_skip,
             )
             self._add_nodes_to_mapping(results)
             return [self._id_to_obj[result.element_id] for result in results]

--- a/demisto_sdk/commands/content_graph/interface/neo4j/queries/validations.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/queries/validations.py
@@ -312,7 +312,7 @@ def validate_duplicate_ids(
 
 
 def validate_test_playbook_in_use(
-    tx: Transaction, test_playbook_ids: List[str], tests_skipped: List[str]
+    tx: Transaction, test_playbook_ids: List[str], test_playbooks_ids_to_skip
 ) -> List[graph.Node]:
     query = """
 MATCH (tp:TestPlaybook) WHERE
@@ -322,7 +322,7 @@ MATCH (tp:TestPlaybook) WHERE
     query += f"""
  NOT EXISTS {{ MATCH ()-[:TESTED_BY]->(tp) }}
 AND tp.deprecated = false
-AND NOT (tp.object_id IN {tests_skipped})
+AND NOT (tp.object_id IN {test_playbooks_ids_to_skip})
 MATCH (tp)-[:IN_PACK]->(p:Pack)
 WHERE p.support = "xsoar"
 AND p.deprecated = false

--- a/demisto_sdk/commands/validate/tests/GR_validators_test.py
+++ b/demisto_sdk/commands/validate/tests/GR_validators_test.py
@@ -145,6 +145,7 @@ def prepared_graph_repo(graph_repo: Repo):
     sample_pack_2.create_classifier("SampleClassifier")
     sample_pack_2.create_test_playbook("SampleTestPlaybook")
     sample_pack_2.create_test_playbook("TestPlaybookNoInUse")
+    sample_pack_2.create_test_playbook("TestReputationPlaybook")
     sample_pack_2.create_test_playbook("TestPlaybookDeprecated").set_data(
         deprecated="true"
     )
@@ -266,6 +267,7 @@ def test_IsTestPlaybookInUseValidatorAllFiles_is_valid(
     - Ensure that the validator correctly identifies the playbook in use with no errors.
     - Ensure that the validator correctly identifies the playbook not in use and returns an appropriate error message.
     - Ensure that the validator correctly identifies the deprecated playbook with no errors.
+    - Ensure reputation test playbook is not test if they under the `reputation_tests` key in the conf.json.
     """
     mock_conf = ConfJSON.from_path("demisto_sdk/tests/test_files/conf.json")
     mocker.patch.object(ConfJSON, "from_path", return_value=mock_conf)
@@ -298,7 +300,7 @@ def test_IsTestPlaybookInUseValidatorAllFiles_is_valid(
     )
 
     playbook_deprecated = (
-        prepared_graph_repo.packs[1].test_playbooks[2].get_graph_object(graph_interface)
+        prepared_graph_repo.packs[1].test_playbooks[3].get_graph_object(graph_interface)
     )
     validation_results = (
         IsTestPlaybookInUseValidatorListFiles().obtain_invalid_content_items(
@@ -306,3 +308,13 @@ def test_IsTestPlaybookInUseValidatorAllFiles_is_valid(
         )
     )
     assert validation_results == []  # the test playbook is deprecated
+
+    reputation_playbook = (
+        prepared_graph_repo.packs[1].test_playbooks[2].get_graph_object(graph_interface)
+    )
+    validation_results = (
+        IsTestPlaybookInUseValidatorListFiles().obtain_invalid_content_items(
+            [reputation_playbook]
+        )
+    )
+    assert validation_results == []

--- a/demisto_sdk/commands/validate/tests/GR_validators_test.py
+++ b/demisto_sdk/commands/validate/tests/GR_validators_test.py
@@ -295,7 +295,7 @@ def test_IsTestPlaybookInUseValidatorAllFiles_is_valid(
         validation_results[0].message
         == (  # the test playbook not in use
             "Test playbook 'TestPlaybookNoInUse' is not linked to any content item."
-            " Make sure at least one integration, script or playbook mentions the test-playbook id under the `tests:` key."
+            " Make sure at least one integration, script or playbook mentions the test-playbook ID under the `tests:` key."
         )
     )
 

--- a/demisto_sdk/commands/validate/validators/GR_validators/GR106_is_testplaybook_in_use.py
+++ b/demisto_sdk/commands/validate/validators/GR_validators/GR106_is_testplaybook_in_use.py
@@ -32,13 +32,15 @@ class IsTestPlaybookInUseValidator(BaseValidator[ContentTypes], ABC):
         self, content_items: Iterable[ContentTypes], validate_all_files: bool
     ) -> List[ValidationResult]:
         conf_data = ConfJSON.from_path(CONTENT_PATH / "Tests/conf.json")
-        skipped_tests_keys = list(conf_data.skipped_tests.keys())
-
+        test_playbooks_ids_to_skip = list(
+            set(conf_data.skipped_tests.keys()) | set(conf_data.reputation_tests)
+        )
+        #  the collect test for reputation playbooks checks the reputation_tests field in conf.json and not the `tests` key in the yml
         test_playbook_ids_to_validate = (
-            [item.object_id for item in content_items] if not validate_all_files else []
+            [] if validate_all_files else [item.object_id for item in content_items]
         )
         invalid_content_items = self.graph.find_unused_test_playbook(
-            test_playbook_ids_to_validate, skipped_tests_keys
+            test_playbook_ids_to_validate, test_playbooks_ids_to_skip
         )
         return [
             ValidationResult(

--- a/demisto_sdk/commands/validate/validators/GR_validators/GR106_is_testplaybook_in_use.py
+++ b/demisto_sdk/commands/validate/validators/GR_validators/GR106_is_testplaybook_in_use.py
@@ -18,13 +18,13 @@ class IsTestPlaybookInUseValidator(BaseValidator[ContentTypes], ABC):
     error_code = "GR106"
     description = (
         "Checks that every test playbook is linked to at least one content item."
-        " (the content item has a 'tests:' key with the id of the test playbook)"
+        " (the content item has a 'tests:' key with the ID of the test playbook)"
     )
     rationale = (
         "In the demisto/content repo, unlinked test playbooks are not run in CI (for PRs) unless the test playbook itself is modified. Proper linkage of test playbooks ensures content quality. "
         "See  https://xsoar.pan.dev/docs/integrations/test-playbooks#adding-the-playbook-to-your-project"
     )
-    error_message = "Test playbook '{}' is not linked to any content item. Make sure at least one integration, script or playbook mentions the test-playbook id under the `tests:` key."
+    error_message = "Test playbook '{}' is not linked to any content item. Make sure at least one integration, script or playbook mentions the test-playbook ID under the `tests:` key."
     related_field = "tests"
     is_auto_fixable = False
 

--- a/demisto_sdk/tests/test_files/conf.json
+++ b/demisto_sdk/tests/test_files/conf.json
@@ -67,6 +67,7 @@
         "Sanity Test"
     ],
     "reputation_tests": [
-        "FormattingPerformance - Test"
+        "FormattingPerformance - Test",
+        "TestReputationPlaybook"
     ]
 }


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-11761

## Description
This validation 
```
Checks that every test playbook is linked to at least one content item.
 (the content item has a 'tests:' key with the id of the test playbook)
 ```
But the the collect test for reputation playbooks checks the r`eputation_tests` field in conf.json and not the `tests` key in the yml so we need to ignore reputation test