### PR TITLE
bug - test test_xsoar_linter_errors fails after python 3.12

### DIFF
--- a/demisto_sdk/tests/integration_tests/xsoar_linter_pre_commit_integration_test.py
+++ b/demisto_sdk/tests/integration_tests/xsoar_linter_pre_commit_integration_test.py
@@ -238,7 +238,6 @@ files = [
 ]
 
 
-@pytest.mark.skip("CIAC-12008")
 @pytest.mark.parametrize(
     "file, python_version,support_level,long_running,exit_code,error_msgs,commands",
     files,


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes:

## Description
