### PR TITLE
Fix intermittent JSON serialization issue in BaseContent.to_dict() method

### DIFF
--- a/.changelog/4921.yml
+++ b/.changelog/4921.yml
@@ -1,4 +1,4 @@
 changes:
 - description: "Fixed an intermittent JSON serialization issue in **demisto-sdk validate** command that was causing validation failures in GitHub Actions."
-  type: fix
+  type: internal
 pr_number: 4921

--- a/.changelog/4921.yml
+++ b/.changelog/4921.yml
@@ -1,0 +1,4 @@
+changes:
+- description: "Fixed an intermittent JSON serialization issue in **demisto-sdk validate** command that was causing validation failures in GitHub Actions."
+  type: fix
+pr_number: 4921

--- a/demisto_sdk/commands/content_graph/objects/base_content.py
+++ b/demisto_sdk/commands/content_graph/objects/base_content.py
@@ -193,10 +193,15 @@ class BaseNode(ABC, BaseModel, metaclass=BaseContentMetaclass):
         #     )
         # )
         json_dct = self.dict(exclude=exclude_set)
-        if "path" in json_dct and Path(json_dct["path"]).is_absolute():
-            json_dct["path"] = (
-                Path(json_dct["path"]).relative_to(CONTENT_PATH)
-            ).as_posix()  # type: ignore
+
+        if "path" in json_dct and isinstance(json_dct["path"], Path):
+            if json_dct["path"].is_absolute():
+                json_dct["path"] = (
+                    json_dct["path"].relative_to(CONTENT_PATH)
+                ).as_posix()
+            else:
+                json_dct["path"] = str(json_dct["path"])
+
         json_dct["content_type"] = self.content_type
         return json_dct
 

--- a/demisto_sdk/commands/content_graph/objects/base_content.py
+++ b/demisto_sdk/commands/content_graph/objects/base_content.py
@@ -167,20 +167,32 @@ class BaseNode(ABC, BaseModel, metaclass=BaseContentMetaclass):
         """
 
         self.__add_lazy_properties()
+        print(f"sk-- {self.object_id}, {self.content_type}")
+        print(
+            f"the full data: {[(name, value, type(value)) for name, value in inspect.getmembers(self.__class__)]}"
+        )
         cached_properties = {
             name
             for name, value in inspect.getmembers(self.__class__)
             if isinstance(value, cached_property)
         }
-        json_dct = json.loads(
-            self.json(
-                exclude={
-                    "commands",
-                    "database_id",
-                }
-                | cached_properties
-            )
-        )
+        print(f"cached_properties = {cached_properties}")
+        exclude_set = {
+            "commands",
+            "database_id",
+        } | cached_properties
+        print(f"{exclude_set=}")
+
+        # json_dct = json.loads(
+        #     self.json(
+
+        #         exclude={
+        #             "commands",
+        #             "database_id",
+        #     } | cached_properties
+        #     )
+        # )
+        json_dct = self.dict(exclude=exclude_set)
         if "path" in json_dct and Path(json_dct["path"]).is_absolute():
             json_dct["path"] = (
                 Path(json_dct["path"]).relative_to(CONTENT_PATH)

--- a/demisto_sdk/commands/content_graph/objects/base_content.py
+++ b/demisto_sdk/commands/content_graph/objects/base_content.py
@@ -179,15 +179,13 @@ class BaseNode(ABC, BaseModel, metaclass=BaseContentMetaclass):
             }
             | cached_properties
         )
-
-        if "path" in json_dct and isinstance(json_dct["path"], Path):
-            if json_dct["path"].is_absolute():
-                json_dct["path"] = (
-                    json_dct["path"].relative_to(CONTENT_PATH)
-                ).as_posix()
-            else:
-                json_dct["path"] = str(json_dct["path"])
-
+        content_item_path = json_dct.get("path")
+        if content_item_path and isinstance(content_item_path, Path):
+            json_dct["path"] = (
+                content_item_path.relative_to(CONTENT_PATH).as_posix()
+                if content_item_path.is_absolute()
+                else str(content_item_path)
+            )
         json_dct["content_type"] = self.content_type
         return json_dct
 

--- a/demisto_sdk/commands/content_graph/objects/base_content.py
+++ b/demisto_sdk/commands/content_graph/objects/base_content.py
@@ -172,11 +172,13 @@ class BaseNode(ABC, BaseModel, metaclass=BaseContentMetaclass):
             for name, value in inspect.getmembers(self.__class__)
             if isinstance(value, cached_property)
         }
-        json_dct = self.dict(exclude={
-            "commands",
-            "database_id",
-        } | cached_properties
-                             )
+        json_dct = self.dict(
+            exclude={
+                "commands",
+                "database_id",
+            }
+            | cached_properties
+        )
 
         if "path" in json_dct and isinstance(json_dct["path"], Path):
             if json_dct["path"].is_absolute():

--- a/demisto_sdk/commands/content_graph/objects/base_content.py
+++ b/demisto_sdk/commands/content_graph/objects/base_content.py
@@ -167,32 +167,16 @@ class BaseNode(ABC, BaseModel, metaclass=BaseContentMetaclass):
         """
 
         self.__add_lazy_properties()
-        print(f"sk-- {self.object_id}, {self.content_type}")
-        print(
-            f"the full data: {[(name, value, type(value)) for name, value in inspect.getmembers(self.__class__)]}"
-        )
         cached_properties = {
             name
             for name, value in inspect.getmembers(self.__class__)
             if isinstance(value, cached_property)
         }
-        print(f"cached_properties = {cached_properties}")
-        exclude_set = {
+        json_dct = self.dict(exclude={
             "commands",
             "database_id",
         } | cached_properties
-        print(f"{exclude_set=}")
-
-        # json_dct = json.loads(
-        #     self.json(
-
-        #         exclude={
-        #             "commands",
-        #             "database_id",
-        #     } | cached_properties
-        #     )
-        # )
-        json_dct = self.dict(exclude=exclude_set)
+                             )
 
         if "path" in json_dct and isinstance(json_dct["path"], Path):
             if json_dct["path"].is_absolute():


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes:

## Description
This PR fixes an intermittent JSON serialization issue in the BaseContent.to_dict() method that was causing validation failures in GitHub Actions. The issue occurred when trying to serialize complex objects like RNRelatedFile that don't have JSON serialization methods defined.

Solution
Changed to_dict() to use self.dict() directly instead of using self.json() followed by json.loads(), avoiding the serialization step that was failing with complex objects.