### PR TITLE
Enum Validation for --update-type Flag in update-release-notes Command

### DIFF
--- a/.changelog/4765.yml
+++ b/.changelog/4765.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where the update-release-notes command would delete the version from the pack metadata when using the -u flag with an invalid value.
+  type: fix
+pr_number: 4765

--- a/demisto_sdk/commands/update_release_notes/update_release_notes_setup.py
+++ b/demisto_sdk/commands/update_release_notes/update_release_notes_setup.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from pathlib import Path
 from typing import Optional
 
@@ -26,6 +27,13 @@ def validate_version(value: Optional[str]) -> Optional[str]:
     raise typer.Exit(1)
 
 
+class UpdateType(str, Enum):
+    major = "major"
+    minor = "minor"
+    revision = "revision"
+    documentation = "documentation"
+
+
 @logging_setup_decorator
 def update_release_notes(
     ctx: typer.Context,
@@ -35,7 +43,7 @@ def update_release_notes(
         "--input",
         help="The relative path of the content pack. For example Packs/Pack_Name",
     ),
-    update_type: str = typer.Option(
+    update_type: UpdateType = typer.Option(
         None,
         "-u",
         "--update-type",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-12598

## Description
Fixed an issue where the update-release-notes delete the version from the pack metadata when using the -u flag with an invalid value
After the fix:

![image](https://github.com/user-attachments/assets/69e5096d-5ad3-4209-9c9b-9cd51acee03b)

