### PR TITLE
Fix validate content paths

### DIFF
--- a/demisto_sdk/scripts/validate_content_path.py
+++ b/demisto_sdk/scripts/validate_content_path.py
@@ -407,10 +407,15 @@ def _validate_integration_script_file(path: Path, parts_after_packs: Sequence[st
             raise InvalidIntegrationScriptFileName
 
     elif path.suffix == ".py":
-        if not path.stem.startswith(parent) and path.stem not in {
-            "conftest",
-            ".vulture_whitelist",
-        }:
+        if path.stem in {parent, "conftest", ".vulture_whitelist"}:
+            # These are special exceptions allowed
+            return
+
+        if not path.stem.startswith(parent):
+            raise InvalidIntegrationScriptFileName
+        elif not path.stem.partition(parent)[-1].islower():
+            raise InvalidIntegrationScriptFileName
+        elif path.stem.partition(parent)[-1].endswith('tests'):
             raise InvalidIntegrationScriptFileName
 
     elif path.suffix == ".md":


### PR DESCRIPTION
## Description

As being discussed with @itssapir, the validation of paths may be failing with valid paths, like `/Packs/PolySwarm/Integrations/PolySwarmV2/PolySwarmV2_vendored_pytest_vcr.py`

The error message produced is 
```
This file's name must start with the name of its parent folder.
```

but the file `PolySwarmV2_vendored_pytest_vcr.py` clearly start with the name of its parent folder.

When reviewing the checking code, I found only a handsome of filenames that could pass the check.

This PR improves the validation by allowing any filename complying with the error description "must start with the name of its parent folder", except the ones that are already explicitly denied by existing tests, e. g. `*_tests.py`

It also keeps passing the current exceptions: `conftest.py` and `.vulture_whitelist.py`