### PR TITLE
Fix imported files git status

### DIFF
--- a/.changelog/4829.yml
+++ b/.changelog/4829.yml
@@ -1,4 +1,4 @@
 changes:
-- description: Fix misidentifies non-new packs as new in contribution flow
+- description: Resolved an issue in external contributions pull requests where incorrect Git status fetching led to validation failures.
   type: fix
 pr_number: 4829

--- a/.changelog/4829.yml
+++ b/.changelog/4829.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fix misidentifies non-new packs as new in contribution flow
+  type: fix
+pr_number: 4829

--- a/demisto_sdk/commands/secrets/secrets.py
+++ b/demisto_sdk/commands/secrets/secrets.py
@@ -128,13 +128,9 @@ class SecretsValidator:
     def get_secrets(self, commit, is_circle):
         secret_to_location_mapping = {}
         if self.input_paths:
-            logger.info("self.input_paths is true")
             secrets_file_paths = self.input_paths
         else:
-            logger.info("We are getting all the text files")
-            logger.info(f"{is_circle}=")
             secrets_file_paths = self.get_all_diff_text_files(commit, is_circle)
-            logger.info(f"len of number of files: {len(secrets_file_paths)}=")
         # If a input path supplied, should not run on git. If not supplied make sure not in middle of merge.
         if not run_command("git rev-parse -q --verify MERGE_HEAD") or self.input_paths:
             secret_to_location_mapping = self.search_potential_secrets(
@@ -265,7 +261,6 @@ class SecretsValidator:
                 )
                 continue
             # Init vars for current loop
-            logger.info(f"Checking secrets for: {file_path}")
             file_name = Path(file_path).name
             _, file_extension = os.path.splitext(file_path)
             # get file contents

--- a/demisto_sdk/commands/validate/initializer.py
+++ b/demisto_sdk/commands/validate/initializer.py
@@ -265,7 +265,9 @@ class Initializer:
         See CIAC-12482 for more info.
         """
         if os.getenv("CONTRIB_BRANCH"):
-            with open("contribution_files_relative_paths.txt", "r") as contribution_file:
+            with open(
+                "contribution_files_relative_paths.txt", "r"
+            ) as contribution_file:
                 contribution_files_relative_paths_count_lines = sum(
                     1 for line in contribution_file if line.strip()
                 )

--- a/demisto_sdk/commands/validate/initializer.py
+++ b/demisto_sdk/commands/validate/initializer.py
@@ -269,7 +269,6 @@ class Initializer:
             with open(
                 "contribution_files_relative_paths.txt", "r"
             ) as contribution_file:
-                logger.info(f"\n{contribution_file=}")  # TODO: remove line
                 for single_line in contribution_file:
                     clean_line: str = single_line.rstrip("\n")
                     relative_untracked_files_paths.add(Path(clean_line))
@@ -278,6 +277,10 @@ class Initializer:
             )
             # modified_files = modified_files.union(relative_untracked_files_paths)
             added_files = set(added_files).union(relative_untracked_files_paths)
+            logger.info(f"\n<cyan>first: {added_files=}</cyan>")  # TODO: remove line
+            added_files = added_files.intersection(relative_untracked_files_paths)  # TODO: remove
+            logger.info(f"\n<cyan>second: {added_files=}</cyan>")  # TODO: remove line
+
 
         return modified_files, added_files, renamed_files
 

--- a/demisto_sdk/commands/validate/initializer.py
+++ b/demisto_sdk/commands/validate/initializer.py
@@ -263,7 +263,7 @@ class Initializer:
                 "\n<cyan>CONTRIB_BRANCH environment variable found, running validate in contribution flow "
                 "on files staged by Utils/update_contribution_pack_in_base_branch.py (Infra repository)</cyan>"
             )
-            logger.info("\n<cyan>ITAMAR TEST 1</cyan>")
+            logger.info(f"\n{modified_files=} {added_files=} {renamed_files=}")
             # Open contribution_files_paths.txt created in Utils/update_contribution_pack_in_base_branch.py (Infra) and read file paths
             relative_untracked_files_paths: Set[Path] = set()
             with open(

--- a/demisto_sdk/commands/validate/initializer.py
+++ b/demisto_sdk/commands/validate/initializer.py
@@ -265,22 +265,24 @@ class Initializer:
         See CIAC-12482 for more info.
         """
         if os.getenv("CONTRIB_BRANCH"):
+            logger.info(
+                "\n<cyan>CONTRIB_BRANCH environment variable found, running validate in contribution flow "
+                "on files staged by Utils/update_contribution_pack_in_base_branch.py (Infra repository)</cyan>"
+            )
+            # Open contribution_files_paths.txt created in Utils/update_contribution_pack_in_base_branch.py (Infra)
+            # and read file paths
+
             with open(
                 "contribution_files_relative_paths.txt", "r"
             ) as contribution_file:
-                contribution_files_relative_paths_count_lines = sum(
-                    1 for line in contribution_file if line.strip()
-                )
+                contribution_files_relative_paths_count_lines = len(contribution_file.readlines())
 
-            if contribution_files_relative_paths_count_lines != (
-                len(modified_files) + len(added_files) + len(renamed_files)
-            ):
-                logger.info(
-                    "The number of fetched files does not match the number of files in the "
-                    "contribution_files_relative_paths.txt file. This indicates that there are untracked files."
-                )
+            affected_files = modified_files.union(added_files, renamed_files)
+            if contribution_files_relative_paths_count_lines != len(affected_files):
                 raise ValueError(
-                    "Error: Mismatch in the number of files. Unable to proceed."
+                    "Error: Mismatch in the number of files. The number of fetched files does not match the number"
+                    " of files in the contribution_files_relative_paths.txt file."
+                    " This indicates that there are untracked files. Unable to proceed."
                 )
 
         return modified_files, added_files, renamed_files

--- a/demisto_sdk/commands/validate/initializer.py
+++ b/demisto_sdk/commands/validate/initializer.py
@@ -271,7 +271,7 @@ class Initializer:
             )
 
         if contribution_files_relative_paths_count_lines != (
-                len(modified_files) + len(added_files) + len(renamed_files)
+            len(modified_files) + len(added_files) + len(renamed_files)
         ):
             logger.info(
                 "The number of fetched files does not match the number of files in the "

--- a/demisto_sdk/commands/validate/initializer.py
+++ b/demisto_sdk/commands/validate/initializer.py
@@ -266,13 +266,20 @@ class Initializer:
         """
 
         with open("contribution_files_relative_paths.txt", "r") as contribution_file:
-            contribution_files_relative_paths_count_lines = sum(1 for line in contribution_file if line.strip())
+            contribution_files_relative_paths_count_lines = sum(
+                1 for line in contribution_file if line.strip()
+            )
 
         if contribution_files_relative_paths_count_lines != (
-                len(modified_files) + len(added_files) + len(renamed_files)):
-            logger.info("The number of fetched files does not match the number of files in the "
-                        "contribution_files_relative_paths.txt file. This indicates that there are untracked files.")
-            raise ValueError("Error: Mismatch in the number of files. Unable to proceed.")
+                len(modified_files) + len(added_files) + len(renamed_files)
+        ):
+            logger.info(
+                "The number of fetched files does not match the number of files in the "
+                "contribution_files_relative_paths.txt file. This indicates that there are untracked files."
+            )
+            raise ValueError(
+                "Error: Mismatch in the number of files. Unable to proceed."
+            )
 
         return modified_files, added_files, renamed_files
 

--- a/demisto_sdk/commands/validate/initializer.py
+++ b/demisto_sdk/commands/validate/initializer.py
@@ -275,12 +275,9 @@ class Initializer:
             logger.info(
                 f"\n######## - Added untracked:\n{relative_untracked_files_paths}"
             )
-            # modified_files = modified_files.union(relative_untracked_files_paths)
-            added_files = set(added_files).union(relative_untracked_files_paths)
-            logger.info(f"\n<cyan>first: {added_files=}</cyan>")  # TODO: remove line
-            added_files = added_files.intersection(relative_untracked_files_paths)  # TODO: remove
-            logger.info(f"\n<cyan>second: {added_files=}</cyan>")  # TODO: remove line
-
+            modified_files = modified_files.union(relative_untracked_files_paths)
+            # added_files = set(added_files).union(relative_untracked_files_paths)
+            logger.info(f"<cyan>\n{modified_files=} {added_files=} {renamed_files=}</cyan>")  # TODO: remove line
 
         return modified_files, added_files, renamed_files
 

--- a/demisto_sdk/commands/validate/initializer.py
+++ b/demisto_sdk/commands/validate/initializer.py
@@ -263,7 +263,7 @@ class Initializer:
                 "\n<cyan>CONTRIB_BRANCH environment variable found, running validate in contribution flow "
                 "on files staged by Utils/update_contribution_pack_in_base_branch.py (Infra repository)</cyan>"
             )
-            logger.info("ITAMAR TEST 1")
+            logger.info("\n<cyan>ITAMAR TEST 1</cyan>")
             # Open contribution_files_paths.txt created in Utils/update_contribution_pack_in_base_branch.py (Infra) and read file paths
             relative_untracked_files_paths: Set[Path] = set()
             with open(

--- a/demisto_sdk/commands/validate/initializer.py
+++ b/demisto_sdk/commands/validate/initializer.py
@@ -252,32 +252,32 @@ class Initializer:
             debug=True,
             get_only_current_file_names=False,
         )
-        if os.getenv("CONTRIB_BRANCH"):
-            """
-            If this command runs on a build triggered by an external contribution PR,
-            the relevant modified files would have an "untracked" status in git.
-            The following code segment retrieves all relevant untracked files that were changed in the external contribution PR
-            See CIAC-10968 for more info.
-            """
-            logger.info(
-                "\n<cyan>CONTRIB_BRANCH environment variable found, running validate in contribution flow "
-                "on files staged by Utils/update_contribution_pack_in_base_branch.py (Infra repository)</cyan>"
-            )
-            logger.info(f"\n{modified_files=} {added_files=} {renamed_files=}")  # TODO: remove line
-            # Open contribution_files_paths.txt created in Utils/update_contribution_pack_in_base_branch.py (Infra) and read file paths
-            relative_untracked_files_paths: Set[Path] = set()
-            with open(
-                "contribution_files_relative_paths.txt", "r"
-            ) as contribution_file:
-                for single_line in contribution_file:
-                    clean_line: str = single_line.rstrip("\n")
-                    relative_untracked_files_paths.add(Path(clean_line))
-            logger.info(
-                f"\n######## - Added untracked:\n{relative_untracked_files_paths}"
-            )
-            # modified_files = modified_files.union(relative_untracked_files_paths)
-            added_files = set(added_files).union(relative_untracked_files_paths)
-            logger.info(f"<cyan>\n{modified_files=} {added_files=} {renamed_files=}</cyan>")  # TODO: remove line
+        # if os.getenv("CONTRIB_BRANCH"):
+        #     """
+        #     If this command runs on a build triggered by an external contribution PR,
+        #     the relevant modified files would have an "untracked" status in git.
+        #     The following code segment retrieves all relevant untracked files that were changed in the external contribution PR
+        #     See CIAC-10968 for more info.
+        #     """
+        #     logger.info(
+        #         "\n<cyan>CONTRIB_BRANCH environment variable found, running validate in contribution flow "
+        #         "on files staged by Utils/update_contribution_pack_in_base_branch.py (Infra repository)</cyan>"
+        #     )
+        #     logger.info(f"\n{modified_files=} {added_files=} {renamed_files=}")  # TODO: remove line
+        #     # Open contribution_files_paths.txt created in Utils/update_contribution_pack_in_base_branch.py (Infra) and read file paths
+        #     relative_untracked_files_paths: Set[Path] = set()
+        #     with open(
+        #         "contribution_files_relative_paths.txt", "r"
+        #     ) as contribution_file:
+        #         for single_line in contribution_file:
+        #             clean_line: str = single_line.rstrip("\n")
+        #             relative_untracked_files_paths.add(Path(clean_line))
+        #     logger.info(
+        #         f"\n######## - Added untracked:\n{relative_untracked_files_paths}"
+        #     )
+        #     # modified_files = modified_files.union(relative_untracked_files_paths)
+        #     added_files = set(added_files).union(relative_untracked_files_paths)
+        #     logger.info(f"<cyan>\n{modified_files=} {added_files=} {renamed_files=}</cyan>")  # TODO: remove line
 
         return modified_files, added_files, renamed_files
 

--- a/demisto_sdk/commands/validate/initializer.py
+++ b/demisto_sdk/commands/validate/initializer.py
@@ -269,41 +269,12 @@ class Initializer:
 
         with open("contribution_files_relative_paths.txt", "r") as contribution_file:
             contribution_files_relative_paths_count_lines = sum(1 for line in contribution_file if line.strip())
-        logger.info(f"{contribution_files_relative_paths_count_lines=}")
+
         if contribution_files_relative_paths_count_lines != (
                 len(modified_files) + len(added_files) + len(renamed_files)):
             logger.info("The number of fetched files does not match the number of files in the "
                         "contribution_files_relative_paths.txt file. This indicates that there are untracked files.")
             raise ValueError("Error: Mismatch in the number of files. Unable to proceed.")
-
-        # add len(txt file) == sum[len(add,modi,rename)] -> raise + add doc
-
-        # if os.getenv("CONTRIB_BRANCH"):
-        #     """
-        #     If this command runs on a build triggered by an external contribution PR,
-        #     the relevant modified files would have an "untracked" status in git.
-        #     The following code segment retrieves all relevant untracked files that were changed in the external contribution PR
-        #     See CIAC-10968 for more info.
-        #     """
-        #     logger.info(
-        #         "\n<cyan>CONTRIB_BRANCH environment variable found, running validate in contribution flow "
-        #         "on files staged by Utils/update_contribution_pack_in_base_branch.py (Infra repository)</cyan>"
-        #     )
-        #     logger.info(f"\n{modified_files=} {added_files=} {renamed_files=}")  # TODO: remove line
-        #     # Open contribution_files_paths.txt created in Utils/update_contribution_pack_in_base_branch.py (Infra) and read file paths
-        #     relative_untracked_files_paths: Set[Path] = set()
-        #     with open(
-        #         "contribution_files_relative_paths.txt", "r"
-        #     ) as contribution_file:
-        #         for single_line in contribution_file:
-        #             clean_line: str = single_line.rstrip("\n")
-        #             relative_untracked_files_paths.add(Path(clean_line))
-        #     logger.info(
-        #         f"\n######## - Added untracked:\n{relative_untracked_files_paths}"
-        #     )
-        #     # modified_files = modified_files.union(relative_untracked_files_paths)
-        #     added_files = set(added_files).union(relative_untracked_files_paths)
-        #     logger.info(f"<cyan>\n{modified_files=} {added_files=} {renamed_files=}</cyan>")  # TODO: remove line
 
         return modified_files, added_files, renamed_files
 

--- a/demisto_sdk/commands/validate/initializer.py
+++ b/demisto_sdk/commands/validate/initializer.py
@@ -263,12 +263,13 @@ class Initializer:
                 "\n<cyan>CONTRIB_BRANCH environment variable found, running validate in contribution flow "
                 "on files staged by Utils/update_contribution_pack_in_base_branch.py (Infra repository)</cyan>"
             )
-            logger.info(f"\n{modified_files=} {added_files=} {renamed_files=}")
+            logger.info(f"\n{modified_files=} {added_files=} {renamed_files=}")  # TODO: remove line
             # Open contribution_files_paths.txt created in Utils/update_contribution_pack_in_base_branch.py (Infra) and read file paths
             relative_untracked_files_paths: Set[Path] = set()
             with open(
                 "contribution_files_relative_paths.txt", "r"
             ) as contribution_file:
+                logger.info(f"\n{contribution_file=}")  # TODO: remove line
                 for single_line in contribution_file:
                     clean_line: str = single_line.rstrip("\n")
                     relative_untracked_files_paths.add(Path(clean_line))

--- a/demisto_sdk/commands/validate/initializer.py
+++ b/demisto_sdk/commands/validate/initializer.py
@@ -269,7 +269,7 @@ class Initializer:
 
         with open("contribution_files_relative_paths.txt", "r") as contribution_file:
             contribution_files_relative_paths_count_lines = sum(1 for line in contribution_file if line.strip())
-
+        logger.info(f"{contribution_files_relative_paths_count_lines=}")
         if contribution_files_relative_paths_count_lines != (
                 len(modified_files) + len(added_files) + len(renamed_files)):
             logger.info("The number of fetched files does not match the number of files in the "

--- a/demisto_sdk/commands/validate/initializer.py
+++ b/demisto_sdk/commands/validate/initializer.py
@@ -263,6 +263,7 @@ class Initializer:
                 "\n<cyan>CONTRIB_BRANCH environment variable found, running validate in contribution flow "
                 "on files staged by Utils/update_contribution_pack_in_base_branch.py (Infra repository)</cyan>"
             )
+            logger.info("ITAMAR TEST 1")
             # Open contribution_files_paths.txt created in Utils/update_contribution_pack_in_base_branch.py (Infra) and read file paths
             relative_untracked_files_paths: Set[Path] = set()
             with open(

--- a/demisto_sdk/commands/validate/initializer.py
+++ b/demisto_sdk/commands/validate/initializer.py
@@ -264,22 +264,22 @@ class Initializer:
         it raises a ValueError to halt execution due to a mismatch in file counts.
         See CIAC-12482 for more info.
         """
+        if os.getenv("CONTRIB_BRANCH"):
+            with open("contribution_files_relative_paths.txt", "r") as contribution_file:
+                contribution_files_relative_paths_count_lines = sum(
+                    1 for line in contribution_file if line.strip()
+                )
 
-        with open("contribution_files_relative_paths.txt", "r") as contribution_file:
-            contribution_files_relative_paths_count_lines = sum(
-                1 for line in contribution_file if line.strip()
-            )
-
-        if contribution_files_relative_paths_count_lines != (
-            len(modified_files) + len(added_files) + len(renamed_files)
-        ):
-            logger.info(
-                "The number of fetched files does not match the number of files in the "
-                "contribution_files_relative_paths.txt file. This indicates that there are untracked files."
-            )
-            raise ValueError(
-                "Error: Mismatch in the number of files. Unable to proceed."
-            )
+            if contribution_files_relative_paths_count_lines != (
+                len(modified_files) + len(added_files) + len(renamed_files)
+            ):
+                logger.info(
+                    "The number of fetched files does not match the number of files in the "
+                    "contribution_files_relative_paths.txt file. This indicates that there are untracked files."
+                )
+                raise ValueError(
+                    "Error: Mismatch in the number of files. Unable to proceed."
+                )
 
         return modified_files, added_files, renamed_files
 

--- a/demisto_sdk/commands/validate/initializer.py
+++ b/demisto_sdk/commands/validate/initializer.py
@@ -253,8 +253,6 @@ class Initializer:
             get_only_current_file_names=False,
         )
 
-        logger.info(f"\n{modified_files=}\n{added_files=}\n{renamed_files=}")
-
         """
         If this command runs on a build triggered by an external contribution PR,
         the relevant modified files may have an "untracked" status in git.

--- a/demisto_sdk/commands/validate/initializer.py
+++ b/demisto_sdk/commands/validate/initializer.py
@@ -275,8 +275,8 @@ class Initializer:
             logger.info(
                 f"\n######## - Added untracked:\n{relative_untracked_files_paths}"
             )
-            modified_files = modified_files.union(relative_untracked_files_paths)
-            # added_files = set(added_files).union(relative_untracked_files_paths)
+            # modified_files = modified_files.union(relative_untracked_files_paths)
+            added_files = set(added_files).union(relative_untracked_files_paths)
             logger.info(f"<cyan>\n{modified_files=} {added_files=} {renamed_files=}</cyan>")  # TODO: remove line
 
         return modified_files, added_files, renamed_files

--- a/demisto_sdk/commands/validate/initializer.py
+++ b/demisto_sdk/commands/validate/initializer.py
@@ -275,7 +275,9 @@ class Initializer:
             with open(
                 "contribution_files_relative_paths.txt", "r"
             ) as contribution_file:
-                contribution_files_relative_paths_count_lines = len(contribution_file.readlines())
+                contribution_files_relative_paths_count_lines = len(
+                    contribution_file.readlines()
+                )
 
             affected_files = modified_files.union(added_files, renamed_files)
             if contribution_files_relative_paths_count_lines != len(affected_files):

--- a/demisto_sdk/commands/validate/initializer.py
+++ b/demisto_sdk/commands/validate/initializer.py
@@ -252,6 +252,7 @@ class Initializer:
             debug=True,
             get_only_current_file_names=False,
         )
+        logger.info(f"\n{modified_files=} {added_files=} {renamed_files=}")  # TODO: remove line
         # if os.getenv("CONTRIB_BRANCH"):
         #     """
         #     If this command runs on a build triggered by an external contribution PR,

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -857,9 +857,9 @@ def test_get_unfiltered_changed_files_from_git_case_untracked_files_identify(moc
     """
     initializer = Initializer()
     initializer.validate_git_installed()
-    mocker.patch.object(GitUtil, "modified_files", return_value={})
-    mocker.patch.object(GitUtil, "added_files", return_value={})
-    mocker.patch.object(GitUtil, "renamed_files", return_value={})
+    mocker.patch.object(GitUtil, "modified_files", return_value=set())
+    mocker.patch.object(GitUtil, "added_files", return_value=set())
+    mocker.patch.object(GitUtil, "renamed_files", return_value=set())
     mocker.patch.dict(os.environ, {"CONTRIB_BRANCH": "true"})
     with open("contribution_files_relative_paths.txt", "w") as file:
         temp_file = Path("contribution_files_relative_paths.txt")

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 from pathlib import Path
 from typing import Dict, List, Optional, Set
@@ -859,6 +860,7 @@ def test_get_unfiltered_changed_files_from_git_case_untracked_files_identify(moc
     mocker.patch.object(GitUtil, "modified_files", return_value={})
     mocker.patch.object(GitUtil, "added_files", return_value={})
     mocker.patch.object(GitUtil, "renamed_files", return_value={})
+    mocker.patch.dict(os.environ, {"CONTRIB_BRANCH": "true"})
     with open("contribution_files_relative_paths.txt", "w") as file:
         temp_file = Path("contribution_files_relative_paths.txt")
         file.write("untrack_file")

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -867,7 +867,7 @@ def test_get_unfiltered_changed_files_from_git_case_untracked_files_identify(moc
     try:
         _, _, _ = initializer.get_unfiltered_changed_files_from_git()
     except ValueError as e:
-        assert str(e) == "Error: Mismatch in the number of files. Unable to proceed."
+        assert "Error: Mismatch in the number of files." in str(e)
     finally:
         if Path.exists(temp_file):
             Path.unlink(temp_file)

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -1,4 +1,3 @@
-import os
 import tempfile
 from pathlib import Path
 from typing import Dict, List, Optional, Set
@@ -844,6 +843,17 @@ def test_description():
 
 
 def test_get_unfiltered_changed_files_from_git_case_untracked_files_identify(mocker):
+    """
+    Given:
+        An Initializer instance where the fetched git files are not equal to the amount of files written
+         in the contribution_files_relative_paths file.
+    When:
+        Calling get_unfiltered_changed_files_from_git in a scenario where modified_files, added_files,
+         and rename_files are empty, and the contribution_files_relative_paths file contains some file names.
+    Then:
+        Ensure that the error is raised and the function does not return modified_files,
+         added_files, or rename_files.
+    """
     initializer = Initializer()
     initializer.validate_git_installed()
     mocker.patch.object(GitUtil, "modified_files", return_value={})
@@ -851,7 +861,7 @@ def test_get_unfiltered_changed_files_from_git_case_untracked_files_identify(moc
     mocker.patch.object(GitUtil, "renamed_files", return_value={})
     with open("contribution_files_relative_paths.txt", "w") as file:
         temp_file = Path("contribution_files_relative_paths.txt")
-        file.write(f"'untrack_file'")
+        file.write("untrack_file")
     try:
         _, _, _ = initializer.get_unfiltered_changed_files_from_git()
     except ValueError as e:

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -905,53 +905,53 @@ def test_description():
         "No modified files, invalid and valid untracked files only",
     ],
 )
-def test_get_unfiltered_changed_files_from_git_in_external_pr_use_case(
-    mocker,
-    untracked_files,
-    modified_files,
-    untracked_files_in_content,
-    list_of_file_paths,
-    expected_output,
-):
-    """
-    This UT verifies changes made to validate command to support collection of
-    untracked files when running the build on an external contribution PR.
-    The UT mocks reading form the contribution_files_relative_paths.txt created
-    in Utils/update_contribution_pack_in_base_branch.py (Infra) as part of this flow.
-
-    Given:
-        - A content build is running on external contribution PR, meaning:
-            - `CONTRIB_BRANCH` environment variable exists.
-            - validate command is running in context of an external contribution PR
-    When:
-        Case 1: All untracked files have a "Pack/..." path, regular modified files are also exist.
-        Case 2: Not all untracked files have a "Pack/..." path, irrelevant untracked files exist which validate shouldn't run on.
-                Regular modified files are also exist.
-        Case 3: Not all untracked files have a "Pack/..." path, irrelevant untracked files also exist, regular modified files are also exist, No modified files.
-
-    Then:
-        - Collect all files within "Packs/" path and run the pre commit on them along with regular modified files if exist.
-    """
-    initializer = Initializer()
-    initializer.validate_git_installed()
-    mocker.patch.object(GitUtil, "modified_files", return_value=modified_files)
-    mocker.patch.dict(os.environ, {"CONTRIB_BRANCH": "true"})
-    mocker.patch.object(GitUtil, "added_files", return_value={})
-    mocker.patch.object(GitUtil, "renamed_files", return_value={})
-    mocker.patch(
-        "git.repo.base.Repo._get_untracked_files", return_value=untracked_files
-    )
-
-    with open("contribution_files_relative_paths.txt", "w") as file:
-        temp_file = Path("contribution_files_relative_paths.txt")
-        for line in list_of_file_paths:
-            file.write(f"{line}\n")
-
-    output = initializer.get_unfiltered_changed_files_from_git()
-    assert output[1] == expected_output
-
-    if Path.exists(temp_file):
-        Path.unlink(temp_file)
+# def test_get_unfiltered_changed_files_from_git_in_external_pr_use_case(
+#     mocker,
+#     untracked_files,
+#     modified_files,
+#     untracked_files_in_content,
+#     list_of_file_paths,
+#     expected_output,
+# ):
+#     """
+#     This UT verifies changes made to validate command to support collection of
+#     untracked files when running the build on an external contribution PR.
+#     The UT mocks reading form the contribution_files_relative_paths.txt created
+#     in Utils/update_contribution_pack_in_base_branch.py (Infra) as part of this flow.
+#
+#     Given:
+#         - A content build is running on external contribution PR, meaning:
+#             - `CONTRIB_BRANCH` environment variable exists.
+#             - validate command is running in context of an external contribution PR
+#     When:
+#         Case 1: All untracked files have a "Pack/..." path, regular modified files are also exist.
+#         Case 2: Not all untracked files have a "Pack/..." path, irrelevant untracked files exist which validate shouldn't run on.
+#                 Regular modified files are also exist.
+#         Case 3: Not all untracked files have a "Pack/..." path, irrelevant untracked files also exist, regular modified files are also exist, No modified files.
+#
+#     Then:
+#         - Collect all files within "Packs/" path and run the pre commit on them along with regular modified files if exist.
+#     """
+#     initializer = Initializer()
+#     initializer.validate_git_installed()
+#     mocker.patch.object(GitUtil, "modified_files", return_value=modified_files)
+#     mocker.patch.dict(os.environ, {"CONTRIB_BRANCH": "true"})
+#     mocker.patch.object(GitUtil, "added_files", return_value={})
+#     mocker.patch.object(GitUtil, "renamed_files", return_value={})
+#     mocker.patch(
+#         "git.repo.base.Repo._get_untracked_files", return_value=untracked_files
+#     )
+#
+#     with open("contribution_files_relative_paths.txt", "w") as file:
+#         temp_file = Path("contribution_files_relative_paths.txt")
+#         for line in list_of_file_paths:
+#             file.write(f"{line}\n")
+#
+#     output = initializer.get_unfiltered_changed_files_from_git()
+#     assert output[1] == expected_output
+#
+#     if Path.exists(temp_file):
+#         Path.unlink(temp_file)
 
 
 def test_ignored_with_run_all(mocker):

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -844,15 +844,21 @@ def test_description():
 
 
 def test_get_unfiltered_changed_files_from_git_case_untracked_files_identify(mocker):
-    from ..initializer import Initializer
+    initializer = Initializer()
+    initializer.validate_git_installed()
     mocker.patch.object(GitUtil, "modified_files", return_value={})
     mocker.patch.object(GitUtil, "added_files", return_value={})
     mocker.patch.object(GitUtil, "renamed_files", return_value={})
-    mocker.patch.object(Initializer, "open", return_value='untrack_file')
+    with open("contribution_files_relative_paths.txt", "w") as file:
+        temp_file = Path("contribution_files_relative_paths.txt")
+        file.write(f"'untrack_file'")
     try:
-        _, _, _ = Initializer.get_unfiltered_changed_files_from_git(None)
+        _, _, _ = initializer.get_unfiltered_changed_files_from_git()
     except ValueError as e:
         assert str(e) == "Error: Mismatch in the number of files. Unable to proceed."
+    finally:
+        if Path.exists(temp_file):
+            Path.unlink(temp_file)
 
 
 def test_ignored_with_run_all(mocker):

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -849,7 +849,6 @@ def test_get_unfiltered_changed_files_from_git_case_untracked_files_identify(moc
     mocker.patch.object(GitUtil, "added_files", return_value={})
     mocker.patch.object(GitUtil, "renamed_files", return_value={})
     mocker.patch.object(Initializer, "open", return_value='untrack_file')
-    Initializer.get_unfiltered_changed_files_from_git(None)
     try:
         _, _, _ = Initializer.get_unfiltered_changed_files_from_git(None)
     except ValueError as e:

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -843,115 +843,17 @@ def test_description():
     ]
 
 
-@pytest.mark.parametrize(
-    "untracked_files, modified_files, untracked_files_in_content, list_of_file_paths ,expected_output",
-    [
-        (
-            ["Packs/untracked.txt"],
-            set([Path("Packs/modified.txt")]),
-            set([Path("Packs/untracked.txt")]),
-            ["Packs/modified.txt", "Packs/untracked.txt"],
-            set([Path("Packs/modified.txt"), Path("Packs/untracked.txt")]),
-        ),
-        (
-            [
-                "Packs/untracked_1.txt",
-                "Packs/untracked_2.txt",
-                "invalid/path/untracked.txt",
-                "another/invalid/path/untracked.txt",
-            ],
-            set([Path("Packs/modified.txt")]),
-            set(
-                [
-                    Path("Packs/untracked_1.txt"),
-                    Path("Packs/untracked_2.txt"),
-                ]
-            ),
-            ["Packs/modified.txt", "Packs/untracked_1.txt", "Packs/untracked_2.txt"],
-            set(
-                [
-                    Path("Packs/modified.txt"),
-                    Path("Packs/untracked_1.txt"),
-                    Path("Packs/untracked_2.txt"),
-                ]
-            ),
-        ),
-        (
-            [
-                "Packs/untracked_1.txt",
-                "Packs/untracked_2.txt",
-                "invalid/path/untracked.txt",
-                "another/invalid/path/untracked.txt",
-            ],
-            set(),
-            set(
-                [
-                    Path("Packs/untracked_1.txt"),
-                    Path("Packs/untracked_2.txt"),
-                ]
-            ),
-            ["Packs/untracked_1.txt", "Packs/untracked_2.txt"],
-            set(
-                [
-                    Path("Packs/untracked_1.txt"),
-                    Path("Packs/untracked_2.txt"),
-                ]
-            ),
-        ),
-    ],
-    ids=[
-        "Valid untracked and modified files",
-        "Invalid untracked, valid untracked and modified files",
-        "No modified files, invalid and valid untracked files only",
-    ],
-)
-# def test_get_unfiltered_changed_files_from_git_in_external_pr_use_case(
-#     mocker,
-#     untracked_files,
-#     modified_files,
-#     untracked_files_in_content,
-#     list_of_file_paths,
-#     expected_output,
-# ):
-#     """
-#     This UT verifies changes made to validate command to support collection of
-#     untracked files when running the build on an external contribution PR.
-#     The UT mocks reading form the contribution_files_relative_paths.txt created
-#     in Utils/update_contribution_pack_in_base_branch.py (Infra) as part of this flow.
-#
-#     Given:
-#         - A content build is running on external contribution PR, meaning:
-#             - `CONTRIB_BRANCH` environment variable exists.
-#             - validate command is running in context of an external contribution PR
-#     When:
-#         Case 1: All untracked files have a "Pack/..." path, regular modified files are also exist.
-#         Case 2: Not all untracked files have a "Pack/..." path, irrelevant untracked files exist which validate shouldn't run on.
-#                 Regular modified files are also exist.
-#         Case 3: Not all untracked files have a "Pack/..." path, irrelevant untracked files also exist, regular modified files are also exist, No modified files.
-#
-#     Then:
-#         - Collect all files within "Packs/" path and run the pre commit on them along with regular modified files if exist.
-#     """
-#     initializer = Initializer()
-#     initializer.validate_git_installed()
-#     mocker.patch.object(GitUtil, "modified_files", return_value=modified_files)
-#     mocker.patch.dict(os.environ, {"CONTRIB_BRANCH": "true"})
-#     mocker.patch.object(GitUtil, "added_files", return_value={})
-#     mocker.patch.object(GitUtil, "renamed_files", return_value={})
-#     mocker.patch(
-#         "git.repo.base.Repo._get_untracked_files", return_value=untracked_files
-#     )
-#
-#     with open("contribution_files_relative_paths.txt", "w") as file:
-#         temp_file = Path("contribution_files_relative_paths.txt")
-#         for line in list_of_file_paths:
-#             file.write(f"{line}\n")
-#
-#     output = initializer.get_unfiltered_changed_files_from_git()
-#     assert output[1] == expected_output
-#
-#     if Path.exists(temp_file):
-#         Path.unlink(temp_file)
+def test_get_unfiltered_changed_files_from_git_case_untracked_files_identify(mocker):
+    from ..initializer import Initializer
+    mocker.patch.object(GitUtil, "modified_files", return_value={})
+    mocker.patch.object(GitUtil, "added_files", return_value={})
+    mocker.patch.object(GitUtil, "renamed_files", return_value={})
+    mocker.patch.object(Initializer, "open", return_value='untrack_file')
+    Initializer.get_unfiltered_changed_files_from_git(None)
+    try:
+        _, _, _ = Initializer.get_unfiltered_changed_files_from_git(None)
+    except ValueError as e:
+        assert str(e) == "Error: Mismatch in the number of files. Unable to proceed."
 
 
 def test_ignored_with_run_all(mocker):


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: [CIAC-12482](https://jira-dc.paloaltonetworks.com/browse/CIAC-12482)

## Description
rn108 used to failed due to mismatch classifying git statuses of files.
The fix ensures that the number of fetched files matches the number of files in the contribution_files_relative_paths.txt file. If a discrepancy is found, indicating untracked files, it halt execution due to a mismatch in file counts.