### PR TITLE
[pre-commit] Fixed an issue with running on all files

### DIFF
--- a/.changelog/4668.yml
+++ b/.changelog/4668.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where `pre-commit` inadvertently skipped all files when executed with the `--all-files` flag.
+  type: fix
+pr_number: 4668

--- a/demisto_sdk/commands/pre_commit/pre_commit_command.py
+++ b/demisto_sdk/commands/pre_commit/pre_commit_command.py
@@ -328,9 +328,10 @@ class PreCommitRunner:
         PreCommitRunner.prepare_hooks(pre_commit_context)
 
         if pre_commit_context.all_files:
-            pre_commit_context.precommit_template["exclude"] += (
-                f"|{join_files(exclude_files or set())}"
-            )
+            if exclude_files:
+                pre_commit_context.precommit_template["exclude"] += (
+                    f"|{join_files(exclude_files)}"
+                )
         else:
             pre_commit_context.precommit_template["files"] = join_files(
                 pre_commit_context.files_to_run


### PR DESCRIPTION
## Related Issues
fixes:

## Description
Fixed an issue where `pre-commit` inadvertently skipped all files when executed with the `--all-files` flag.