### PR TITLE
Add poll_alert_state to XsiamClient

### DIFF
--- a/.changelog/4910.yml
+++ b/.changelog/4910.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Add a new `XsiamClient.poll_alert_state` method that polls a Cortex XSIAM alert until it reaches any of the expected states.
+  type: feature
+pr_number: 4910

--- a/demisto_sdk/commands/common/clients/xsiam/xsiam_api_client.py
+++ b/demisto_sdk/commands/common/clients/xsiam/xsiam_api_client.py
@@ -236,7 +236,7 @@ class XsiamClient(XsoarSaasClient):
 
         Args:
             alert_id (str): The XSIAM alert ID to poll its state.
-            expected_states (Tuple[IncidentState, ...]): The states the XSIAM alert is expected to reach.
+            expected_states (Tuple[XsiamAlertState, ...]): The states the XSIAM alert is expected to reach.
             timeout (int): The time limit in seconds to wait for the expected states, defaults to 120.
 
         Returns:

--- a/demisto_sdk/commands/common/clients/xsiam/xsiam_api_client.py
+++ b/demisto_sdk/commands/common/clients/xsiam/xsiam_api_client.py
@@ -1,6 +1,6 @@
 import gzip
 from pprint import pformat
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Tuple, Union
 from urllib.parse import urljoin
 
 import requests
@@ -10,7 +10,7 @@ from demisto_sdk.commands.common.clients.xsoar.xsoar_api_client import ServerTyp
 from demisto_sdk.commands.common.clients.xsoar_saas.xsoar_saas_api_client import (
     XsoarSaasClient,
 )
-from demisto_sdk.commands.common.constants import MarketplaceVersions
+from demisto_sdk.commands.common.constants import MarketplaceVersions, XsiamAlertState
 from demisto_sdk.commands.common.handlers import DEFAULT_JSON_HANDLER
 from demisto_sdk.commands.common.logger import logger
 
@@ -224,6 +224,28 @@ class XsiamClient(XsoarSaasClient):
             ]
         )
         return data["alerts"][0]["alert_id"]
+
+    def poll_alert_state(
+        self,
+        alert_id: str,
+        expected_states: Tuple[XsiamAlertState, ...] = (XsiamAlertState.RESOLVED,),
+        timeout: int = 120,
+    ) -> dict:
+        """
+        Polls for the state of an XSIAM alert until it matches any of the expected states or times out.
+
+        Args:
+            alert_id (str): The XSIAM alert ID to poll its state.
+            expected_states (Tuple[IncidentState, ...]): The states the XSIAM alert is expected to reach.
+            timeout (int): The time limit in seconds to wait for the expected states, defaults to 120.
+
+        Returns:
+            dict: Raw response of the XSIAM alert that reached the relevant state.
+
+        Raises:
+            PollTimeout: If the alert did not reach any of the expected states in time.
+        """
+        return self.poll_incident_state(alert_id, expected_states, timeout)
 
     def update_alert(self, alert_id: Union[str, list[str]], updated_data: dict) -> dict:
         """

--- a/demisto_sdk/commands/common/clients/xsoar/xsoar_api_client.py
+++ b/demisto_sdk/commands/common/clients/xsoar/xsoar_api_client.py
@@ -766,15 +766,18 @@ class XsoarClient:
         timeout: int = 120,
     ) -> dict:
         """
-        Polls for an XSOAR incident state
+        Polls for the state of an XSOAR incident until it matches any of the expected states or times out.
 
         Args:
-            incident_id: The XSOAR incident ID to poll its state
-            expected_states: Which states are considered to be valid for the XSOAR incident to reach
-            timeout: How long to query until the XSOAR incident reaches the expected state
+            incident_id (str): The XSOAR incident ID to poll its state.
+            expected_states (Tuple[IncidentState, ...]): The states the XSOAR incident is expected to reach.
+            timeout (int): The time limit in seconds to wait for the expected states, defaults to 120.
 
         Returns:
-            dict: raw response of the XSOAR incident that reached the relevant state.
+            dict: Raw response of the XSOAR incident that reached the relevant state.
+
+        Raises:
+            PollTimeout: If the incident did not reach any of the expected states in time.
         """
         if timeout <= 0:
             raise ValueError("timeout argument must be larger than 0")
@@ -812,7 +815,7 @@ class XsoarClient:
                 elapsed_time = int(time.time() - start_time)
 
         raise PollTimeout(
-            f"status of incident {incident_name} is {incident_status}",
+            f"The status of {incident_name} is {incident_status}",
             expected_states=expected_states,
             timeout=timeout,
         )

--- a/demisto_sdk/commands/common/clients/xsoar/xsoar_api_client.py
+++ b/demisto_sdk/commands/common/clients/xsoar/xsoar_api_client.py
@@ -29,10 +29,10 @@ from demisto_sdk.commands.common.clients.errors import (
 )
 from demisto_sdk.commands.common.constants import (
     MINIMUM_XSOAR_SAAS_VERSION,
-    IncidentState,
     InvestigationPlaybookState,
     MarketplaceVersions,
     XsiamAlertState,
+    XsoarIncidentState,
 )
 from demisto_sdk.commands.common.handlers import DEFAULT_JSON_HANDLER as json
 from demisto_sdk.commands.common.logger import logger
@@ -762,7 +762,7 @@ class XsoarClient:
     def poll_incident_state(
         self,
         incident_id: str,
-        expected_states: Tuple[IncidentState, ...] = (IncidentState.CLOSED,),
+        expected_states: Tuple[XsoarIncidentState, ...] = (XsoarIncidentState.CLOSED,),
         timeout: int = 120,
     ) -> dict:
         """
@@ -770,7 +770,7 @@ class XsoarClient:
 
         Args:
             incident_id (str): The XSOAR incident ID to poll its state.
-            expected_states (Tuple[IncidentState, ...]): The states the XSOAR incident is expected to reach.
+            expected_states (Tuple[XsoarIncidentState, ...]): The states the XSOAR incident is expected to reach.
             timeout (int): The time limit in seconds to wait for the expected states, defaults to 120.
 
         Returns:
@@ -803,7 +803,7 @@ class XsoarClient:
             incident_status = (
                 XsiamAlertState(incident.get("status", 0)).name
                 if self.server_type is ServerType.XSIAM
-                else IncidentState(str(incident.get("status"))).name
+                else XsoarIncidentState(incident.get("status", 0)).name
             )
 
             incident_name = incident.get("name")
@@ -816,7 +816,7 @@ class XsoarClient:
 
         raise PollTimeout(
             f"The status of {incident_name} is {incident_status}",
-            expected_states=expected_states,
+            expected_states=expected_state_names,
             timeout=timeout,
         )
 

--- a/demisto_sdk/commands/common/clients/xsoar/xsoar_api_client.py
+++ b/demisto_sdk/commands/common/clients/xsoar/xsoar_api_client.py
@@ -800,6 +800,8 @@ class XsoarClient:
             logger.debug(f"Incident raw response {incident}")
 
             logger.debug(f"Getting status of incident on {self.server_type} server")
+            # Incident 'status' in API response is an integer:
+            # https://docs-cortex.paloaltonetworks.com/r/Cortex-XSOAR-6-API/Search-incidents-by-filter
             incident_status = (
                 XsiamAlertState(incident.get("status", 0)).name
                 if self.server_type is ServerType.XSIAM

--- a/demisto_sdk/commands/common/constants.py
+++ b/demisto_sdk/commands/common/constants.py
@@ -2207,11 +2207,11 @@ class InvestigationPlaybookState(StrEnum):
     WAITING = "waiting"  # indicates that playbook currently stopped and waiting for user input on manual task
 
 
-class IncidentState(StrEnum):  # XSOAR
-    NEW = "NEW"
-    IN_PROGRESS = "IN_PROGRESS"
-    CLOSED = "CLOSED"
-    ACKNOWLEDGED = "ACKNOWLEDGED"
+class XsoarIncidentState(IntEnum):
+    NEW = 0
+    IN_PROGRESS = 1
+    CLOSED = 2
+    ACKNOWLEDGED = 3
 
 
 class XsiamAlertState(IntEnum):

--- a/demisto_sdk/commands/common/constants.py
+++ b/demisto_sdk/commands/common/constants.py
@@ -1,6 +1,6 @@
 import os
 import re
-from enum import Enum
+from enum import Enum, IntEnum
 from functools import reduce
 from pathlib import Path
 from typing import Dict, List
@@ -2207,11 +2207,17 @@ class InvestigationPlaybookState(StrEnum):
     WAITING = "waiting"  # indicates that playbook currently stopped and waiting for user input on manual task
 
 
-class IncidentState(StrEnum):
+class IncidentState(StrEnum):  # XSOAR
     NEW = "NEW"
     IN_PROGRESS = "IN_PROGRESS"
     CLOSED = "CLOSED"
     ACKNOWLEDGED = "ACKNOWLEDGED"
+
+
+class XsiamAlertState(IntEnum):
+    NEW = 0
+    UNDER_INVESTIGATION = 1
+    RESOLVED = 2
 
 
 class PlaybookTaskType(StrEnum):


### PR DESCRIPTION
## Related Issues
fixes: [link to issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-13077)

## Description
Add a new `XsiamClient.poll_alert_state` method that polls a Cortex XSIAM alert until it reaches any of the expected states.