### PR TITLE
[demisto-sdk] Add support for non-default ports when parsing docker image values

### DIFF
--- a/.changelog/4674.yml
+++ b/.changelog/4674.yml
@@ -1,0 +1,4 @@
+changes:
+- description: "Added support for non-default registry ports when using custom docker images. i.e: 'registry:5000/repository/image:main'"
+  type: feature
+pr_number: 4674

--- a/demisto_sdk/commands/common/docker_helper.py
+++ b/demisto_sdk/commands/common/docker_helper.py
@@ -380,7 +380,7 @@ class DockerBase:
             )
         repository, tag = image.rsplit(
             ":", 1
-        )  # rsplit is used to support non-default docker ports which require extra colon. i.e: `image.registry:5050/repo/test-python3:main`
+        )  # rsplit is used to support non-default docker ports which require extra colon. i.e: `image.registry:5000/repo/some-image:main`
         container.commit(
             repository=repository, tag=tag, changes=self.changes[container_type]
         )

--- a/demisto_sdk/commands/common/docker_helper.py
+++ b/demisto_sdk/commands/common/docker_helper.py
@@ -378,7 +378,9 @@ class DockerBase:
                 reason=f"Installation script failed to run on container '{container.id}', {container_logs=}",
                 build_log=container_logs,
             )
-        repository, tag = image.split(":")
+        repository, tag = image.rsplit(
+            ":", 1
+        )  # rsplit is used to support non-default docker ports which require extra colon. i.e: `image.registry:5050/repo/test-python3:main`
         container.commit(
             repository=repository, tag=tag, changes=self.changes[container_type]
         )


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: [XSUP-43593](https://jira-dc.paloaltonetworks.com/browse/XSUP-43593)

## Description
Add support for non-default ports when parsing docker image values. i.e: `image.registry:5000/repo/some-image:main`, where default docker image values looked like this: `registry/some-image:main`