### PR TITLE
[setup-env] Fix  logging

### DIFF
--- a/.changelog/4597.yml
+++ b/.changelog/4597.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where debug-logging in **setup-env** failed.
+  type: fix
+pr_number: 4597

--- a/demisto_sdk/commands/common/clients/xsiam/xsiam_api_client.py
+++ b/demisto_sdk/commands/common/clients/xsiam/xsiam_api_client.py
@@ -32,7 +32,10 @@ class XsiamClient(XsoarSaasClient):
             self.get_ioc_rules()
             return True
         except ApiException as error:
-            logger.debug("{}", f"<cyan>{self} is not {self.server_type} server, error: {error}</cyan>")  # noqa: PLE1205
+            logger.debug(  # noqa: PLE1205
+                "{}",
+                f"<cyan>{self} is not {self.server_type} server, error: {error}</cyan>",
+            )
             return False
 
     @property

--- a/demisto_sdk/commands/common/clients/xsiam/xsiam_api_client.py
+++ b/demisto_sdk/commands/common/clients/xsiam/xsiam_api_client.py
@@ -32,7 +32,7 @@ class XsiamClient(XsoarSaasClient):
             self.get_ioc_rules()
             return True
         except ApiException as error:
-            logger.debug(f"{self} is not {self.server_type} server, error: {error}")
+            logger.debug("{}", f"<cyan>{self} is not {self.server_type} server, error: {error}</cyan>")  # noqa: PLE1205
             return False
 
     @property


### PR DESCRIPTION
## Related Issues

fixes:  https://jira-dc.paloaltonetworks.com/browse/CIAC-11907

## Description

`Fixed an issue where debug-logging in **setup-env** failed.`
*demisto-sdk version:* 1.32.1

```
raise ValueError('Closing tag "%s" has no corresponding opening tag' % markup)
```

