### PR TITLE
Case Layout Structure

### DIFF
--- a/.changelog/4763.yml
+++ b/.changelog/4763.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where **ST110** validation failed when adding marketplaces key to the CaseLayout content item.
+  type: fix
+pr_number: 4763

--- a/.changelog/4763.yml
+++ b/.changelog/4763.yml
@@ -1,4 +1,4 @@
 changes:
-- description: Fixed an issue where **ST110** validation failed when adding marketplaces key to the CaseLayout content item.
+- description: Fixed an issue where the **ST110** validation failed when adding the marketplaces key to the CaseLayout content item.
   type: fix
 pr_number: 4763

--- a/demisto_sdk/commands/content_graph/strict_objects/case_layout.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/case_layout.py
@@ -59,7 +59,7 @@ class StrictCaseLayout(BaseStrictModel):
     to_version: Optional[str] = Field(None, alias="toVersion")
     description: Optional[str] = None
     system: Optional[bool] = None
-    marketplaces: Optional[Literal[MarketplaceVersions.MarketplaceV2]] = None
+    marketplaces: Optional[List[Literal[MarketplaceVersions.MarketplaceV2]]] = None
     edit: Optional[TabsAndSections] = None
     indicators_details: Optional[TabsAndSections] = Field(
         None, alias="indicatorsDetails"


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-12595
blocks: https://github.com/demisto/content/pull/37625
## Description
Fixed an issue where **ST110** validation failed on unexpected value when adding the marketplace key to the CaseLayout content item.

```
Packs/Core/CaseLayouts/layoutscontainer-Default_XSIAM_Case.json: [ST110] - Structure error (value_error.const) in field marketplaces of layoutscontainer-Default_XSIAM_Case.json: unexpected value; permitted: <MarketplaceVersions.MarketplaceV2: 'marketplacev2'>
```