### PR TITLE
modify tests collection

### DIFF
--- a/.changelog/4761.yml
+++ b/.changelog/4761.yml
@@ -1,4 +1,4 @@
 changes:
-- description: Modified the tests collections flow to collect all tests files in the same directory as a changed script for improved robustness.
+- description: Modified the pre-commit tests collections flow to collect all tests files in the same directory as a changed script for improved robustness.
   type: feature
 pr_number: 4761

--- a/.changelog/4761.yml
+++ b/.changelog/4761.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Modified the tests collections flow to collect all tests files in the same directory as a changed script for improved robustness.
+  type: feature
+pr_number: 4761


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: [CIAC-12128](https://jira-dc.paloaltonetworks.com/browse/CIAC-12128)

## Description
Modifying tests collection to collect all tests located in the same directory of a changed script file, rather than collecting tests matching the script file name.

This puts us on the safe side when working on a content item and seeking its tests to be executed in CI/CD without concerning about file names discrepancies. 