### PR TITLE
feat: add get-schema command to retrieve content item JSON schema

### DIFF
--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -427,6 +427,14 @@ def register_commands(_args: list[str] = []):  # noqa: C901
             name="error-code", help="Quickly find relevant info for an error code."
         )(error_code)
 
+    if command_name == "get-schema" or register_all:
+        from demisto_sdk.commands.get_schema.get_schema_setup import get_schema
+
+        app.command(
+            name="get-schema",
+            help="Returns the JSON schema of a content item type based on its strict pydantic model.",
+        )(get_schema)
+
     if command_name == "test-content" or register_all:
         from demisto_sdk.commands.test_content.content_test_setup import test_content
 

--- a/demisto_sdk/commands/get_schema/get_schema.py
+++ b/demisto_sdk/commands/get_schema/get_schema.py
@@ -1,0 +1,229 @@
+"""
+get-schema command: returns the JSON schema of a content item's strict (pydantic) model.
+"""
+
+import json
+from typing import Dict, Optional, Type
+
+from demisto_sdk.commands.common.logger import logger
+from demisto_sdk.commands.content_graph.strict_objects.agentix_action import (
+    AgentixAction,
+)
+from demisto_sdk.commands.content_graph.strict_objects.agentix_action_test import (
+    StrictAgentixActionTest,
+)
+from demisto_sdk.commands.content_graph.strict_objects.agentix_agent import (
+    AgentixAgent,
+)
+from demisto_sdk.commands.content_graph.strict_objects.asset_modeling_rule import (
+    StrictAssetsModelingRule,
+)
+from demisto_sdk.commands.content_graph.strict_objects.case_field import StrictCaseField
+from demisto_sdk.commands.content_graph.strict_objects.case_layout import (
+    StrictCaseLayout,
+)
+from demisto_sdk.commands.content_graph.strict_objects.case_layout_rule import (
+    StrictCaseLayoutRule,
+)
+from demisto_sdk.commands.content_graph.strict_objects.classifier import (
+    StrictClassifier,
+)
+from demisto_sdk.commands.content_graph.strict_objects.common import BaseStrictModel
+from demisto_sdk.commands.content_graph.strict_objects.correlation_rule import (
+    StrictCorrelationRule,
+)
+from demisto_sdk.commands.content_graph.strict_objects.dashboard import StrictDashboard
+from demisto_sdk.commands.content_graph.strict_objects.generic_definition import (
+    StrictGenericDefinition,
+)
+from demisto_sdk.commands.content_graph.strict_objects.generic_field import (
+    StrictGenericField,
+)
+from demisto_sdk.commands.content_graph.strict_objects.generic_module import (
+    StrictGenericModule,
+)
+from demisto_sdk.commands.content_graph.strict_objects.generic_type import (
+    StrictGenericType,
+)
+from demisto_sdk.commands.content_graph.strict_objects.incident_field import (
+    StrictIncidentField,
+)
+from demisto_sdk.commands.content_graph.strict_objects.incident_type import (
+    StrictIncidentType,
+)
+from demisto_sdk.commands.content_graph.strict_objects.indicator_field import (
+    StrictIndicatorField,
+)
+from demisto_sdk.commands.content_graph.strict_objects.indicator_type import (
+    StrictIndicatorType,
+)
+from demisto_sdk.commands.content_graph.strict_objects.integration import (
+    StrictIntegration,
+)
+from demisto_sdk.commands.content_graph.strict_objects.job import StrictJob
+from demisto_sdk.commands.content_graph.strict_objects.layout import StrictLayout
+from demisto_sdk.commands.content_graph.strict_objects.layout_rule import (
+    StrictLayoutRule,
+)
+from demisto_sdk.commands.content_graph.strict_objects.list import StrictList
+from demisto_sdk.commands.content_graph.strict_objects.mapper import StrictMapper
+from demisto_sdk.commands.content_graph.strict_objects.modeling_rule import (
+    StrictModelingRule,
+)
+from demisto_sdk.commands.content_graph.strict_objects.pack_meta_data import (
+    StrictPackMetadata,
+)
+from demisto_sdk.commands.content_graph.strict_objects.parsing_rule import (
+    StrictParsingRule,
+)
+from demisto_sdk.commands.content_graph.strict_objects.playbook import StrictPlaybook
+from demisto_sdk.commands.content_graph.strict_objects.pre_process_rule import (
+    StrictPreProcessRule,
+)
+from demisto_sdk.commands.content_graph.strict_objects.report import StrictReport
+from demisto_sdk.commands.content_graph.strict_objects.script import StrictScript
+from demisto_sdk.commands.content_graph.strict_objects.trigger import StrictTrigger
+from demisto_sdk.commands.content_graph.strict_objects.widget import StrictWidget
+from demisto_sdk.commands.content_graph.strict_objects.wizard import StrictWizard
+from demisto_sdk.commands.content_graph.strict_objects.xdrc_template import (
+    StrictXDRCTemplate,
+)
+from demisto_sdk.commands.content_graph.strict_objects.xsiam_dashboard import (
+    StrictXSIAMDashboard,
+)
+from demisto_sdk.commands.content_graph.strict_objects.xsiam_report import (
+    StrictXSIAMReport,
+)
+
+# Mapping from content item name (case-insensitive) to its strict pydantic model.
+# Both underscore-separated and concatenated variants are registered so that
+# e.g. both "agentix_action" and "agentixaction" resolve correctly.
+CONTENT_ITEM_NAME_TO_STRICT_OBJECT: Dict[str, Type[BaseStrictModel]] = {
+    "integration": StrictIntegration,
+    "script": StrictScript,
+    "playbook": StrictPlaybook,
+    "testplaybook": StrictPlaybook,
+    "test_playbook": StrictPlaybook,
+    "classifier": StrictClassifier,
+    "mapper": StrictMapper,
+    "incidentfield": StrictIncidentField,
+    "incident_field": StrictIncidentField,
+    "indicatorfield": StrictIndicatorField,
+    "indicator_field": StrictIndicatorField,
+    "incidenttype": StrictIncidentType,
+    "incident_type": StrictIncidentType,
+    "indicatortype": StrictIndicatorType,
+    "indicator_type": StrictIndicatorType,
+    "layout": StrictLayout,
+    "layoutrule": StrictLayoutRule,
+    "layout_rule": StrictLayoutRule,
+    "dashboard": StrictDashboard,
+    "report": StrictReport,
+    "widget": StrictWidget,
+    "job": StrictJob,
+    "list": StrictList,
+    "genericdefinition": StrictGenericDefinition,
+    "generic_definition": StrictGenericDefinition,
+    "genericfield": StrictGenericField,
+    "generic_field": StrictGenericField,
+    "genericmodule": StrictGenericModule,
+    "generic_module": StrictGenericModule,
+    "generictype": StrictGenericType,
+    "generic_type": StrictGenericType,
+    "correlationrule": StrictCorrelationRule,
+    "correlation_rule": StrictCorrelationRule,
+    "modelingrule": StrictModelingRule,
+    "modeling_rule": StrictModelingRule,
+    "assetsmodelrule": StrictAssetsModelingRule,
+    "assetsmodellingrule": StrictAssetsModelingRule,
+    "assets_modeling_rule": StrictAssetsModelingRule,
+    "parsingrule": StrictParsingRule,
+    "parsing_rule": StrictParsingRule,
+    "preprocessrule": StrictPreProcessRule,
+    "preprocess_rule": StrictPreProcessRule,
+    "pre_process_rule": StrictPreProcessRule,
+    "trigger": StrictTrigger,
+    "wizard": StrictWizard,
+    "xsiamdashboard": StrictXSIAMDashboard,
+    "xsiam_dashboard": StrictXSIAMDashboard,
+    "xsiamreport": StrictXSIAMReport,
+    "xsiam_report": StrictXSIAMReport,
+    "xdrctemplate": StrictXDRCTemplate,
+    "xdrc_template": StrictXDRCTemplate,
+    "casefield": StrictCaseField,
+    "case_field": StrictCaseField,
+    "caselayout": StrictCaseLayout,
+    "case_layout": StrictCaseLayout,
+    "caselayoutrule": StrictCaseLayoutRule,
+    "case_layout_rule": StrictCaseLayoutRule,
+    "agentixaction": AgentixAction,
+    "agentix_action": AgentixAction,
+    "agentixactiontest": StrictAgentixActionTest,
+    "agentix_action_test": StrictAgentixActionTest,
+    "agentixagent": AgentixAgent,
+    "agentix_agent": AgentixAgent,
+    "pack": StrictPackMetadata,
+    "pack_metadata": StrictPackMetadata,
+    "packmetadata": StrictPackMetadata,
+}
+
+
+def get_content_item_schema(content_item_name: str) -> Optional[dict]:
+    """
+    Returns the JSON schema of the strict pydantic model for the given content item name.
+
+    Args:
+        content_item_name: The name of the content item type (e.g. 'integration', 'script').
+
+    Returns:
+        A dict representing the JSON schema, or None if the content item name is not recognized.
+    """
+    # Normalise: lower-case, replace hyphens/spaces with underscores.
+    normalized = content_item_name.strip().lower().replace("-", "_").replace(" ", "_")
+    strict_model = CONTENT_ITEM_NAME_TO_STRICT_OBJECT.get(normalized)
+    if strict_model is None:
+        return None
+    return strict_model.schema()
+
+
+def print_schema(content_item_name: str, output_file: Optional[str] = None) -> int:
+    """
+    Retrieves and prints (or writes) the JSON schema for the given content item name.
+
+    Args:
+        content_item_name: The name of the content item type.
+        output_file: Optional path to write the schema JSON to. If None, prints to stdout.
+
+    Returns:
+        0 on success, 1 on failure.
+    """
+    schema = get_content_item_schema(content_item_name)
+    if schema is None:
+        available = sorted(
+            {
+                k
+                for k in CONTENT_ITEM_NAME_TO_STRICT_OBJECT
+                if "_" not in k
+                or k.replace("_", "") not in CONTENT_ITEM_NAME_TO_STRICT_OBJECT
+            }
+        )
+        logger.error(
+            f"Unknown content item type: '{content_item_name}'.\n"
+            f"Available content item types: {', '.join(available)}"
+        )
+        return 1
+
+    schema_json = json.dumps(schema, indent=2)
+
+    if output_file:
+        try:
+            with open(output_file, "w", encoding="utf-8") as f:
+                f.write(schema_json)
+            logger.info(f"Schema written to {output_file}")
+        except OSError as e:
+            logger.error(f"Failed to write schema to '{output_file}': {e}")
+            return 1
+    else:
+        print(schema_json)
+
+    return 0

--- a/demisto_sdk/commands/get_schema/get_schema_setup.py
+++ b/demisto_sdk/commands/get_schema/get_schema_setup.py
@@ -1,0 +1,99 @@
+import sys
+from typing import Optional
+
+import typer
+
+from demisto_sdk.commands.common.logger import logging_setup_decorator
+from demisto_sdk.commands.get_schema.get_schema import (
+    CONTENT_ITEM_NAME_TO_STRICT_OBJECT,
+    print_schema,
+)
+
+
+# Canonical names: prefer the underscore-separated form when it exists,
+# otherwise fall back to the concatenated form.  Deduplicate by strict model.
+def _build_canonical_names() -> list[str]:
+    seen_models: set = set()
+    canonical: list[str] = []
+    # First pass: collect underscore-separated names (most readable).
+    for k, model in sorted(CONTENT_ITEM_NAME_TO_STRICT_OBJECT.items()):
+        if "_" in k and id(model) not in seen_models:
+            seen_models.add(id(model))
+            canonical.append(k)
+    # Second pass: add concatenated names for models not yet covered.
+    for k, model in sorted(CONTENT_ITEM_NAME_TO_STRICT_OBJECT.items()):
+        if "_" not in k and id(model) not in seen_models:
+            seen_models.add(id(model))
+            canonical.append(k)
+    return sorted(canonical)
+
+
+_AVAILABLE_TYPES = _build_canonical_names()
+
+
+@logging_setup_decorator
+def get_schema(
+    ctx: typer.Context,
+    input: Optional[str] = typer.Option(
+        None,
+        "-i",
+        "--input",
+        help=(
+            "The content item type name to retrieve the schema for "
+            "(e.g. 'integration', 'script', 'agentix_action'). "
+            "Use --list-types to see all supported values."
+        ),
+    ),
+    list_types: bool = typer.Option(
+        False,
+        "-l",
+        "--list-types",
+        help="Print all supported content item type names and exit.",
+    ),
+    output: Optional[str] = typer.Option(
+        None,
+        "-o",
+        "--output",
+        help="Path to a file where the JSON schema will be written. If not provided, prints to stdout.",
+    ),
+    console_log_threshold: str = typer.Option(
+        None,
+        "--console-log-threshold",
+        help="Minimum logging threshold for console output. Possible values: DEBUG, INFO, SUCCESS, WARNING, ERROR.",
+    ),
+    file_log_threshold: str = typer.Option(
+        None,
+        "--file-log-threshold",
+        help="Minimum logging threshold for file output.",
+    ),
+    log_file_path: str = typer.Option(
+        None,
+        "--log-file-path",
+        help="Path to save log files.",
+    ),
+):
+    """
+    Returns the JSON schema of a content item type based on its strict pydantic model.
+
+    Example usage:\n
+        demisto-sdk get-schema -i integration\n
+        demisto-sdk get-schema -i agentix_action\n
+        demisto-sdk get-schema -i script -o /tmp/script_schema.json\n
+        demisto-sdk get-schema --list-types
+    """
+    if list_types:
+        typer.echo("Supported content item types:")
+        for name in _AVAILABLE_TYPES:
+            typer.echo(f"  {name}")
+        raise typer.Exit(0)
+
+    if not input:
+        typer.echo(
+            "Error: Missing option '-i' / '--input'. "
+            "Provide a content item type name or use --list-types to see all supported values.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    result = print_schema(content_item_name=input, output_file=output)
+    sys.exit(result)


### PR DESCRIPTION
Adds a new SDK command 'get-schema' that accepts a content item type name and returns its JSON schema derived from the strict pydantic model.

Features:
- '-i' / '--input': content item type name (e.g. 'integration', 'agentix_action')
- '-o' / '--output': optional file path to write the schema JSON
- '-l' / '--list-types': print all 37 supported content item type names and exit
- Mapping covers all content types: integration, script, playbook, classifier, mapper, incident_field, indicator_field, incident_type, indicator_type, layout, layout_rule, dashboard, report, widget, job, list, correlation_rule, modeling_rule, assets_modeling_rule, parsing_rule, pre_process_rule, trigger, wizard, xsiam_dashboard, xsiam_report, xdrc_template, case_field, case_layout, case_layout_rule, agentix_action, agentix_action_test, agentix_agent, pack

<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes:

## Description
