### PR TITLE
[demisto-sdk] Upgrade release-notes flag output

### DIFF
--- a/.changelog/4687.yml
+++ b/.changelog/4687.yml
@@ -1,0 +1,4 @@
+changes:
+  - description: Modified the ***demisto-sdk release-notes*** command to print a much nicer markdown format of the currently installed demisto-sdk changelog.
+type: feature
+pr_number: 4687

--- a/.changelog/4687.yml
+++ b/.changelog/4687.yml
@@ -1,4 +1,4 @@
 changes:
-  - description: Modified the ***demisto-sdk release-notes*** command to print a much nicer markdown format of the currently installed demisto-sdk changelog.
+  - description: Modified the ***demisto-sdk --release-notes*** command to print a much nicer markdown format of the currently installed demisto-sdk changelog.
 type: feature
 pr_number: 4687

--- a/.changelog/4687.yml
+++ b/.changelog/4687.yml
@@ -1,4 +1,4 @@
 changes:
   - description: Modified the ***demisto-sdk --release-notes*** command to print a much nicer markdown representation of the currently installed demisto-sdk changelog.
-type: feature
+    type: feature
 pr_number: 4687

--- a/.changelog/4687.yml
+++ b/.changelog/4687.yml
@@ -1,4 +1,4 @@
 changes:
-  - description: Modified the ***demisto-sdk --release-notes*** command to print a much nicer markdown format of the currently installed demisto-sdk changelog.
+  - description: Modified the ***demisto-sdk --release-notes*** command to print a much nicer markdown representation of the currently installed demisto-sdk changelog.
 type: feature
 pr_number: 4687

--- a/.changelog/4687.yml
+++ b/.changelog/4687.yml
@@ -1,4 +1,4 @@
 changes:
-  - description: Modified the ***demisto-sdk --release-notes*** command to print a much nicer markdown representation of the currently installed demisto-sdk changelog.
+  - description: Modified the ***demisto-sdk --release-notes*** command to print a markdown representation of the currently installed demisto-sdk changelog.
     type: feature
 pr_number: 4687

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -302,22 +302,27 @@ def show_release_notes():
     """Display release notes for the currently installed demisto-sdk version."""
     current_version, _ = get_version_info()
     rn_entries = get_release_note_entries(current_version)
-    console = Console()
+    remote_changelog_referral = typer.style(
+        "See https://github.com/demisto/demisto-sdk/blob/master/CHANGELOG.md for the full demisto-sdk changelog",
+        fg=typer.colors.YELLOW,
+    )
     if rn_entries:
         # rich library places md headings in the center by default, so the ### prefix is removed to align the sub-titles to the left
         rn_entries = rn_entries.replace("###", "")
         md = Markdown(rn_entries, justify="left")
-        console.print(
+        Console().print(
             Panel(
                 md,
                 title_align="left",
                 subtitle_align="left",
-                subtitle="See https://github.com/demisto/demisto-sdk/blob/master/CHANGELOG.md for the full demisto-sdk changelog",
-                title=f"Release notes of the currently installed demisto-sdk version: {current_version}",
+                subtitle=remote_changelog_referral,
+                title=f"Release notes of the currently installed demisto-sdk version: {current_version}.",
             )
         )
     else:
-        typer.echo("Could not retrieve release notes for this version.")
+        typer.echo(
+            f"Could not retrieve release notes for this version. {remote_changelog_referral}"
+        )
 
 
 if __name__ == "__main__":

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -4,6 +4,9 @@ import platform
 import typer
 from dotenv import load_dotenv
 from pkg_resources import DistributionNotFound, get_distribution
+from rich.console import Console
+from rich.markdown import Markdown
+from rich.panel import Panel
 
 from demisto_sdk.commands.common.configuration import Configuration, DemistoSDK
 from demisto_sdk.commands.common.content_constant_paths import CONTENT_PATH
@@ -296,13 +299,23 @@ def show_version():
 
 
 def show_release_notes():
-    """Display release notes for the current version."""
+    """Display release notes for the currently installed demisto-sdk version."""
     current_version, _ = get_version_info()
     rn_entries = get_release_note_entries(current_version)
-
+    console = Console()
     if rn_entries:
-        typer.echo("\nRelease notes for the current version:\n")
-        typer.echo(rn_entries)
+        # rich library places md headings in the center by default, so the ### prefix is removed to align the sub-titles to the left
+        rn_entries = rn_entries.replace("###", "")
+        md = Markdown(rn_entries, justify="left")
+        console.print(
+            Panel(
+                md,
+                title_align="left",
+                subtitle_align="left",
+                subtitle="See https://github.com/demisto/demisto-sdk/blob/master/CHANGELOG.md for the full demisto-sdk changelog",
+                title=f"Release notes of the currently installed demisto-sdk version: {current_version}",
+            )
+        )
     else:
         typer.echo("Could not retrieve release notes for this version.")
 

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -307,7 +307,7 @@ def show_release_notes():
         fg=typer.colors.YELLOW,
     )
     if rn_entries:
-        # The Rich library centers Markdown headings by default. 
+        # The Rich library centers Markdown headings by default.
         # So the '###' prefix is removed temporary in this command so subtitles will be aligned to the left when printed.
         rn_entries = rn_entries.replace("###", "")
         md = Markdown(rn_entries, justify="left")

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -307,7 +307,8 @@ def show_release_notes():
         fg=typer.colors.YELLOW,
     )
     if rn_entries:
-        # rich library places md headings in the center by default, so the ### prefix is removed to align the sub-titles to the left
+        # The Rich library centers Markdown headings by default. 
+        # So the '###' prefix is removed temporary in this command so subtitles will be aligned to the left when printed.
         rn_entries = rn_entries.replace("###", "")
         md = Markdown(rn_entries, justify="left")
         Console().print(


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Description
`demisto-sdk --release-notes` command will now print a much nicer markdown representation of the currently installed demisto-sdk version (using the newly added typer library support in demisto-sdk).

![image](https://github.com/user-attachments/assets/eec99b43-f260-401d-b962-59f967a2b187)

