### PR TITLE
Add support for CommonServerUserPython config in pre-commit

### DIFF
--- a/.changelog/5274.yml
+++ b/.changelog/5274.yml
@@ -1,0 +1,4 @@
+changes:
+    - description: Add [pre-commit] section to .demisto-sdk-conf file. Add logic to read and use directory value here for pythonpath rather than adding empty CommonServerUserPython.py in root of content repository.
+      type: feature
+pr_number: 5274

--- a/demisto_sdk/commands/pre_commit/pre_commit_command.py
+++ b/demisto_sdk/commands/pre_commit/pre_commit_command.py
@@ -565,6 +565,7 @@ def pre_commit_manager(
     run_hook: Optional[str] = None,
     pre_commit_template_path: Optional[Path] = None,
     json_output_path: Optional[Path] = None,
+    common_server_user_python_dir: Optional[str] = None,
 ) -> int:
     """Run pre-commit hooks .
 
@@ -588,11 +589,30 @@ def pre_commit_manager(
         pre_commit_template_path (Path, optional): Path to the template pre-commit file.
         json_output_path (Path, optional): Optional path to a JSON formatted output file/dir where pre-commit hooks results
             are stored. None by default, and file is not created.
+        common_server_user_python_dir (str, optional): Directory containing CommonServerUserPython.py,
+            relative to CONTENT_PATH. When set (via .demisto-sdk-conf), the directory is added to
+            PYTHONPATH so that `from CommonServerUserPython import *` resolves without creating a stub
+            file. Defaults to None, in which case an empty stub is created in CONTENT_PATH.
     Returns:
         int: Return code of pre-commit.
     """
-    # We have imports to this module, however it does not exists in the repo.
-    (CONTENT_PATH / "CommonServerUserPython.py").touch()
+    # Many integrations/scripts import CommonServerUserPython, but this file is a
+    # per-installation customization that doesn't ship in the repo by default.
+    # If a directory is configured via .demisto-sdk-conf, add it to PYTHONPATH so
+    # the import resolves naturally. Otherwise, fall back to creating an empty stub
+    # file in CONTENT_PATH to prevent import errors.
+    if common_server_user_python_dir:
+        resolved_dir = (CONTENT_PATH / common_server_user_python_dir).resolve()
+        if not (resolved_dir / "CommonServerUserPython.py").is_file():
+            logger.warning(
+                f"CommonServerUserPython.py not found in configured directory: {resolved_dir}. "
+                "Falling back to creating an empty stub."
+            )
+            (CONTENT_PATH / "CommonServerUserPython.py").touch()
+        else:
+            PYTHONPATH.append(resolved_dir)
+    else:
+        (CONTENT_PATH / "CommonServerUserPython.py").touch()
 
     if not any((input_files, staged_only, git_diff, all_files)):
         logger.info("No arguments were given, running on staged files and git changes.")

--- a/demisto_sdk/commands/pre_commit/pre_commit_setup.py
+++ b/demisto_sdk/commands/pre_commit/pre_commit_setup.py
@@ -5,6 +5,7 @@ from typing import Optional
 import typer
 
 from demisto_sdk.commands.common.logger import logging_setup
+from demisto_sdk.utils.utils import update_command_args_from_config_file
 
 
 def pre_commit(
@@ -138,6 +139,15 @@ def pre_commit(
 
     from demisto_sdk.commands.pre_commit.pre_commit_command import pre_commit_manager
 
+    # Read pre-commit settings from .demisto-sdk-conf, e.g.:
+    #   [pre-commit]
+    #   common-server-user-python-dir=Packs/Base/Scripts/CommonServerUserPython
+    config_args: dict = {}
+    update_command_args_from_config_file("pre-commit", config_args)
+    common_server_user_python_dir: Optional[str] = config_args.get(
+        "common-server-user-python-dir"
+    )
+
     if handling_private_repositories:
         os.environ["DEMISTO_SDK_PRIVATE_REPO_MODE"] = "true"
 
@@ -161,6 +171,7 @@ def pre_commit(
         dry_run=dry_run,
         run_hook=run_hook,
         pre_commit_template_path=pre_commit_template_path,
+        common_server_user_python_dir=common_server_user_python_dir,
     )
     if return_code:
         raise typer.Exit(1)


### PR DESCRIPTION
Add support for CommonServerUserPython config in [pre-commit] section in .demisto-sdk-conf

Read the directory from .demisto-sdk-conf and add it to PYTHONPATH if configured, otherwise create an empty stub file. This prevents import errors for integrations/scripts using CommonServerUserPython.

This fixes the annoying situation where demisto-sdk creates an empty CommonServerUserPython.py file in the root of the content repository. Chances are users will have this file as part of a content pack instead. It also allows for a cleaner project root.

relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-16213
