### PR TITLE
Add search_alerts_by_name and fix search_alerts_by_uuid in XsiamClient

### DIFF
--- a/.changelog/4909.yml
+++ b/.changelog/4909.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fix an issue in `XsiamClient.search_alerts_by_uuid` that caused the logic to iterate over the first 100 results only.
+  type: fix
+pr_number: 4909

--- a/.changelog/4909.yml
+++ b/.changelog/4909.yml
@@ -1,4 +1,4 @@
 changes:
-- description: Fix an issue in `XsiamClient.search_alerts_by_uuid` that caused the logic to iterate over the first 100 results only.
-  type: fix
+- description: Add a new `XsiamClient.search_alerts_by_name` method and fix an issue in the `XsiamClient.search_alerts_by_uuid` method that caused the logic to iterate over the first 100 results only.
+  type: feature
 pr_number: 4909

--- a/demisto_sdk/commands/common/clients/xsiam/xsiam_api_client.py
+++ b/demisto_sdk/commands/common/clients/xsiam/xsiam_api_client.py
@@ -257,7 +257,7 @@ class XsiamClient(XsoarSaasClient):
         """
         logger.debug(
             f"Searching alerts by filters: {filters}. "
-            f"Start offset: {search_from}, end offset: {search_to}. "
+            f"Start offset: {search_from}, end offset: {search_to}."
         )
         body = {
             "request_data": {

--- a/demisto_sdk/commands/common/clients/xsiam/xsiam_api_client.py
+++ b/demisto_sdk/commands/common/clients/xsiam/xsiam_api_client.py
@@ -1,6 +1,6 @@
 import gzip
 from pprint import pformat
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urljoin
 
 import requests
@@ -15,6 +15,7 @@ from demisto_sdk.commands.common.handlers import DEFAULT_JSON_HANDLER
 from demisto_sdk.commands.common.logger import logger
 
 json = DEFAULT_JSON_HANDLER
+GET_ALERTS_BATCH_SIZE = 100
 
 
 class XsiamClient(XsoarSaasClient):
@@ -254,6 +255,10 @@ class XsiamClient(XsoarSaasClient):
         [{field: alert_id_list, operator: in, value: [1,2,3,4]}]
         Allowed values for fields - alert_id_list, alert_source, severity, creation_time
         """
+        logger.debug(
+            f"Searching alerts by filters: {filters}. "
+            f"Start offset: {search_from}, end offset: {search_to}. "
+        )
         body = {
             "request_data": {
                 "filters": filters,
@@ -268,21 +273,42 @@ class XsiamClient(XsoarSaasClient):
         res = self._xdr_client.post(endpoint, json=body)
         return self._process_response(res, res.status_code, 200)["reply"]
 
-    def search_alerts_by_uuid(self, alert_uuids: list = None, filters: list = None):
+    def search_alerts_by_uuid(
+        self,
+        alert_uuids: Optional[list] = None,
+        filters: Optional[list] = None,
+    ) -> list[str]:
+        """Finds XSIAM alerts where the alert description ends with any of the given UUIDs.
+
+        Args:
+            alert_uuids (list | None): Optional list of UUIDs to find. Defaults to None.
+            filters (list | None): Optional list of field filters. Defaults to None.
+
+        Returns:
+            list[str]: List of found alert IDs.
+        """
         alert_uuids = alert_uuids or []
-        alert_ids: list = []
+        alert_ids: list[str] = []
+
+        # If not specified, API uses search_from = 0 and search_to = 100 by default
         res = self.search_alerts(filters=filters)
-        alerts: list = res.get("alerts")  # type: ignore
-        count: int = res.get("result_count")  # type: ignore
+        alerts: list[dict] = res.get("alerts", [])
+        cumulative_count: int = res.get("result_count", 0)  # Count of results so far
 
         while len(alerts) > 0 and len(alert_uuids) > len(alert_ids):
             for alert in alerts:
-                for uuid in alert_uuids:
-                    if alert.get("description").endswith(uuid):
-                        alert_ids.append(alert.get("alert_id"))
+                if alert.get("description", "").endswith(tuple(alert_uuids)):
+                    alert_ids.append(alert.get("alert_id", ""))
 
-            res = self.search_alerts(filters=filters, search_from=count)
-            alerts = res.get("alerts")  # type: ignore
-            count = res.get("result_count")  # type: ignore
+            search_from = cumulative_count  # Start offset
+            search_to = cumulative_count + GET_ALERTS_BATCH_SIZE  # End offset
+            # Advance start and end alert offsets for the next search batch
+            res = self.search_alerts(
+                filters=filters,
+                search_from=search_from,
+                search_to=search_to,
+            )
+            alerts = res.get("alerts", [])
+            cumulative_count += res.get("result_count", 0)
 
         return alert_ids


### PR DESCRIPTION
## Related Issues
fixes: [link to issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-13075)

## Description
Add a new `XsiamClient.search_alerts_by_name` method and fix an issue in the `XsiamClient.search_alerts_by_uuid` method that caused the logic to iterate over the first 100 results only.