### PR TITLE
Fix logger setup

### DIFF
--- a/.changelog/4657.yml
+++ b/.changelog/4657.yml
@@ -1,4 +1,4 @@
 changes:
-- description: Fixing logger crashes when imported as library in content scripts/integrations.
+- description: Fixing logger crashes when imported as library.
   type: fix
 pr_number: 4657

--- a/.changelog/4657.yml
+++ b/.changelog/4657.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixing logger crashes when imported as library in content scripts/integrations.
+  type: fix
+pr_number: 4657

--- a/demisto_sdk/__init__.py
+++ b/demisto_sdk/__init__.py
@@ -1,3 +1,3 @@
 from demisto_sdk.commands.common.logger import logging_setup
 
-logging_setup(initial=True, calling_function="__init__")
+# logging_setup(initial=True, calling_function="__init__")

--- a/demisto_sdk/__init__.py
+++ b/demisto_sdk/__init__.py
@@ -1,4 +1,4 @@
-
-if __name__ in ["__main__", 'demisto_sdk']:
+if __name__ in ["__main__", "demisto_sdk"]:
     from demisto_sdk.commands.common.logger import logging_setup
+
     logging_setup(initial=True, calling_function="__init__")

--- a/demisto_sdk/__init__.py
+++ b/demisto_sdk/__init__.py
@@ -1,3 +1,3 @@
-# from demisto_sdk.commands.common.logger import logging_setup
-
-# logging_setup(initial=True, calling_function="__init__")
+if __name__ == "__main__":
+    from demisto_sdk.commands.common.logger import logging_setup
+    logging_setup(initial=True, calling_function="__init__")

--- a/demisto_sdk/__init__.py
+++ b/demisto_sdk/__init__.py
@@ -1,3 +1,3 @@
-from demisto_sdk.commands.common.logger import logging_setup
+# from demisto_sdk.commands.common.logger import logging_setup
 
 # logging_setup(initial=True, calling_function="__init__")

--- a/demisto_sdk/__init__.py
+++ b/demisto_sdk/__init__.py
@@ -1,3 +1,4 @@
 if __name__ == "__main__":
     from demisto_sdk.commands.common.logger import logging_setup
+
     logging_setup(initial=True, calling_function="__init__")

--- a/demisto_sdk/__init__.py
+++ b/demisto_sdk/__init__.py
@@ -1,4 +1,4 @@
-if __name__ == "__main__":
-    from demisto_sdk.commands.common.logger import logging_setup
 
+if __name__ in ["__main__", 'demisto_sdk']:
+    from demisto_sdk.commands.common.logger import logging_setup
     logging_setup(initial=True, calling_function="__init__")

--- a/demisto_sdk/commands/common/logger.py
+++ b/demisto_sdk/commands/common/logger.py
@@ -105,24 +105,25 @@ def logging_setup(
     diagnose = string_to_bool(os.getenv("LOGURU_DIAGNOSE", 'False'))
     colorize = not string_to_bool(os.getenv(DEMISTO_SDK_LOG_NO_COLORS, 'False'))
 
-    logger = logger.opt(
-        colors=colorize
-    )  # allows using color tags in logs (e.g. logger.info("<blue>foo</blue>"))
+    # logger = logger.opt(
+    #     colors=colorize
+    # )  # allows using color tags in logs (e.g. logger.info("<blue>foo</blue>"))
     _add_console_logger(
         colorize=colorize, threshold=console_threshold, diagnose=diagnose
     )
 
     # if not initial:
-    #     _add_file_logger(
-    #         log_path=calculate_log_dir(path) / LOG_FILE_NAME,
-    #         threshold=file_threshold,
-    #         diagnose=diagnose,
-    #     )
-    #     os.environ[DEMISTO_SDK_LOGGING_SET] = "true"
-
-    logger.debug(
-        f"logger setup: {calling_function=},{console_threshold=},{file_threshold=},{path=},{initial=}"
-    )
+    # _add_file_logger(
+    #     log_path=calculate_log_dir(path) / LOG_FILE_NAME,
+    #     threshold=file_threshold,
+    #     diagnose=diagnose,
+    # )
+    os.environ[DEMISTO_SDK_LOGGING_SET] = "true"
+    logger.info('BARRY BARRY')
+    logger.debug('YOSI YOSI')
+    # logger.debug(
+    #     f"logger setup: {calling_function=},{console_threshold=},{file_threshold=},{path=},{initial=}"
+    # )
 
 
 def _add_file_logger(log_path: Path, threshold: Optional[str], diagnose: bool):

--- a/demisto_sdk/commands/common/logger.py
+++ b/demisto_sdk/commands/common/logger.py
@@ -30,7 +30,6 @@ DEFAULT_CONSOLE_THRESHOLD = "INFO"
 DEFAULT_FILE_SIZE = 1 * (1024**2)  # 1 MB
 DEFAULT_FILE_COUNT = 10
 
-global logger
 logger = loguru.logger  # all SDK modules should import from this file, not from loguru
 logger.disable(None)  # enabled at setup_logging()
 

--- a/demisto_sdk/commands/common/logger.py
+++ b/demisto_sdk/commands/common/logger.py
@@ -34,11 +34,11 @@ logger = loguru.logger  # all SDK modules should import from this file, not from
 logger.disable(None)  # enabled at setup_logging()
 
 
-def _setup_neo4j_logger():
-    import logging  # noqa: TID251 # special case, to control the neo4j logging
+# def _setup_neo4j_logger():
+#     import logging  # noqa: TID251 # special case, to control the neo4j logging
 
-    neo4j_log = logging.getLogger("neo4j")
-    neo4j_log.setLevel(logging.CRITICAL)
+#     neo4j_log = logging.getLogger("neo4j")
+#     neo4j_log.setLevel(logging.CRITICAL)
 
 
 def calculate_log_size() -> int:
@@ -98,12 +98,12 @@ def logging_setup(
     In the initial set up there is NO file logging (only console)
     """
     global logger
-    _setup_neo4j_logger()
+    # _setup_neo4j_logger()
 
     logger.remove(None)  # Removes all pre-existing handlers
 
-    diagnose = string_to_bool(os.getenv("LOGURU_DIAGNOSE", False))
-    colorize = not string_to_bool(os.getenv(DEMISTO_SDK_LOG_NO_COLORS), False)
+    diagnose = string_to_bool(os.getenv("LOGURU_DIAGNOSE", 'False'))
+    colorize = not string_to_bool(os.getenv(DEMISTO_SDK_LOG_NO_COLORS, 'False'))
 
     logger = logger.opt(
         colors=colorize

--- a/demisto_sdk/commands/common/logger.py
+++ b/demisto_sdk/commands/common/logger.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import platform
 import sys
@@ -5,7 +6,7 @@ from pathlib import Path
 from typing import Iterable, Optional, Union
 
 import loguru  # noqa: TID251 # This is the only place where we allow it
-import logging
+
 from demisto_sdk.commands.common.constants import (
     DEMISTO_SDK_LOG_FILE_PATH,
     DEMISTO_SDK_LOG_FILE_SIZE,

--- a/demisto_sdk/commands/common/logger.py
+++ b/demisto_sdk/commands/common/logger.py
@@ -100,7 +100,7 @@ def logging_setup(
     global logger
     _setup_neo4j_logger()
 
-    logger.remove(None)  # Removes all pre-existing handlers
+    logger.remove()  # Removes all pre-existing handlers
 
     diagnose = string_to_bool(os.getenv("LOGURU_DIAGNOSE", 'False'))
     colorize = not string_to_bool(os.getenv(DEMISTO_SDK_LOG_NO_COLORS, 'False'))
@@ -120,9 +120,9 @@ def logging_setup(
     #     )
     #     os.environ[DEMISTO_SDK_LOGGING_SET] = "true"
 
-    # logger.debug(
-    #     f"logger setup: {calling_function=},{console_threshold=},{file_threshold=},{path=},{initial=}"
-    # )
+    logger.debug(
+        f"logger setup: {calling_function=},{console_threshold=},{file_threshold=},{path=},{initial=}"
+    )
 
 
 def _add_file_logger(log_path: Path, threshold: Optional[str], diagnose: bool):

--- a/demisto_sdk/commands/common/logger.py
+++ b/demisto_sdk/commands/common/logger.py
@@ -108,9 +108,9 @@ def logging_setup(
     logger = logger.opt(
         colors=colorize
     )  # allows using color tags in logs (e.g. logger.info("<blue>foo</blue>"))
-    # _add_console_logger(
-    #     colorize=colorize, threshold=console_threshold, diagnose=diagnose
-    # )
+    _add_console_logger(
+        colorize=colorize, threshold=console_threshold, diagnose=diagnose
+    )
 
     # if not initial:
     #     _add_file_logger(

--- a/demisto_sdk/commands/common/logger.py
+++ b/demisto_sdk/commands/common/logger.py
@@ -100,10 +100,10 @@ def logging_setup(
     global logger
     _setup_neo4j_logger()
 
-    # logger.remove(None)  # Removes all pre-existing handlers
+    logger.remove(None)  # Removes all pre-existing handlers
 
-    # diagnose = string_to_bool(os.getenv("LOGURU_DIAGNOSE", 'False'))
-    # colorize = not string_to_bool(os.getenv(DEMISTO_SDK_LOG_NO_COLORS, 'False'))
+    diagnose = string_to_bool(os.getenv("LOGURU_DIAGNOSE", 'False'))
+    colorize = not string_to_bool(os.getenv(DEMISTO_SDK_LOG_NO_COLORS, 'False'))
 
     # logger = logger.opt(
     #     colors=colorize

--- a/demisto_sdk/commands/common/logger.py
+++ b/demisto_sdk/commands/common/logger.py
@@ -34,11 +34,11 @@ logger = loguru.logger  # all SDK modules should import from this file, not from
 logger.disable(None)  # enabled at setup_logging()
 
 
-# def _setup_neo4j_logger():
-#     import logging  # noqa: TID251 # special case, to control the neo4j logging
+def _setup_neo4j_logger():
+    import logging  # noqa: TID251 # special case, to control the neo4j logging
 
-#     neo4j_log = logging.getLogger("neo4j")
-#     neo4j_log.setLevel(logging.CRITICAL)
+    neo4j_log = logging.getLogger("neo4j")
+    neo4j_log.setLevel(logging.CRITICAL)
 
 
 def calculate_log_size() -> int:
@@ -98,31 +98,31 @@ def logging_setup(
     In the initial set up there is NO file logging (only console)
     """
     global logger
-    # _setup_neo4j_logger()
+    _setup_neo4j_logger()
 
-    logger.remove(None)  # Removes all pre-existing handlers
+    # logger.remove(None)  # Removes all pre-existing handlers
 
-    diagnose = string_to_bool(os.getenv("LOGURU_DIAGNOSE", 'False'))
-    colorize = not string_to_bool(os.getenv(DEMISTO_SDK_LOG_NO_COLORS, 'False'))
+    # diagnose = string_to_bool(os.getenv("LOGURU_DIAGNOSE", 'False'))
+    # colorize = not string_to_bool(os.getenv(DEMISTO_SDK_LOG_NO_COLORS, 'False'))
 
-    logger = logger.opt(
-        colors=colorize
-    )  # allows using color tags in logs (e.g. logger.info("<blue>foo</blue>"))
-    _add_console_logger(
-        colorize=colorize, threshold=console_threshold, diagnose=diagnose
-    )
+    # logger = logger.opt(
+    #     colors=colorize
+    # )  # allows using color tags in logs (e.g. logger.info("<blue>foo</blue>"))
+    # _add_console_logger(
+    #     colorize=colorize, threshold=console_threshold, diagnose=diagnose
+    # )
 
-    if not initial:
-        _add_file_logger(
-            log_path=calculate_log_dir(path) / LOG_FILE_NAME,
-            threshold=file_threshold,
-            diagnose=diagnose,
-        )
-        os.environ[DEMISTO_SDK_LOGGING_SET] = "true"
+    # if not initial:
+    #     _add_file_logger(
+    #         log_path=calculate_log_dir(path) / LOG_FILE_NAME,
+    #         threshold=file_threshold,
+    #         diagnose=diagnose,
+    #     )
+    #     os.environ[DEMISTO_SDK_LOGGING_SET] = "true"
 
-    logger.debug(
-        f"logger setup: {calling_function=},{console_threshold=},{file_threshold=},{path=},{initial=}"
-    )
+    # logger.debug(
+    #     f"logger setup: {calling_function=},{console_threshold=},{file_threshold=},{path=},{initial=}"
+    # )
 
 
 def _add_file_logger(log_path: Path, threshold: Optional[str], diagnose: bool):

--- a/demisto_sdk/commands/common/logger.py
+++ b/demisto_sdk/commands/common/logger.py
@@ -105,9 +105,9 @@ def logging_setup(
     diagnose = string_to_bool(os.getenv("LOGURU_DIAGNOSE", 'False'))
     colorize = not string_to_bool(os.getenv(DEMISTO_SDK_LOG_NO_COLORS, 'False'))
 
-    # logger = logger.opt(
-    #     colors=colorize
-    # )  # allows using color tags in logs (e.g. logger.info("<blue>foo</blue>"))
+    logger = logger.opt(
+        colors=colorize
+    )  # allows using color tags in logs (e.g. logger.info("<blue>foo</blue>"))
     # _add_console_logger(
     #     colorize=colorize, threshold=console_threshold, diagnose=diagnose
     # )

--- a/demisto_sdk/commands/common/logger.py
+++ b/demisto_sdk/commands/common/logger.py
@@ -101,7 +101,16 @@ def logging_setup(
 ):
     """
     The initial set up is required since we have code (e.g. get_content_path) that runs in __main__ before the typer/click commands set up the logger.
-    In the initial set up there is NO file logging (only console)
+    In the initial set up there is NO file logging (only console).
+
+    Parameters:
+    - calling_function (str): The name of the function invoking the logger setup, included in all logs.
+    - console_threshold (str): Log level for console output.
+    - file_threshold (str): Log level for file output.
+    - path (Union[Path, str], optional): Path for file logs. If None, defaults to the calculated log directory.
+    - initial (bool): Indicates if the setup is for the initial configuration (console-only if True).
+    - propagate (bool): If True, propagates logs to Python's logging system.
+
     """
     global logger
     _setup_neo4j_logger()
@@ -112,7 +121,7 @@ def logging_setup(
     colorize = not string_to_bool(os.getenv(DEMISTO_SDK_LOG_NO_COLORS, 'False'))
 
     if propagate:
-        logger.add(PropagateHandler(), format=calling_function+"-{message}")
+        _propagate_logger(console_threshold)
     else:
 
         logger = logger.opt(
@@ -128,10 +137,18 @@ def logging_setup(
                 diagnose=diagnose,
             )
     os.environ[DEMISTO_SDK_LOGGING_SET] = "true"
-    logger.info('BARRY BARRY')
-    logger.debug('YOSI YOSI')
     logger.debug(
         f"logger setup: {calling_function=},{console_threshold=},{file_threshold=},{path=},{initial=}"
+    )
+
+def _propagate_logger(threshold: Optional[str],):
+    """
+    Adds a PropagateHandler to Loguru's logger to forward logs to Python's logging system.
+    """
+    logger.add(
+        PropagateHandler(),
+        format=CONSOLE_FORMAT,
+        level=(threshold or DEFAULT_CONSOLE_THRESHOLD),
     )
 
 

--- a/demisto_sdk/commands/common/logger.py
+++ b/demisto_sdk/commands/common/logger.py
@@ -1,4 +1,4 @@
-import logging
+import logging  # noqa: TID251 # Required for propagation handling.
 import os
 import platform
 import sys
@@ -98,7 +98,7 @@ def logging_setup(
     file_threshold: str = DEFAULT_FILE_THRESHOLD,
     path: Optional[Union[Path, str]] = None,
     initial: bool = False,
-    propagate: bool = False
+    propagate: bool = False,
 ):
     """
     The initial set up is required since we have code (e.g. get_content_path) that runs in __main__ before the typer/click commands set up the logger.
@@ -118,13 +118,12 @@ def logging_setup(
 
     logger.remove()  # Removes all pre-existing handlers
 
-    diagnose = string_to_bool(os.getenv("LOGURU_DIAGNOSE", 'False'))
-    colorize = not string_to_bool(os.getenv(DEMISTO_SDK_LOG_NO_COLORS, 'False'))
+    diagnose = string_to_bool(os.getenv("LOGURU_DIAGNOSE", "False"))
+    colorize = not string_to_bool(os.getenv(DEMISTO_SDK_LOG_NO_COLORS, "False"))
 
     if propagate:
         _propagate_logger(console_threshold)
     else:
-
         logger = logger.opt(
             colors=colorize
         )  # allows using color tags in logs (e.g. logger.info("<blue>foo</blue>"))
@@ -142,7 +141,10 @@ def logging_setup(
         f"logger setup: {calling_function=},{console_threshold=},{file_threshold=},{path=},{initial=}"
     )
 
-def _propagate_logger(threshold: Optional[str],):
+
+def _propagate_logger(
+    threshold: Optional[str],
+):
     """
     Adds a PropagateHandler to Loguru's logger to forward logs to Python's logging system.
     """
@@ -177,7 +179,6 @@ def _add_console_logger(colorize: bool, threshold: Optional[str], diagnose: bool
         diagnose=diagnose,
         level=(threshold or DEFAULT_CONSOLE_THRESHOLD),
     )
-
 
 
 def log_system_details():

--- a/demisto_sdk/commands/common/logger.py
+++ b/demisto_sdk/commands/common/logger.py
@@ -31,6 +31,8 @@ DEFAULT_CONSOLE_THRESHOLD = "INFO"
 DEFAULT_FILE_SIZE = 1 * (1024**2)  # 1 MB
 DEFAULT_FILE_COUNT = 10
 
+LOGURU_DIAGNOSE = "LOGURU_DIAGNOSE"
+
 logger = loguru.logger  # all SDK modules should import from this file, not from loguru
 logger.disable(None)  # enabled at setup_logging()
 
@@ -118,7 +120,7 @@ def logging_setup(
 
     logger.remove()  # Removes all pre-existing handlers
 
-    diagnose = string_to_bool(os.getenv("LOGURU_DIAGNOSE", "False"))
+    diagnose = string_to_bool(os.getenv(LOGURU_DIAGNOSE, "False"))
     colorize = not string_to_bool(os.getenv(DEMISTO_SDK_LOG_NO_COLORS, "False"))
 
     if propagate:
@@ -136,7 +138,7 @@ def logging_setup(
                 threshold=file_threshold,
                 diagnose=diagnose,
             )
-    os.environ[DEMISTO_SDK_LOGGING_SET] = "true"
+        os.environ[DEMISTO_SDK_LOGGING_SET] = "true"
     logger.debug(
         f"logger setup: {calling_function=},{console_threshold=},{file_threshold=},{path=},{initial=}"
     )

--- a/demisto_sdk/commands/common/logger.py
+++ b/demisto_sdk/commands/common/logger.py
@@ -97,6 +97,7 @@ def logging_setup(
     file_threshold: str = DEFAULT_FILE_THRESHOLD,
     path: Optional[Union[Path, str]] = None,
     initial: bool = False,
+    propagate: bool = False
 ):
     """
     The initial set up is required since we have code (e.g. get_content_path) that runs in __main__ before the typer/click commands set up the logger.
@@ -110,27 +111,28 @@ def logging_setup(
     diagnose = string_to_bool(os.getenv("LOGURU_DIAGNOSE", 'False'))
     colorize = not string_to_bool(os.getenv(DEMISTO_SDK_LOG_NO_COLORS, 'False'))
 
-    logger.add(PropagateHandler(), format="{message}")
-    
-    # logger = logger.opt(
-    #     colors=colorize
-    # )  # allows using color tags in logs (e.g. logger.info("<blue>foo</blue>"))
-    # _add_console_logger(
-    #     colorize=colorize, threshold=console_threshold, diagnose=diagnose
-    # )
+    if propagate:
+        logger.add(PropagateHandler(), format=calling_function+"-{message}")
+    else:
 
-    # if not initial:
-    # _add_file_logger(
-    #     log_path=calculate_log_dir(path) / LOG_FILE_NAME,
-    #     threshold=file_threshold,
-    #     diagnose=diagnose,
-    # )
+        logger = logger.opt(
+            colors=colorize
+        )  # allows using color tags in logs (e.g. logger.info("<blue>foo</blue>"))
+        _add_console_logger(
+            colorize=colorize, threshold=console_threshold, diagnose=diagnose
+        )
+        if not initial:
+            _add_file_logger(
+                log_path=calculate_log_dir(path) / LOG_FILE_NAME,
+                threshold=file_threshold,
+                diagnose=diagnose,
+            )
     os.environ[DEMISTO_SDK_LOGGING_SET] = "true"
     logger.info('BARRY BARRY')
     logger.debug('YOSI YOSI')
-    # logger.debug(
-    #     f"logger setup: {calling_function=},{console_threshold=},{file_threshold=},{path=},{initial=}"
-    # )
+    logger.debug(
+        f"logger setup: {calling_function=},{console_threshold=},{file_threshold=},{path=},{initial=}"
+    )
 
 
 def _add_file_logger(log_path: Path, threshold: Optional[str], diagnose: bool):


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: [CIAC-12159](https://jira-dc.paloaltonetworks.com/browse/CIAC-12159)

## Description

When using 'demisto-sdk' as a library within content scripts/integrations, the new logging setup/initialization conflicts with existing logger and causes the container to crash when initialized statically.

Additionally, logs does not show up on default python's logging which is used in content scripts/integration.

## Solution:
 - Excluding sdk's logging initialization logic when imported as a library.
 - Propagating log entries to default logging system when flagged.
