### PR TITLE
Handle empty URL path for images in README.md during `prepare-content` command

### DIFF
--- a/.changelog/4938.yml
+++ b/.changelog/4938.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue in the ***prepare-content*** command where wrong handling of the Image URL in the README.md file would cause the image file not to be created.
+  type: internal
+pr_number: 4938

--- a/demisto_sdk/commands/prepare_content/markdown_images_handler.py
+++ b/demisto_sdk/commands/prepare_content/markdown_images_handler.py
@@ -376,10 +376,6 @@ def generate_random_string(length: int) -> str:
     """
     Generate a random string of specified length using alphanumeric characters.
 
-    This function is used to create random filepath when the original path is empty or just "/",
-    which would cause the image file name to be invalid. The randomness ensures uniqueness
-    when there are multiple such cases in the same README.md file.
-
     Args:
         length (int): The desired length of the random filename
 
@@ -387,5 +383,5 @@ def generate_random_string(length: int) -> str:
         str: A random string composed of ASCII letters and digits
     """
     characters = string.ascii_letters + string.digits  # Use letters and digits
-    random_string = ''.join(random.choices(characters, k=length))
+    random_string = "".join(random.choices(characters, k=length))
     return random_string


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes:

## Description
Fixed an issue in the `prepare-content` command where wrong handling of the Image URL in the README.md file would cause the image file not to be created due to file naming issues.
Each image in the README.md file in being parsed and named temporarily after the the path value of the URL, in some cases, there are no further paths after the domain, which causes the image file name to be empty string or "/", which are invalid file names, and the image file ends-up not being created.
For example, given the URL: "www.example.test", the original logic would fail:
`Failed downloading the image in url ParseResult(scheme='https', netloc='www.example.test', path='', params='', query='', fragment=''). ........ No such file or directory: ''`
For URL with path values, like: "www.example.test/A/B/some-name", the file name value would be: "some-name".
This solution should generate random path value in such cases, in order for the image to be successfully created. 