### PR TITLE
[Typer] Set pretty_exceptions_enable to False

### DIFF
--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -18,7 +18,7 @@ from demisto_sdk.commands.common.tools import (
     is_sdk_defined_working_offline,
 )
 
-app = typer.Typer()
+app = typer.Typer(pretty_exceptions_enable=False)
 
 
 @logging_setup_decorator


### PR DESCRIPTION
## Description
When pretty_exceptions_enable is set, it sometimes causes the Traceback to be over 300,000(!!) lines, so we disable it.