### PR TITLE
Fix incident to alert issue /CRTX-145079

### DIFF
--- a/.changelog/4736.yml
+++ b/.changelog/4736.yml
@@ -1,0 +1,3 @@
+changes:
+- description: Fixed an issue where the "incident to alert" conversion was not applied to the metadata file during the execution of the **prepare-content** command.
+pr_number: 4736

--- a/.changelog/4736.yml
+++ b/.changelog/4736.yml
@@ -1,3 +1,4 @@
 changes:
 - description: Fixed an issue where the "incident to alert" conversion was not applied to the metadata file during the execution of the **prepare-content** command.
+  type: fix
 pr_number: 4736

--- a/demisto_sdk/commands/content_graph/common.py
+++ b/demisto_sdk/commands/content_graph/common.py
@@ -534,7 +534,10 @@ def replace_incorrect_marketplace(
         Any: The same data object with replacements made if applicable.
     """
     try:
-        if marketplace in {MarketplaceVersions.MarketplaceV2, MarketplaceVersions.XPANSE}:
+        if marketplace in {
+            MarketplaceVersions.MarketplaceV2,
+            MarketplaceVersions.XPANSE,
+        }:
             if isinstance(data, dict):
                 for k, v in data.items():
                     data[k] = replace_incorrect_marketplace(v, marketplace, path)

--- a/demisto_sdk/commands/content_graph/common.py
+++ b/demisto_sdk/commands/content_graph/common.py
@@ -530,25 +530,20 @@ def replace_incorrect_marketplace(
         marketplace (MarketplaceVersions): The marketplace version to check against.
         path (str): The path of the item being processed.
 
-
-    Returns:
-        Any: The processed data with replacements made if applicable.
+        Returns:
+        Any: The same data object with replacements made if applicable.
     """
     try:
-        if marketplace in {
-            MarketplaceVersions.MarketplaceV2,
-            MarketplaceVersions.XPANSE,
-        }:
+        if marketplace in {MarketplaceVersions.MarketplaceV2, MarketplaceVersions.XPANSE}:
             if isinstance(data, dict):
-                return {
-                    k: replace_incorrect_marketplace(v, marketplace)
-                    for k, v in data.items()
-                }
+                for k, v in data.items():
+                    data[k] = replace_incorrect_marketplace(v, marketplace, path)
             elif isinstance(data, list):
-                return [replace_incorrect_marketplace(v, marketplace) for v in data]
+                for i in range(len(data)):
+                    data[i] = replace_incorrect_marketplace(data[i], marketplace, path)
             elif isinstance(data, str):
                 # Replace "Cortex XSOAR" and the following word if it contains a number
-                return re.sub(r"Cortex XSOAR(?: \w*\d\w*)?", "Cortex", data)
+                data = re.sub(r"Cortex XSOAR(?: \w*\d\w*)?", "Cortex", data)
     except Exception as e:
         logger.error(
             f"Error processing data for replacing incorrect marketplace at path '{path}': {e}"

--- a/demisto_sdk/commands/content_graph/common.py
+++ b/demisto_sdk/commands/content_graph/common.py
@@ -518,7 +518,7 @@ CONTENT_PRIVATE_ITEMS: dict = {
 }
 
 
-def replace_incorrect_marketplace(
+def replace_marketplace_references(
     data: Any, marketplace: MarketplaceVersions, path: str = ""
 ) -> Any:
     """
@@ -540,10 +540,10 @@ def replace_incorrect_marketplace(
         }:
             if isinstance(data, dict):
                 for k, v in data.items():
-                    data[k] = replace_incorrect_marketplace(v, marketplace, path)
+                    data[k] = replace_marketplace_references(v, marketplace, path)
             elif isinstance(data, list):
                 for i in range(len(data)):
-                    data[i] = replace_incorrect_marketplace(data[i], marketplace, path)
+                    data[i] = replace_marketplace_references(data[i], marketplace, path)
             elif isinstance(data, str):
                 # Replace "Cortex XSOAR" and the following word if it contains a number
                 data = re.sub(r"Cortex XSOAR(?: \w*\d\w*)?", "Cortex", data)

--- a/demisto_sdk/commands/content_graph/objects/content_item.py
+++ b/demisto_sdk/commands/content_graph/objects/content_item.py
@@ -34,7 +34,7 @@ from demisto_sdk.commands.common.tools import (
 from demisto_sdk.commands.content_graph.common import (
     ContentType,
     RelationshipType,
-    replace_incorrect_marketplace,
+    replace_marketplace_references,
 )
 from demisto_sdk.commands.content_graph.objects.base_content import (
     BaseContent,
@@ -276,7 +276,7 @@ class ContentItem(BaseContent):
         logger.debug(f"preparing {self.path}")
 
         # Replace incorrect marketplace references
-        data = replace_incorrect_marketplace(data, current_marketplace, str(self.path))
+        data = replace_marketplace_references(data, current_marketplace, str(self.path))
         return MarketplaceSuffixPreparer.prepare(data, current_marketplace)
 
     def summary(

--- a/demisto_sdk/commands/content_graph/objects/content_item_xsiam.py
+++ b/demisto_sdk/commands/content_graph/objects/content_item_xsiam.py
@@ -16,7 +16,6 @@ from demisto_sdk.commands.common.tools import (
 )
 from demisto_sdk.commands.content_graph.common import (
     ContentType,
-    replace_incorrect_marketplace,
 )
 from demisto_sdk.commands.content_graph.objects.content_item import (
     ContentItem,
@@ -56,8 +55,6 @@ class ContentItemXSIAM(ContentItem, ABC):
         data = self.prepare_for_upload(
             marketplace,
         )
-        # Replace incorrect marketplace references
-        data = replace_incorrect_marketplace(data, marketplace, str(self.path))
 
         for file in output_paths:
             write_dict(file, data=data, handler=self.handler)

--- a/demisto_sdk/commands/content_graph/objects/pack.py
+++ b/demisto_sdk/commands/content_graph/objects/pack.py
@@ -34,7 +34,7 @@ from demisto_sdk.commands.content_graph.common import (
     Nodes,
     Relationships,
     RelationshipType,
-    replace_incorrect_marketplace,
+    replace_marketplace_references,
 )
 from demisto_sdk.commands.content_graph.objects.base_content import (
     BaseContent,
@@ -282,7 +282,7 @@ class Pack(BaseContent, PackMetadata, content_type=ContentType.PACK):
             self._format_metadata(marketplace, self.content_items, self.depends_on)
         )
         # Replace incorrect marketplace references
-        metadata = replace_incorrect_marketplace(metadata, marketplace, str(self.path))
+        metadata = replace_marketplace_references(metadata, marketplace, str(self.path))
         write_dict(path, data=metadata, indent=4, sort_keys=True)
 
     def dump_readme(self, path: Path, marketplace: MarketplaceVersions) -> None:
@@ -300,7 +300,7 @@ class Pack(BaseContent, PackMetadata, content_type=ContentType.PACK):
             try:
                 text = f.read()
                 # Replace incorrect marketplace references
-                text = replace_incorrect_marketplace(text, marketplace)
+                text = replace_marketplace_references(text, marketplace)
 
                 if (
                     marketplace == MarketplaceVersions.XSOAR

--- a/demisto_sdk/commands/content_graph/tests/common_test.py
+++ b/demisto_sdk/commands/content_graph/tests/common_test.py
@@ -158,12 +158,7 @@ def test_replace_incorrect_marketplace_list():
             "description": "This is a Cortex XSOAR v2 example.",
             "details": "Cortex XSOAR should be replaced in details.",
         },
-        {
-            "nested_list": [
-                "Cortex XSOAR v3 example.",
-                "Another Cortex XSOAR example."
-            ]
-        }
+        {"nested_list": ["Cortex XSOAR v3 example.", "Another Cortex XSOAR example."]},
     ]
     expected = [
         "This is a Cortex example.",
@@ -172,12 +167,7 @@ def test_replace_incorrect_marketplace_list():
             "description": "This is a Cortex example.",
             "details": "Cortex should be replaced in details.",
         },
-        {
-            "nested_list": [
-                "Cortex example.",
-                "Another Cortex example."
-            ]
-        }
+        {"nested_list": ["Cortex example.", "Another Cortex example."]},
     ]
     result = replace_incorrect_marketplace(
         data, MarketplaceVersions.MarketplaceV2, path="example/path"

--- a/demisto_sdk/commands/content_graph/tests/common_test.py
+++ b/demisto_sdk/commands/content_graph/tests/common_test.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from demisto_sdk.commands.content_graph.common import (
     ContentType,
     MarketplaceVersions,
-    replace_incorrect_marketplace,
+    replace_marketplace_references,
 )
 from demisto_sdk.commands.content_graph.interface.neo4j.queries.common import (
     to_node_pattern,
@@ -40,9 +40,9 @@ def test_to_neo4j_pattern():
     )
 
 
-def test_replace_incorrect_marketplace_string_with_number():
+def test_replace_marketplace_references_string_with_number():
     """
-    Test the replace_incorrect_marketplace function with a string containing a number.
+    Test the replace_marketplace_references function with a string containing a number.
 
     Given:
         - A string data object.
@@ -57,15 +57,15 @@ def test_replace_incorrect_marketplace_string_with_number():
     """
     data = "This is a Cortex XSOAR v1 example."
     expected = "This is a Cortex example."
-    result = replace_incorrect_marketplace(
+    result = replace_marketplace_references(
         data, MarketplaceVersions.MarketplaceV2, path="example/path"
     )
     assert result == expected
 
 
-def test_replace_incorrect_marketplace_string_without_number():
+def test_replace_marketplace_references__string_without_number():
     """
-    Test the replace_incorrect_marketplace function with a string not containing a number.
+    Test the replace_marketplace_references function with a string not containing a number.
 
     Given:
         - A string data object.
@@ -79,15 +79,15 @@ def test_replace_incorrect_marketplace_string_without_number():
     """
     data = "This is a Cortex XSOAR example."
     expected = "This is a Cortex example."
-    result = replace_incorrect_marketplace(
+    result = replace_marketplace_references(
         data, MarketplaceVersions.MarketplaceV2, path="example/path"
     )
     assert result == expected
 
 
-def test_replace_incorrect_marketplace_string_no_replacement():
+def test_replace_marketplace_references__string_no_replacement():
     """
-    Test the replace_incorrect_marketplace function with a string where no replacement should occur in the specific marketplace..
+    Test the replace_marketplace_references function with a string where no replacement should occur in the specific marketplace..
 
     Given:
         - A string data object.
@@ -101,55 +101,61 @@ def test_replace_incorrect_marketplace_string_no_replacement():
     """
     data = "This is a Cortex XSOAR v1 example."
     expected = "This is a Cortex XSOAR v1 example."
-    result = replace_incorrect_marketplace(
+    result = replace_marketplace_references(
         data, MarketplaceVersions.XSOAR, path="example/path"
     )
     assert result == expected
 
 
-def test_replace_incorrect_marketplace_dict():
+def test_replace_marketplace_references__dict():
     """
-    Test the replace_incorrect_marketplace function with a dictionary.
+    Test the replace_marketplace_references function with a dictionary.
 
     Given:
         - A dictionary data object.
-        - A marketplace version.
+        - A marketplace version (MarketplaceV2 or XPANSE).
 
     When:
-        - The function is called to replace all occurrences of "Cortex XSOAR" with "Cortex" if the marketplace is MarketplaceV2 or XPANSE.
+        - The function is called to replace all occurrences of "Cortex XSOAR" with "Cortex".
         - If the word following "Cortex XSOAR" contains a number, it will also be removed.
 
     Then:
         - The function should return the data with the replacements made if applicable.
+        - The function should modify the data in place and not create a copy.
+        - The identity of the data object should remain unchanged.
     """
     data = {
         "description": "This is a Cortex XSOAR v1 example.",
         "details": "Cortex XSOAR should be replaced.",
     }
+    original_id = id(data)
     expected = {
         "description": "This is a Cortex example.",
         "details": "Cortex should be replaced.",
     }
-    result = replace_incorrect_marketplace(
+    result = replace_marketplace_references(
         data, MarketplaceVersions.MarketplaceV2, path="example/path"
     )
+    assert id(result) == original_id
     assert result == expected
 
 
-def test_replace_incorrect_marketplace_list():
+def test_replace_marketplace_references__list():
     """
-    Test the replace_incorrect_marketplace function with a list containing strings and dictionaries.
+    Test the replace_marketplace_references function with a list containing strings and dictionaries.
 
     Given:
         - A list data object containing strings and dictionaries.
-        - A marketplace version.
+        - A marketplace version (MarketplaceV2 or XPANSE).
 
     When:
-        - The function is called to replace all occurrences of "Cortex XSOAR" with "Cortex" if the marketplace is MarketplaceV2 or XPANSE.
+        - The function is called to replace all occurrences of "Cortex XSOAR" with "Cortex".
         - If the word following "Cortex XSOAR" contains a number, it will also be removed.
 
     Then:
         - The function should return the data with the replacements made if applicable.
+        - The function should modify the data in place and not create a copy.
+        - The identity of the data object should remain unchanged.
     """
     data = [
         "This is a Cortex XSOAR v1 example.",
@@ -160,6 +166,7 @@ def test_replace_incorrect_marketplace_list():
         },
         {"nested_list": ["Cortex XSOAR v3 example.", "Another Cortex XSOAR example."]},
     ]
+    original_id = id(data)
     expected = [
         "This is a Cortex example.",
         "Cortex should be replaced.",
@@ -169,15 +176,16 @@ def test_replace_incorrect_marketplace_list():
         },
         {"nested_list": ["Cortex example.", "Another Cortex example."]},
     ]
-    result = replace_incorrect_marketplace(
+    result = replace_marketplace_references(
         data, MarketplaceVersions.MarketplaceV2, path="example/path"
     )
+    assert id(result) == original_id
     assert result == expected
 
 
-def test_replace_incorrect_marketplace_error_handling():
+def test_replace_marketplace_references__error_handling():
     """
-    Test the error handling of the replace_incorrect_marketplace function.
+    Test the error handling of the replace_marketplace_references function.
 
     Given:
         - A data object that causes an exception.
@@ -194,11 +202,11 @@ def test_replace_incorrect_marketplace_error_handling():
     marketplace = MarketplaceVersions.MarketplaceV2
 
     with patch(
-        "demisto_sdk.commands.content_graph.common.replace_incorrect_marketplace",
+        "demisto_sdk.commands.content_graph.common.replace_marketplace_references",
         side_effect=Exception("Test exception"),
     ):
         with patch("demisto_sdk.commands.content_graph.common.logger") as mock_logger:
-            result = replace_incorrect_marketplace(
+            result = replace_marketplace_references(
                 data, marketplace, path="example/path"
             )
 

--- a/demisto_sdk/commands/content_graph/tests/common_test.py
+++ b/demisto_sdk/commands/content_graph/tests/common_test.py
@@ -138,10 +138,10 @@ def test_replace_incorrect_marketplace_dict():
 
 def test_replace_incorrect_marketplace_list():
     """
-    Test the replace_incorrect_marketplace function with a list.
+    Test the replace_incorrect_marketplace function with a list containing strings and dictionaries.
 
     Given:
-        - A list data object.
+        - A list data object containing strings and dictionaries.
         - A marketplace version.
 
     When:
@@ -154,10 +154,30 @@ def test_replace_incorrect_marketplace_list():
     data = [
         "This is a Cortex XSOAR v1 example.",
         "Cortex XSOAR should be replaced.",
+        {
+            "description": "This is a Cortex XSOAR v2 example.",
+            "details": "Cortex XSOAR should be replaced in details.",
+        },
+        {
+            "nested_list": [
+                "Cortex XSOAR v3 example.",
+                "Another Cortex XSOAR example."
+            ]
+        }
     ]
     expected = [
         "This is a Cortex example.",
         "Cortex should be replaced.",
+        {
+            "description": "This is a Cortex example.",
+            "details": "Cortex should be replaced in details.",
+        },
+        {
+            "nested_list": [
+                "Cortex example.",
+                "Another Cortex example."
+            ]
+        }
     ]
     result = replace_incorrect_marketplace(
         data, MarketplaceVersions.MarketplaceV2, path="example/path"


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
relates: https://jira-dc.paloaltonetworks.com/browse/CRTX-145079

## Description
Simplified the `replace_incorrect_marketplace` function to modify the input data directly, addressing the issue where "incident to alert" was not applied. This occurred because a copy of the data was inadvertently created, leading to unexpected behavior in downstream processes.

For the record:  
Here are two versions of the Phishing pack that went through the **prepare content** command, one with and one without my `replace_marketplace_references` function.  
https://drive.google.com/drive/folders/10m6dv0MSBTUpdAFZ1vhUIKnb_D7CVZBs

I compared them using [this tool](https://marketplace.visualstudio.com/items?itemName=L13RARY.l13-diff)

The only change is the expected update to "Cortex XSOAR."  
The "incident to alert" functionality works the same in both versions.
<img width="1687" alt="Screenshot 2024-12-25 at 14 49 45" src="https://github.com/user-attachments/assets/44b4fb33-5f44-4a93-abac-f966cbae9b14" />

<img width="1687" alt="Screenshot 2024-12-25 at 14 48 58" src="https://github.com/user-attachments/assets/cf6ac360-1e73-45e2-bb59-8148ca1a3e82" />
