### PR TITLE
Optimize disabling of mirroring settings in IntegrationScriptUnifier to avoid adding new fields

### DIFF
--- a/.changelog/4849.yml
+++ b/.changelog/4849.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fix disabling of mirroring settings in IntegrationScriptUnifier to avoid adding new fields
+  type: fix
+pr_number: 4849

--- a/.changelog/4849.yml
+++ b/.changelog/4849.yml
@@ -1,4 +1,4 @@
 changes:
-- description: Fix disabling of mirroring settings in IntegrationScriptUnifier to avoid adding new fields
+- description: Optimize disabling of mirroring settings in IntegrationScriptUnifier to avoid adding new fields to the unified integration YML.
   type: fix
 pr_number: 4849

--- a/demisto_sdk/commands/prepare_content/integration_script_unifier.py
+++ b/demisto_sdk/commands/prepare_content/integration_script_unifier.py
@@ -209,9 +209,10 @@ class IntegrationScriptUnifier(Unifier):
         logger.debug(
             f"Disabling mirroring settings in {name} for marketplace: {marketplace.value}"
         )
-        data["script"]["ismappable"] = False
-        data["script"]["isremotesyncin"] = False
-        data["script"]["isremotesyncout"] = False
+        mirroring_setting_fields = ["ismappable", "isremotesyncin", "isremotesyncout"]
+        for setting_field in mirroring_setting_fields:
+            if data["script"].get(setting_field) is True:
+                data["script"][setting_field] = False
 
     @staticmethod
     def add_custom_section(


### PR DESCRIPTION
## Related Issues
fixes:

## Description
Optimize disabling of mirroring in IntegrationScriptUnifier to avoid adding new fields to the Integration YML