### PR TITLE
[Github Workflow] Logging Failure During `Add PR link to Related Jira Issue`

### DIFF
--- a/.changelog/4649.yml
+++ b/.changelog/4649.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where logging would fail when linking PR to Jira issue in the GitHub workflow step.
+  type: fix
+pr_number: 4649

--- a/Utils/github_workflow_scripts/jira_integration_scripts/link_pr_to_jira_issue.py
+++ b/Utils/github_workflow_scripts/jira_integration_scripts/link_pr_to_jira_issue.py
@@ -82,7 +82,9 @@ def trigger_generic_webhook(options):
     password = options.password
     instance_url = options.url
 
-    logger.info(f"Detected Pr: {pr_title=}, {pr_link=}, {pr_body=}")
+    logger.info(  # noqa: PLE1205
+        "{}", f"<yellow>Detected Pr: {pr_title=}, {pr_link=}, {pr_body=}</yellow>"
+    )
 
     # Handle cases where the PR did not intend to add links:
     if (


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-12138

## Description
```
  File "/home/runner/work/demisto-sdk/demisto-sdk/Utils/github_workflow_scripts/jira_integration_scripts/./link_pr_to_jira_issue.py", line 85, in trigger_generic_webhook
    logger.info(f"Detected Pr: {pr_title=}, {pr_link=}, {pr_body=}")
  File "/home/runner/work/demisto-sdk/demisto-sdk/.venv/lib/python3.9/site-packages/loguru/_logger.py", line 2044, in info
    __self._log("INFO", False, __self._options, __message, args, kwargs)
  File "/home/runner/work/demisto-sdk/demisto-sdk/.venv/lib/python3.9/site-packages/loguru/_logger.py", line 2017, in _log
    colored_message = Colorizer.prepare_simple_message(str(message))
  File "/home/runner/work/demisto-sdk/demisto-sdk/.venv/lib/python3.9/site-packages/loguru/_colorizer.py", line 3[68](https://github.com/demisto/demisto-sdk/actions/runs/11764096196/job/32768859984?pr=4648#step:7:69), in prepare_simple_message
    parser.feed(string)
  File "/home/runner/work/demisto-sdk/demisto-sdk/.venv/lib/python3.9/site-packages/loguru/_colorizer.py", line 252, in feed
    raise ValueError(
ValueError: Tag "<2.0.0,>" does not correspond to any known color directive, make sure you did not misspelled it (or prepend '\' to escape it)
```