### PR TITLE
Logging Failure During Docker Creation

### DIFF
--- a/.changelog/4648.yml
+++ b/.changelog/4648.yml
@@ -1,4 +1,4 @@
 changes:
-- description: Fixed an issue where critical-logging in docker failed.
+- description: Fixed an issue where logging would fail when creating a Docker image.
   type: fix
 pr_number: 4648

--- a/.changelog/4648.yml
+++ b/.changelog/4648.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where critical-logging in docker failed.
+  type: fix
+pr_number: 4648

--- a/demisto_sdk/commands/common/docker_helper.py
+++ b/demisto_sdk/commands/common/docker_helper.py
@@ -477,7 +477,7 @@ class DockerBase:
             except (docker.errors.BuildError, docker.errors.APIError, Exception) as e:
                 errors = str(e)
                 logger.critical(  # noqa: PLE1205
-                    "{}", f"<cyan>{log_prompt} - Build errors occurred: {errors}</cyan>"
+                    "{}", f"<red>{log_prompt} - Build errors occurred: {errors}</red>"
                 )
         return test_docker_image, errors
 

--- a/demisto_sdk/commands/common/docker_helper.py
+++ b/demisto_sdk/commands/common/docker_helper.py
@@ -476,7 +476,9 @@ class DockerBase:
                 )
             except (docker.errors.BuildError, docker.errors.APIError, Exception) as e:
                 errors = str(e)
-                logger.critical(f"{log_prompt} - Build errors occurred: {errors}")
+                logger.critical(  # noqa: PLE1205
+                    "{}", f"<cyan>{log_prompt} - Build errors occurred: {errors}</cyan>"
+                )
         return test_docker_image, errors
 
 


### PR DESCRIPTION
## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-12137

## Description
- description: Fixed an issue where logging would fail when creating a Docker image.

```
 File "content/.venv/lib/python3.10/site-packages/demisto_sdk/commands/common/docker_helper.py", line 479, in get_or_create_test_image
    logger.critical(f"{log_prompt} - Build errors occurred: {errors}")
  File "content/.venv/lib/python3.10/site-packages/loguru/_logger.py", line 2060, in critical
    __self._log("CRITICAL", False, __self._options, __message, args, kwargs)
  File "content/.venv/lib/python3.10/site-packages/loguru/_logger.py", line 2017, in _log
    colored_message = Colorizer.prepare_simple_message(str(message))
  File "content/.venv/lib/python3.10/site-packages/loguru/_colorizer.py", line 368, in prepare_simple_message
    parser.feed(string)
  File "content/.venv/lib/python3.10/site-packages/loguru/_colorizer.py", line 252, in feed
    raise ValueError(
ValueError: Tag "<2.0.0,>" does not correspond to any known color directive, make sure you did not misspelled it (or prepend '\' to escape it)
```
