### PR TITLE
Platform MP: update parsers with the required fields

### DIFF
--- a/.changelog/4823.yml
+++ b/.changelog/4823.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Update Graph parsers to support the new marketplace properties.
+  type: feature
+pr_number: 4823

--- a/demisto_sdk/commands/common/schemas/integration.yml
+++ b/demisto_sdk/commands/common/schemas/integration.yml
@@ -181,7 +181,7 @@ mapping:
       enum: ['xsoar', 'marketplacev2', 'xpanse', 'xsoar_saas', 'xsoar_on_prem']
   hybrid:
     type: bool
-  
+
 
 # integration->configuration
   name:xsoar:

--- a/demisto_sdk/commands/common/schemas/integration.yml
+++ b/demisto_sdk/commands/common/schemas/integration.yml
@@ -363,6 +363,7 @@ schema;argument_schema:
     prettyname:
       type: str
     prettypredefined:
+      allowempty: true
       type: map
       mapping:
         ".*":

--- a/demisto_sdk/commands/common/schemas/integration.yml
+++ b/demisto_sdk/commands/common/schemas/integration.yml
@@ -117,6 +117,8 @@ mapping:
         type: bool
       isremotesyncout_x2:
         type: bool
+      supportsquickactions:
+        type: bool
       commands:
         type: seq
         sequence:
@@ -179,6 +181,7 @@ mapping:
       enum: ['xsoar', 'marketplacev2', 'xpanse', 'xsoar_saas', 'xsoar_on_prem']
   hybrid:
     type: bool
+  
 
 # integration->configuration
   name:xsoar:
@@ -287,6 +290,8 @@ schema;command_schema:
     name:
       type: str
       required: true
+    prettyname:
+      type: str
     execution:
       type: bool
     description:
@@ -316,7 +321,8 @@ schema;command_schema:
       type: bool
     polling:
       type: bool
-
+    quickaction:
+      type: bool
 # int
     name:xsoar:
       type: str
@@ -354,6 +360,12 @@ schema;argument_schema:
     name:
       type: str
       required: true
+    prettyname:
+      type: str
+    prettyPredefined:
+      type: seq
+      sequence:
+      - type: map
     required:
       type: bool
     default:

--- a/demisto_sdk/commands/common/schemas/integration.yml
+++ b/demisto_sdk/commands/common/schemas/integration.yml
@@ -362,10 +362,11 @@ schema;argument_schema:
       required: true
     prettyname:
       type: str
-    prettyPredefined:
-      type: seq
-      sequence:
-      - type: map
+    prettypredefined:
+      type: map
+      mapping:
+        ".*":
+          type: str
     required:
       type: bool
     default:

--- a/demisto_sdk/commands/common/schemas/script.yml
+++ b/demisto_sdk/commands/common/schemas/script.yml
@@ -126,6 +126,10 @@ mapping:
     sequence:
     - type: str
       enum: ['script-name-incident-to-alert']
+  quickaction:
+      type: bool
+  prettyname:
+      type: str
 
 # script->args
   name:xsoar:
@@ -184,6 +188,14 @@ schema;argument_schema:
       type: str
     hidden:
       type: bool
+    prettyname:
+      type: str
+    prettypredefined:
+      allowempty: true
+      type: map
+      mapping:
+        ".*":
+          type: str
 
 # script->outputs
     name:xsoar:

--- a/demisto_sdk/commands/content_graph/strict_objects/base_strict_model.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/base_strict_model.py
@@ -40,6 +40,8 @@ CommonFields = create_model(
 
 class _Argument(BaseStrictModel):
     name: str
+    prettyname: Optional[str] = None
+    pretty_predefined: Optional[dict] = Field(None, alias="prettyPredefined")
     required: Optional[bool] = None
     default: Optional[bool] = None
     description: str

--- a/demisto_sdk/commands/content_graph/strict_objects/base_strict_model.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/base_strict_model.py
@@ -41,7 +41,7 @@ CommonFields = create_model(
 class _Argument(BaseStrictModel):
     name: str
     prettyname: Optional[str] = None
-    pretty_predefined: Optional[dict] = Field(None, alias="prettyPredefined")
+    pretty_predefined: Optional[dict] = Field(None, alias="prettypredefined")
     required: Optional[bool] = None
     default: Optional[bool] = None
     description: str

--- a/demisto_sdk/commands/content_graph/strict_objects/integration.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/integration.py
@@ -84,6 +84,8 @@ class _Command(BaseStrictModel):
     timeout: Optional[int] = None
     hidden: Optional[bool] = None
     polling: Optional[bool] = None
+    prettyname: Optional[str] = None
+    quickaction: Optional[bool] = None
 
 
 Command = create_model(
@@ -111,6 +113,7 @@ class _Script(BaseStrictModel):
     is_mappable: Optional[bool] = Field(None, alias="ismappable")
     is_remote_sync_in: Optional[bool] = Field(None, alias="isremotesyncin")
     is_remote_sync_out: Optional[bool] = Field(None, alias="isremotesyncout")
+    supports_quick_actions: Optional[bool] = Field(None, alias="supportsquickactions")
     commands: Optional[List[Command]] = None  # type:ignore[valid-type]
     run_once: Optional[bool] = Field(None, alias="runonce")
     sub_type: Optional[str] = Field([TYPE_PYTHON2, TYPE_PYTHON3], alias="subtype")

--- a/demisto_sdk/commands/content_graph/strict_objects/script.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/script.py
@@ -87,6 +87,8 @@ class _StrictScript(BaseIntegrationScript):  # type:ignore[misc,valid-type]
     )
     polling: Optional[bool] = None
     skip_prepare: Optional[List[SkipPrepare]] = Field(None, alias="skipprepare")
+    prettyname: Optional[str] = None
+    quickaction: Optional[bool] = None
 
 
 StrictScript = create_model(


### PR DESCRIPTION
## Related Issues
fixes:https://jira-dc.paloaltonetworks.com/browse/CIAC-12740
Done as part of: [Cortex Platform Content Marketplace Support](https://jira-dc.paloaltonetworks.com/browse/CIAC-12736)

## Description
update parser to supporting:
- `prettyPredefined`
- `prettyname`
- `quickaction`
- `supportsquickactions`