### PR TITLE
Fix wrong operator name in ST110 structure validation

### DIFF
--- a/.changelog/5034.yml
+++ b/.changelog/5034.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fix wrong operator name in ST110 structure validation.
+  type: fix
+pr_number: 5034

--- a/demisto_sdk/commands/common/schemas/integration.yml
+++ b/demisto_sdk/commands/common/schemas/integration.yml
@@ -201,7 +201,7 @@ mapping:
                     required: true
                   operator:
                     type: str
-                    enum: ["exists", "not_exists", "equals", "not_equals"]
+                    enum: ["exists", "not_exists", "equal", "not_equal"]
                     required: true
                   value:
                     type: str

--- a/demisto_sdk/commands/content_graph/strict_objects/integration.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/integration.py
@@ -156,8 +156,8 @@ CommonFieldsIntegration = create_model(
 class ConditionOperator(StrEnum):
     EXISTS = "exists"
     NOT_EXISTS = "not_exists"
-    EQUALS = "equals"
-    NOT_EQUALS = "not_equals"
+    EQUAL = "equal"
+    NOT_EQUAL = "not_equal"
 
 
 class Condition(BaseStrictModel):

--- a/demisto_sdk/commands/validate/tests/ST_validators_test.py
+++ b/demisto_sdk/commands/validate/tests/ST_validators_test.py
@@ -704,7 +704,7 @@ def test_SchemaValidator_triggers_section__valid(pack: Pack):
         ),
         pytest.param(
             {
-                "conditions": [{"name": "engine", "operator": "equals", "value": 123}],
+                "conditions": [{"name": "engine", "operator": "equal", "value": 123}],
                 "effects": [
                     {
                         "name": "effect1",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->


## Description
We have a structure validation for our integration structure. in the new "triggers" fetcher the name of the allowed key was wrong (The decided name was different than the actual name being used on front-end side), fixing it now.
