### PR TITLE
[setup-env] fix empty var issue

### DIFF
--- a/.changelog/4791.yml
+++ b/.changelog/4791.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where the ***demisto-sdk setup-env*** command ran failed when no *file_paths* argument was provided.
+  type: fix
+pr_number: 4791

--- a/.changelog/4791.yml
+++ b/.changelog/4791.yml
@@ -1,4 +1,4 @@
 changes:
-- description: Fixed an issue where the ***demisto-sdk setup-env*** command ran failed when no *file_paths* argument was provided.
+- description: Fixed an issue where the ***demisto-sdk setup-env*** command failed when no *file_paths* argument was provided.
   type: fix
 pr_number: 4791

--- a/demisto_sdk/commands/setup_env/README.md
+++ b/demisto_sdk/commands/setup_env/README.md
@@ -27,8 +27,7 @@ The command will configure VSCode and XSOAR/XSIAM instances for development and 
 - **--clean**: Clean the repository of temporary files created by the 'lint' command.
   - Default: `False`
 
-- **file_paths**:
-  - Default: `<class 'list'>`
+- **file_paths**: 
 
 - **--console-log-threshold**: Minimum logging threshold for console output. Possible values: DEBUG, INFO, SUCCESS, WARNING, ERROR.
 

--- a/demisto_sdk/commands/setup_env/README.md
+++ b/demisto_sdk/commands/setup_env/README.md
@@ -27,7 +27,7 @@ The command will configure VSCode and XSOAR/XSIAM instances for development and 
 - **--clean**: Clean the repository of temporary files created by the 'lint' command.
   - Default: `False`
 
-- **file_paths**: 
+- **file_paths**:
 
 - **--console-log-threshold**: Minimum logging threshold for console output. Possible values: DEBUG, INFO, SUCCESS, WARNING, ERROR.
 

--- a/demisto_sdk/commands/setup_env/setup_env_setup.py
+++ b/demisto_sdk/commands/setup_env/setup_env_setup.py
@@ -96,12 +96,8 @@ def setup_env_command(
     )
 
     # If no input key was found, try to resolve arg
-    if not resolved_file_paths:
-        file_paths = (
-            tuple(Path(path).resolve() for path in file_paths)
-            if file_paths
-            else tuple()
-        )
+    if not resolved_file_paths and file_paths:
+        file_paths = tuple(Path(path).resolve() for path in file_paths)
         resolved_file_paths = file_paths
 
     setup_env(

--- a/demisto_sdk/commands/setup_env/setup_env_setup.py
+++ b/demisto_sdk/commands/setup_env/setup_env_setup.py
@@ -52,7 +52,7 @@ def setup_env_command(
         help="Clean the repository of temporary files created by the 'lint' command.",
     ),
     file_paths: Tuple[Path, ...] = typer.Argument(
-        default_factory=list,
+        None,
         resolve_path=True,
         show_default=False,
     ),
@@ -91,12 +91,18 @@ def setup_env_command(
         ide_type = IDEType(ide)
 
     # Resolve input paths if provided
-    if input:
-        resolved_input = [path.resolve() for path in input]
-    else:
-        resolved_input = []
+    resolved_file_paths = (
+        tuple(Path(path).resolve() for path in input) if input else tuple()
+    )
 
-    resolved_file_paths = resolved_input or file_paths
+    # If no input key was found, try to resolve arg
+    if not resolved_file_paths:
+        file_paths = (
+            tuple(Path(path).resolve() for path in file_paths)
+            if file_paths
+            else tuple()
+        )
+        resolved_file_paths = file_paths
 
     setup_env(
         file_paths=resolved_file_paths,


### PR DESCRIPTION
## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-12692

## Description
Fixed an issue where this error appeared:
```
      ╭─ Error ──────────────────────────────────────────────────────────────────────╮
4392  │ Invalid value for '[FILE_PATHS]...': 2 values are required, but 0 were       │
4393  │ given.                                                                       │
4394  ╰──────────────────────────────────────────────────────────────────────────────╯
```