### PR TITLE
Fix NEO4J memory limitation issue

### DIFF
--- a/.changelog/4899.yml
+++ b/.changelog/4899.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Increased Content Graph memory allocation to 3GB to support heavier queries.
+  type: fix
+pr_number: 4899

--- a/demisto_sdk/commands/content_graph/neo4j_service.py
+++ b/demisto_sdk/commands/content_graph/neo4j_service.py
@@ -118,7 +118,7 @@ def _docker_start():
             "NEO4J_dbms_security_procedures_allowlist": "apoc.*",
             "NEO4J_dbms_connector_http_advertised__address": "127.0.0.1:7474",
             "NEO4J_dbms_connector_bolt_advertised__address": "127.0.0.1:7687",
-            "NEO4J_dbms_memory_transaction_total_max": "2000m",
+            "NEO4J_dbms_memory_transaction_total_max": "3G",
         },
         healthcheck={
             "test": f"curl --fail {NEO4J_DATABASE_HTTP} || exit 1",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-13209

## Description
Since we introduced the graph dashboard, we've been running heavy queries on the Neo4j graph during the 'upload-content-graph-data-to-bigquery' step. This caused us to hit the memory limit allocated to the graph.
In this fix, I'm increasing the memory allocation from the original 2GB to 3GB by adding an additional 1GB.
