### PR TITLE
Fix repeated typo in demisto-sdk

### DIFF
--- a/.changelog/4587.yml
+++ b/.changelog/4587.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed a typo in several demisto-sdk files.
+  type: internal
+pr_number: 4587

--- a/demisto_sdk/commands/common/errors.py
+++ b/demisto_sdk/commands/common/errors.py
@@ -2690,7 +2690,7 @@ class Errors:
             "For more information, refer to the following documentation: "
             "https://xsoar.pan.dev/docs/documentation/release-notes"
         )
-        return f'Did not find content items headers under "{content_type}" - might be duo to invalid format.\n{error}'
+        return f'Did not find content items headers under "{content_type}" - might be due to invalid format.\n{error}'
 
     @staticmethod
     @error_code_decorator

--- a/demisto_sdk/commands/common/hook_validations/release_notes.py
+++ b/demisto_sdk/commands/common/hook_validations/release_notes.py
@@ -105,7 +105,7 @@ class ReleaseNotesValidator(BaseValidator):
                 content_type_sections_str
             )
             if not content_type_sections_ls:
-                #  Did not find content items headers under content type - might be duo to invalid format.
+                #  Did not find content items headers under content type - might be due to invalid format.
                 #  Will raise error in rn_valid_header_format.
                 headers[content_type] = []
             for content_type_section in content_type_sections_ls:

--- a/demisto_sdk/tests/integration_tests/create_id_set_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/create_id_set_integration_test.py
@@ -23,7 +23,7 @@ class TestCreateIdSet:  # Use classes to speed up test - multi threaded py pytes
             - Running create-id-set command
 
         When
-            - some items should be excluded from the id set duo to mismatch in the marketplaces
+            - some items should be excluded from the id set due to mismatch in the marketplaces
 
         Then
             - Ensure create-id-set passes.


### PR DESCRIPTION
> [!NOTE]  
> Fix a repeated typo in demisto-sdk: "duo to" --> "due to".