### PR TITLE
Fixed logging for sdk-changelog command.

### DIFF
--- a/.changelog/4932.yml
+++ b/.changelog/4932.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed logging for the **sdk-changelog** command.
+  type: internal
+pr_number: 4932

--- a/demisto_sdk/scripts/changelog/changelog.py
+++ b/demisto_sdk/scripts/changelog/changelog.py
@@ -1,3 +1,6 @@
+import os
+
+os.environ["DEMISTO_SDK_IGNORE_CONTENT_WARNING"] = "true"
 import re
 import sys
 from datetime import datetime
@@ -10,6 +13,7 @@ from github import Github
 from more_itertools import bucket
 from pydantic import ValidationError
 
+from demisto_sdk.commands.common.constants import DEMISTO_GIT_UPSTREAM
 from demisto_sdk.commands.common.files.yml_file import YmlFile
 from demisto_sdk.commands.common.git_util import GitUtil
 from demisto_sdk.commands.common.handlers import (
@@ -36,6 +40,25 @@ GIT_UTIL = GitUtil(".")
 yaml = DEFAULT_YAML_HANDLER
 json = DEFAULT_JSON_HANDLER
 sys.tracebacklimit = 0
+
+
+def warn_if_not_in_sdk_repo():
+    try:
+        git_repo = GitUtil().repo
+        remote_urls = list(git_repo.remote(name=DEMISTO_GIT_UPSTREAM).urls)
+        if not any("demisto-sdk" in url for url in remote_urls):
+            logger.info(
+                "This command should only be run inside the demisto-sdk repository."
+            )
+            sys.exit(1)
+    except Exception:
+        logger.info(
+            "Could not determine repository. This command should only run inside the demisto-sdk repo."
+        )
+        sys.exit(1)
+
+
+warn_if_not_in_sdk_repo()
 
 
 class Changelog:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-12713

## Description
- Ignored the info logging _Please run demisto-sdk in a content repository_ for the SDK-changelog command
- Added logging for the content repo, now it will say that this command should run only from sdk
![image](https://github.com/user-attachments/assets/1dff83d8-e983-44d8-8d7e-11bc720a0e91)
 
