### PR TITLE
Demisto-sdk release 1.33.0

### DIFF
--- a/.changelog/4589.yml
+++ b/.changelog/4589.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Fixed an issue where the *generate-docs* command failed to ignore hidden parameters.
-  type: fix
-pr_number: 4589

--- a/.changelog/4637.yml
+++ b/.changelog/4637.yml
@@ -1,4 +1,0 @@
-changes:
-- description: The Demisto-SDK CLI has been upgraded to use Typer for command-line interface (CLI) management.
-  type: feature
-pr_number: 4637

--- a/.changelog/4659.yml
+++ b/.changelog/4659.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Modifying the `prepare-content` command to replace all occurrences of an incorrect marketplace reference in the content.
-  type: feature
-pr_number: 4659

--- a/.changelog/4667.yml
+++ b/.changelog/4667.yml
@@ -1,6 +1,0 @@
-changes:
-- description: Fixed an issue where validate GR107 was failing on unrelated content-item when running on deprecated content-items.
-  type: fix
-- description: The GR107 validation now fails once on each item and the message contains all deprecated item used, instead of failing multiple times.
-  type: feature
-pr_number: 4667

--- a/.changelog/4680.yml
+++ b/.changelog/4680.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Added the deprecated merge-id-sets command to Typer app.
-  type: internal
-pr_number: 4680

--- a/.changelog/4685.yml
+++ b/.changelog/4685.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Update commands documentation and docstrings.
-  type: internal
-pr_number: 4685

--- a/.changelog/4686.yml
+++ b/.changelog/4686.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Fixed the demisto-sdk-nightly run-end-to-end-tests-xsoar step, and updated the `test-content` missing flags.
-  type: internal
-pr_number: 4686

--- a/.changelog/4687.yml
+++ b/.changelog/4687.yml
@@ -1,4 +1,0 @@
-changes:
-  - description: Modified the ***demisto-sdk --release-notes*** command to print a markdown representation of the currently installed demisto-sdk changelog.
-    type: feature
-pr_number: 4687

--- a/.changelog/4689.yml
+++ b/.changelog/4689.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Added isSilent key to the Playbook and Trigger schemas.
-  type: feature
-pr_number: 4689

--- a/.changelog/4690.yml
+++ b/.changelog/4690.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Fixed an issue where using the `-i` flag with **setup-env** would fail.
-  type: fix
-pr_number: 4690

--- a/.changelog/4691.yml
+++ b/.changelog/4691.yml
@@ -1,4 +1,0 @@
-changes:
-- description: fixed an issue where -t flag was missing from update-release-notes command setup
-  type: fix
-pr_number: 4691

--- a/.changelog/4694.yml
+++ b/.changelog/4694.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Fixed an issue where setup-env would fail when FILE_PATHS argument was missing.
-  type: internal
-pr_number: 4694

--- a/.changelog/4695.yml
+++ b/.changelog/4695.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Determining logger setup via environment variable.
-  type: fix
-pr_number: 4695

--- a/.changelog/4696.yml
+++ b/.changelog/4696.yml
@@ -1,4 +1,0 @@
-changes:
-- description: YmlSplitter fix.
-  type: fix
-pr_number: 4695

--- a/.changelog/4698.yml
+++ b/.changelog/4698.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Demisto-SDK will soon stop supporting Python 3.9
-  type: internal
-pr_number: 4698

--- a/.changelog/4699.yml
+++ b/.changelog/4699.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Added support for a new pack version_config.json file.
-  type: feature
-pr_number: 4699

--- a/.changelog/4700.yml
+++ b/.changelog/4700.yml
@@ -1,8 +1,0 @@
-changes:
-- description: Fixed an issue where RN108 validation raised an exception when executed on a new pack.
-  type: fix
-- description: Fixed an issue in the **validate** command where new files could not be parsed.
-  type: fix
-- description: Fixed an issue in the **validate** command where .pack-ignore files could not be parsed.
-  type: fix
-pr_number: 4700

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,14 @@
 ### Feature
 * Modified the ***demisto-sdk --release-notes*** command to print a markdown representation of the currently installed demisto-sdk changelog. [#4687](https://github.com/demisto/demisto-sdk/pull/4687)
 * Added support for a new pack version_config.json file. [#4699](https://github.com/demisto/demisto-sdk/pull/4699)
-* Modifying the `prepare-content` command to replace all occurrences of an incorrect marketplace reference in the content. [#4659](https://github.com/demisto/demisto-sdk/pull/4659)
+* Updated the `prepare-content` command to replace all occurrences of an incorrect marketplace reference in the content. [#4659](https://github.com/demisto/demisto-sdk/pull/4659)
 * The Demisto-SDK CLI has been upgraded to use Typer for command-line interface (CLI) management. [#4637](https://github.com/demisto/demisto-sdk/pull/4637)
-* Added isSilent key to the Playbook and Trigger schemas. [#4689](https://github.com/demisto/demisto-sdk/pull/4689)
-* The GR107 validation now fails once on each item and the message contains all deprecated item used, instead of failing multiple times. [#4667](https://github.com/demisto/demisto-sdk/pull/4667)
+* Added an isSilent key to the Playbook and Trigger schemas. [#4689](https://github.com/demisto/demisto-sdk/pull/4689)
+* Updated the GR107 validation to fail once on each item, and the message will contain all deprecated items in use instead of failing multiple times. [#4667](https://github.com/demisto/demisto-sdk/pull/4667)
 
 ### Fix
 * YmlSplitter fix. [#4695](https://github.com/demisto/demisto-sdk/pull/4695)
-* fixed an issue where -t flag was missing from update-release-notes command setup [#4691](https://github.com/demisto/demisto-sdk/pull/4691)
+* Fixed an issue where -t flag was missing from update-release-notes command setup [#4691](https://github.com/demisto/demisto-sdk/pull/4691)
 * Fixed an issue where RN108 validation raised an exception when executed on a new pack. [#4700](https://github.com/demisto/demisto-sdk/pull/4700)
 * Fixed an issue in the **validate** command where new files could not be parsed. [#4700](https://github.com/demisto/demisto-sdk/pull/4700)
 * Fixed an issue in the **validate** command where .pack-ignore files could not be parsed. [#4700](https://github.com/demisto/demisto-sdk/pull/4700)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,32 @@
 # Changelog
+## 1.33.0 (2024-12-08)
+### Feature
+* Modified the ***demisto-sdk --release-notes*** command to print a markdown representation of the currently installed demisto-sdk changelog. [#4687](https://github.com/demisto/demisto-sdk/pull/4687)
+* Added support for a new pack version_config.json file. [#4699](https://github.com/demisto/demisto-sdk/pull/4699)
+* Modifying the `prepare-content` command to replace all occurrences of an incorrect marketplace reference in the content. [#4659](https://github.com/demisto/demisto-sdk/pull/4659)
+* The Demisto-SDK CLI has been upgraded to use Typer for command-line interface (CLI) management. [#4637](https://github.com/demisto/demisto-sdk/pull/4637)
+* Added isSilent key to the Playbook and Trigger schemas. [#4689](https://github.com/demisto/demisto-sdk/pull/4689)
+* The GR107 validation now fails once on each item and the message contains all deprecated item used, instead of failing multiple times. [#4667](https://github.com/demisto/demisto-sdk/pull/4667)
+
+### Fix
+* YmlSplitter fix. [#4695](https://github.com/demisto/demisto-sdk/pull/4695)
+* fixed an issue where -t flag was missing from update-release-notes command setup [#4691](https://github.com/demisto/demisto-sdk/pull/4691)
+* Fixed an issue where RN108 validation raised an exception when executed on a new pack. [#4700](https://github.com/demisto/demisto-sdk/pull/4700)
+* Fixed an issue in the **validate** command where new files could not be parsed. [#4700](https://github.com/demisto/demisto-sdk/pull/4700)
+* Fixed an issue in the **validate** command where .pack-ignore files could not be parsed. [#4700](https://github.com/demisto/demisto-sdk/pull/4700)
+* Fixed an issue where using the `-i` flag with **setup-env** would fail. [#4690](https://github.com/demisto/demisto-sdk/pull/4690)
+* Fixed an issue where the *generate-docs* command failed to ignore hidden parameters. [#4589](https://github.com/demisto/demisto-sdk/pull/4589)
+* Determining logger setup via environment variable. [#4695](https://github.com/demisto/demisto-sdk/pull/4695)
+* Fixed an issue where validate GR107 was failing on unrelated content-item when running on deprecated content-items. [#4667](https://github.com/demisto/demisto-sdk/pull/4667)
+
+### Internal
+* Fixed the demisto-sdk-nightly run-end-to-end-tests-xsoar step, and updated the `test-content` missing flags. [#4686](https://github.com/demisto/demisto-sdk/pull/4686)
+* Added the deprecated merge-id-sets command to Typer app. [#4680](https://github.com/demisto/demisto-sdk/pull/4680)
+* Update commands documentation and docstrings. [#4685](https://github.com/demisto/demisto-sdk/pull/4685)
+* Fixed an issue where setup-env would fail when FILE_PATHS argument was missing. [#4694](https://github.com/demisto/demisto-sdk/pull/4694)
+* Demisto-SDK will soon stop supporting Python 3.9 [#4698](https://github.com/demisto/demisto-sdk/pull/4698)
+
+
 ## 1.32.5 (2024-11-24)
 ### Breaking
 * Removed PA134 from the old validate. The validation ensures that the pack has exactly one category and that this category is valid. [#4673](https://github.com/demisto/demisto-sdk/pull/4673)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,28 +3,28 @@
 ### Feature
 * Modified the ***demisto-sdk --release-notes*** command to print a markdown representation of the currently installed demisto-sdk changelog. [#4687](https://github.com/demisto/demisto-sdk/pull/4687)
 * Added support for a new pack version_config.json file. [#4699](https://github.com/demisto/demisto-sdk/pull/4699)
-* Updated the `prepare-content` command to replace all occurrences of an incorrect marketplace reference in the content. [#4659](https://github.com/demisto/demisto-sdk/pull/4659)
+* Updated the ***prepare-content*** command to replace all occurrences of an incorrect marketplace reference in the content. [#4659](https://github.com/demisto/demisto-sdk/pull/4659)
 * The Demisto-SDK CLI has been upgraded to use Typer for command-line interface (CLI) management. [#4637](https://github.com/demisto/demisto-sdk/pull/4637)
 * Added an isSilent key to the Playbook and Trigger schemas. [#4689](https://github.com/demisto/demisto-sdk/pull/4689)
 * Updated the GR107 validation to fail once on each item, and the message will contain all deprecated items in use instead of failing multiple times. [#4667](https://github.com/demisto/demisto-sdk/pull/4667)
 
 ### Fix
 * Fixed an issue where YmlSplitter attributes were being unintentionally updated. [#4695](https://github.com/demisto/demisto-sdk/pull/4695)
-* Fixed an issue where -t flag was missing from update-release-notes command setup [#4691](https://github.com/demisto/demisto-sdk/pull/4691)
+* Fixed an issue where *-t* flag was missing from ***update-release-notes*** command setup. [#4691](https://github.com/demisto/demisto-sdk/pull/4691)
 * Fixed an issue where RN108 validation raised an exception when executed on a new pack. [#4700](https://github.com/demisto/demisto-sdk/pull/4700)
-* Fixed an issue in the **validate** command where new files could not be parsed. [#4700](https://github.com/demisto/demisto-sdk/pull/4700)
-* Fixed an issue in the **validate** command where .pack-ignore files could not be parsed. [#4700](https://github.com/demisto/demisto-sdk/pull/4700)
-* Fixed an issue where using the `-i` flag with **setup-env** would fail. [#4690](https://github.com/demisto/demisto-sdk/pull/4690)
-* Fixed an issue where the *generate-docs* command failed to ignore hidden parameters. [#4589](https://github.com/demisto/demisto-sdk/pull/4589)
+* Fixed an issue in the ***validate*** command where new files could not be parsed. [#4700](https://github.com/demisto/demisto-sdk/pull/4700)
+* Fixed an issue in the ***validate*** command where .pack-ignore files could not be parsed. [#4700](https://github.com/demisto/demisto-sdk/pull/4700)
+* Fixed an issue where using the *-i* flag with ***setup-env*** command would fail. [#4690](https://github.com/demisto/demisto-sdk/pull/4690)
+* Fixed an issue where the ***generate-docs*** command failed to ignore hidden parameters. [#4589](https://github.com/demisto/demisto-sdk/pull/4589)
 * Fixed an issue where logger was not initialized properly. [#4695](https://github.com/demisto/demisto-sdk/pull/4695)
 * Fixed an issue where validate GR107 was failing on unrelated content-item when running on deprecated content-items. [#4667](https://github.com/demisto/demisto-sdk/pull/4667)
 
 ### Internal
-* Fixed the demisto-sdk-nightly run-end-to-end-tests-xsoar step, and updated the `test-content` missing flags. [#4686](https://github.com/demisto/demisto-sdk/pull/4686)
-* Added the deprecated merge-id-sets command to Typer app. [#4680](https://github.com/demisto/demisto-sdk/pull/4680)
-* Update commands documentation and docstrings. [#4685](https://github.com/demisto/demisto-sdk/pull/4685)
-* Fixed an issue where setup-env would fail when FILE_PATHS argument was missing. [#4694](https://github.com/demisto/demisto-sdk/pull/4694)
-* Demisto-SDK will soon stop supporting Python 3.9 [#4698](https://github.com/demisto/demisto-sdk/pull/4698)
+* Fixed the demisto-sdk nightly's `run-end-to-end-tests-xsoar` step, and updated the `test-content` missing flags. [#4686](https://github.com/demisto/demisto-sdk/pull/4686)
+* Added the deprecated ***merge-id-sets*** command to Typer app. [#4680](https://github.com/demisto/demisto-sdk/pull/4680)
+* Update demisto-sdk commands documentation. [#4685](https://github.com/demisto/demisto-sdk/pull/4685)
+* Fixed an issue where ***setup-env*** command would fail when `FILE_PATHS` argument was missing. [#4694](https://github.com/demisto/demisto-sdk/pull/4694)
+* ***NOTICE:*** Demisto-SDK will soon stop supporting Python 3.9 [#4698](https://github.com/demisto/demisto-sdk/pull/4698)
 
 
 ## 1.32.5 (2024-11-24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,14 @@
 * Updated the GR107 validation to fail once on each item, and the message will contain all deprecated items in use instead of failing multiple times. [#4667](https://github.com/demisto/demisto-sdk/pull/4667)
 
 ### Fix
-* YmlSplitter fix. [#4695](https://github.com/demisto/demisto-sdk/pull/4695)
+* Fixed an issue where YmlSplitter attributes were being unintentionally updated. [#4695](https://github.com/demisto/demisto-sdk/pull/4695)
 * Fixed an issue where -t flag was missing from update-release-notes command setup [#4691](https://github.com/demisto/demisto-sdk/pull/4691)
 * Fixed an issue where RN108 validation raised an exception when executed on a new pack. [#4700](https://github.com/demisto/demisto-sdk/pull/4700)
 * Fixed an issue in the **validate** command where new files could not be parsed. [#4700](https://github.com/demisto/demisto-sdk/pull/4700)
 * Fixed an issue in the **validate** command where .pack-ignore files could not be parsed. [#4700](https://github.com/demisto/demisto-sdk/pull/4700)
 * Fixed an issue where using the `-i` flag with **setup-env** would fail. [#4690](https://github.com/demisto/demisto-sdk/pull/4690)
 * Fixed an issue where the *generate-docs* command failed to ignore hidden parameters. [#4589](https://github.com/demisto/demisto-sdk/pull/4589)
-* Determining logger setup via environment variable. [#4695](https://github.com/demisto/demisto-sdk/pull/4695)
+* Fixed an issue where logger was not initialized properly. [#4695](https://github.com/demisto/demisto-sdk/pull/4695)
 * Fixed an issue where validate GR107 was failing on unrelated content-item when running on deprecated content-items. [#4667](https://github.com/demisto/demisto-sdk/pull/4667)
 
 ### Internal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ exclude = "tests/.*|demisto_sdk/commands/init/templates/.*"
 
 [tool.poetry]
 name = "demisto-sdk"
-version = "1.32.5"
+version = "1.33.0"
 description = "\"A Python library for the Demisto SDK\""
 authors = ["Demisto"]
 license = "MIT"


### PR DESCRIPTION
### Feature
* Modified the ***demisto-sdk --release-notes*** command to print a markdown representation of the currently installed demisto-sdk changelog. [#4687](https://github.com/demisto/demisto-sdk/pull/4687)
* Added support for a new pack version_config.json file. [#4699](https://github.com/demisto/demisto-sdk/pull/4699)
* Updated the ***prepare-content*** command to replace all occurrences of an incorrect marketplace reference in the content. [#4659](https://github.com/demisto/demisto-sdk/pull/4659)
* The Demisto-SDK CLI has been upgraded to use Typer for command-line interface (CLI) management. [#4637](https://github.com/demisto/demisto-sdk/pull/4637)
* Added an isSilent key to the Playbook and Trigger schemas. [#4689](https://github.com/demisto/demisto-sdk/pull/4689)
* Updated the GR107 validation to fail once on each item, and the message will contain all deprecated items in use instead of failing multiple times. [#4667](https://github.com/demisto/demisto-sdk/pull/4667)

### Fix
* Fixed an issue where YmlSplitter attributes were being unintentionally updated. [#4695](https://github.com/demisto/demisto-sdk/pull/4695)
* Fixed an issue where *-t* flag was missing from ***update-release-notes*** command setup. [#4691](https://github.com/demisto/demisto-sdk/pull/4691)
* Fixed an issue where RN108 validation raised an exception when executed on a new pack. [#4700](https://github.com/demisto/demisto-sdk/pull/4700)
* Fixed an issue in the ***validate*** command where new files could not be parsed. [#4700](https://github.com/demisto/demisto-sdk/pull/4700)
* Fixed an issue in the ***validate*** command where .pack-ignore files could not be parsed. [#4700](https://github.com/demisto/demisto-sdk/pull/4700)
* Fixed an issue where using the *-i* flag with ***setup-env*** command would fail. [#4690](https://github.com/demisto/demisto-sdk/pull/4690)
* Fixed an issue where the ***generate-docs*** command failed to ignore hidden parameters. [#4589](https://github.com/demisto/demisto-sdk/pull/4589)
* Fixed an issue where logger was not initialized properly. [#4695](https://github.com/demisto/demisto-sdk/pull/4695)
* Fixed an issue where validate GR107 was failing on unrelated content-item when running on deprecated content-items. [#4667](https://github.com/demisto/demisto-sdk/pull/4667)

### Internal
* Fixed the demisto-sdk nightly's `run-end-to-end-tests-xsoar` step, and updated the `test-content` missing flags. [#4686](https://github.com/demisto/demisto-sdk/pull/4686)
* Added the deprecated ***merge-id-sets*** command to Typer app. [#4680](https://github.com/demisto/demisto-sdk/pull/4680)
* Update demisto-sdk commands documentation. [#4685](https://github.com/demisto/demisto-sdk/pull/4685)
* Fixed an issue where ***setup-env*** command would fail when `FILE_PATHS` argument was missing. [#4694](https://github.com/demisto/demisto-sdk/pull/4694)
* ***NOTICE:*** Demisto-SDK will soon stop supporting Python 3.9 [#4698](https://github.com/demisto/demisto-sdk/pull/4698)