### PR TITLE
Lock mypy on 1.14.1

### DIFF
--- a/.changelog/4806.yml
+++ b/.changelog/4806.yml
@@ -1,4 +1,4 @@
 changes:
-- description: Locked the MyPy version to 1.15.0 in the ***mypy-in-docker*** **pre-commit** hook to ensure consistent type checking.
+- description: Locked the MyPy version to 1.14.1 in the ***mypy-in-docker*** **pre-commit** hook to ensure consistent type checking.
   type: feature
 pr_number: 4806

--- a/.changelog/4812.yml
+++ b/.changelog/4812.yml
@@ -1,4 +1,4 @@
 changes:
 - description: Locked the MyPy version to 1.14.1 in the ***mypy-in-docker*** **pre-commit** hook to ensure consistent type checking.
   type: feature
-pr_number: 4806
+pr_number: 4812

--- a/demisto_sdk/commands/lint/resources/python3_requirements/dev-requirements.txt
+++ b/demisto_sdk/commands/lint/resources/python3_requirements/dev-requirements.txt
@@ -15,4 +15,4 @@ dictdiffer==0.9.0
 pytest-pretty==1.2.0
 pytest-github-actions-annotate-failures==0.2.0
 pytest
-mypy==1.15.0
+mypy==1.14.1


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
Related: https://jira-dc.paloaltonetworks.com/browse/CIAC-12856

## Description
https://github.com/demisto/demisto-sdk/pull/4806

Because of this error, we are going to lock on 1.14.1

![image](https://github.com/user-attachments/assets/5b174e26-9abe-4b17-8b08-1fd0b176c6b8)
