### PR TITLE
checking if parent folder exists before iterating on it

### DIFF
--- a/.changelog/4855.yml
+++ b/.changelog/4855.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where pre-commit failed on deleted content folders.
+  type: fix
+pr_number: 4855

--- a/demisto_sdk/commands/pre_commit/pre_commit_command.py
+++ b/demisto_sdk/commands/pre_commit/pre_commit_command.py
@@ -684,7 +684,9 @@ def add_related_files(file: Path) -> Set[Path]:
             else PS1_TEST_FILE_SUFFIX
         )
 
-        test_files = [
+test_files = []
+if file.parent.exists():
+    test_files = [_file for _file in file.parent.iterdir() if _file.name.endswith(test_file_suffix)]
             _file
             for _file in file.parent.iterdir()
             if file.parent.exists and _file.name.endswith(test_file_suffix)

--- a/demisto_sdk/commands/pre_commit/pre_commit_command.py
+++ b/demisto_sdk/commands/pre_commit/pre_commit_command.py
@@ -684,13 +684,9 @@ def add_related_files(file: Path) -> Set[Path]:
             else PS1_TEST_FILE_SUFFIX
         )
 
-test_files = []
-if file.parent.exists():
-    test_files = [_file for _file in file.parent.iterdir() if _file.name.endswith(test_file_suffix)]
-            _file
-            for _file in file.parent.iterdir()
-            if file.parent.exists and _file.name.endswith(test_file_suffix)
-        ]
+    test_files = []
+    if file.parent.exists():
+        test_files = [_file for _file in file.parent.iterdir() if _file.name.endswith(test_file_suffix)]
         files_to_run.update(test_files)
     return files_to_run
 

--- a/demisto_sdk/commands/pre_commit/pre_commit_command.py
+++ b/demisto_sdk/commands/pre_commit/pre_commit_command.py
@@ -668,26 +668,26 @@ def add_related_files(file: Path) -> Set[Path]:
     Returns:
         Set[Path]: The set of related files.
     """
-    files_to_run = set()
-    files_to_run.add(file)
-    if ".yml" in (file.suffix for file in files_to_run):
+    files_to_run = {file}
+    if ".yml" in file.suffix:
         py_file_path = file.with_suffix(".py")
         if py_file_path.exists():
             files_to_run.add(py_file_path)
 
     # Identifying test files by their suffix.
-    if {".py", ".ps1"}.intersection({file.suffix for file in files_to_run}):
-        test_files = []
-        test_file_suffix = (
-            PY_TEST_FILE_SUFFIX
-            if ".py" in (file.suffix for file in files_to_run)
-            else PS1_TEST_FILE_SUFFIX
-        )
+    if not {".py", ".ps1"}.intersection({file.suffix for file in files_to_run}):
+        return files_to_run
 
+    test_file_suffix = (
+        PY_TEST_FILE_SUFFIX
+        if ".py" in (file.suffix for file in files_to_run)
+        else PS1_TEST_FILE_SUFFIX
+    )
     test_files = []
     if file.parent.exists():
         test_files = [_file for _file in file.parent.iterdir() if _file.name.endswith(test_file_suffix)]
         files_to_run.update(test_files)
+
     return files_to_run
 
 

--- a/demisto_sdk/commands/pre_commit/pre_commit_command.py
+++ b/demisto_sdk/commands/pre_commit/pre_commit_command.py
@@ -687,7 +687,7 @@ def add_related_files(file: Path) -> Set[Path]:
         test_files = [
             _file
             for _file in file.parent.iterdir()
-            if _file.name.endswith(test_file_suffix)
+            if file.parent.exists and _file.name.endswith(test_file_suffix)
         ]
         files_to_run.update(test_files)
     return files_to_run

--- a/demisto_sdk/commands/pre_commit/pre_commit_command.py
+++ b/demisto_sdk/commands/pre_commit/pre_commit_command.py
@@ -685,7 +685,11 @@ def add_related_files(file: Path) -> Set[Path]:
     )
     test_files = []
     if file.parent.exists():
-        test_files = [_file for _file in file.parent.iterdir() if _file.name.endswith(test_file_suffix)]
+        test_files = [
+            _file
+            for _file in file.parent.iterdir()
+            if _file.name.endswith(test_file_suffix)
+        ]
         files_to_run.update(test_files)
 
     return files_to_run


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-13074

## Description
When deleting a folder with a file inside it in content.
When we are collecting test for the deleted file it try to iterate over the files in the parent (also deleted folder). 

Failing with file not found error due to the fact the folder does not exists any more. 