### PR TITLE
[setup-env] Missing The `-i` Flag

### DIFF
--- a/.changelog/4690.yml
+++ b/.changelog/4690.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where the **setup-env** command is missing the `-i` flag.
+  type: fix
+pr_number: 4690

--- a/.changelog/4690.yml
+++ b/.changelog/4690.yml
@@ -1,4 +1,4 @@
 changes:
-- description: Fixed an issue where the **setup-env** command is missing the `-i` flag.
+- description: Fixed an issue where using the `-i` flag with **setup-env** would fail.
   type: fix
 pr_number: 4690

--- a/demisto_sdk/commands/setup_env/setup_env_setup.py
+++ b/demisto_sdk/commands/setup_env/setup_env_setup.py
@@ -17,6 +17,8 @@ def setup_env_command(
     ),
     input: list[Path] = typer.Option(
         None,
+        "-i",
+        "--input",
         help="Paths to content integrations or script to setup the environment. If not provided, "
         "will configure the environment for the content repository.",
     ),


### PR DESCRIPTION
## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-12289

## Description
fixes an issue where the `-i` flag was missing from the **setup-env** command following the`typer` update (#4637).

In the VSCode extension, we are using the `-i` flag instead of the `--input` flag.
To reproduce the issue, follow these steps:

1. Install the demisto-sdk from your local demisto-sdk project by running the command:
   ```
   pip install -e '~/dev/demisto/demisto-sdk/'
   ```
2. Attempt to execute the VSCode extension command: `setup integration/script environment`.

You should encounter the following error:
 
![Screenshot 2024-11-28 at 15 53 47](https://github.com/user-attachments/assets/66e8cdff-14c8-423f-b604-5d4c05b6d297)

 