### PR TITLE
Warn about upcoming python 3.9 support removal

### DIFF
--- a/.changelog/4698.yml
+++ b/.changelog/4698.yml
@@ -1,4 +1,4 @@
 changes:
-- description: Demisto-SDK will soon stop supporting Python 3.8
+- description: Demisto-SDK will soon stop supporting Python 3.9
   type: internal
 pr_number: 4698

--- a/.changelog/4698.yml
+++ b/.changelog/4698.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Demisto-SDK will soon stop supporting Python 3.8
+  type: internal
+pr_number: 4698

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -254,6 +254,13 @@ def main(
     sdk.configuration = Configuration()  # Initialize the configuration
     ctx.obj = sdk  # Pass sdk instance to context
     load_dotenv(CONTENT_PATH / ".env", override=True)
+    if platform.python_version_tuple()[:2] == ("3", "9"):
+        message = typer.style(
+            "Warning: Demisto-SDK will soon stop supporting Python 3.9. Please update your python environment.",
+            fg=typer.colors.RED,
+        )
+        typer.echo(message)
+
     if platform.system() == "Windows":
         typer.echo(
             "Warning: Using Demisto-SDK on Windows is not supported. Use WSL2 or run in a container."


### PR DESCRIPTION
Related: [CIAC-12263](https://jira-dc.paloaltonetworks.com/browse/CIAC-12263)

## Description
Adds a warning message when using the SDK with python 3.9.xx installed