### PR TITLE
Manual Release 1.32.4

### DIFF
--- a/.changelog/4625.yml
+++ b/.changelog/4625.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Fixed an issue where getting a malformed file raised an non-indicative error.
-  type: fix
-pr_number: 4625

--- a/.changelog/4635.yml
+++ b/.changelog/4635.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Moved RN113 to the new validate format. The validation ensures that all the first level headers in the release note are valid content types.
-  type: internal
-pr_number: 4635

--- a/.changelog/4638.yml
+++ b/.changelog/4638.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Moved CJ102 to the new validate format. The validation's error number is now BA103 and it ensure that the tests section is either a non-empty list or "No tests".
-  type: breaking
-pr_number: 4638

--- a/.changelog/4639.yml
+++ b/.changelog/4639.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Fixed an issue where the **validate** and **create-id-set** commands would fail to process correctly when encountering null values in the filters or transformers fields.
-  type: fix
-pr_number: 4639

--- a/.changelog/4640.yml
+++ b/.changelog/4640.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Moved RN115 to the new validate format. The validation ensure that the release notes first level headers are valid.
-  type: internal
-pr_number: 4640

--- a/.changelog/4646.yml
+++ b/.changelog/4646.yml
@@ -1,4 +1,0 @@
-changes:
-- description: "The following commands will be deprecated and removed entirely in the next SDK release in two weeks: convert, create-content-artifacts, create-id-set, extract-code and lint."
-  type: breaking
-pr_number: 4646

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 * Moved RN113 to the new validate format. The validation ensures that all the first level headers in the release note are valid content types.
 * Moved RN115 to the new validate format. The validation ensure that the release notes first level headers are valid.
 
-
 ## 1.32.3
 * Fixed an issue where integrations and scripts validations didn't run in builds. [#4609](https://github.com/demisto/demisto-sdk/pull/4609)
 * Added BA127 new validation. The validation checks that the level of depth of the context output path in the yml is lower or equal to 5 in XSOAR supported content items. [#4490](https://github.com/demisto/demisto-sdk/pull/4490)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+## 1.32.4 (2024-11-10)
+### Breaking
+* The following commands will be deprecated and removed entirely in the next SDK release in two weeks: convert, create-content-artifacts, create-id-set, extract-code and lint.
+* Moved CJ102 to the new validate format. The validation's error number is now BA103 and it ensure that the tests section is either a non-empty list or "No tests".
+
+### Fix
+* Fixed an issue where getting a malformed file raised an non-indicative error.
+* Fixed an issue where the **validate** and **create-id-set** commands would fail to process correctly when encountering null values in the filters or transformers fields.
+
+### Internal
+* Moved RN113 to the new validate format. The validation ensures that all the first level headers in the release note are valid content types.
+* Moved RN115 to the new validate format. The validation ensure that the release notes first level headers are valid.
+
+
 ## 1.32.3
 * Fixed an issue where integrations and scripts validations didn't run in builds. [#4609](https://github.com/demisto/demisto-sdk/pull/4609)
 * Added BA127 new validation. The validation checks that the level of depth of the context output path in the yml is lower or equal to 5 in XSOAR supported content items. [#4490](https://github.com/demisto/demisto-sdk/pull/4490)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ exclude = "tests/.*|demisto_sdk/commands/init/templates/.*"
 
 [tool.poetry]
 name = "demisto-sdk"
-version = "1.32.3"
+version = "1.32.4"
 description = "\"A Python library for the Demisto SDK\""
 authors = ["Demisto"]
 license = "MIT"


### PR DESCRIPTION
## 1.32.4 (2024-11-10)
### Breaking
* The following commands will be deprecated and removed entirely in the next SDK release in two weeks: convert, create-content-artifacts, create-id-set, extract-code and lint.
* Moved CJ102 to the new validate format. The validation's error number is now BA103 and it ensure that the tests section is either a non-empty list or "No tests".

### Fix
* Fixed an issue where getting a malformed file raised an non-indicative error.
* Fixed an issue where the **validate** and **create-id-set** commands would fail to process correctly when encountering null values in the filters or transformers fields.

### Internal
* Moved RN113 to the new validate format. The validation ensures that all the first level headers in the release note are valid content types.
* Moved RN115 to the new validate format. The validation ensure that the release notes first level headers are valid.