### PR TITLE
Updated README.md to include the DEMISTO_ADVANCED_API_KEY variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ To use these functions, Set the following environment variables, or place an [.e
     export DEMISTO_API_KEY=<API_KEY>
     export XSIAM_AUTH_ID=<THE_XSIAM_AUTH_ID>
     ```
+- Please note that using an Advanced security level key will require using the DEMISTO_ADVANCED_API_KEY as an environment variable parameter in place of the DEMISTO_API_KEY. 
+
+   ```bash
+   export DEMISTO_ADVANCED_API_KEY
+   ```
 
 - Please note that once the `XSIAM_AUTH_ID` environment variable is set, the SDK commands will be configured to work with a Cortex XSIAM / XSOAR 8.x instance.
 In order to set Demisto SDK to work with a Cortex XSOAR 6.x instance, you need to delete the `XSIAM_AUTH_ID` parameter from your environment. To do this, please run the following command:


### PR DESCRIPTION
Updated README.md to include the DEMISTO_ADVANCED_API_KEY variable

<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: N/A

## Description
When working with an Advanced Security Level key you must use the DEMISTO_ADVANCE_API_KEY to successfully authenticate.
