### PR TITLE
Demisto-sdk release 1.33.1

### DIFF
--- a/.changelog/4569.yml
+++ b/.changelog/4569.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Moved the CR101 validation, checking names of Correlation Rule files match standards, to `validate_content_path`.
-  type: feature
-pr_number: 4569

--- a/.changelog/4662.yml
+++ b/.changelog/4662.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Added validation checks whether the silent playbook name id and the isSilent key are set correctly.
-  type: feature
-pr_number: 4662

--- a/.changelog/4670.yml
+++ b/.changelog/4670.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Added validation to ensure every silent trigger points to a silent playbook, and vice versa.
-  type: feature
-pr_number: 4670

--- a/.changelog/4692.yml
+++ b/.changelog/4692.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Exclude silent-Playbooks/Triggers from the metadata.
-  type: feature
-pr_number: 4692

--- a/.changelog/4696.yml
+++ b/.changelog/4696.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Fixed an issue where YmlSplitter attributes were being unintentionally updated.
-  type: fix
-pr_number: 4696

--- a/.changelog/4697.yml
+++ b/.changelog/4697.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Added support for writing pre-commit results to files.
-  type: feature
-pr_number: 4697

--- a/.changelog/4706.yml
+++ b/.changelog/4706.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Added support for CaseLayouts and CaseFields content items paths to the `validate-content-paths` **pre-commit** hook.
-  type: feature
-pr_number: 4706

--- a/.changelog/4710.yml
+++ b/.changelog/4710.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Fix an issue where *RN106* and *PA114* validations would fail on new packs.
-  type: fix
-pr_number: 4710

--- a/.changelog/4711.yml
+++ b/.changelog/4711.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Fixed an issue where *RN107* validation would fail on new content items and specific content types.
-  type: fix
-pr_number: 4711

--- a/.changelog/4712.yml
+++ b/.changelog/4712.yml
@@ -1,6 +1,0 @@
-changes:
-- description: Removed support for DS107 and RM106 validations - ensure no 'demist'o word in description and readme files for both new & old validate.
-  type: breaking
-- description: Changed the code of RM116 - Validate that the readme file is not to short to RM117 due to error code duplication.
-  type: breaking
-pr_number: 4712

--- a/.changelog/4713.yml
+++ b/.changelog/4713.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Fixed an issue where YmlSplitter attributes were being unintentionally updated.
-  type: fix
-pr_number: 4713

--- a/.changelog/4714.yml
+++ b/.changelog/4714.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Fixed an issue where RN111 would fail when it should not when the docker entry message was missing.
-  type: fix
-pr_number: 4714

--- a/.changelog/4715.yml
+++ b/.changelog/4715.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Updated validation rules to allow the deletion of silent Playbooks and silent Triggers.
-  type: feature
-pr_number: 4715

--- a/.changelog/4716.yml
+++ b/.changelog/4716.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Fixed an issue where ST110 would incorrectly fail when adding the isSilent field.
-  type: fix
-pr_number: 4716

--- a/.changelog/4717.yml
+++ b/.changelog/4717.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Fixed an issue where RM114 falsely failed when it concatenated "Packs/" twice to the file path.
-  type: fix
-pr_number: 4717

--- a/.changelog/4718.yml
+++ b/.changelog/4718.yml
@@ -1,4 +1,0 @@
-changes:
-- description: '**Breaking Change**: Removed the support for python 3.9, and upgraded the *mitmproxy* dependency version.'
-  type: breaking
-pr_number: 4718

--- a/.changelog/4720.yml
+++ b/.changelog/4720.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Exclude silent items from release notes validation.
-  type: feature
-pr_number: 4720

--- a/.changelog/4723.yml
+++ b/.changelog/4723.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Added the **PB132** validation to ensure that silent playbooks do not have a README file.
-  type: feature
-pr_number: 4723

--- a/.changelog/4726.yml
+++ b/.changelog/4726.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Added support for Silent-Playbooks in the old-validate.
-  type: feature
-pr_number: 4726

--- a/.changelog/4727.yml
+++ b/.changelog/4727.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Fixed an issue where the error message wasn't clear when attempting to upload a content item to an unsupported marketplace.
-  type: fix
-pr_number: 4727

--- a/.changelog/4728.yml
+++ b/.changelog/4728.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Changed the isSilent key to be lower case.
-  type: fix
-pr_number: 4728

--- a/.changelog/4733.yml
+++ b/.changelog/4733.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Fixed an issue in the ***modeling-rules*** command where colored logs were not printed properly.
-  type: fix
-pr_number: 4733

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,36 @@
 # Changelog
+## 1.33.1 (2024-12-25)
+### Feature
+* Moved the CR101 validation, checking names of Correlation Rule files match standards, to `validate_content_path`. [#4596](https://github.com/demisto/demisto-sdk/pull/4569)
+* Added validation checks whether the silent playbook name id and the isSilent key are set correctly. [#4662](https://github.com/demisto/demisto-sdk/pull/4662)
+* Added validation to ensure every silent trigger points to a silent playbook, and vice versa. [#4670](https://github.com/demisto/demisto-sdk/pull/4670)
+* Exclude silent-Playbooks/Triggers from the metadata. [#4692](https://github.com/demisto/demisto-sdk/pull/4692)
+* Added support for writing pre-commit results to files. [#4697](https://github.com/demisto/demisto-sdk/pull/4697)
+* Added support for CaseLayouts and CaseFields content items paths to the `validate-content-paths` **pre-commit** hook. [#4706](https://github.com/demisto/demisto-sdk/pull/4706)
+* Updated validation rules to allow the deletion of silent Playbooks and silent Triggers. [#4715](https://github.com/demisto/demisto-sdk/pull/4715)
+* Exclude silent items from release notes validation. [#4720](https://github.com/demisto/demisto-sdk/pull/4720)
+* Added the **PB132** validation to ensure that silent playbooks do not have a README file. [#4723](https://github.com/demisto/demisto-sdk/pull/4723)
+* Added support for Silent-Playbooks in the old-validate. [#4726](https://github.com/demisto/demisto-sdk/pull/4726)
+
+### Fix
+* Fixed an issue where YmlSplitter attributes were being unintentionally updated. [#4696](https://github.com/demisto/demisto-sdk/pull/4696)
+* Fix an issue where *RN106* and *PA114* validations would fail on new packs. [#4710](https://github.com/demisto/demisto-sdk/pull/4710)
+* Fixed an issue where *RN107* validation would fail on new content items and specific content types. [#4711](https://github.com/demisto/demisto-sdk/pull/4711)
+* Fixed an issue where YmlSplitter attributes were being unintentionally updated. [#4713](https://github.com/demisto/demisto-sdk/pull/4713)
+* Fixed an issue where RN111 would fail when it should not when the docker entry message was missing. [#4714](https://github.com/demisto/demisto-sdk/pull/4714)
+* Fixed an issue where ST110 would incorrectly fail when adding the isSilent field. [#4716](https://github.com/demisto/demisto-sdk/pull/4716)
+* Fixed an issue where RM114 falsely failed when it concatenated "Packs/" twice to the file path. [#4717](https://github.com/demisto/demisto-sdk/pull/4717)
+* Fixed an issue where the error message wasn't clear when attempting to upload a content item to an unsupported marketplace. [#4727](https://github.com/demisto/demisto-sdk/pull/4727)
+* Changed the isSilent key to be lower case. [#4728](https://github.com/demisto/demisto-sdk/pull/4728)
+* Fixed an issue in the ***modeling-rules*** command where colored logs were not printed properly. [#4733](https://github.com/demisto/demisto-sdk/pull/4733)
+
+### Breaking
+* Removed support for DS107 and RM106 validations - ensure no 'demist'o word in description and readme files for both new & old validate. [#4712](https://github.com/demisto/demisto-sdk/pull/4712)
+* Changed the code of RM116 - Validate that the readme file is not to short to RM117 due to error code duplication. [#4712](https://github.com/demisto/demisto-sdk/pull/4712)
+* **Breaking Change**: Removed the support for python 3.9, and upgraded the *mitmproxy* dependency version. [#4718](https://github.com/demisto/demisto-sdk/pull/4718)
+
+
+# Changelog
 ## 1.33.0 (2024-12-08)
 ### Feature
 * Modified the ***demisto-sdk --release-notes*** command to print a markdown representation of the currently installed demisto-sdk changelog. [#4687](https://github.com/demisto/demisto-sdk/pull/4687)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,32 +1,32 @@
 # Changelog
 ## 1.33.1 (2024-12-25)
 ### Feature
-* Moved the CR101 validation, checking names of Correlation Rule files match standards, to `validate_content_path`. [#4596](https://github.com/demisto/demisto-sdk/pull/4569)
-* Added validation checks whether the silent playbook name id and the isSilent key are set correctly. [#4662](https://github.com/demisto/demisto-sdk/pull/4662)
-* Added validation to ensure every silent trigger points to a silent playbook, and vice versa. [#4670](https://github.com/demisto/demisto-sdk/pull/4670)
+* Moved the CR101 validation to the new validation format. Checks names if "Correlation Rule" files match standards to `validate_content_path`. [#4596](https://github.com/demisto/demisto-sdk/pull/4569)
+* Added *PB130* validation. Checks whether the silent playbook name id and the *isSilent* key are set correctly. [#4662](https://github.com/demisto/demisto-sdk/pull/4662) PB130
+* Added *PB131* validation. Ensures every silent trigger points to a silent playbook, and vice versa. [#4670](https://github.com/demisto/demisto-sdk/pull/4670)
 * Exclude silent-Playbooks/Triggers from the metadata. [#4692](https://github.com/demisto/demisto-sdk/pull/4692)
-* Added support for writing pre-commit results to files. [#4697](https://github.com/demisto/demisto-sdk/pull/4697)
-* Added support for CaseLayouts and CaseFields content items paths to the `validate-content-paths` **pre-commit** hook. [#4706](https://github.com/demisto/demisto-sdk/pull/4706)
+* Added support for writing ***demisto-sdk pre-commit*** command results to files. [#4697](https://github.com/demisto/demisto-sdk/pull/4697)
+* Added support for CaseLayouts and CaseFields content items paths to the `validate-content-paths` ***demisto-sdk pre-commit*** hook. [#4706](https://github.com/demisto/demisto-sdk/pull/4706)
 * Updated validation rules to allow the deletion of silent Playbooks and silent Triggers. [#4715](https://github.com/demisto/demisto-sdk/pull/4715)
 * Exclude silent items from release notes validation. [#4720](https://github.com/demisto/demisto-sdk/pull/4720)
-* Added the **PB132** validation to ensure that silent playbooks do not have a README file. [#4723](https://github.com/demisto/demisto-sdk/pull/4723)
+* Added *PB132* validation. Ensures that silent playbooks do not have a README file. [#4723](https://github.com/demisto/demisto-sdk/pull/4723)
 * Added support for Silent-Playbooks in the old-validate. [#4726](https://github.com/demisto/demisto-sdk/pull/4726)
 
 ### Fix
 * Fixed an issue where YmlSplitter attributes were being unintentionally updated. [#4696](https://github.com/demisto/demisto-sdk/pull/4696)
-* Fix an issue where *RN106* and *PA114* validations would fail on new packs. [#4710](https://github.com/demisto/demisto-sdk/pull/4710)
+* Fixed an issue where *RN106* and *PA114* validations would fail on new packs. [#4710](https://github.com/demisto/demisto-sdk/pull/4710)
 * Fixed an issue where *RN107* validation would fail on new content items and specific content types. [#4711](https://github.com/demisto/demisto-sdk/pull/4711)
 * Fixed an issue where YmlSplitter attributes were being unintentionally updated. [#4713](https://github.com/demisto/demisto-sdk/pull/4713)
-* Fixed an issue where RN111 would fail when it should not when the docker entry message was missing. [#4714](https://github.com/demisto/demisto-sdk/pull/4714)
-* Fixed an issue where ST110 would incorrectly fail when adding the isSilent field. [#4716](https://github.com/demisto/demisto-sdk/pull/4716)
-* Fixed an issue where RM114 falsely failed when it concatenated "Packs/" twice to the file path. [#4717](https://github.com/demisto/demisto-sdk/pull/4717)
+* Fixed an issue where *RN111* would fail when it should not when the docker entry message was missing. [#4714](https://github.com/demisto/demisto-sdk/pull/4714)
+* Fixed an issue where *ST110* would incorrectly fail when adding the isSilent field. [#4716](https://github.com/demisto/demisto-sdk/pull/4716)
+* Fixed an issue where *RM114* falsely failed when it concatenated "Packs/" twice to the file path. [#4717](https://github.com/demisto/demisto-sdk/pull/4717)
 * Fixed an issue where the error message wasn't clear when attempting to upload a content item to an unsupported marketplace. [#4727](https://github.com/demisto/demisto-sdk/pull/4727)
 * Changed the isSilent key to be lower case. [#4728](https://github.com/demisto/demisto-sdk/pull/4728)
-* Fixed an issue in the ***modeling-rules*** command where colored logs were not printed properly. [#4733](https://github.com/demisto/demisto-sdk/pull/4733)
+* Fixed an issue in the ***demisto-sdk modeling-rules*** command where colored logs were not printed properly. [#4733](https://github.com/demisto/demisto-sdk/pull/4733)
 
 ### Breaking
-* Removed support for DS107 and RM106 validations - ensure no 'demist'o word in description and readme files for both new & old validate. [#4712](https://github.com/demisto/demisto-sdk/pull/4712)
-* Changed the code of RM116 - Validate that the readme file is not to short to RM117 due to error code duplication. [#4712](https://github.com/demisto/demisto-sdk/pull/4712)
+* Removed support for *DS107* and *RM106* validations. Ensures no "demisto" word in description and readme files for both new & old validate formats. [#4712](https://github.com/demisto/demisto-sdk/pull/4712)
+* Changed the code of *RM116*. Validates that the readme file is not to short to *RM117* due to error code duplication. [#4712](https://github.com/demisto/demisto-sdk/pull/4712)
 * **Breaking Change**: Removed the support for python 3.9, and upgraded the *mitmproxy* dependency version. [#4718](https://github.com/demisto/demisto-sdk/pull/4718)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## 1.33.1 (2024-12-25)
 ### Feature
 * Moved the CR101 validation to the new validation format. Checks names if "Correlation Rule" files match standards to `validate_content_path`. [#4596](https://github.com/demisto/demisto-sdk/pull/4569)
-* Added *PB130* validation. Checks whether the silent playbook name id and the *isSilent* key are set correctly. [#4662](https://github.com/demisto/demisto-sdk/pull/4662) PB130
+* Added *PB130* validation. Checks whether the silent playbook name id and the *isSilent* key are set correctly. [#4662](https://github.com/demisto/demisto-sdk/pull/4662)
 * Added *PB131* validation. Ensures every silent trigger points to a silent playbook, and vice versa. [#4670](https://github.com/demisto/demisto-sdk/pull/4670)
 * Exclude silent-Playbooks/Triggers from the metadata. [#4692](https://github.com/demisto/demisto-sdk/pull/4692)
 * Added support for writing ***demisto-sdk pre-commit*** command results to files. [#4697](https://github.com/demisto/demisto-sdk/pull/4697)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ exclude = "tests/.*|demisto_sdk/commands/init/templates/.*"
 
 [tool.poetry]
 name = "demisto-sdk"
-version = "1.33.0"
+version = "1.33.1"
 description = "\"A Python library for the Demisto SDK\""
 authors = ["Demisto"]
 license = "MIT"


### PR DESCRIPTION
### Feature
* Moved the CR101 validation to the new validation format. Checks names if "Correlation Rule" files match standards to `validate_content_path`. [#4596](https://github.com/demisto/demisto-sdk/pull/4569)
* Added *PB130* validation. Checks whether the silent playbook name id and the *isSilent* key are set correctly. [#4662](https://github.com/demisto/demisto-sdk/pull/4662)
* Added *PB131* validation. Ensures every silent trigger points to a silent playbook, and vice versa. [#4670](https://github.com/demisto/demisto-sdk/pull/4670)
* Exclude silent-Playbooks/Triggers from the metadata. [#4692](https://github.com/demisto/demisto-sdk/pull/4692)
* Added support for writing ***demisto-sdk pre-commit*** command results to files. [#4697](https://github.com/demisto/demisto-sdk/pull/4697)
* Added support for CaseLayouts and CaseFields content items paths to the `validate-content-paths` ***demisto-sdk pre-commit*** hook. [#4706](https://github.com/demisto/demisto-sdk/pull/4706)
* Updated validation rules to allow the deletion of silent Playbooks and silent Triggers. [#4715](https://github.com/demisto/demisto-sdk/pull/4715)
* Exclude silent items from release notes validation. [#4720](https://github.com/demisto/demisto-sdk/pull/4720)
* Added *PB132* validation. Ensures that silent playbooks do not have a README file. [#4723](https://github.com/demisto/demisto-sdk/pull/4723)
* Added support for Silent-Playbooks in the old-validate. [#4726](https://github.com/demisto/demisto-sdk/pull/4726)

### Fix
* Fixed an issue where YmlSplitter attributes were being unintentionally updated. [#4696](https://github.com/demisto/demisto-sdk/pull/4696)
* Fixed an issue where *RN106* and *PA114* validations would fail on new packs. [#4710](https://github.com/demisto/demisto-sdk/pull/4710)
* Fixed an issue where *RN107* validation would fail on new content items and specific content types. [#4711](https://github.com/demisto/demisto-sdk/pull/4711)
* Fixed an issue where YmlSplitter attributes were being unintentionally updated. [#4713](https://github.com/demisto/demisto-sdk/pull/4713)
* Fixed an issue where *RN111* would fail when it should not when the docker entry message was missing. [#4714](https://github.com/demisto/demisto-sdk/pull/4714)
* Fixed an issue where *ST110* would incorrectly fail when adding the isSilent field. [#4716](https://github.com/demisto/demisto-sdk/pull/4716)
* Fixed an issue where *RM114* falsely failed when it concatenated "Packs/" twice to the file path. [#4717](https://github.com/demisto/demisto-sdk/pull/4717)
* Fixed an issue where the error message wasn't clear when attempting to upload a content item to an unsupported marketplace. [#4727](https://github.com/demisto/demisto-sdk/pull/4727)
* Changed the isSilent key to be lower case. [#4728](https://github.com/demisto/demisto-sdk/pull/4728)
* Fixed an issue in the ***demisto-sdk modeling-rules*** command where colored logs were not printed properly. [#4733](https://github.com/demisto/demisto-sdk/pull/4733)

### Breaking
* Removed support for *DS107* and *RM106* validations. Ensures no "demisto" word in description and readme files for both new & old validate formats. [#4712](https://github.com/demisto/demisto-sdk/pull/4712)
* Changed the code of *RM116*. Validates that the readme file is not to short to *RM117* due to error code duplication. [#4712](https://github.com/demisto/demisto-sdk/pull/4712)
* **Breaking Change**: Removed the support for python 3.9, and upgraded the *mitmproxy* dependency version. [#4718](https://github.com/demisto/demisto-sdk/pull/4718)