### PR TITLE
Fix the "replace_marketplace_references" regex / CIAC-12759

### DIFF
--- a/.changelog/4798.yml
+++ b/.changelog/4798.yml
@@ -1,4 +1,4 @@
 changes:
-- description: Updated regex in prepare_content to remove XSOAR versions, except in unique documentation references.
+- description: Updated regex in **demisto-sdk prepare-content** command to remove XSOAR unrelated version references, except in unique documentation cases.
   type: fix
 pr_number: 4798

--- a/.changelog/4798.yml
+++ b/.changelog/4798.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Updated regex in prepare_content to remove XSOAR versions, except in unique documentation references.
+  type: fix
+pr_number: 4798

--- a/demisto_sdk/commands/content_graph/common.py
+++ b/demisto_sdk/commands/content_graph/common.py
@@ -528,6 +528,7 @@ def replace_marketplace_references(
     """
     Recursively replaces "Cortex XSOAR" with "Cortex" in the given data if the marketplace is MarketplaceV2 or XPANSE.
     If the word following "Cortex XSOAR" contains a number, it will also be removed.
+    The replacement will be skipped if "https" appears within 20 characters after "Cortex XSOAR." This ensures that documentation with distinct links for different products or versions remains unchanged. see CIAC-12049 for details.
 
     Args:
         data (Any): The data to process, which can be a dictionary, list, or string.
@@ -537,6 +538,7 @@ def replace_marketplace_references(
     Returns:
         Any: The same data object with replacements made if applicable.
     """
+    pattern = r"Cortex XSOAR(?: \w*\d\w*)?(?!.{0,20}https)"
     try:
         if marketplace in {
             MarketplaceVersions.MarketplaceV2,
@@ -547,7 +549,8 @@ def replace_marketplace_references(
                 for key, value in data.items():
                     # Process the key
                     new_key = (
-                        re.sub(r"Cortex XSOAR(?: [\w.]*\d[\w.]*)?", "Cortex", key)
+                        re.sub(pattern, "Cortex", key)
+
                         if isinstance(key, str)
                         else key
                     )
@@ -564,10 +567,11 @@ def replace_marketplace_references(
             elif isinstance(data, FoldedScalarString):
                 # if data is a FoldedScalarString (yml unification), we need to convert it to a string and back
                 data = FoldedScalarString(
-                    re.sub(r"Cortex XSOAR(?: [\w.]*\d[\w.]*)?", "Cortex", str(data))
+                    re.sub(pattern, "Cortex", str(data))
+
                 )
             elif isinstance(data, str):
-                data = re.sub(r"Cortex XSOAR(?: [\w.]*\d[\w.]*)?", "Cortex", data)
+                data = re.sub(pattern, "Cortex", data)
     except Exception as e:
         logger.error(
             f"Error processing data for replacing incorrect marketplace at path '{path}': {e}"

--- a/demisto_sdk/commands/content_graph/common.py
+++ b/demisto_sdk/commands/content_graph/common.py
@@ -538,7 +538,7 @@ def replace_marketplace_references(
     Returns:
         Any: The same data object with replacements made if applicable.
     """
-    pattern = r"Cortex XSOAR(?: [\w.]*\d[\w.]*)?(?!(?:.{0,20})https)"
+    pattern = r"\bCortex XSOAR\b(?![\S]*\/)(?:\s+[\w.]*\d[\w.]*)?(?!(?:.{0,20})https)"
     try:
         if marketplace in {
             MarketplaceVersions.MarketplaceV2,

--- a/demisto_sdk/commands/content_graph/common.py
+++ b/demisto_sdk/commands/content_graph/common.py
@@ -546,7 +546,7 @@ def replace_marketplace_references(
                 for key, value in data.items():
                     # Process the key
                     new_key = (
-                        re.sub(r"Cortex XSOAR(?: \w*\d\w*)?", "Cortex", key)
+                        re.sub(r"Cortex XSOAR(?: [\w.]*\d[\w.]*)?", "Cortex", key)
                         if isinstance(key, str)
                         else key
                     )
@@ -563,10 +563,10 @@ def replace_marketplace_references(
             elif isinstance(data, FoldedScalarString):
                 # if data is a FoldedScalarString (yml unification), we need to convert it to a string and back
                 data = FoldedScalarString(
-                    re.sub(r"Cortex XSOAR(?: \w*\d\w*)?", "Cortex", str(data))
+                    re.sub(r"Cortex XSOAR(?: [\w.]*\d[\w.]*)?", "Cortex", str(data))
                 )
             elif isinstance(data, str):
-                data = re.sub(r"Cortex XSOAR(?: \w*\d\w*)?", "Cortex", data)
+                data = re.sub(r"Cortex XSOAR(?: [\w.]*\d[\w.]*)?", "Cortex", data)
     except Exception as e:
         logger.error(
             f"Error processing data for replacing incorrect marketplace at path '{path}': {e}"

--- a/demisto_sdk/commands/content_graph/common.py
+++ b/demisto_sdk/commands/content_graph/common.py
@@ -538,7 +538,7 @@ def replace_marketplace_references(
     Returns:
         Any: The same data object with replacements made if applicable.
     """
-    pattern = r"Cortex XSOAR(?: \w*\d\w*)?(?!.{0,20}https)"
+    pattern = r"Cortex XSOAR(?: [\w.]*\d[\w.]*)?(?!(?:.{0,20})https)"
     try:
         if marketplace in {
             MarketplaceVersions.MarketplaceV2,

--- a/demisto_sdk/commands/content_graph/common.py
+++ b/demisto_sdk/commands/content_graph/common.py
@@ -549,10 +549,7 @@ def replace_marketplace_references(
                 for key, value in data.items():
                     # Process the key
                     new_key = (
-                        re.sub(pattern, "Cortex", key)
-
-                        if isinstance(key, str)
-                        else key
+                        re.sub(pattern, "Cortex", key) if isinstance(key, str) else key
                     )
                     if new_key != key:
                         keys_to_update[key] = new_key
@@ -566,10 +563,7 @@ def replace_marketplace_references(
                     data[i] = replace_marketplace_references(data[i], marketplace, path)
             elif isinstance(data, FoldedScalarString):
                 # if data is a FoldedScalarString (yml unification), we need to convert it to a string and back
-                data = FoldedScalarString(
-                    re.sub(pattern, "Cortex", str(data))
-
-                )
+                data = FoldedScalarString(re.sub(pattern, "Cortex", str(data)))
             elif isinstance(data, str):
                 data = re.sub(pattern, "Cortex", data)
     except Exception as e:

--- a/demisto_sdk/commands/content_graph/tests/common_test.py
+++ b/demisto_sdk/commands/content_graph/tests/common_test.py
@@ -131,7 +131,7 @@ def test_replace_marketplace_references__dict():
     data = {
         "description": "This is a Cortex XSOAR v1 example.",
         "details": "Cortex XSOAR should be replaced.",
-        "Cortex XSOAR": "Cortex XSOAR",
+        "Cortex XSOAR 5.6 is": "Cortex XSOAR",
         "folded": FoldedScalarString(
             "Cortex XSOAR should be replaced in FoldedScalarString."
         ),
@@ -140,7 +140,7 @@ def test_replace_marketplace_references__dict():
     expected = {
         "description": "This is a Cortex example.",
         "details": "Cortex should be replaced.",
-        "Cortex": "Cortex",
+        "Cortex is": "Cortex",
         "folded": FoldedScalarString(
             "Cortex should be replaced in FoldedScalarString."
         ),

--- a/demisto_sdk/commands/content_graph/tests/common_test.py
+++ b/demisto_sdk/commands/content_graph/tests/common_test.py
@@ -59,8 +59,8 @@ def test_replace_marketplace_references_string_with_number():
     Then:
         - The function should return the data with the replacements made if applicable.
     """
-    data = "This is a Cortex XSOAR v1 example."
-    expected = "This is a Cortex example."
+    data = "This is for Cortex XSOAR 8.7 On-prem."
+    expected = "This is for Cortex On-prem."
     result = replace_marketplace_references(
         data, MarketplaceVersions.MarketplaceV2, path="example/path"
     )

--- a/demisto_sdk/commands/content_graph/tests/common_test.py
+++ b/demisto_sdk/commands/content_graph/tests/common_test.py
@@ -162,6 +162,12 @@ def test_replace_marketplace_references_strings(data, marketplace, expected):
             ["This is a cortex xsoar v6.6.8 example."],
             id="No replace for case insensitive in list",
         ),
+        pytest.param(
+            ["This is a Cortex XSOAR/8."],
+            MarketplaceVersions.MarketplaceV2,
+            ["This is a Cortex XSOAR/8."],
+            id="No replace within word in list ",
+        ),
     ],
 )
 def test_replace_marketplace_references_lists(data, marketplace, expected):


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-12759
relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-10198

## Description

- Updated the regex for replacing incorrect marketplace versions to remove the entire version following "XSOAR."
    
    For example:
    "Cortex XSOAR V6.5.3 example" → "Cortex example"

- Additionally, added an exception to preserve references that point to unique documentation specific to a product/version—no replacement occurs in such cases.