### PR TITLE
Fixed Layouts Schemas

### DIFF
--- a/.changelog/5014.yml
+++ b/.changelog/5014.yml
@@ -1,4 +1,4 @@
 changes:
-- description: Fixed an issue where `display filters` were missing in layout containers' schemas.
+- description: Fixed an issue where `display filters` were missing in layout container's schemas.
   type: fix
 pr_number: 5014

--- a/.changelog/5014.yml
+++ b/.changelog/5014.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where `display filters` were missing in layout containers' schemas.
+  type: fix
+pr_number: 5014

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fix
 * Added ASM and Exposure Management to supported modules const. [#5012](https://github.com/demisto/demisto-sdk/pull/5012)
 
+
 ## 1.38.7 (2025-07-20)
 ### Feature
 * Added support for `supportedModules` field in integrations, commands, and command arguments. [#4996](https://github.com/demisto/demisto-sdk/pull/4996)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 ## 1.38.8 (2025-07-22)
 ### Fix
 * Added ASM and Exposure Management to supported modules const. [#5012](https://github.com/demisto/demisto-sdk/pull/5012)
-* Fixed an issue where `display filters` were missing in layout contatiners' schemas.
 
 ## 1.38.7 (2025-07-20)
 ### Feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## 1.38.8 (2025-07-22)
 ### Fix
 * Added ASM and Exposure Management to supported modules const. [#5012](https://github.com/demisto/demisto-sdk/pull/5012)
-
+* Fixed an issue where `display filters` were missing in layout contatiners' schemas.
 
 ## 1.38.7 (2025-07-20)
 ### Feature

--- a/demisto_sdk/commands/common/schemas/layoutscontainer.yml
+++ b/demisto_sdk/commands/common/schemas/layoutscontainer.yml
@@ -184,6 +184,10 @@ schema;section_schema:
       type: seq
       sequence:
       - include: field_schema
+    filters:
+      type: seq
+      sequence:
+      - include: arg_filters_schema
 
     name:xsoar:
       type: str

--- a/demisto_sdk/commands/content_graph/strict_objects/layout.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/layout.py
@@ -54,6 +54,7 @@ class _Section(BaseStrictModel):
     query_type: Optional[str] = Field(None, alias="queryType")
     sort_values: Optional[str] = Field(None, alias="sortValues")
     fields: Optional[List[SectionField]] = None  # type:ignore[valid-type]
+    filters: Optional[List[ArgFilters]] = None
 
 
 Section = create_model(


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: [XSUP-53187](https://jira-dc.paloaltonetworks.com/browse/XSUP-53187).

## Description

- As described in this ticket - [XSUP-53187](https://jira-dc.paloaltonetworks.com/browse/XSUP-53187), the ST110 validation is failing for `layouts` that include `display filters` at the layout `section` level. 
It appears that the layout schemas allowed display filters only for the `section field` level, but not for the `section` level. 

- Added the filters schema to:
1. The Graph - strict objects layout schema (used in the validate command). 
2. The old layout container schema (used by the format command). 

