### PR TITLE
Fix Docker Logs

### DIFF
--- a/demisto_sdk/commands/common/docker_helper.py
+++ b/demisto_sdk/commands/common/docker_helper.py
@@ -412,9 +412,6 @@ class DockerBase:
                     f"{log_prompt} - Attempt {attempt + 1}: Failed to push image {test_image_name_to_push} to repository due to {type(e).__name__}",
                     exc_info=True,
                 )
-                logger.debug(
-                    f"{log_prompt} - Push details (after exception) for image {test_image_name_to_push}: {docker_push_output}"
-                )
 
     def create_image(
         self,


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes:

## Description
We improved the Docker logs in #4500.
These changes caused the build to fail with the following error: 

```
docker.errors.DockerException: local variable 'docker_push_output' referenced before assignment
```

![Screenshot 2024-10-10 at 9 47 14](https://github.com/user-attachments/assets/27823aae-670c-42ef-895f-f2c46cdd3077)

