### PR TITLE
Platform MP: update schemas used by old validator

### DIFF
--- a/demisto_sdk/commands/common/schemas/indicatorfield.yml
+++ b/demisto_sdk/commands/common/schemas/indicatorfield.yml
@@ -90,7 +90,7 @@ mapping:
     type: seq
     sequence:
     - type: str
-      enum: ['xsoar', 'marketplacev2', 'xpanse', 'xsoar_saas', 'xsoar_on_prem']
+      enum: ['xsoar', 'marketplacev2', 'xpanse', 'xsoar_saas', 'xsoar_on_prem', 'platform']
   name:xsoar:
     type: str
   name:marketplacev2:

--- a/demisto_sdk/commands/common/schemas/integration.yml
+++ b/demisto_sdk/commands/common/schemas/integration.yml
@@ -178,7 +178,7 @@ mapping:
     type: seq
     sequence:
     - type: str
-      enum: ['xsoar', 'marketplacev2', 'xpanse', 'xsoar_saas', 'xsoar_on_prem']
+      enum: ['xsoar', 'marketplacev2', 'xpanse', 'xsoar_saas', 'xsoar_on_prem', 'platform']
   hybrid:
     type: bool
 

--- a/demisto_sdk/commands/common/schemas/layoutscontainer.yml
+++ b/demisto_sdk/commands/common/schemas/layoutscontainer.yml
@@ -28,7 +28,7 @@ mapping:
     type: seq
     sequence:
     - type: str
-      enum: ['xsoar', 'marketplacev2', 'xpanse', 'xsoar_saas', 'xsoar_on_prem']
+      enum: ['xsoar', 'marketplacev2', 'xpanse', 'xsoar_saas', 'xsoar_on_prem', 'platform']
   edit:
     type: map
     mapping:

--- a/demisto_sdk/commands/common/schemas/playbook.yml
+++ b/demisto_sdk/commands/common/schemas/playbook.yml
@@ -404,7 +404,7 @@ mapping:
     type: seq
     sequence:
     - type: str
-      enum: ['xsoar', 'marketplacev2', 'xpanse', 'xsoar_saas', 'xsoar_on_prem']
+      enum: ['xsoar', 'marketplacev2', 'xpanse', 'xsoar_saas', 'xsoar_on_prem', 'platform']
 
 
 # playbook->tasks

--- a/demisto_sdk/commands/common/schemas/releasenotesconfig.yml
+++ b/demisto_sdk/commands/common/schemas/releasenotesconfig.yml
@@ -11,4 +11,4 @@ mapping:
     required: false
     sequence:
     - type: str
-      enum: ['xsoar', 'marketplacev2', 'xpanse', 'xsoar_saas', 'xsoar_on_prem']
+      enum: ['xsoar', 'marketplacev2', 'xpanse', 'xsoar_saas', 'xsoar_on_prem', 'platform']

--- a/demisto_sdk/commands/common/schemas/reputation.yml
+++ b/demisto_sdk/commands/common/schemas/reputation.yml
@@ -72,7 +72,7 @@ mapping:
     type: seq
     sequence:
     - type: str
-      enum: ['xsoar', 'marketplacev2', 'xpanse', 'xsoar_saas', 'xsoar_on_prem']
+      enum: ['xsoar', 'marketplacev2', 'xpanse', 'xsoar_saas', 'xsoar_on_prem', 'platform']
   id:xsoar:
     type: str
   id:marketplacev2:

--- a/demisto_sdk/commands/common/schemas/script.yml
+++ b/demisto_sdk/commands/common/schemas/script.yml
@@ -120,7 +120,7 @@ mapping:
     type: seq
     sequence:
     - type: str
-      enum: ['xsoar', 'marketplacev2', 'xpanse', 'xsoar_saas', 'xsoar_on_prem']
+      enum: ['xsoar', 'marketplacev2', 'xpanse', 'xsoar_saas', 'xsoar_on_prem', 'platform']
   skipprepare:
     type: seq
     sequence:


### PR DESCRIPTION

## Related Issues
fixes:https://jira-dc.paloaltonetworks.com/browse/CIAC-12972

## Description
currently, [the build will fail](https://gitlab.xdr.pan.local/xdr/cortex-content/content/-/jobs/16733835/raw#L909) on content items with the `platform` as marketpklace
because old validator used the schemas.