### PR TITLE
[validate] empty filters and transformers fields

### DIFF
--- a/.changelog/4639.yml
+++ b/.changelog/4639.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where the **validate** and **create-id-set** commands would fail to process correctly when encountering null values in the filters or transformers fields.
+  type: fix
+pr_number: 4639

--- a/demisto_sdk/commands/common/tests/update_id_set_test.py
+++ b/demisto_sdk/commands/common/tests/update_id_set_test.py
@@ -4028,9 +4028,12 @@ def test_get_filters_and_transformers_with_none_values():
         "transformers": None,
         "filters": None,
     }
-    transformers, filters = get_filters_and_transformers_from_complex_value(data_with_none)
+    transformers, filters = get_filters_and_transformers_from_complex_value(
+        data_with_none
+    )
     assert transformers == []
     assert filters == []
+
 
 @pytest.mark.parametrize("dict_to_test, expected_result", TEST_DICTS)
 def test_does_dict_have_alternative_key(dict_to_test, expected_result):

--- a/demisto_sdk/commands/common/tests/update_id_set_test.py
+++ b/demisto_sdk/commands/common/tests/update_id_set_test.py
@@ -4012,6 +4012,26 @@ TEST_DICTS = [
 ]
 
 
+def test_get_filters_and_transformers_with_none_values():
+    """
+    Given
+    - complex value with None values for transformers and filters.
+
+    When
+    - parsing transformers and filters from the value.
+
+    Then
+    - both transformers and filters should default to empty lists without errors.
+    """
+
+    data_with_none = {
+        "transformers": None,
+        "filters": None,
+    }
+    transformers, filters = get_filters_and_transformers_from_complex_value(data_with_none)
+    assert transformers == []
+    assert filters == []
+
 @pytest.mark.parametrize("dict_to_test, expected_result", TEST_DICTS)
 def test_does_dict_have_alternative_key(dict_to_test, expected_result):
     result = does_dict_have_alternative_key(dict_to_test)

--- a/demisto_sdk/commands/common/update_id_set.py
+++ b/demisto_sdk/commands/common/update_id_set.py
@@ -480,14 +480,14 @@ def get_filters_and_transformers_from_complex_value(
     all_transformers = set()
 
     # add the filters to all_filters set
-    filters = complex_value.get("filters", [])
+    filters = complex_value.get("filters") or []
     for tmp_filter in filters:
         if tmp_filter:
             operator = tmp_filter[0].get("operator")
             all_filters.add(operator)
 
     # add the transformers to all_transformers set
-    transformers = complex_value.get("transformers", [])
+    transformers = complex_value.get("transformers") or []
     for tmp_transformer in transformers:
         if tmp_transformer:
             operator = tmp_transformer.get("operator")

--- a/demisto_sdk/commands/content_graph/parsers/classifier.py
+++ b/demisto_sdk/commands/content_graph/parsers/classifier.py
@@ -47,12 +47,14 @@ class ClassifierParser(JSONContentItemParser, content_type=ContentType.CLASSIFIE
     def get_filters_and_transformers_from_complex_value(
         self, complex_value: dict
     ) -> None:
-        for filter in complex_value.get("filters", []):
+        filters = complex_value.get("filters") or []
+        for filter in filters:
             if filter:
                 filter_script = filter[0].get("operator").split(".")[-1]
                 self.add_dependency_by_id(filter_script, ContentType.SCRIPT)
 
-        for transformer in complex_value.get("transformers", []):
+        transformers = complex_value.get("transformers") or []
+        for transformer in transformers:
             if transformer:
                 transformer_script = transformer.get("operator").split(".")[-1]
                 self.add_dependency_by_id(transformer_script, ContentType.SCRIPT)

--- a/demisto_sdk/commands/content_graph/parsers/mapper.py
+++ b/demisto_sdk/commands/content_graph/parsers/mapper.py
@@ -43,12 +43,13 @@ class MapperParser(JSONContentItemParser, content_type=ContentType.MAPPER):
     def get_filters_and_transformers_from_complex_value(
         self, complex_value: dict
     ) -> None:
-        for filter in complex_value.get("filters", []):
+        filters = complex_value.get("filters") or []
+        for filter in filters:
             if filter:
                 filter_script = filter[0].get("operator").split(".")[-1]
                 self.add_dependency_by_id(filter_script, ContentType.SCRIPT)
-
-        for transformer in complex_value.get("transformers", []):
+        transformers = complex_value.get("transformers") or []
+        for transformer in transformers:
             if transformer:
                 transformer_script = transformer.get("operator").split(".")[-1]
                 self.add_dependency_by_id(transformer_script, ContentType.SCRIPT)


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-12087

## Description
Fixed an issue where the validate and create-id-set commands would fail to process correctly when encountering null values in the filters or transformers fields.
