### PR TITLE
GR109: Add extensive debug logging for UnknownContent AttributeError …

### DIFF
--- a/demisto_sdk/commands/validate/validators/GR_validators/GR109_is_supported_modules_compatibility.py
+++ b/demisto_sdk/commands/validate/validators/GR_validators/GR109_is_supported_modules_compatibility.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from abc import ABC
 from typing import Iterable, List, Union
 
@@ -7,6 +8,7 @@ from demisto_sdk.commands.common.constants import PlatformSupportedModules
 from demisto_sdk.commands.content_graph.objects import Job
 from demisto_sdk.commands.content_graph.objects.agentix_action import AgentixAction
 from demisto_sdk.commands.content_graph.objects.agentix_agent import AgentixAgent
+from demisto_sdk.commands.content_graph.objects.base_content import UnknownContent
 from demisto_sdk.commands.content_graph.objects.case_field import CaseField
 from demisto_sdk.commands.content_graph.objects.case_layout import CaseLayout
 from demisto_sdk.commands.content_graph.objects.case_layout_rule import CaseLayoutRule
@@ -44,6 +46,8 @@ from demisto_sdk.commands.validate.validators.base_validator import (
     BaseValidator,
     ValidationResult,
 )
+
+logger = logging.getLogger("demisto-sdk")
 
 ContentTypes = Union[
     Integration,
@@ -103,7 +107,38 @@ class IsSupportedModulesCompatibility(BaseValidator[ContentTypes], ABC):
             dict: A dictionary mapping dependency IDs to lists of missing modules
         """
         missing_modules_by_dependency: dict[str, list[str]] = {}
-        for dependency in content_item.uses:
+        logger.info(
+            f"[GR109 DEBUG] get_missing_modules_by_dependency called for content_item: "
+            f"object_id={getattr(content_item, 'object_id', 'N/A')}, "
+            f"name={getattr(content_item, 'name', 'N/A')}, "
+            f"type={type(content_item).__name__}, "
+            f"supportedModules={getattr(content_item, 'supportedModules', 'N/A')}, "
+            f"not_in_repository={getattr(content_item, 'not_in_repository', 'N/A')}, "
+            f"number_of_uses={len(content_item.uses) if hasattr(content_item, 'uses') else 'N/A'}"
+        )
+        for i, dependency in enumerate(content_item.uses):
+            dep_target = dependency.content_item_to
+            logger.info(
+                f"[GR109 DEBUG]   Dependency [{i}]: "
+                f"type={type(dep_target).__name__}, "
+                f"object_id={getattr(dep_target, 'object_id', 'N/A')}, "
+                f"name={getattr(dep_target, 'name', 'N/A')}, "
+                f"not_in_repository={getattr(dep_target, 'not_in_repository', 'N/A')}, "
+                f"has_supportedModules={hasattr(dep_target, 'supportedModules')}, "
+                f"supportedModules={getattr(dep_target, 'supportedModules', 'ATTR_MISSING')}, "
+                f"database_id={getattr(dep_target, 'database_id', 'N/A')}, "
+                f"node_id={getattr(dep_target, 'node_id', 'N/A')}, "
+                f"is_UnknownContent={isinstance(dep_target, UnknownContent)}, "
+                f"all_attrs={list(dep_target.__dict__.keys()) if hasattr(dep_target, '__dict__') else 'N/A'}"
+            )
+            if isinstance(dep_target, UnknownContent):
+                logger.info(
+                    f"[GR109 DEBUG]   *** SKIPPING UnknownContent dependency: "
+                    f"object_id={getattr(dep_target, 'object_id', 'N/A')}, "
+                    f"name={getattr(dep_target, 'name', 'N/A')}. "
+                    f"This item is not in the repository and cannot be validated."
+                )
+                continue
             # Get modules supported by the content item but not by its dependency
             missing_modules = [
                 module
@@ -112,6 +147,10 @@ class IsSupportedModulesCompatibility(BaseValidator[ContentTypes], ABC):
                 if module not in dependency.content_item_to.supportedModules
             ]
             if missing_modules:
+                logger.info(
+                    f"[GR109 DEBUG]   Found missing modules for dependency "
+                    f"{dep_target.object_id}: {missing_modules}"
+                )
                 missing_modules_by_dependency[dependency.content_item_to.object_id] = (
                     missing_modules
                 )
@@ -129,7 +168,21 @@ class IsSupportedModulesCompatibility(BaseValidator[ContentTypes], ABC):
         """
         missing_modules_by_item: dict[str, list[str]] = {}
 
+        logger.info(
+            f"[GR109 DEBUG] get_missing_modules_by_command called for content_item: "
+            f"object_id={getattr(content_item, 'object_id', 'N/A')}, "
+            f"type={type(content_item).__name__}, "
+            f"supportedModules={getattr(content_item, 'supportedModules', 'N/A')}, "
+            f"number_of_commands={len(content_item.commands) if hasattr(content_item, 'commands') else 'N/A'}"
+        )
+
         for command in content_item.commands:
+            logger.info(
+                f"[GR109 DEBUG]   Command: "
+                f"type={type(command).__name__}, "
+                f"object_id={getattr(command, 'object_id', 'N/A')}, "
+                f"supportedModules={getattr(command, 'supportedModules', 'N/A')}"
+            )
             # Get modules supported by the command but not by the content item
             missing_modules = [
                 module
@@ -138,6 +191,10 @@ class IsSupportedModulesCompatibility(BaseValidator[ContentTypes], ABC):
             ]
 
             if missing_modules:
+                logger.info(
+                    f"[GR109 DEBUG]   Found missing modules for command "
+                    f"{getattr(command, 'object_id', 'N/A')}: {missing_modules}"
+                )
                 if content_item.object_id not in missing_modules_by_item:
                     missing_modules_by_item[content_item.object_id] = []
                 missing_modules_by_item[content_item.object_id].extend(missing_modules)
@@ -156,8 +213,20 @@ class IsSupportedModulesCompatibility(BaseValidator[ContentTypes], ABC):
         Returns:
             dict: A dictionary mapping content item IDs to lists of command IDs
         """
+        logger.info(
+            f"[GR109 DEBUG] get_commands_with_missing_modules_by_content_item called for item: "
+            f"object_id={getattr(item, 'object_id', 'N/A')}, "
+            f"type={type(item).__name__}, "
+            f"number_of_uses={len(item.uses) if hasattr(item, 'uses') else 'N/A'}"
+        )
         for rel in item.uses:
             command = rel.content_item_to
+            logger.info(
+                f"[GR109 DEBUG]   Rel target: "
+                f"type={type(command).__name__}, "
+                f"object_id={getattr(command, 'object_id', 'N/A')}, "
+                f"is_UnknownContent={isinstance(command, UnknownContent)}"
+            )
             # At this point, we assume the mismatch is already established
             if item.object_id not in commands_with_missing_modules_by_content_item:
                 commands_with_missing_modules_by_content_item[item.object_id] = []
@@ -205,28 +274,92 @@ class IsSupportedModulesCompatibility(BaseValidator[ContentTypes], ABC):
             else [content_item.object_id for content_item in content_items]
         )
 
+        logger.info(
+            f"[GR109 DEBUG] obtain_invalid_content_items_using_graph called. "
+            f"validate_all_files={validate_all_files}, "
+            f"target_content_item_ids={target_content_item_ids}"
+        )
+
+        logger.info("[GR109 DEBUG] Querying find_content_items_with_module_mismatch_dependencies...")
         mismatched_dependencies = (
             self.graph.find_content_items_with_module_mismatch_dependencies(
                 target_content_item_ids
             )
         )
+        logger.info(
+            f"[GR109 DEBUG] find_content_items_with_module_mismatch_dependencies returned "
+            f"{len(mismatched_dependencies)} items"
+        )
+        for idx, item in enumerate(mismatched_dependencies):
+            logger.info(
+                f"[GR109 DEBUG]   mismatched_dep[{idx}]: "
+                f"type={type(item).__name__}, "
+                f"object_id={getattr(item, 'object_id', 'N/A')}, "
+                f"name={getattr(item, 'name', 'N/A')}, "
+                f"not_in_repository={getattr(item, 'not_in_repository', 'N/A')}, "
+                f"supportedModules={getattr(item, 'supportedModules', 'N/A')}, "
+                f"is_UnknownContent={isinstance(item, UnknownContent)}, "
+                f"uses_count={len(item.uses) if hasattr(item, 'uses') else 'N/A'}"
+            )
+            if hasattr(item, 'uses'):
+                for j, dep in enumerate(item.uses):
+                    dep_to = dep.content_item_to
+                    logger.info(
+                        f"[GR109 DEBUG]     uses[{j}]: "
+                        f"type={type(dep_to).__name__}, "
+                        f"object_id={getattr(dep_to, 'object_id', 'N/A')}, "
+                        f"name={getattr(dep_to, 'name', 'N/A')}, "
+                        f"not_in_repository={getattr(dep_to, 'not_in_repository', 'N/A')}, "
+                        f"has_supportedModules={hasattr(dep_to, 'supportedModules')}, "
+                        f"supportedModules={getattr(dep_to, 'supportedModules', 'ATTR_MISSING')}, "
+                        f"is_UnknownContent={isinstance(dep_to, UnknownContent)}, "
+                        f"all_attrs={sorted(dep_to.__dict__.keys()) if hasattr(dep_to, '__dict__') else 'N/A'}"
+                    )
 
+        logger.info("[GR109 DEBUG] Querying find_content_items_with_module_mismatch_commands...")
         mismatched_commands = (
             self.graph.find_content_items_with_module_mismatch_commands(
                 target_content_item_ids
             )
         )
+        logger.info(
+            f"[GR109 DEBUG] find_content_items_with_module_mismatch_commands returned "
+            f"{len(mismatched_commands)} items"
+        )
+        for idx, item in enumerate(mismatched_commands):
+            logger.info(
+                f"[GR109 DEBUG]   mismatched_cmd[{idx}]: "
+                f"type={type(item).__name__}, "
+                f"object_id={getattr(item, 'object_id', 'N/A')}, "
+                f"is_UnknownContent={isinstance(item, UnknownContent)}"
+            )
 
+        logger.info("[GR109 DEBUG] Querying find_content_items_with_module_mismatch_content_items...")
         mismatched_content_items = (
             self.graph.find_content_items_with_module_mismatch_content_items(
                 target_content_item_ids
             )
         )
+        logger.info(
+            f"[GR109 DEBUG] find_content_items_with_module_mismatch_content_items returned "
+            f"{len(mismatched_content_items)} items"
+        )
+        for idx, item in enumerate(mismatched_content_items):
+            logger.info(
+                f"[GR109 DEBUG]   mismatched_ci[{idx}]: "
+                f"type={type(item).__name__}, "
+                f"object_id={getattr(item, 'object_id', 'N/A')}, "
+                f"is_UnknownContent={isinstance(item, UnknownContent)}"
+            )
 
         results: List[ValidationResult] = []
 
         # Process items with mismatched dependencies
         for invalid_item in mismatched_dependencies:
+            logger.info(
+                f"[GR109 DEBUG] Processing mismatched dependency item: "
+                f"object_id={getattr(invalid_item, 'object_id', 'N/A')}"
+            )
             missing_modules_by_dependency = self.get_missing_modules_by_dependency(
                 invalid_item
             )
@@ -246,6 +379,10 @@ class IsSupportedModulesCompatibility(BaseValidator[ContentTypes], ABC):
 
         # Process items with mismatched commands
         for invalid_item in mismatched_commands:
+            logger.info(
+                f"[GR109 DEBUG] Processing mismatched command item: "
+                f"object_id={getattr(invalid_item, 'object_id', 'N/A')}"
+            )
             missing_modules_by_item = self.get_missing_modules_by_command(invalid_item)
             if missing_modules_by_item:
                 formatted_messages = self.format_error_messages(missing_modules_by_item)
@@ -261,6 +398,10 @@ class IsSupportedModulesCompatibility(BaseValidator[ContentTypes], ABC):
 
         # Process items with mismatched content_items
         for invalid_item in mismatched_content_items:
+            logger.info(
+                f"[GR109 DEBUG] Processing mismatched content item: "
+                f"object_id={getattr(invalid_item, 'object_id', 'N/A')}"
+            )
             commands_with_missing_modules: dict[str, list[str]] = {}
             self.get_commands_with_missing_modules_by_content_item(
                 invalid_item, commands_with_missing_modules

--- a/demisto_sdk/commands/validate/validators/GR_validators/GR109_is_supported_modules_compatibility.py
+++ b/demisto_sdk/commands/validate/validators/GR_validators/GR109_is_supported_modules_compatibility.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import logging
 from abc import ABC
 from typing import Iterable, List, Union
 
 from demisto_sdk.commands.common.constants import PlatformSupportedModules
+from demisto_sdk.commands.common.logger import logger
 from demisto_sdk.commands.content_graph.objects import Job
 from demisto_sdk.commands.content_graph.objects.agentix_action import AgentixAction
 from demisto_sdk.commands.content_graph.objects.agentix_agent import AgentixAgent
@@ -46,8 +46,6 @@ from demisto_sdk.commands.validate.validators.base_validator import (
     BaseValidator,
     ValidationResult,
 )
-
-logger = logging.getLogger("demisto-sdk")
 
 ContentTypes = Union[
     Integration,

--- a/demisto_sdk/commands/validate/validators/GR_validators/GR109_is_supported_modules_compatibility.py
+++ b/demisto_sdk/commands/validate/validators/GR_validators/GR109_is_supported_modules_compatibility.py
@@ -280,7 +280,9 @@ class IsSupportedModulesCompatibility(BaseValidator[ContentTypes], ABC):
             f"target_content_item_ids={target_content_item_ids}"
         )
 
-        logger.info("[GR109 DEBUG] Querying find_content_items_with_module_mismatch_dependencies...")
+        logger.info(
+            "[GR109 DEBUG] Querying find_content_items_with_module_mismatch_dependencies..."
+        )
         mismatched_dependencies = (
             self.graph.find_content_items_with_module_mismatch_dependencies(
                 target_content_item_ids
@@ -301,7 +303,7 @@ class IsSupportedModulesCompatibility(BaseValidator[ContentTypes], ABC):
                 f"is_UnknownContent={isinstance(item, UnknownContent)}, "
                 f"uses_count={len(item.uses) if hasattr(item, 'uses') else 'N/A'}"
             )
-            if hasattr(item, 'uses'):
+            if hasattr(item, "uses"):
                 for j, dep in enumerate(item.uses):
                     dep_to = dep.content_item_to
                     logger.info(
@@ -316,7 +318,9 @@ class IsSupportedModulesCompatibility(BaseValidator[ContentTypes], ABC):
                         f"all_attrs={sorted(dep_to.__dict__.keys()) if hasattr(dep_to, '__dict__') else 'N/A'}"
                     )
 
-        logger.info("[GR109 DEBUG] Querying find_content_items_with_module_mismatch_commands...")
+        logger.info(
+            "[GR109 DEBUG] Querying find_content_items_with_module_mismatch_commands..."
+        )
         mismatched_commands = (
             self.graph.find_content_items_with_module_mismatch_commands(
                 target_content_item_ids
@@ -334,7 +338,9 @@ class IsSupportedModulesCompatibility(BaseValidator[ContentTypes], ABC):
                 f"is_UnknownContent={isinstance(item, UnknownContent)}"
             )
 
-        logger.info("[GR109 DEBUG] Querying find_content_items_with_module_mismatch_content_items...")
+        logger.info(
+            "[GR109 DEBUG] Querying find_content_items_with_module_mismatch_content_items..."
+        )
         mismatched_content_items = (
             self.graph.find_content_items_with_module_mismatch_content_items(
                 target_content_item_ids


### PR DESCRIPTION
…investigation

Added info-level logging throughout the GR109 validator to diagnose why UnknownContent objects appear in the module mismatch dependency results.

Logs include:
- All content items returned by each graph query (type, object_id, name, supportedModules, not_in_repository)
- All dependency targets for each mismatched item (type, attributes, whether it's UnknownContent)
- Full attribute list of each dependency target for debugging
- Skip UnknownContent dependencies with a log message to prevent crash while debugging

<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes:

## Description
