### PR TITLE
feat: add Field descriptions to all strict object models

### DIFF
--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -427,6 +427,14 @@ def register_commands(_args: list[str] = []):  # noqa: C901
             name="error-code", help="Quickly find relevant info for an error code."
         )(error_code)
 
+    if command_name == "get-schema" or register_all:
+        from demisto_sdk.commands.get_schema.get_schema_setup import get_schema
+
+        app.command(
+            name="get-schema",
+            help="Returns the JSON schema of a content item type based on its strict pydantic model.",
+        )(get_schema)
+
     if command_name == "test-content" or register_all:
         from demisto_sdk.commands.test_content.content_test_setup import test_content
 

--- a/demisto_sdk/commands/content_graph/strict_objects/agentix_action.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/agentix_action.py
@@ -9,39 +9,118 @@ from demisto_sdk.commands.content_graph.strict_objects.common import BaseStrictM
 
 
 class AgentixActionArgument(BaseStrictModel):
-    name: str
-    description: str
-    type: str
-    required: bool = False
-    default_value: Optional[str] = Field(None, alias="defaultvalue")
-    hidden: bool = False
-    disabled: bool = False
-    content_item_arg_name: str = Field(..., alias="underlyingargname")
-    isgeneratable: bool = False
+    name: str = Field(
+        ...,
+        description="Unique identifier for this argument as it appears in the action definition. Must match the underlying content item's argument name.",
+    )
+    description: str = Field(
+        ...,
+        description="Human-readable explanation of what this argument represents and how it should be used by the AI agent.",
+    )
+    type: str = Field(
+        ...,
+        description="Data type of the argument (e.g. 'String', 'Number', 'Boolean', 'Date'). Must be a valid XSOAR field type.",
+    )
+    required: bool = Field(
+        False,
+        description="Whether this argument must be supplied when invoking the action. Defaults to False (optional).",
+    )
+    default_value: Optional[str] = Field(
+        None,
+        alias="defaultvalue",
+        description="Default value used for this argument when none is provided by the caller. Only applicable when required=False.",
+    )
+    hidden: bool = Field(
+        False,
+        description="When True, the argument is hidden from the UI and cannot be set by users directly. Defaults to False.",
+    )
+    disabled: bool = Field(
+        False,
+        description="When True, the argument is disabled and cannot be set or overridden. Defaults to False.",
+    )
+    content_item_arg_name: str = Field(
+        ...,
+        alias="underlyingargname",
+        description="The exact name of the corresponding argument in the underlying content item (integration command or script). Must match exactly.",
+    )
+    isgeneratable: bool = Field(
+        False,
+        description="When True, the AI agent can auto-generate a value for this argument based on context. Defaults to False.",
+    )
 
 
 class AgentixActionOutput(BaseStrictModel):
-    description: str
-    type: str
-    content_item_output_name: str = Field(..., alias="underlyingoutputcontextpath")
-    name: str
-    disabled: bool = False
+    description: str = Field(
+        ...,
+        description="Human-readable explanation of what this output field represents and what data it contains.",
+    )
+    type: str = Field(
+        ...,
+        description="Data type of the output (e.g. 'String', 'Number', 'Boolean', 'Date'). Must be a valid XSOAR field type.",
+    )
+    content_item_output_name: str = Field(
+        ...,
+        alias="underlyingoutputcontextpath",
+        description="The context path of the corresponding output in the underlying content item (e.g. 'IP.Address'). Must match exactly.",
+    )
+    name: str = Field(
+        ...,
+        description="Unique name of the output field as it appears in the action definition.",
+    )
+    disabled: bool = Field(
+        False,
+        description="When True, this output is disabled and will not be returned by the action. Defaults to False.",
+    )
 
 
 class UnderlyingContentItem(BaseStrictModel):
-    id: Optional[str] = None
-    name: Optional[str] = None
-    type: str
-    command: Optional[str] = None
-    version: str
+    id: Optional[str] = Field(
+        None,
+        description="Unique identifier of the underlying content item (integration or script). Used to resolve the exact item when name is ambiguous.",
+    )
+    name: Optional[str] = Field(
+        None,
+        description="Display name of the underlying content item (integration or script name).",
+    )
+    type: str = Field(
+        ...,
+        description="Type of the underlying content item. Must be one of: 'integration', 'script'.",
+    )
+    command: Optional[str] = Field(
+        None,
+        description="Specific command name within the underlying integration to invoke. Required when type is 'integration'. Leave empty for scripts.",
+    )
+    version: str = Field(
+        ...,
+        description="Version of the underlying content item this action is bound to (e.g. '-1' for latest).",
+    )
 
 
 class AgentixAction(AgentixBase):
-    display: str
-    args: Optional[list[AgentixActionArgument]] = None
-    outputs: Optional[list[AgentixActionOutput]] = None
-    underlying_content_item: UnderlyingContentItem = Field(
-        ..., alias="underlyingcontentitem"
+    display: str = Field(
+        ...,
+        description="Human-readable display name of the action shown in the UI and to the AI agent. Should be concise and descriptive.",
     )
-    requires_user_approval: bool = Field(False, alias="requiresuserapproval")
-    few_shots: Optional[list[str]] = Field(None, alias="fewshots")
+    args: Optional[list[AgentixActionArgument]] = Field(
+        None,
+        description="List of input arguments accepted by this action. Each argument maps to a parameter of the underlying content item.",
+    )
+    outputs: Optional[list[AgentixActionOutput]] = Field(
+        None,
+        description="List of output fields returned by this action. Each output maps to a context path of the underlying content item.",
+    )
+    underlying_content_item: UnderlyingContentItem = Field(
+        ...,
+        alias="underlyingcontentitem",
+        description="The content item (integration command or script) that this action wraps. Defines what gets executed when the action is invoked.",
+    )
+    requires_user_approval: bool = Field(
+        False,
+        alias="requiresuserapproval",
+        description="When True, the action requires explicit user approval before execution. Use for destructive or sensitive operations. Defaults to False.",
+    )
+    few_shots: Optional[list[str]] = Field(
+        None,
+        alias="fewshots",
+        description="Optional list of few-shot example prompts to guide the AI agent when deciding to invoke this action.",
+    )

--- a/demisto_sdk/commands/content_graph/strict_objects/agentix_agent.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/agentix_agent.py
@@ -1,15 +1,44 @@
+from pydantic import Field
+
 from demisto_sdk.commands.content_graph.strict_objects.base_strict_model import (
     AgentixBase,
 )
 
 
 class AgentixAgent(AgentixBase):
-    color: str
-    visibility: str
-    actionids: list[str] = []
-    systeminstructions: str = ""
-    conversationstarters: list[str] = []
-    builtinactions: list[str] = []
-    autoenablenewactions: bool = False
-    roles: list[str] = []
-    sharedwithroles: list[str] = []
+    color: str = Field(
+        ...,
+        description="Display color of the agent in the UI (hex color code, e.g. '#FF5733'). Used to visually distinguish agents.",
+    )
+    visibility: str = Field(
+        ...,
+        description="Visibility scope of the agent. Controls who can see and use this agent (e.g. 'public', 'private').",
+    )
+    actionids: list[str] = Field(
+        [],
+        description="List of action IDs (AgentixAction names) that this agent is allowed to invoke. Empty list means no actions are assigned.",
+    )
+    systeminstructions: str = Field(
+        "",
+        description="System-level instructions provided to the AI model that define the agent's persona, behavior, and constraints. Supports markdown.",
+    )
+    conversationstarters: list[str] = Field(
+        [],
+        description="List of suggested conversation starter prompts shown to users when they first interact with this agent.",
+    )
+    builtinactions: list[str] = Field(
+        [],
+        description="List of built-in platform action IDs that this agent can use in addition to its assigned actions.",
+    )
+    autoenablenewactions: bool = Field(
+        False,
+        description="When True, newly created actions are automatically enabled for this agent. Defaults to False.",
+    )
+    roles: list[str] = Field(
+        [],
+        description="List of XSOAR roles that are allowed to interact with this agent. Empty list means all roles can access it.",
+    )
+    sharedwithroles: list[str] = Field(
+        [],
+        description="List of XSOAR roles this agent is shared with. Controls visibility and access in multi-tenant environments.",
+    )

--- a/demisto_sdk/commands/content_graph/strict_objects/base_strict_model.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/base_strict_model.py
@@ -27,7 +27,10 @@ from demisto_sdk.commands.content_graph.strict_objects.common import (
 
 
 class _CommonFields(BaseStrictModel):
-    version: int
+    version: int = Field(
+        ...,
+        description="Schema version of this content item. Used for conflict detection and migration. Typically -1 for new items.",
+    )
 
 
 CommonFields = create_model(
@@ -40,22 +43,66 @@ CommonFields = create_model(
 
 
 class _Argument(BaseStrictModel):
-    name: str
-    prettyname: Optional[str] = None
-    pretty_predefined: Optional[dict] = Field(None, alias="prettypredefined")
-    required: Optional[bool] = None
-    default: Optional[bool] = None
-    description: str
-    auto: Optional[Auto] = None
-    predefined: Optional[List[str]] = None
-    is_array: Optional[bool] = Field(None, alias="isArray")
-    secret: Optional[bool] = None
-    deprecated: Optional[bool] = None
-    type: Optional[str] = None
-    hidden: Optional[bool] = None
+    name: str = Field(
+        ...,
+        description="Unique name of the argument as it appears in the integration/script YAML. Used in API calls and playbooks.",
+    )
+    prettyname: Optional[str] = Field(
+        None,
+        description="Human-readable display name of the argument shown in the UI. If not set, the name field is used.",
+    )
+    pretty_predefined: Optional[dict] = Field(
+        None,
+        alias="prettypredefined",
+        description="Human-readable labels for predefined argument values. Maps raw values to display labels.",
+    )
+    required: Optional[bool] = Field(
+        None,
+        description="When True, this argument must be provided when calling the command. Omitting it causes an error.",
+    )
+    default: Optional[bool] = Field(
+        None,
+        description="When True, this argument receives the default input value from the playbook task.",
+    )
+    description: str = Field(
+        ...,
+        description="Human-readable description of what this argument does and what values are expected.",
+    )
+    auto: Optional[Auto] = Field(
+        None,
+        description="When set to 'PREDEFINED', the argument value must be one of the predefined values. Enables dropdown selection in the UI.",
+    )
+    predefined: Optional[List[str]] = Field(
+        None,
+        description="List of allowed values for this argument when auto='PREDEFINED'. Users can only select from these values.",
+    )
+    is_array: Optional[bool] = Field(
+        None,
+        alias="isArray",
+        description="When True, this argument accepts a list of values instead of a single value.",
+    )
+    secret: Optional[bool] = Field(
+        None,
+        description="When True, the argument value is treated as sensitive and masked in logs and the UI.",
+    )
+    deprecated: Optional[bool] = Field(
+        None,
+        description="When True, this argument is deprecated and should not be used in new playbooks.",
+    )
+    type: Optional[str] = Field(
+        None,
+        description="Data type of the argument (e.g. 'String', 'Number', 'Boolean', 'Date'). Used for input validation.",
+    )
+    hidden: Optional[bool] = Field(
+        None,
+        description="When True, this argument is hidden from the UI but can still be set programmatically.",
+    )
     supportedModules: Optional[
         Annotated[List[PlatformSupportedModules], Field(min_length=1, max_length=7)]
-    ]
+    ] = Field(
+        None,
+        description="Optional list of platform modules that support this argument. Restricts availability to specific modules.",
+    )
 
 
 HIDDEN_MARKETPLACE_V2_DYNAMIC_MODEL = create_dynamic_model(
@@ -80,26 +127,66 @@ Argument = create_model(
 
 
 class BaseOptionalVersionYaml(BaseStrictModel):
-    from_version: Optional[str] = Field(None, alias="fromversion")
-    to_version: Optional[str] = Field(None, alias="toversion")
+    from_version: Optional[str] = Field(
+        None,
+        alias="fromversion",
+        description="Minimum platform version required to use this content item (e.g. '6.0.0'). Items are not loaded on older platforms.",
+    )
+    to_version: Optional[str] = Field(
+        None,
+        alias="toversion",
+        description="Maximum platform version this content item is compatible with (e.g. '99.99.99'). Items are not loaded on newer platforms.",
+    )
 
 
 class BaseOptionalVersionJson(BaseStrictModel):
-    from_version: Optional[str] = Field(None, alias="fromVersion")
-    to_version: Optional[str] = Field(None, alias="toVersion")
+    from_version: Optional[str] = Field(
+        None,
+        alias="fromVersion",
+        description="Minimum platform version required to use this content item (e.g. '6.0.0'). Items are not loaded on older platforms.",
+    )
+    to_version: Optional[str] = Field(
+        None,
+        alias="toVersion",
+        description="Maximum platform version this content item is compatible with (e.g. '99.99.99'). Items are not loaded on newer platforms.",
+    )
 
 
 class Output(BaseStrictModel):
-    content_path: Optional[str] = Field(None, alias="contentPath")
-    context_path: Optional[str] = Field(None, alias="contextPath")
-    description: str
-    type: Optional[str] = None
+    content_path: Optional[str] = Field(
+        None,
+        alias="contentPath",
+        description="Path to the content item that produces this output. Used for cross-content-item output references.",
+    )
+    context_path: Optional[str] = Field(
+        None,
+        alias="contextPath",
+        description="Dot-notation path where this output is stored in the XSOAR context (e.g. 'IP.Address', 'File.MD5'). Used by playbooks to access the output.",
+    )
+    description: str = Field(
+        ...,
+        description="Human-readable description of what this output contains and how to use it.",
+    )
+    type: Optional[str] = Field(
+        None,
+        description="Data type of the output (e.g. 'String', 'Number', 'Boolean', 'Date', 'Unknown'). Used for type checking in playbooks.",
+    )
 
 
 class _Important(BaseModel):
-    context_path: str = Field(..., alias="contextPath")
-    description: str
-    related: Optional[str] = None
+    context_path: str = Field(
+        ...,
+        alias="contextPath",
+        description="Context path of the important output to highlight (e.g. 'IP.Address').",
+    )
+    description: str = Field(
+        ...,
+        description="Human-readable description of why this output is important.",
+    )
+    related: Optional[str] = Field(
+        None,
+        description="Related context path or field name.",
+    )
 
 
 Important = create_model(
@@ -139,15 +226,38 @@ class StructureError(BaseStrictModel):
 
 
 class _BaseIntegrationScript(BaseStrictModel):
-    name: str
-    deprecated: Optional[bool] = None
-    system: Optional[bool] = None
-    tests: Optional[List[str]] = None
-    auto_update_docker_image: Optional[bool] = Field(
-        None, alias="autoUpdateDockerImage"
+    name: str = Field(
+        ...,
+        description="Unique name of the integration or script. Used as the identifier in playbooks and API calls.",
     )
-    marketplaces: Optional[Union[MarketplaceVersions, List[MarketplaceVersions]]] = None
-    supportedModules: Optional[List[str]] = Field(None, alias="supportedModules")
+    deprecated: Optional[bool] = Field(
+        None,
+        description="When True, this integration/script is deprecated and should not be used in new playbooks.",
+    )
+    system: Optional[bool] = Field(
+        None,
+        description="When True, this is a system-provided integration/script that cannot be deleted.",
+    )
+    tests: Optional[List[str]] = Field(
+        None,
+        description="List of test playbook names used to test this integration/script. Referenced during CI/CD validation.",
+    )
+    auto_update_docker_image: Optional[bool] = Field(
+        None,
+        alias="autoUpdateDockerImage",
+        description="When True, the Docker image is automatically updated to the latest version during pack release.",
+    )
+    marketplaces: Optional[Union[MarketplaceVersions, List[MarketplaceVersions]]] = (
+        Field(
+            None,
+            description="Marketplace(s) this integration/script is available in. Allowed values: xsoar, marketplacev2, xpanse, xsoar_saas, xsoar_on_prem, platform.",
+        )
+    )
+    supportedModules: Optional[List[str]] = Field(
+        None,
+        alias="supportedModules",
+        description="Optional list of platform modules that support this integration/script. Restricts availability to specific modules.",
+    )
 
 
 BaseIntegrationScript = create_model(
@@ -240,14 +350,52 @@ class AlertsFilter(BaseStrictModel):
 
 
 class AgentixBase(BaseStrictModel):
-    common_fields: CommonFields = Field(..., alias="commonfields")  # type:ignore[valid-type]
-    tags: Optional[list[str]] = None
-    category: Optional[str] = None
-    name: str
-    description: str
-    disabled: bool = False
-    internal: Optional[bool] = None
-    from_version: Optional[str] = Field(None, alias="fromversion")
-    to_version: Optional[str] = Field(None, alias="toversion")
-    marketplaces: Optional[Union[MarketplaceVersions, List[MarketplaceVersions]]] = None
-    supportedModules: Optional[List[str]] = None
+    common_fields: CommonFields = Field(  # type:ignore[valid-type]
+        ...,
+        alias="commonfields",
+        description="Common metadata fields shared by all content items, including the unique ID and schema version.",
+    )
+    tags: Optional[list[str]] = Field(
+        None,
+        description="Optional list of tags used to categorise and filter this content item in the marketplace.",
+    )
+    category: Optional[str] = Field(
+        None,
+        description="Category this content item belongs to (e.g. 'Data Enrichment & Threat Intelligence'). Used for marketplace filtering.",
+    )
+    name: str = Field(
+        ...,
+        description="Unique machine-readable name of this content item. Must be unique within the pack.",
+    )
+    description: str = Field(
+        ...,
+        description="Human-readable description of what this content item does. Shown in the UI and used by the AI agent to decide when to invoke it.",
+    )
+    disabled: bool = Field(
+        False,
+        description="When True, this content item is disabled and will not be available for use. Defaults to False.",
+    )
+    internal: Optional[bool] = Field(
+        None,
+        description="When True, marks this content item as internal and not intended for direct use by end users.",
+    )
+    from_version: Optional[str] = Field(
+        None,
+        alias="fromversion",
+        description="Minimum platform version required to use this content item (e.g. '8.0.0'). Items are not loaded on older platforms.",
+    )
+    to_version: Optional[str] = Field(
+        None,
+        alias="toversion",
+        description="Maximum platform version this content item is compatible with (e.g. '99.99.99'). Items are not loaded on newer platforms.",
+    )
+    marketplaces: Optional[Union[MarketplaceVersions, List[MarketplaceVersions]]] = (
+        Field(
+            None,
+            description="Marketplace(s) this content item is available in. Allowed values: xsoar, marketplacev2, xpanse, xsoar_saas, xsoar_on_prem, platform.",
+        )
+    )
+    supportedModules: Optional[List[str]] = Field(
+        None,
+        description="Optional list of platform modules that support this content item. Restricts availability to specific modules.",
+    )

--- a/demisto_sdk/commands/content_graph/strict_objects/case_layout_rule.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/case_layout_rule.py
@@ -10,11 +10,37 @@ from demisto_sdk.commands.content_graph.strict_objects.common import BaseStrictM
 
 
 class StrictCaseLayoutRule(BaseStrictModel):
-    rule_id: str
-    rule_name: str
-    layout_id: str
-    from_version: str = Field(alias="fromVersion")
-    description: Optional[str] = None
-    incidents_filter: Optional[AlertsFilter] = None
-    marketplaces: Optional[List[MarketplaceVersions]] = None
-    supportedModules: Optional[List[str]] = Field(None, alias="supportedModules")
+    rule_id: str = Field(
+        ...,
+        description="Unique identifier of the case layout rule. Used internally to reference this rule.",
+    )
+    rule_name: str = Field(
+        ...,
+        description="Display name of the case layout rule shown in the UI.",
+    )
+    layout_id: str = Field(
+        ...,
+        description="ID of the case layout to apply when this rule matches. Must reference a valid case layout ID.",
+    )
+    from_version: str = Field(
+        ...,
+        alias="fromVersion",
+        description="Minimum platform version required to use this case layout rule (e.g. '8.3.0'). Required field.",
+    )
+    description: Optional[str] = Field(
+        None,
+        description="Human-readable description of when this case layout rule applies and what it does.",
+    )
+    incidents_filter: Optional[AlertsFilter] = Field(
+        None,
+        description="Filter conditions that determine when this case layout rule is applied. When the filter matches, the associated case layout is used.",
+    )
+    marketplaces: Optional[List[MarketplaceVersions]] = Field(
+        None,
+        description="Marketplace(s) this case layout rule is available in. Restricted to: marketplacev2, platform.",
+    )
+    supportedModules: Optional[List[str]] = Field(
+        None,
+        alias="supportedModules",
+        description="Optional list of platform modules that support this case layout rule. Restricts availability to specific modules.",
+    )

--- a/demisto_sdk/commands/content_graph/strict_objects/classifier.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/classifier.py
@@ -18,28 +18,99 @@ from demisto_sdk.commands.content_graph.strict_objects.common import (
 
 
 class _StrictClassifier(BaseStrictModel):
-    feed: Optional[bool] = None
-    incident_samples: Optional[List[str]] = Field(None, alias="incidentSamples")
-    indicator_samples: Optional[List[str]] = Field(None, alias="indicatorSamples")
-    propagation_labels: Optional[Any] = Field(None, alias="propagationLabels")
-    is_default: Optional[bool] = Field(None, alias="isDefault")
-    sort_values: Optional[Any] = Field(None, alias="sortValues")
-    modified: Optional[str] = None
-    default_incident_type: Optional[str] = Field(None, alias="defaultIncidentType")
-    unclassified_cases: Optional[dict] = Field(None, alias="unclassifiedCases")
-    transformer: Optional[dict] = None
-    key_type_map: Optional[dict] = Field(None, alias="keyTypeMap")
-    custom: Optional[bool] = None
-    name: str
-    type_: str = Field(..., alias="type")
-    description: str
-    definition_id: Optional[str] = Field(None, alias="definitionId")
-    marketplaces: Optional[List[MarketplaceVersions]] = Field(
-        None, alias="marketplaces"
+    feed: Optional[bool] = Field(
+        None,
+        description="When True, this classifier is used for feed (indicator) incidents rather than regular incidents.",
     )
-    supportedModules: Optional[List[str]] = Field(None, alias="supportedModules")
-    id_: str = Field(..., alias="id")
-    version: int
+    incident_samples: Optional[List[str]] = Field(
+        None,
+        alias="incidentSamples",
+        description="List of sample incident JSON strings used to test and preview the classifier mapping.",
+    )
+    indicator_samples: Optional[List[str]] = Field(
+        None,
+        alias="indicatorSamples",
+        description="List of sample indicator JSON strings used to test and preview the classifier mapping for feed classifiers.",
+    )
+    propagation_labels: Optional[Any] = Field(
+        None,
+        alias="propagationLabels",
+        description="Labels used for data propagation in multi-tenant environments. Controls which tenants receive classified incidents.",
+    )
+    is_default: Optional[bool] = Field(
+        None,
+        alias="isDefault",
+        description="When True, this classifier is the default classifier applied to incidents that do not match any other classifier.",
+    )
+    sort_values: Optional[Any] = Field(
+        None,
+        alias="sortValues",
+        description="Internal field used for sorting classifiers in the UI. Not typically set manually.",
+    )
+    modified: Optional[str] = Field(
+        None,
+        description="ISO 8601 timestamp of when this classifier was last modified. Set automatically by the platform.",
+    )
+    default_incident_type: Optional[str] = Field(
+        None,
+        alias="defaultIncidentType",
+        description="Default incident type to assign when no mapping rule matches. Must reference a valid incident type name.",
+    )
+    unclassified_cases: Optional[dict] = Field(
+        None,
+        alias="unclassifiedCases",
+        description="Mapping of unclassified event keys to incident types. Used as a fallback when the main keyTypeMap has no match.",
+    )
+    transformer: Optional[dict] = Field(
+        None,
+        description="Transformation rules applied to incoming event data before classification. Supports complex field extraction and manipulation.",
+    )
+    key_type_map: Optional[dict] = Field(
+        None,
+        alias="keyTypeMap",
+        description="Mapping from event field values to incident types. The classifier uses this map to determine the incident type for each incoming event.",
+    )
+    custom: Optional[bool] = Field(
+        None,
+        description="When True, marks this as a custom (user-created) classifier rather than a system-provided one.",
+    )
+    name: str = Field(
+        ...,
+        description="Unique display name of the classifier. Must be unique within the platform.",
+    )
+    type_: str = Field(
+        ...,
+        alias="type",
+        description="Type of classifier. Must be 'classification' for incident classifiers or 'mapping' for mapper-type classifiers.",
+    )
+    description: str = Field(
+        ...,
+        description="Human-readable description of what this classifier does and which integrations or event sources it supports.",
+    )
+    definition_id: Optional[str] = Field(
+        None,
+        alias="definitionId",
+        description="ID of the generic object definition this classifier is associated with. Used for generic object classifiers.",
+    )
+    marketplaces: Optional[List[MarketplaceVersions]] = Field(
+        None,
+        alias="marketplaces",
+        description="Marketplace(s) this classifier is available in. Allowed values: xsoar, marketplacev2, xpanse, xsoar_saas, xsoar_on_prem, platform.",
+    )
+    supportedModules: Optional[List[str]] = Field(
+        None,
+        alias="supportedModules",
+        description="Optional list of platform modules that support this classifier. Restricts availability to specific modules.",
+    )
+    id_: str = Field(
+        ...,
+        alias="id",
+        description="Unique identifier of the classifier. Used internally to reference this classifier from integrations and other content items.",
+    )
+    version: int = Field(
+        ...,
+        description="Schema version of this classifier. Used for conflict detection and migration. Typically -1 for new items.",
+    )
 
 
 StrictClassifier = create_model(

--- a/demisto_sdk/commands/content_graph/strict_objects/common.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/common.py
@@ -93,6 +93,7 @@ def create_dynamic_model(
     suffixes: Sequence[str] = marketplace_suffixes,
     alias: Optional[str] = None,
     include_without_suffix: bool = False,
+    description: Optional[str] = None,
 ) -> BaseModel:
     """
     This function creates a sub-model for avoiding duplicate lines of parsing arguments with different suffix.
@@ -107,12 +108,19 @@ def create_dynamic_model(
     fields = {
         f"{field_name}_{suffix}": (
             type_,
-            FieldInfo(default, alias=f"{alias or field_name}:{suffix}"),
+            FieldInfo(
+                default,
+                alias=f"{alias or field_name}:{suffix}",
+                description=description,
+            ),
         )
         for suffix in suffixes
     }
     if include_without_suffix:
-        fields[field_name] = (type_, FieldInfo(default, alias=alias or field_name))
+        fields[field_name] = (
+            type_,
+            FieldInfo(default, alias=alias or field_name, description=description),
+        )
 
     return create_model(
         model_name=f"Dynamic{field_name.title()}Model",
@@ -122,22 +130,35 @@ def create_dynamic_model(
 
 
 DESCRIPTION_DYNAMIC_MODEL = create_dynamic_model(
-    field_name="description", type_=Optional[str], default=None
+    field_name="description",
+    type_=Optional[str],
+    default=None,
+    description="Marketplace-specific description override for this content item. Overrides the base description field for the specified marketplace.",
 )
 NAME_DYNAMIC_MODEL = create_dynamic_model(
-    field_name="name", type_=Optional[str], default=None
+    field_name="name",
+    type_=Optional[str],
+    default=None,
+    description="Marketplace-specific name override for this content item. Overrides the base name field for the specified marketplace.",
 )
 DEPRECATED_DYNAMIC_MODEL = deprecated_dynamic_model = create_dynamic_model(
-    field_name="deprecated", type_=Optional[bool], default=None
+    field_name="deprecated",
+    type_=Optional[bool],
+    default=None,
+    description="Marketplace-specific deprecated flag. When True, marks this content item as deprecated for the specified marketplace.",
 )
 REQUIRED_DYNAMIC_MODEL = create_dynamic_model(
-    field_name="required", type_=Optional[bool], default=None
+    field_name="required",
+    type_=Optional[bool],
+    default=None,
+    description="Marketplace-specific required flag. When True, this field is required for the specified marketplace.",
 )
 DEFAULT_DYNAMIC_MODEL = create_dynamic_model(
     field_name="defaultValue",
     type_=Optional[Any],
     default=None,
     include_without_suffix=True,
+    description="Marketplace-specific default value override. Overrides the base defaultValue for the specified marketplace.",
 )
 DEFAULT_DYNAMIC_MODEL_LOWER_CASE = create_dynamic_model(
     # field name here defaultvalue vs defaultValue
@@ -145,63 +166,74 @@ DEFAULT_DYNAMIC_MODEL_LOWER_CASE = create_dynamic_model(
     type_=Optional[Any],
     default=None,
     include_without_suffix=True,
+    description="Marketplace-specific default value override (lowercase variant). Overrides the base defaultvalue for the specified marketplace.",
 )
 ID_DYNAMIC_MODEL = create_dynamic_model(
     field_name="id",
     type_=Optional[Any],
     default=None,
     include_without_suffix=True,
+    description="Unique identifier of this content item. The marketplace-suffixed variants allow different IDs per marketplace.",
 )
 KEY_DYNAMIC_MODEL = create_dynamic_model(
     field_name="key",
     type_=Optional[str],
     default=None,
+    description="Marketplace-specific key override for this field.",
 )
 VALUE_DYNAMIC_MODEL = create_dynamic_model(
     field_name="value",
     type_=Optional[Any],
     default=None,
+    description="Marketplace-specific value override for this field.",
 )
 PLAYBOOK_INPUT_QUERY_DYNAMIC_MODEL = create_dynamic_model(
     field_name="playbookInputQuery",
     type_=Optional[Any],
     default=None,
+    description="Marketplace-specific playbook input query override.",
 )
 FORM_DYNAMIC_MODEL = create_dynamic_model(
     field_name="form",
     type_=Optional[Dict],
     default=None,
     include_without_suffix=True,
+    description="Marketplace-specific form configuration override.",
 )
 MESSAGE_DYNAMIC_MODEL = create_dynamic_model(
     field_name="message",
     type_=Optional[Dict],
     default=None,
     include_without_suffix=True,
+    description="Marketplace-specific message configuration override.",
 )
 SCRIPT_ARGUMENTS_LOWER_CASE_DYNAMIC_MODEL = create_dynamic_model(
     field_name="scriptarguments",
     type_=Optional[Dict],
     default=None,
     include_without_suffix=True,
+    description="Marketplace-specific script arguments override (lowercase variant). Key-value pairs passed to the script.",
 )
 SCRIPT_ARGUMENTS_UPPER_CASE_DYNAMIC_MODEL = create_dynamic_model(
     field_name="scriptArguments",
     type_=Optional[Dict],
     default=None,
     include_without_suffix=True,
+    description="Marketplace-specific script arguments override (camelCase variant). Key-value pairs passed to the script.",
 )
 SCRIPT_ID_DYNAMIC_MODEL = create_dynamic_model(
     field_name="scriptId",
     type_=Optional[str],
     default=None,
     include_without_suffix=True,
+    description="Marketplace-specific script ID override. References the script to execute for this task.",
 )
 IS_CONTEXT_DYNAMIC_MODEL = create_dynamic_model(
     field_name="iscontext",
     type_=Optional[bool],
     default=None,
     include_without_suffix=True,
+    description="Marketplace-specific isContext flag. When True, the value is read from the XSOAR context rather than used as a literal.",
 )
 
 QUICK_ACTION_DYNAMIC_MODEL = create_dynamic_model(
@@ -209,6 +241,7 @@ QUICK_ACTION_DYNAMIC_MODEL = create_dynamic_model(
     type_=Optional[bool],
     default=None,
     include_without_suffix=True,
+    description="Marketplace-specific quick action flag. When True, this command appears as a quick action in the UI.",
 )
 
 HIDDEN_DYNAMIC_MODEL = create_dynamic_model(
@@ -216,6 +249,7 @@ HIDDEN_DYNAMIC_MODEL = create_dynamic_model(
     type_=Optional[bool],
     default=None,
     include_without_suffix=True,
+    description="Marketplace-specific hidden flag. When True, this command/field is hidden from the UI for the specified marketplace.",
 )
 
 

--- a/demisto_sdk/commands/content_graph/strict_objects/correlation_rule.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/correlation_rule.py
@@ -14,29 +14,102 @@ from demisto_sdk.commands.content_graph.strict_objects.common import (
 
 
 class _StrictCorrelationRule(BaseStrictModel):
-    global_rule_id: str
-    name: str  # not included in NAME_DYNAMIC_MODEL
-    alert_name: str
-    description: str
-    alert_description: str
-    alert_category: str
-    alert_fields: Optional[Any] = None
-    cron_tab: Optional[str] = Field(None, alias="crontab")
-    dataset: str
-    drill_down_query_timeframe: str = Field(..., alias="drilldown_query_timeframe")
-    execution_mode: str = Field(..., enum=["REAL_TIME", "SCHEDULED"])
-    mitre_defs: Optional[Any] = None
-    search_window: Optional[str] = None
-    severity: str
-    suppression_enabled: bool
-    suppression_duration: Optional[str] = None
-    suppression_fields: Optional[str] = None
-    user_defined_category: Optional[str] = None
-    user_defined_severity: Optional[str] = None
-    xql_query: str
-    investigation_query_link: Optional[str] = None
-    mapping_strategy: Optional[str] = None
-    supportedModules: Optional[List[str]] = Field(None, alias="supportedModules")
+    global_rule_id: str = Field(
+        ...,
+        description="Globally unique identifier for this correlation rule. Used to reference the rule across the platform.",
+    )
+    name: str = Field(
+        ...,
+        description="Display name of the correlation rule shown in the UI. Must be unique within the platform.",
+    )
+    alert_name: str = Field(
+        ...,
+        description="Name of the alert generated when this rule fires. Shown as the alert title in the UI.",
+    )
+    description: str = Field(
+        ...,
+        description="Human-readable description of what this correlation rule detects and why it is important.",
+    )
+    alert_description: str = Field(
+        ...,
+        description="Description included in the generated alert. Provides context about the detected threat or anomaly.",
+    )
+    alert_category: str = Field(
+        ...,
+        description="Category of the generated alert (e.g. 'Malware', 'Lateral Movement', 'Exfiltration'). Used for filtering and reporting.",
+    )
+    alert_fields: Optional[Any] = Field(
+        None,
+        description="Additional fields to include in the generated alert. Mapped from the XQL query results.",
+    )
+    cron_tab: Optional[str] = Field(
+        None,
+        alias="crontab",
+        description="Cron expression defining the schedule for SCHEDULED execution mode (e.g. '0 * * * *' for hourly). Not used in REAL_TIME mode.",
+    )
+    dataset: str = Field(
+        ...,
+        description="XDR dataset to query (e.g. 'xdr_data', 'cloud_audit'). Must be a valid dataset name available in the platform.",
+    )
+    drill_down_query_timeframe: str = Field(
+        ...,
+        alias="drilldown_query_timeframe",
+        description="Time frame for the drill-down investigation query (e.g. '1h', '24h', '7d'). Used when investigating triggered alerts.",
+    )
+    execution_mode: str = Field(
+        ...,
+        enum=["REAL_TIME", "SCHEDULED"],
+        description="Execution mode of the rule. REAL_TIME: rule evaluates events as they arrive. SCHEDULED: rule runs on a cron schedule.",
+    )
+    mitre_defs: Optional[Any] = Field(
+        None,
+        description="MITRE ATT&CK technique and tactic definitions associated with this rule (e.g. T1059, TA0002).",
+    )
+    search_window: Optional[str] = Field(
+        None,
+        description="Time window for the XQL query in SCHEDULED mode (e.g. '1h', '24h'). Defines how far back to look for matching events.",
+    )
+    severity: str = Field(
+        ...,
+        description="Severity of the generated alert. Must be one of: 'informational', 'low', 'medium', 'high', 'critical'.",
+    )
+    suppression_enabled: bool = Field(
+        ...,
+        description="When True, alert suppression is enabled. Prevents duplicate alerts from firing within the suppression window.",
+    )
+    suppression_duration: Optional[str] = Field(
+        None,
+        description="Duration of the suppression window (e.g. '1h', '24h'). Alerts are suppressed for this period after the first occurrence.",
+    )
+    suppression_fields: Optional[str] = Field(
+        None,
+        description="Comma-separated list of fields used to identify duplicate alerts for suppression purposes.",
+    )
+    user_defined_category: Optional[str] = Field(
+        None,
+        description="Custom category defined by the user. Overrides the default alert_category for organizational purposes.",
+    )
+    user_defined_severity: Optional[str] = Field(
+        None,
+        description="Custom severity defined by the user. Overrides the default severity for organizational purposes.",
+    )
+    xql_query: str = Field(
+        ...,
+        description="XQL (XDR Query Language) query that defines the detection logic. Must be a valid XQL query against the specified dataset.",
+    )
+    investigation_query_link: Optional[str] = Field(
+        None,
+        description="URL or XQL query link for investigating triggered alerts. Provides a starting point for threat hunting.",
+    )
+    mapping_strategy: Optional[str] = Field(
+        None,
+        description="Strategy for mapping XQL query results to alert fields. Defines how query output is transformed into alert data.",
+    )
+    supportedModules: Optional[List[str]] = Field(
+        None,
+        alias="supportedModules",
+        description="Optional list of platform modules that support this correlation rule. Restricts availability to specific modules.",
+    )
 
 
 StrictCorrelationRule = create_model(

--- a/demisto_sdk/commands/content_graph/strict_objects/generic_definition.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/generic_definition.py
@@ -11,16 +11,50 @@ from demisto_sdk.commands.content_graph.strict_objects.common import (
 
 
 class _StrictGenericDefinition(BaseStrictModel):
-    id_: str = Field(alias="id")
-    name: str
-    partitioned: Optional[bool] = None
-    auditable: bool
-    rbac_support: Optional[bool] = Field(None, alias="rbacSupport")
-    version: Optional[int] = None
-    locked: Optional[bool] = None
-    system: Optional[bool] = None
-    from_version: str = Field(alias="fromVersion")
-    plural_name: Optional[str] = Field(None, alias="pluralName")
+    id_: str = Field(
+        ...,
+        alias="id",
+        description="Unique identifier of the generic object definition. Used to reference this definition from generic fields, modules, and types.",
+    )
+    name: str = Field(
+        ...,
+        description="Display name of the generic object definition shown in the UI.",
+    )
+    partitioned: Optional[bool] = Field(
+        None,
+        description="When True, generic objects of this type are partitioned per tenant in multi-tenant environments.",
+    )
+    auditable: bool = Field(
+        ...,
+        description="When True, changes to generic objects of this type are tracked in the audit log.",
+    )
+    rbac_support: Optional[bool] = Field(
+        None,
+        alias="rbacSupport",
+        description="When True, Role-Based Access Control (RBAC) is enforced for generic objects of this type.",
+    )
+    version: Optional[int] = Field(
+        None,
+        description="Schema version of this definition. Used for conflict detection. Typically -1 for new items.",
+    )
+    locked: Optional[bool] = Field(
+        None,
+        description="When True, this definition is locked and cannot be modified by users.",
+    )
+    system: Optional[bool] = Field(
+        None,
+        description="When True, this is a system-defined generic object definition that cannot be deleted.",
+    )
+    from_version: str = Field(
+        ...,
+        alias="fromVersion",
+        description="Minimum platform version required to use this generic object definition (e.g. '6.5.0'). Required field.",
+    )
+    plural_name: Optional[str] = Field(
+        None,
+        alias="pluralName",
+        description="Plural form of the object name used in the UI (e.g. 'Assets', 'Vulnerabilities').",
+    )
 
 
 StrictGenericDefinition = create_model(

--- a/demisto_sdk/commands/content_graph/strict_objects/generic_module.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/generic_module.py
@@ -11,33 +11,96 @@ from demisto_sdk.commands.content_graph.strict_objects.common import (
 
 
 class Tab(BaseStrictModel):
-    name: Optional[str] = None
-    new_button_definition_id: Optional[str] = Field(None, alias="newButtonDefinitionId")
-    table_view: Optional[bool] = Field(None, alias="tableView")
-    table_view_widget_groups: Optional[List[str]] = Field(
-        None, alias="tableViewWidgetGroups"
+    name: Optional[str] = Field(
+        None,
+        description="Display name of the tab shown in the generic module UI.",
     )
-    table_view_columns: Optional[List[str]] = Field(None, alias="tableViewColumns")
-    dashboard: Optional[Any] = None
+    new_button_definition_id: Optional[str] = Field(
+        None,
+        alias="newButtonDefinitionId",
+        description="ID of the generic object definition used when creating new objects from this tab.",
+    )
+    table_view: Optional[bool] = Field(
+        None,
+        alias="tableView",
+        description="When True, objects in this tab are displayed in a table view instead of the default card view.",
+    )
+    table_view_widget_groups: Optional[List[str]] = Field(
+        None,
+        alias="tableViewWidgetGroups",
+        description="List of widget group names to display in the table view.",
+    )
+    table_view_columns: Optional[List[str]] = Field(
+        None,
+        alias="tableViewColumns",
+        description="List of field names to display as columns in the table view.",
+    )
+    dashboard: Optional[Any] = Field(
+        None,
+        description="Dashboard configuration for this tab. Defines widgets and layout for the tab's dashboard view.",
+    )
 
 
 class View(BaseStrictModel):
-    icon: Optional[str] = None
-    name: Optional[str] = None
-    title: Optional[str] = None
-    id_: str = Field(alias="id")
-    tabs: Optional[List[Tab]] = None
+    icon: Optional[str] = Field(
+        None,
+        description="Icon name or path for this view shown in the navigation menu.",
+    )
+    name: Optional[str] = Field(
+        None,
+        description="Internal name of the view used for routing and references.",
+    )
+    title: Optional[str] = Field(
+        None,
+        description="Display title of the view shown in the UI.",
+    )
+    id_: str = Field(
+        ...,
+        alias="id",
+        description="Unique identifier of the view within this module.",
+    )
+    tabs: Optional[List[Tab]] = Field(
+        None,
+        description="List of tabs within this view. Each tab displays a different subset of generic objects.",
+    )
 
 
 class _StrictGenericModule(BaseStrictModel):
-    id_: str = Field(alias="id")
-    version: int
-    locked: Optional[bool] = None
-    system: Optional[bool] = None
-    name: str
-    from_version: Optional[str] = Field(None, alias="fromVersion")
-    definition_ids: List[str] = Field(None, alias="definitionIds")
-    views: List[View]
+    id_: str = Field(
+        ...,
+        alias="id",
+        description="Unique identifier of the generic module. Used to reference this module from generic definitions and types.",
+    )
+    version: int = Field(
+        ...,
+        description="Schema version of this module. Used for conflict detection. Typically -1 for new items.",
+    )
+    locked: Optional[bool] = Field(
+        None,
+        description="When True, this module is locked and cannot be modified by users.",
+    )
+    system: Optional[bool] = Field(
+        None,
+        description="When True, this is a system-defined generic module that cannot be deleted.",
+    )
+    name: str = Field(
+        ...,
+        description="Display name of the generic module shown in the navigation menu.",
+    )
+    from_version: Optional[str] = Field(
+        None,
+        alias="fromVersion",
+        description="Minimum platform version required to use this generic module (e.g. '6.5.0').",
+    )
+    definition_ids: List[str] = Field(
+        None,
+        alias="definitionIds",
+        description="List of generic object definition IDs that this module manages. Each definition represents a type of object displayed in the module.",
+    )
+    views: List[View] = Field(
+        ...,
+        description="List of views in this module. Each view provides a different perspective on the module's generic objects.",
+    )
 
 
 StrictGenericModule = create_model(

--- a/demisto_sdk/commands/content_graph/strict_objects/generic_type.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/generic_type.py
@@ -10,8 +10,16 @@ from demisto_sdk.commands.content_graph.strict_objects.common import (
 
 
 class _StrictGenericType(BaseStrictModel):
-    definition_id: str = Field(..., alias="definitionId")
-    generic_module_id: str = Field(..., alias="genericModuleId")
+    definition_id: str = Field(
+        ...,
+        alias="definitionId",
+        description="ID of the generic object definition this type belongs to. Must reference a valid GenericDefinition ID.",
+    )
+    generic_module_id: str = Field(
+        ...,
+        alias="genericModuleId",
+        description="ID of the generic module that contains this type. Must reference a valid GenericModule ID.",
+    )
 
 
 StrictGenericType = create_model(

--- a/demisto_sdk/commands/content_graph/strict_objects/indicator_field.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/indicator_field.py
@@ -19,47 +19,196 @@ from demisto_sdk.commands.content_graph.strict_objects.common import (
 
 
 class _StrictIndicatorField(BaseStrictModel):
-    modified: Optional[str] = None
-    name: str
-    owner_only: Optional[bool] = Field(None, alias="ownerOnly")
-    place_holder: Optional[str] = Field(None, alias="placeholder")
-    description: Optional[str] = None
-    field_calc_script: Optional[str] = Field(None, alias="fieldCalcScript")
-    cli_name: str = Field(..., alias="cliName")
-    type_: str = Field(..., alias="type")
-    close_form: Optional[bool] = Field(None, alias="closeForm")
-    edit_form: Optional[bool] = Field(None, alias="editForm")
-    required: Optional[bool] = None
-    script: Optional[str] = None
-    never_set_as_required: Optional[bool] = Field(None, alias="neverSetAsRequired")
-    is_read_only: Optional[bool] = Field(None, alias="isReadOnly")
-    select_values: Optional[Any] = Field(None, alias="selectValues")
-    validation_regex: Optional[str] = Field(None, alias="validationRegex")
-    use_as_kpi: Optional[bool] = Field(None, alias="useAsKpi")
-    locked: Optional[bool] = None
-    system: Optional[bool] = None
-    group: Optional[int] = None
-    hidden: Optional[bool] = None
-    columns: Optional[Any] = None
-    default_rows: Optional[Any] = Field(None, alias="defaultRows")
-    threshold: Optional[int] = None
-    sla: Optional[int] = None
-    case_insensitive: Optional[bool] = Field(None, alias="caseInsensitive")
-    breach_script: Optional[str] = Field(None, alias="breachScript")
-    associated_types: Optional[Any] = Field(None, alias="associatedTypes")
-    system_associated_types: Optional[Any] = Field(None, alias="systemAssociatedTypes")
-    associated_to_all: Optional[bool] = Field(None, alias="associatedToAll")
-    unmapped: Optional[bool] = None
-    content: Optional[bool] = None
-    unsearchable: Optional[bool] = None
-    item_version: Optional[str] = Field(None, alias="itemVersion")
-    propagation_labels: Optional[Any] = Field(None, alias="propagationLabels")
-    to_server_version: Optional[str] = Field(None, alias="toServerVersion")
-    open_ended: Optional[bool] = Field(None, alias="openEnded")
-    marketplaces: Optional[Union[MarketplaceVersions, List[MarketplaceVersions]]] = None
-    supportedModules: Optional[List[str]] = Field(None, alias="supportedModules")
-    id_: str = Field(..., alias="id")
-    version: int
+    modified: Optional[str] = Field(
+        None,
+        description="ISO 8601 timestamp of when this field was last modified. Set automatically by the platform.",
+    )
+    name: str = Field(
+        ...,
+        description="Display name of the indicator field shown in the UI. Must be unique within the platform.",
+    )
+    owner_only: Optional[bool] = Field(
+        None,
+        alias="ownerOnly",
+        description="When True, only the owner of the indicator can edit this field.",
+    )
+    place_holder: Optional[str] = Field(
+        None,
+        alias="placeholder",
+        description="Placeholder text shown in the field input when it is empty.",
+    )
+    description: Optional[str] = Field(
+        None,
+        description="Human-readable description of what this field represents and how it should be used.",
+    )
+    field_calc_script: Optional[str] = Field(
+        None,
+        alias="fieldCalcScript",
+        description="Name of the script used to automatically calculate this field's value. The script runs when the indicator is created or updated.",
+    )
+    cli_name: str = Field(
+        ...,
+        alias="cliName",
+        description="CLI-friendly name of the field (lowercase, no spaces). Used in API calls and scripts to reference this field.",
+    )
+    type_: str = Field(
+        ...,
+        alias="type",
+        description="Data type of the field. Must be a valid XSOAR field type (e.g. 'shortText', 'longText', 'number', 'boolean', 'date', 'singleSelect', 'multiSelect', 'url', 'markdown').",
+    )
+    close_form: Optional[bool] = Field(
+        None,
+        alias="closeForm",
+        description="When True, this field appears in the close incident form.",
+    )
+    edit_form: Optional[bool] = Field(
+        None,
+        alias="editForm",
+        description="When True, this field appears in the edit incident form.",
+    )
+    required: Optional[bool] = Field(
+        None,
+        description="When True, this field must be filled in before the indicator can be saved.",
+    )
+    script: Optional[str] = Field(
+        None,
+        description="Name of the script to run when this field's value changes. Used for field-level automation.",
+    )
+    never_set_as_required: Optional[bool] = Field(
+        None,
+        alias="neverSetAsRequired",
+        description="When True, this field can never be marked as required, even by incident type configuration.",
+    )
+    is_read_only: Optional[bool] = Field(
+        None,
+        alias="isReadOnly",
+        description="When True, this field is read-only and cannot be edited by users.",
+    )
+    select_values: Optional[Any] = Field(
+        None,
+        alias="selectValues",
+        description="List of allowed values for singleSelect or multiSelect field types. Users can only choose from these values.",
+    )
+    validation_regex: Optional[str] = Field(
+        None,
+        alias="validationRegex",
+        description="Regular expression pattern that the field value must match. Used for input validation.",
+    )
+    use_as_kpi: Optional[bool] = Field(
+        None,
+        alias="useAsKpi",
+        description="When True, this field is used as a Key Performance Indicator (KPI) in dashboards and reports.",
+    )
+    locked: Optional[bool] = Field(
+        None,
+        description="When True, this field is locked and cannot be modified by users.",
+    )
+    system: Optional[bool] = Field(
+        None,
+        description="When True, this is a system-defined field that cannot be deleted.",
+    )
+    group: Optional[int] = Field(
+        None,
+        description="Group number for organizing fields in the UI. Fields with the same group number are displayed together.",
+    )
+    hidden: Optional[bool] = Field(
+        None,
+        description="When True, this field is hidden from the UI but still accessible via API.",
+    )
+    columns: Optional[Any] = Field(
+        None,
+        description="Column definitions for grid-type fields. Defines the structure of the grid.",
+    )
+    default_rows: Optional[Any] = Field(
+        None,
+        alias="defaultRows",
+        description="Default row data for grid-type fields. Pre-populates the grid when a new indicator is created.",
+    )
+    threshold: Optional[int] = Field(
+        None,
+        description="Threshold value for SLA fields. Used to trigger alerts when the SLA is breached.",
+    )
+    sla: Optional[int] = Field(
+        None,
+        description="Service Level Agreement time in minutes. Used for SLA tracking and breach detection.",
+    )
+    case_insensitive: Optional[bool] = Field(
+        None,
+        alias="caseInsensitive",
+        description="When True, field value comparisons are case-insensitive.",
+    )
+    breach_script: Optional[str] = Field(
+        None,
+        alias="breachScript",
+        description="Name of the script to run when the SLA is breached.",
+    )
+    associated_types: Optional[Any] = Field(
+        None,
+        alias="associatedTypes",
+        description="List of incident/indicator types this field is associated with. The field appears in layouts for these types.",
+    )
+    system_associated_types: Optional[Any] = Field(
+        None,
+        alias="systemAssociatedTypes",
+        description="System-defined list of types this field is associated with. Cannot be modified by users.",
+    )
+    associated_to_all: Optional[bool] = Field(
+        None,
+        alias="associatedToAll",
+        description="When True, this field is associated with all incident/indicator types.",
+    )
+    unmapped: Optional[bool] = Field(
+        None,
+        description="When True, this field is not mapped to any incident type and is only accessible via API.",
+    )
+    content: Optional[bool] = Field(
+        None,
+        description="When True, this field is a content field that is included in content exports.",
+    )
+    unsearchable: Optional[bool] = Field(
+        None,
+        description="When True, this field is excluded from search indexes and cannot be searched.",
+    )
+    item_version: Optional[str] = Field(
+        None,
+        alias="itemVersion",
+        description="Version of the pack that contains this field. Set automatically during pack installation.",
+    )
+    propagation_labels: Optional[Any] = Field(
+        None,
+        alias="propagationLabels",
+        description="Labels used for data propagation in multi-tenant environments.",
+    )
+    to_server_version: Optional[str] = Field(
+        None,
+        alias="toServerVersion",
+        description="Maximum server version this field is compatible with. Field is not loaded on newer server versions.",
+    )
+    open_ended: Optional[bool] = Field(
+        None,
+        alias="openEnded",
+        description="When True, users can enter custom values in addition to the predefined selectValues.",
+    )
+    marketplaces: Optional[Union[MarketplaceVersions, List[MarketplaceVersions]]] = (
+        Field(
+            None,
+            description="Marketplace(s) this field is available in. Allowed values: xsoar, marketplacev2, xpanse, xsoar_saas, xsoar_on_prem, platform.",
+        )
+    )
+    supportedModules: Optional[List[str]] = Field(
+        None,
+        alias="supportedModules",
+        description="Optional list of platform modules that support this field. Restricts availability to specific modules.",
+    )
+    id_: str = Field(
+        ...,
+        alias="id",
+        description="Unique identifier of the field. Used internally to reference this field from layouts and scripts.",
+    )
+    version: int = Field(
+        ...,
+        description="Schema version of this field. Used for conflict detection. Typically -1 for new items.",
+    )
 
 
 StrictIndicatorField = create_model(

--- a/demisto_sdk/commands/content_graph/strict_objects/indicator_type.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/indicator_type.py
@@ -16,39 +16,150 @@ from demisto_sdk.commands.content_graph.strict_objects.common import (
 
 
 class _StrictIndicatorType(BaseStrictModel):
-    modified: Optional[str] = None
-    id_: str = Field(alias="id")
-    version: int
-    sort_values: Optional[Any] = Field(None, alias="sortValues")
-    commit_message: Optional[str] = Field(None, alias="commitMessage")
-    should_publish: Optional[bool] = Field(None, alias="shouldPublish")
-    should_commit: Optional[bool] = Field(None, alias="shouldCommit")
-    regex: str
-    details: str
-    prev_details: Optional[str] = Field(None, alias="prevDetails")
-    reputation_script_name: Optional[str] = Field(None, alias="reputationScriptName")
-    reputation_command: Optional[str] = Field(None, alias="reputationCommand")
-    enhancement_script_names: Optional[Any] = Field(
-        None, alias="enhancementScriptNames"
+    modified: Optional[str] = Field(
+        None,
+        description="ISO 8601 timestamp of when this indicator type was last modified. Set automatically by the platform.",
     )
-    system: Optional[bool] = None
-    locked: Optional[bool] = None
-    disabled: Optional[bool] = None
-    file: Optional[bool] = None
-    update_after: Optional[int] = Field(None, alias="updateAfter")
-    merge_context: Optional[bool] = Field(None, alias="mergeContext")
-    format_script: Optional[str] = Field(None, alias="formatScript")
-    context_path: Optional[str] = Field(None, alias="contextPath")
-    context_value: Optional[str] = Field(None, alias="contextValue")
-    excluded_brands: Optional[Any] = Field(None, alias="excludedBrands")
-    default_mapping: Optional[Any] = Field(None, alias="defaultMapping")
-    manual_mapping: Optional[Any] = Field(None, alias="manualMapping")
-    file_hashes_priority: Optional[Any] = Field(None, alias="fileHashesPriority")
-    expiration: Optional[int] = None
-    layout: Optional[str] = None
-    legacy_names: Optional[List[str]] = Field(None, alias="legacyNames")
-    marketplaces: Optional[List[MarketplaceVersions]] = None
-    supportedModules: Optional[List[str]] = Field(None, alias="supportedModules")
+    id_: str = Field(
+        ...,
+        alias="id",
+        description="Unique identifier of the indicator type. Used internally to reference this type from scripts and integrations.",
+    )
+    version: int = Field(
+        ...,
+        description="Schema version of this indicator type. Used for conflict detection. Typically -1 for new items.",
+    )
+    sort_values: Optional[Any] = Field(
+        None,
+        alias="sortValues",
+        description="Internal field used for sorting indicator types in the UI. Not typically set manually.",
+    )
+    commit_message: Optional[str] = Field(
+        None,
+        alias="commitMessage",
+        description="Commit message describing the changes made to this indicator type. Used for version control tracking.",
+    )
+    should_publish: Optional[bool] = Field(
+        None,
+        alias="shouldPublish",
+        description="When True, this indicator type should be published to the marketplace.",
+    )
+    should_commit: Optional[bool] = Field(
+        None,
+        alias="shouldCommit",
+        description="When True, changes to this indicator type should be committed to version control.",
+    )
+    regex: str = Field(
+        ...,
+        description="Regular expression pattern used to automatically detect and extract this indicator type from text. Must be a valid Python regex.",
+    )
+    details: str = Field(
+        ...,
+        description="Display name of the indicator type shown in the UI (e.g. 'IP Address', 'Domain', 'URL').",
+    )
+    prev_details: Optional[str] = Field(
+        None,
+        alias="prevDetails",
+        description="Previous display name of this indicator type. Used for migration when the name changes.",
+    )
+    reputation_script_name: Optional[str] = Field(
+        None,
+        alias="reputationScriptName",
+        description="Name of the script used to calculate the reputation of indicators of this type.",
+    )
+    reputation_command: Optional[str] = Field(
+        None,
+        alias="reputationCommand",
+        description="Integration command used to enrich indicators of this type (e.g. 'ip', 'domain', 'url').",
+    )
+    enhancement_script_names: Optional[Any] = Field(
+        None,
+        alias="enhancementScriptNames",
+        description="List of script names used to enhance (enrich) indicators of this type with additional context.",
+    )
+    system: Optional[bool] = Field(
+        None,
+        description="When True, this is a system-defined indicator type that cannot be deleted.",
+    )
+    locked: Optional[bool] = Field(
+        None,
+        description="When True, this indicator type is locked and cannot be modified by users.",
+    )
+    disabled: Optional[bool] = Field(
+        None,
+        description="When True, this indicator type is disabled and will not be used for automatic extraction.",
+    )
+    file: Optional[bool] = Field(
+        None,
+        description="When True, this indicator type represents a file indicator (e.g. file hash).",
+    )
+    update_after: Optional[int] = Field(
+        None,
+        alias="updateAfter",
+        description="Number of hours after which the indicator should be re-enriched. Used for automatic refresh.",
+    )
+    merge_context: Optional[bool] = Field(
+        None,
+        alias="mergeContext",
+        description="When True, context data from multiple enrichment sources is merged rather than overwritten.",
+    )
+    format_script: Optional[str] = Field(
+        None,
+        alias="formatScript",
+        description="Name of the script used to format/normalize the indicator value before storage.",
+    )
+    context_path: Optional[str] = Field(
+        None,
+        alias="contextPath",
+        description="Context path where enrichment data for this indicator type is stored (e.g. 'IP', 'Domain').",
+    )
+    context_value: Optional[str] = Field(
+        None,
+        alias="contextValue",
+        description="Context field name that contains the indicator value within the context path.",
+    )
+    excluded_brands: Optional[Any] = Field(
+        None,
+        alias="excludedBrands",
+        description="List of integration brand names excluded from enriching this indicator type.",
+    )
+    default_mapping: Optional[Any] = Field(
+        None,
+        alias="defaultMapping",
+        description="Default field mapping applied when creating indicators of this type.",
+    )
+    manual_mapping: Optional[Any] = Field(
+        None,
+        alias="manualMapping",
+        description="Manual field mapping overrides for this indicator type.",
+    )
+    file_hashes_priority: Optional[Any] = Field(
+        None,
+        alias="fileHashesPriority",
+        description="Priority order for file hash types (e.g. SHA256 > SHA1 > MD5). Used when multiple hash types are available.",
+    )
+    expiration: Optional[int] = Field(
+        None,
+        description="Number of days after which indicators of this type expire and are removed from the system.",
+    )
+    layout: Optional[str] = Field(
+        None,
+        description="Name of the layout used to display indicators of this type in the UI.",
+    )
+    legacy_names: Optional[List[str]] = Field(
+        None,
+        alias="legacyNames",
+        description="List of previous names for this indicator type. Used for backward compatibility when the type is renamed.",
+    )
+    marketplaces: Optional[List[MarketplaceVersions]] = Field(
+        None,
+        description="Marketplace(s) this indicator type is available in. Allowed values: xsoar, marketplacev2, xpanse, xsoar_saas, xsoar_on_prem, platform.",
+    )
+    supportedModules: Optional[List[str]] = Field(
+        None,
+        alias="supportedModules",
+        description="Optional list of platform modules that support this indicator type. Restricts availability to specific modules.",
+    )
 
 
 StrictIndicatorType = create_model(

--- a/demisto_sdk/commands/content_graph/strict_objects/integration.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/integration.py
@@ -51,20 +51,68 @@ class SectionOrderValues(StrEnum):
 
 
 class _Configuration(BaseStrictModel):
-    display: Optional[str] = None
-    section: Optional[str] = None
-    advanced: Optional[str] = None
-    default_value: Optional[Any] = Field(None, alias="defaultvalue")
-    name: str
-    type: int
-    required: Optional[bool] = None
-    hidden: Optional[Any] = None
-    options: Optional[List[str]] = None
-    additional_info: Optional[str] = Field(None, alias="additionalinfo")
-    display_password: Optional[str] = Field(None, alias="displaypassword")
-    hidden_username: Optional[bool] = Field(None, alias="hiddenusername")
-    hidden_password: Optional[bool] = Field(None, alias="hiddenpassword")
-    from_license: Optional[str] = Field(None, alias="fromlicense")
+    display: Optional[str] = Field(
+        None,
+        description="Display label for this configuration parameter shown in the integration settings UI.",
+    )
+    section: Optional[str] = Field(
+        None,
+        description="Section name this parameter belongs to (e.g. 'Connect', 'Collect'). Must be listed in sectionorder.",
+    )
+    advanced: Optional[str] = Field(
+        None,
+        description="When set, marks this parameter as advanced and hides it by default in the UI.",
+    )
+    default_value: Optional[Any] = Field(
+        None,
+        alias="defaultvalue",
+        description="Default value for this configuration parameter. Used when the user does not provide a value.",
+    )
+    name: str = Field(
+        ...,
+        description="Unique machine-readable name of this configuration parameter. Used in code to access the parameter value.",
+    )
+    type: int = Field(
+        ...,
+        description="Parameter type code. Common values: 0=Short text, 4=Encrypted, 8=Boolean, 9=Authentication, 12=Single select, 16=Multi select.",
+    )
+    required: Optional[bool] = Field(
+        None,
+        description="When True, this parameter must be filled in before the integration instance can be saved.",
+    )
+    hidden: Optional[Any] = Field(
+        None,
+        description="When True, this parameter is hidden from the UI. Can be a boolean or marketplace-specific value.",
+    )
+    options: Optional[List[str]] = Field(
+        None,
+        description="List of allowed values for select-type parameters (type 12 or 16). Users can only choose from these values.",
+    )
+    additional_info: Optional[str] = Field(
+        None,
+        alias="additionalinfo",
+        description="Additional help text shown below the parameter in the UI. Provides extra context or instructions.",
+    )
+    display_password: Optional[str] = Field(
+        None,
+        alias="displaypassword",
+        description="Display label for the password field in credential-type parameters.",
+    )
+    hidden_username: Optional[bool] = Field(
+        None,
+        alias="hiddenusername",
+        description="When True, the username field is hidden in credential-type parameters.",
+    )
+    hidden_password: Optional[bool] = Field(
+        None,
+        alias="hiddenpassword",
+        description="When True, the password field is hidden in credential-type parameters.",
+    )
+    from_license: Optional[str] = Field(
+        None,
+        alias="fromlicense",
+        description="License field to populate this parameter from. Used for license-based authentication.",
+    )
 
 
 Configuration = create_model(
@@ -84,24 +132,63 @@ class IntegrationOutput(Output):  # type:ignore[misc,valid-type]
 
 
 class _Command(BaseStrictModel):
-    name: str
-    execution: Optional[bool] = None
-    description: str
-    deprecated: Optional[bool] = None
-    system: Optional[bool] = None
-    arguments: Optional[List[Argument]] = None  # type:ignore[valid-type]
-    outputs: Optional[List[IntegrationOutput]] = None
-    important: Optional[List[Important]] = None  # type:ignore[valid-type]
-    timeout: Optional[int] = None
-    polling: Optional[bool] = None
-    prettyname: Optional[str] = None
-    compliantpolicies: Optional[List[str]] = None
+    name: str = Field(
+        ...,
+        description="Unique name of the command (e.g. 'ip', 'domain', 'get-alerts'). Used in playbooks and the CLI.",
+    )
+    execution: Optional[bool] = Field(
+        None,
+        description="When True, this command performs a write/execution action (not just read). Used for compliance and auditing.",
+    )
+    description: str = Field(
+        ...,
+        description="Human-readable description of what this command does. Shown in the UI and used for documentation.",
+    )
+    deprecated: Optional[bool] = Field(
+        None,
+        description="When True, this command is deprecated and should not be used in new playbooks.",
+    )
+    system: Optional[bool] = Field(
+        None,
+        description="When True, this is a system-provided command that cannot be deleted.",
+    )
+    arguments: Optional[List[Argument]] = Field(  # type:ignore[valid-type]
+        None,
+        description="List of input arguments accepted by this command.",
+    )
+    outputs: Optional[List[IntegrationOutput]] = Field(
+        None,
+        description="List of output fields returned by this command. Defines the context paths populated after execution.",
+    )
+    important: Optional[List[Important]] = Field(  # type:ignore[valid-type]
+        None,
+        description="List of important outputs to highlight in the UI. These outputs are shown prominently in the war room.",
+    )
+    timeout: Optional[int] = Field(
+        None,
+        description="Command execution timeout in seconds. Overrides the integration-level timeout for this specific command.",
+    )
+    polling: Optional[bool] = Field(
+        None,
+        description="When True, this command supports polling mode for long-running operations.",
+    )
+    prettyname: Optional[str] = Field(
+        None,
+        description="Human-readable display name of the command shown in the UI.",
+    )
+    compliantpolicies: Optional[List[str]] = Field(
+        None,
+        description="List of compliance policy names this command satisfies. Used for compliance reporting.",
+    )
     supportedModules: Optional[
         Annotated[
             List[PlatformSupportedModules],
             Field(min_length=1, max_length=len(PlatformSupportedModules)),
         ]
-    ]
+    ] = Field(
+        None,
+        description="Optional list of platform modules that support this command. Restricts availability to specific modules.",
+    )
 
 
 Command = create_model(
@@ -118,26 +205,103 @@ Command = create_model(
 
 
 class _Script(BaseStrictModel):
-    script: str
-    type_: ScriptType = Field(..., alias="type")
-    docker_image: str = Field(None, alias="dockerimage")
-    alt_docker_images: Optional[List[str]] = Field(None, alias="alt_dockerimages")
-    native_image: Optional[List[str]] = Field(None, alias="nativeImage")
-    is_fetch: Optional[bool] = Field(None, alias="isfetch")
-    is_fetch_events: Optional[bool] = Field(None, alias="isfetchevents")
-    is_fetch_assets: Optional[bool] = Field(None, alias="isfetchassets")
-    mcp: Optional[bool] = Field(None, alias="mcp")
-    long_running: Optional[bool] = Field(None, alias="longRunning")
-    long_running_port: Optional[bool] = Field(None, alias="longRunningPort")
-    is_mappable: Optional[bool] = Field(None, alias="ismappable")
-    is_remote_sync_in: Optional[bool] = Field(None, alias="isremotesyncin")
-    is_remote_sync_out: Optional[bool] = Field(None, alias="isremotesyncout")
-    commands: Optional[List[Command]] = None  # type:ignore[valid-type]
-    run_once: Optional[bool] = Field(None, alias="runonce")
-    sub_type: Optional[str] = Field([TYPE_PYTHON2, TYPE_PYTHON3], alias="subtype")
-    feed: Optional[bool] = None
-    is_fetch_samples: Optional[bool] = Field(None, alias="isFetchSamples")
-    reset_context: Optional[bool] = Field(None, alias="resetContext")
+    script: str = Field(
+        ...,
+        description="The integration script code. For Python integrations, this is the Python source code. For unified integrations, this is '-'.",
+    )
+    type_: ScriptType = Field(
+        ...,
+        alias="type",
+        description="Script language type. Must be one of: 'python3', 'python2', 'powershell', 'javascript'.",
+    )
+    docker_image: str = Field(
+        None,
+        alias="dockerimage",
+        description="Docker image used to run this integration (e.g. 'demisto/python3:3.10.12.63474'). Must be a valid Docker image tag.",
+    )
+    alt_docker_images: Optional[List[str]] = Field(
+        None,
+        alias="alt_dockerimages",
+        description="Alternative Docker images for different platforms. Used for multi-architecture support.",
+    )
+    native_image: Optional[List[str]] = Field(
+        None,
+        alias="nativeImage",
+        description="Native image configurations for running without Docker. Used for native execution environments.",
+    )
+    is_fetch: Optional[bool] = Field(
+        None,
+        alias="isfetch",
+        description="When True, this integration fetches incidents from the external service. Enables the fetch incidents mechanism.",
+    )
+    is_fetch_events: Optional[bool] = Field(
+        None,
+        alias="isfetchevents",
+        description="When True, this integration fetches events for XSIAM. Enables the fetch events mechanism.",
+    )
+    is_fetch_assets: Optional[bool] = Field(
+        None,
+        alias="isfetchassets",
+        description="When True, this integration fetches assets for XSIAM. Enables the fetch assets mechanism.",
+    )
+    mcp: Optional[bool] = Field(
+        None,
+        alias="mcp",
+        description="When True, this integration supports the Model Context Protocol (MCP) for AI agent integration.",
+    )
+    long_running: Optional[bool] = Field(
+        None,
+        alias="longRunning",
+        description="When True, this integration runs as a long-running process rather than per-command execution.",
+    )
+    long_running_port: Optional[bool] = Field(
+        None,
+        alias="longRunningPort",
+        description="When True, the long-running integration exposes a port for incoming connections.",
+    )
+    is_mappable: Optional[bool] = Field(
+        None,
+        alias="ismappable",
+        description="When True, this integration supports incident field mapping via the mapper.",
+    )
+    is_remote_sync_in: Optional[bool] = Field(
+        None,
+        alias="isremotesyncin",
+        description="When True, this integration supports incoming mirroring (syncing changes from the external system to XSOAR).",
+    )
+    is_remote_sync_out: Optional[bool] = Field(
+        None,
+        alias="isremotesyncout",
+        description="When True, this integration supports outgoing mirroring (syncing changes from XSOAR to the external system).",
+    )
+    commands: Optional[List[Command]] = Field(  # type:ignore[valid-type]
+        None,
+        description="List of commands provided by this integration. Each command is callable from playbooks and the CLI.",
+    )
+    run_once: Optional[bool] = Field(
+        None,
+        alias="runonce",
+        description="When True, this integration runs only once and then stops. Used for one-time setup integrations.",
+    )
+    sub_type: Optional[str] = Field(
+        [TYPE_PYTHON2, TYPE_PYTHON3],
+        alias="subtype",
+        description="Python sub-type. Must be 'python3' or 'python2'. Determines which Python version is used.",
+    )
+    feed: Optional[bool] = Field(
+        None,
+        description="When True, this integration is a feed integration that ingests threat intelligence indicators.",
+    )
+    is_fetch_samples: Optional[bool] = Field(
+        None,
+        alias="isFetchSamples",
+        description="When True, this integration can fetch sample incidents for testing and configuration.",
+    )
+    reset_context: Optional[bool] = Field(
+        None,
+        alias="resetContext",
+        description="When True, the integration context is reset on each command execution.",
+    )
 
 
 Script = create_model(
@@ -188,40 +352,136 @@ class Trigger(BaseStrictModel):
 
 
 class _StrictIntegration(BaseStrictModel):
-    common_fields: CommonFieldsIntegration = Field(..., alias="commonfields")  # type:ignore[valid-type]
-    display: str
-    beta: Optional[bool] = None
-    category: str
-    section_order: Optional[conlist(SectionOrderValues, min_items=1, max_items=5)] = (  # type:ignore[valid-type]
-        Field(alias="sectionorder")
+    common_fields: CommonFieldsIntegration = Field(  # type:ignore[valid-type]
+        ...,
+        alias="commonfields",
+        description="Common metadata fields including the integration's unique ID and schema version.",
     )
-    configurations: List[Configuration] = Field(..., alias="configuration")  # type:ignore[valid-type]
-    image: Optional[str] = None
-    description: str
-    provider: Optional[str] = None
-    default_mapper_in: Optional[str] = Field(None, alias="defaultmapperin")
-    default_mapper_out: Optional[str] = Field(None, alias="defaultmapperout")
-    default_classifier: Optional[str] = Field(None, alias="defaultclassifier")
-    detailed_description: Optional[str] = Field(None, alias="detaileddescription")
-    auto_config_instance: Optional[bool] = Field(None, alias="autoconfiginstance")
-    support_level_header: MarketplaceVersions = Field(None, alias="supportlevelheader")
-    script: Script  # type:ignore[valid-type]
-    hidden: Optional[bool] = None
-    internal: Optional[bool] = None
-    source: Optional[str] = None
-    videos: Optional[List[str]] = None
-    versioned_fields: dict = Field(None, alias="versionedfields")
-    default_enabled: Optional[bool] = Field(None, alias="defaultEnabled")
-    script_not_visible: Optional[bool] = Field(None, alias="scriptNotVisible")
-    hybrid: Optional[bool] = None
-    supports_quick_actions: Optional[bool] = Field(None, alias="supportsquickactions")
+    display: str = Field(
+        ...,
+        description="Display name of the integration shown in the UI and marketplace.",
+    )
+    beta: Optional[bool] = Field(
+        None,
+        description="When True, marks this integration as a beta release. Beta integrations may have limited support.",
+    )
+    category: str = Field(
+        ...,
+        description="Category of the integration (e.g. 'Data Enrichment & Threat Intelligence', 'Endpoint'). Must use a valid category name.",
+    )
+    section_order: Optional[conlist(SectionOrderValues, min_items=1, max_items=5)] = (
+        Field(  # type:ignore[valid-type]
+            None,
+            alias="sectionorder",
+            description="Ordered list of configuration sections. Allowed values: Connect, Collect, Optimize, Mirroring, Result. Max 5 sections.",
+        )
+    )
+    configurations: List[Configuration] = Field(  # type:ignore[valid-type]
+        ...,
+        alias="configuration",
+        description="List of configuration parameters for this integration. Defines the settings users must fill in when creating an instance.",
+    )
+    image: Optional[str] = Field(
+        None,
+        description="Base64-encoded integration logo image. Shown in the UI and marketplace.",
+    )
+    description: str = Field(
+        ...,
+        description="Short description of the integration shown in the marketplace listing.",
+    )
+    provider: Optional[str] = Field(
+        None,
+        description="Name of the technology provider (e.g. 'Palo Alto Networks', 'CrowdStrike'). Shown in the marketplace.",
+    )
+    default_mapper_in: Optional[str] = Field(
+        None,
+        alias="defaultmapperin",
+        description="Name of the default incoming mapper for this integration. Applied automatically when creating an instance.",
+    )
+    default_mapper_out: Optional[str] = Field(
+        None,
+        alias="defaultmapperout",
+        description="Name of the default outgoing mapper for this integration. Applied automatically when creating an instance.",
+    )
+    default_classifier: Optional[str] = Field(
+        None,
+        alias="defaultclassifier",
+        description="Name of the default classifier for this integration. Applied automatically when creating an instance.",
+    )
+    detailed_description: Optional[str] = Field(
+        None,
+        alias="detaileddescription",
+        description="Detailed description of the integration shown in the integration configuration panel. Supports markdown.",
+    )
+    auto_config_instance: Optional[bool] = Field(
+        None,
+        alias="autoconfiginstance",
+        description="When True, an integration instance is automatically configured during pack installation.",
+    )
+    support_level_header: MarketplaceVersions = Field(
+        None,
+        alias="supportlevelheader",
+        description="Marketplace version for which the support level header is shown.",
+    )
+    script: Script = Field(  # type:ignore[valid-type]
+        ...,
+        description="Script configuration block containing the integration code, commands, and execution settings.",
+    )
+    hidden: Optional[bool] = Field(
+        None,
+        description="When True, this integration is hidden from the marketplace and integration list.",
+    )
+    internal: Optional[bool] = Field(
+        None,
+        description="When True, marks this integration as internal and not intended for direct use by end users.",
+    )
+    source: Optional[str] = Field(
+        None,
+        description="Source repository or origin of this integration.",
+    )
+    videos: Optional[List[str]] = Field(
+        None,
+        description="List of URLs to demo or tutorial videos for this integration.",
+    )
+    versioned_fields: dict = Field(
+        None,
+        alias="versionedfields",
+        description="Dictionary of fields that have marketplace-specific versions. Used for marketplace-specific customization.",
+    )
+    default_enabled: Optional[bool] = Field(
+        None,
+        alias="defaultEnabled",
+        description="When True, the integration instance is enabled by default after installation.",
+    )
+    script_not_visible: Optional[bool] = Field(
+        None,
+        alias="scriptNotVisible",
+        description="When True, the integration script code is not visible to users.",
+    )
+    hybrid: Optional[bool] = Field(
+        None,
+        description="When True, this integration supports both XSOAR and XSIAM platforms simultaneously.",
+    )
+    supports_quick_actions: Optional[bool] = Field(
+        None,
+        alias="supportsquickactions",
+        description="When True, this integration supports quick actions that can be triggered from the UI.",
+    )
     is_cloud_provider_integration: Optional[bool] = Field(
-        False, alias="isCloudProviderIntegration"
+        False,
+        alias="isCloudProviderIntegration",
+        description="When True, marks this as a cloud provider integration with special handling for cloud authentication.",
     )
-    triggers: Optional[List[Trigger]] = None
+    triggers: Optional[List[Trigger]] = Field(
+        None,
+        description="List of UI triggers that dynamically show/hide configuration parameters based on other parameter values.",
+    )
     supportedModules: Optional[
         Annotated[List[PlatformSupportedModules], Field(min_length=1, max_length=7)]
-    ]
+    ] = Field(
+        None,
+        description="Optional list of platform modules that support this integration. Restricts availability to specific modules.",
+    )
 
     def __init__(self, **data):
         """

--- a/demisto_sdk/commands/content_graph/strict_objects/layout_rule.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/layout_rule.py
@@ -14,16 +14,40 @@ from demisto_sdk.commands.content_graph.strict_objects.common import (
 
 
 class _StrictLayoutRule(BaseStrictModel):
-    rule_id: str
-    rule_name: str
-    layout_id: str
+    rule_id: str = Field(
+        ...,
+        description="Unique identifier of the layout rule. Used internally to reference this rule.",
+    )
+    rule_name: str = Field(
+        ...,
+        description="Display name of the layout rule shown in the UI.",
+    )
+    layout_id: str = Field(
+        ...,
+        description="ID of the layout (layout-container) to apply when this rule matches. Must reference a valid layout ID.",
+    )
     from_version: str = Field(
-        alias="fromVersion"
-    )  # not using the base because it's required
-    description: Optional[str] = None
-    alerts_filter: Optional[AlertsFilter] = None
-    supportedModules: Optional[List[str]] = Field(None, alias="supportedModules")
-    marketplaces: Optional[List[MarketplaceVersions]] = None
+        ...,
+        alias="fromVersion",
+        description="Minimum platform version required to use this layout rule (e.g. '6.5.0'). Required field.",
+    )
+    description: Optional[str] = Field(
+        None,
+        description="Human-readable description of when this layout rule applies and what it does.",
+    )
+    alerts_filter: Optional[AlertsFilter] = Field(
+        None,
+        description="Filter conditions that determine when this layout rule is applied. When the filter matches, the associated layout is used.",
+    )
+    supportedModules: Optional[List[str]] = Field(
+        None,
+        alias="supportedModules",
+        description="Optional list of platform modules that support this layout rule. Restricts availability to specific modules.",
+    )
+    marketplaces: Optional[List[MarketplaceVersions]] = Field(
+        None,
+        description="Marketplace(s) this layout rule is available in. Allowed values: xsoar, marketplacev2, xpanse, xsoar_saas, xsoar_on_prem, platform.",
+    )
 
 
 StrictLayoutRule = create_model(

--- a/demisto_sdk/commands/content_graph/strict_objects/mapper.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/mapper.py
@@ -18,17 +18,55 @@ from demisto_sdk.commands.content_graph.strict_objects.common import (
 
 
 class _StrictMapper(BaseStrictModel):
-    id_: str = Field(alias="id")
-    name: str
-    type_: str = Field(alias="type")
-    description: str
-    version: int
-    mapping: Optional[Dict[str, Any]] = Field(default_factory=dict)
-    default_incident_type: Optional[str] = Field(None, alias="defaultIncidentType")
-    feed: Optional[bool] = None
-    definition_id: Optional[str] = Field(None, alias="definitionId")
-    marketplaces: Optional[List[MarketplaceVersions]] = None
-    supportedModules: Optional[List[str]] = Field(None, alias="supportedModules")
+    id_: str = Field(
+        ...,
+        alias="id",
+        description="Unique identifier of the mapper. Used internally to reference this mapper from integrations and classifiers.",
+    )
+    name: str = Field(
+        ...,
+        description="Unique display name of the mapper. Must be unique within the platform.",
+    )
+    type_: str = Field(
+        ...,
+        alias="type",
+        description="Type of mapper. Must be 'mapping-incoming' for incoming mappers or 'mapping-outgoing' for outgoing mappers.",
+    )
+    description: str = Field(
+        ...,
+        description="Human-readable description of what this mapper does and which integrations or event sources it supports.",
+    )
+    version: int = Field(
+        ...,
+        description="Schema version of this mapper. Used for conflict detection. Typically -1 for new items.",
+    )
+    mapping: Optional[Dict[str, Any]] = Field(
+        default_factory=dict,
+        description="The mapping rules dictionary. Keys are incident type names, values are field mapping configurations.",
+    )
+    default_incident_type: Optional[str] = Field(
+        None,
+        alias="defaultIncidentType",
+        description="Default incident type to use when no specific mapping rule matches. Must reference a valid incident type name.",
+    )
+    feed: Optional[bool] = Field(
+        None,
+        description="When True, this mapper is used for feed (indicator) incidents rather than regular incidents.",
+    )
+    definition_id: Optional[str] = Field(
+        None,
+        alias="definitionId",
+        description="ID of the generic object definition this mapper is associated with. Used for generic object mappers.",
+    )
+    marketplaces: Optional[List[MarketplaceVersions]] = Field(
+        None,
+        description="Marketplace(s) this mapper is available in. Allowed values: xsoar, marketplacev2, xpanse, xsoar_saas, xsoar_on_prem, platform.",
+    )
+    supportedModules: Optional[List[str]] = Field(
+        None,
+        alias="supportedModules",
+        description="Optional list of platform modules that support this mapper. Restricts availability to specific modules.",
+    )
 
 
 StrictMapper = create_model(

--- a/demisto_sdk/commands/content_graph/strict_objects/modeling_rule.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/modeling_rule.py
@@ -12,16 +12,51 @@ from demisto_sdk.commands.content_graph.strict_objects.common import (
 
 
 class _StrictModelingRule(BaseStrictModel):
-    id_: str = Field(alias="id")
-    name: str
-    from_version: str = Field(alias="fromversion")
-    to_version: Optional[str] = Field(None, alias="toversion")
-    tags: Optional[str] = None
-    rules: Optional[str] = None
-    schema_: Optional[str] = Field(None, alias="schema")
-    comment: Optional[str] = None
-    deprecated: Optional[bool] = None
-    supportedModules: Optional[List[str]] = Field(None, alias="supportedModules")
+    id_: str = Field(
+        ...,
+        alias="id",
+        description="Unique identifier of the modeling rule. Used internally to reference this rule.",
+    )
+    name: str = Field(
+        ...,
+        description="Display name of the modeling rule shown in the UI.",
+    )
+    from_version: str = Field(
+        ...,
+        alias="fromversion",
+        description="Minimum platform version required to use this modeling rule (e.g. '6.8.0'). Required field.",
+    )
+    to_version: Optional[str] = Field(
+        None,
+        alias="toversion",
+        description="Maximum platform version this modeling rule is compatible with. Rule is not loaded on newer platform versions.",
+    )
+    tags: Optional[str] = Field(
+        None,
+        description="Comma-separated tags used to categorize and filter this modeling rule.",
+    )
+    rules: Optional[str] = Field(
+        None,
+        description="XDM (XDR Data Model) mapping rules in YAML format. Defines how raw log fields are mapped to XDM schema fields.",
+    )
+    schema_: Optional[str] = Field(
+        None,
+        alias="schema",
+        description="JSON schema definition for the raw log data this modeling rule processes. Validates incoming data structure.",
+    )
+    comment: Optional[str] = Field(
+        None,
+        description="Developer comment describing the purpose and usage of this modeling rule.",
+    )
+    deprecated: Optional[bool] = Field(
+        None,
+        description="When True, this modeling rule is deprecated and should not be used in new integrations.",
+    )
+    supportedModules: Optional[List[str]] = Field(
+        None,
+        alias="supportedModules",
+        description="Optional list of platform modules that support this modeling rule. Restricts availability to specific modules.",
+    )
 
 
 StrictModelingRule = create_model(

--- a/demisto_sdk/commands/content_graph/strict_objects/pack_meta_data.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/pack_meta_data.py
@@ -44,61 +44,238 @@ class StrictPackMetadata(BaseStrictModel):
 
         return values
 
-    name: str
-    display_name: Optional[str] = None
-    description: Optional[str] = None
-    created: Optional[str] = None
-    updated: Optional[str] = None
-    legacy: Optional[bool] = None
-    support: PackSupportOption
-    url: Optional[str] = None
-    email: Optional[str] = None
-    eula_link: Optional[str] = Field(None, alias="eulaLink")
-    author: str
-    author_image: Optional[str] = Field(None, alias="authorImage")
-    certification: Optional[str] = None
-    price: Optional[int] = None
-    hidden: Optional[bool] = None
-    server_min_version: Optional[str] = Field(alias="serverMinVersion")
-    current_version: Optional[str] = Field(alias="currentVersion")
-    version_info: str = Field("", alias="versionInfo")
-    commit: Optional[str] = None
-    downloads: Optional[int] = None
-    tags: List[str] = Field(default_factory=list)
-    categories: List[str] = Field(default_factory=list)
-    use_cases: List[str] = Field(default_factory=list, alias="useCases")
-    keywords: Optional[List[str]] = Field(default_factory=list)
-    search_rank: Optional[int] = Field(None, alias="searchRank")
+    name: str = Field(
+        ...,
+        description="Unique machine-readable name of the pack. Used as the pack directory name and in API references. Must not contain spaces.",
+    )
+    display_name: Optional[str] = Field(
+        None,
+        description="Human-readable display name of the pack shown in the marketplace. Can contain spaces and special characters.",
+    )
+    description: Optional[str] = Field(
+        None,
+        description="Short description of the pack shown in the marketplace listing. Should be concise (1-2 sentences).",
+    )
+    created: Optional[str] = Field(
+        None,
+        description="ISO 8601 timestamp of when this pack was first created. Set automatically.",
+    )
+    updated: Optional[str] = Field(
+        None,
+        description="ISO 8601 timestamp of when this pack was last updated. Set automatically.",
+    )
+    legacy: Optional[bool] = Field(
+        None,
+        description="When True, marks this pack as a legacy pack that is no longer actively maintained.",
+    )
+    support: PackSupportOption = Field(
+        ...,
+        description="Support level for this pack. Must be one of: 'xsoar' (Palo Alto Networks), 'partner' (technology partner), 'community' (community-maintained), 'developer' (individual developer).",
+    )
+    url: Optional[str] = Field(
+        None,
+        description="URL to the pack's support page or documentation. Shown in the marketplace listing.",
+    )
+    email: Optional[str] = Field(
+        None,
+        description="Support email address for this pack. Shown in the marketplace listing.",
+    )
+    eula_link: Optional[str] = Field(
+        None,
+        alias="eulaLink",
+        description="URL to the End User License Agreement (EULA) for this pack. Required for paid packs.",
+    )
+    author: str = Field(
+        ...,
+        description="Name of the pack author or organization. Shown in the marketplace listing.",
+    )
+    author_image: Optional[str] = Field(
+        None,
+        alias="authorImage",
+        description="Path to the author's logo image file within the pack. Shown in the marketplace listing.",
+    )
+    certification: Optional[str] = Field(
+        None,
+        description="Certification level of the pack (e.g. 'certified'). Indicates the pack has passed quality review.",
+    )
+    price: Optional[int] = Field(
+        None,
+        description="Price of the pack in marketplace credits. Set to 0 or omit for free packs.",
+    )
+    hidden: Optional[bool] = Field(
+        None,
+        description="When True, the pack is hidden from the marketplace listing but can still be installed directly.",
+    )
+    server_min_version: Optional[str] = Field(
+        ...,
+        alias="serverMinVersion",
+        description="Minimum XSOAR/XSIAM server version required to install this pack (e.g. '6.0.0').",
+    )
+    current_version: Optional[str] = Field(
+        ...,
+        alias="currentVersion",
+        description="Current semantic version of the pack (e.g. '1.2.3'). Must follow semver format. Increment on each release.",
+    )
+    version_info: str = Field(
+        "",
+        alias="versionInfo",
+        description="Additional version information or release notes summary. Set automatically during release.",
+    )
+    commit: Optional[str] = Field(
+        None,
+        description="Git commit hash of the pack's last release. Set automatically during release.",
+    )
+    downloads: Optional[int] = Field(
+        None,
+        description="Number of times this pack has been downloaded from the marketplace. Set automatically.",
+    )
+    tags: List[str] = Field(
+        default_factory=list,
+        description="List of tags for marketplace filtering and discovery (e.g. ['Threat Intelligence', 'Malware']). Use existing tags when possible.",
+    )
+    categories: List[str] = Field(
+        default_factory=list,
+        description="List of marketplace categories this pack belongs to (e.g. ['Data Enrichment & Threat Intelligence']). Must use valid category names.",
+    )
+    use_cases: List[str] = Field(
+        default_factory=list,
+        alias="useCases",
+        description="List of use cases this pack addresses (e.g. ['Phishing', 'Malware']). Helps users discover relevant packs.",
+    )
+    keywords: Optional[List[str]] = Field(
+        default_factory=list,
+        description="Additional keywords for marketplace search. Supplements tags and categories.",
+    )
+    search_rank: Optional[int] = Field(
+        None,
+        alias="searchRank",
+        description="Manual search ranking boost for this pack in marketplace search results. Higher values appear first.",
+    )
     excluded_dependencies: List[str] = Field(
-        default_factory=list, alias="excludedDependencies"
+        default_factory=list,
+        alias="excludedDependencies",
+        description="List of pack names to exclude from automatic dependency resolution. Use when a dependency is optional or causes conflicts.",
     )
-    videos: List[str] = Field(default_factory=list)
-    modules: List[str] = Field(default_factory=list)
-    integrations: Optional[List[str]] = Field(default_factory=list)
-    hybrid: bool = Field(False, alias="hybrid")
-    default_data_source_id: Optional[str] = Field(None, alias="defaultDataSource")
-    default_data_source_name: Optional[str] = Field(None, exclude=True)
-    beta: Optional[bool] = None
-    dependencies: Optional[dict] = Field(default_factory=dict)
-    deprecated: Optional[bool] = None
-    marketplaces: Optional[List[MarketplaceVersions]] = None
+    videos: List[str] = Field(
+        default_factory=list,
+        description="List of URLs to demo or tutorial videos for this pack. Shown in the marketplace listing.",
+    )
+    modules: List[str] = Field(
+        default_factory=list,
+        description="List of platform modules this pack is compatible with. Used for module-specific marketplace filtering.",
+    )
+    integrations: Optional[List[str]] = Field(
+        default_factory=list,
+        description="List of integration names included in this pack. Used for marketplace display.",
+    )
+    hybrid: bool = Field(
+        False,
+        alias="hybrid",
+        description="When True, this pack supports both XSOAR and XSIAM platforms simultaneously.",
+    )
+    default_data_source_id: Optional[str] = Field(
+        None,
+        alias="defaultDataSource",
+        description="ID of the default data source integration in this pack. Used for automatic data source configuration.",
+    )
+    default_data_source_name: Optional[str] = Field(
+        None,
+        exclude=True,
+        description="Display name of the default data source. Derived from defaultDataSource. Not stored in pack_metadata.json.",
+    )
+    beta: Optional[bool] = Field(
+        None,
+        description="When True, marks this pack as a beta release. Beta packs may have limited support and are subject to change.",
+    )
+    dependencies: Optional[dict] = Field(
+        default_factory=dict,
+        description="Dictionary of pack dependencies. Keys are pack names, values are dependency metadata including mandatory flag and display name.",
+    )
+    deprecated: Optional[bool] = Field(
+        None,
+        description="When True, this pack is deprecated and users should migrate to a replacement pack.",
+    )
+    marketplaces: Optional[List[MarketplaceVersions]] = Field(
+        None,
+        description="Marketplace(s) this pack is available in. Allowed values: xsoar, marketplacev2, xpanse, xsoar_saas, xsoar_on_prem, platform.",
+    )
     github_user: Optional[Union[str, List[str]]] = Field(
-        alias="githubUser", default_factory=list
+        alias="githubUser",
+        default_factory=list,
+        description="GitHub username(s) of the pack maintainer(s). Used for contribution tracking.",
     )
-    dev_email: Optional[Union[str, List[str]]] = Field(None, alias="devEmail")
-    displayed_images: Optional[List[str]] = Field(None, alias="displayedImages")
-    item_prefix: Optional[Union[str, List[str]]] = Field(None, alias="itemPrefix")
-    from_version: Optional[str] = Field(None, alias="fromVersion")
-    previous_name: Optional[str] = Field(None, alias="prevName")
-
+    dev_email: Optional[Union[str, List[str]]] = Field(
+        None,
+        alias="devEmail",
+        description="Developer email address(es) for internal communication. Not shown publicly.",
+    )
+    displayed_images: Optional[List[str]] = Field(
+        None,
+        alias="displayedImages",
+        description="List of integration names whose logos are displayed in the pack's marketplace listing.",
+    )
+    item_prefix: Optional[Union[str, List[str]]] = Field(
+        None,
+        alias="itemPrefix",
+        description="Prefix(es) used for content item names in this pack. Helps avoid naming conflicts.",
+    )
+    from_version: Optional[str] = Field(
+        None,
+        alias="fromVersion",
+        description="Minimum platform version required to install this pack (e.g. '6.0.0').",
+    )
+    previous_name: Optional[str] = Field(
+        None,
+        alias="prevName",
+        description="Previous name of this pack before it was renamed. Used for migration and backward compatibility.",
+    )
     # For private packs
-    premium: Optional[bool] = None
-    vendor_id: Optional[str] = Field(None, alias="vendorId")
-    partner_id: Optional[str] = Field(None, alias="partnerId")
-    partner_name: Optional[str] = Field(None, alias="partnerName")
-    preview_only: Optional[bool] = Field(None, alias="previewOnly")
-    disable_monthly: Optional[bool] = Field(None, alias="disableMonthly")
-    content_commit_hash: Optional[str] = Field(None, alias="contentCommitHash")
-    supportedModules: Optional[List[str]] = Field(None, alias="supportedModules")
-    source: Optional[str] = Field("", alias="source")
-    managed: Optional[bool] = Field(False, alias="managed")
+    premium: Optional[bool] = Field(
+        None,
+        description="When True, this is a premium (paid) pack available only to subscribers.",
+    )
+    vendor_id: Optional[str] = Field(
+        None,
+        alias="vendorId",
+        description="Vendor identifier for premium packs. Used for billing and access control.",
+    )
+    partner_id: Optional[str] = Field(
+        None,
+        alias="partnerId",
+        description="Partner identifier for partner-supported packs. Used for partner portal integration.",
+    )
+    partner_name: Optional[str] = Field(
+        None,
+        alias="partnerName",
+        description="Display name of the technology partner who created this pack.",
+    )
+    preview_only: Optional[bool] = Field(
+        None,
+        alias="previewOnly",
+        description="When True, this pack is in preview mode and not yet generally available.",
+    )
+    disable_monthly: Optional[bool] = Field(
+        None,
+        alias="disableMonthly",
+        description="When True, disables monthly billing for this premium pack.",
+    )
+    content_commit_hash: Optional[str] = Field(
+        None,
+        alias="contentCommitHash",
+        description="Git commit hash of the content repository at the time of pack release.",
+    )
+    supportedModules: Optional[List[str]] = Field(
+        None,
+        alias="supportedModules",
+        description="Optional list of platform modules that support this pack. Restricts availability to specific modules.",
+    )
+    source: Optional[str] = Field(
+        "",
+        alias="source",
+        description="Source repository or origin of this pack. Required when managed=True. Identifies where the pack content is maintained.",
+    )
+    managed: Optional[bool] = Field(
+        False,
+        alias="managed",
+        description="When True, this pack is managed externally and its content is synchronized from the source repository. Requires a non-empty source field.",
+    )

--- a/demisto_sdk/commands/content_graph/strict_objects/parsing_rule.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/parsing_rule.py
@@ -12,16 +12,50 @@ from demisto_sdk.commands.content_graph.strict_objects.common import (
 
 
 class _StrictParsingRule(BaseStrictModel):
-    id_: str = Field(alias="id")
-    name: str
-    from_version: str = Field(alias="fromversion")
-    to_version: Optional[str] = Field(None, alias="toversion")
-    tags: List[str]
-    rules: Optional[str] = None
-    samples: Optional[str] = None
-    comment: Optional[str] = None
-    deprecated: Optional[bool] = None
-    supportedModules: Optional[List[str]] = Field(None, alias="supportedModules")
+    id_: str = Field(
+        ...,
+        alias="id",
+        description="Unique identifier of the parsing rule. Used internally to reference this rule.",
+    )
+    name: str = Field(
+        ...,
+        description="Display name of the parsing rule shown in the UI.",
+    )
+    from_version: str = Field(
+        ...,
+        alias="fromversion",
+        description="Minimum platform version required to use this parsing rule (e.g. '6.8.0'). Required field.",
+    )
+    to_version: Optional[str] = Field(
+        None,
+        alias="toversion",
+        description="Maximum platform version this parsing rule is compatible with. Rule is not loaded on newer platform versions.",
+    )
+    tags: List[str] = Field(
+        ...,
+        description="List of dataset tags this parsing rule applies to. Each tag identifies a log source or dataset (e.g. 'vendor_product'). Required.",
+    )
+    rules: Optional[str] = Field(
+        None,
+        description="XQL-based parsing rules in YAML format. Defines how raw log data is parsed and structured.",
+    )
+    samples: Optional[str] = Field(
+        None,
+        description="Sample raw log data used for testing and validating the parsing rules.",
+    )
+    comment: Optional[str] = Field(
+        None,
+        description="Developer comment describing the purpose and usage of this parsing rule.",
+    )
+    deprecated: Optional[bool] = Field(
+        None,
+        description="When True, this parsing rule is deprecated and should not be used in new integrations.",
+    )
+    supportedModules: Optional[List[str]] = Field(
+        None,
+        alias="supportedModules",
+        description="Optional list of platform modules that support this parsing rule. Restricts availability to specific modules.",
+    )
 
 
 StrictParsingRule = create_model(

--- a/demisto_sdk/commands/content_graph/strict_objects/pre_process_rule.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/pre_process_rule.py
@@ -12,40 +12,114 @@ from demisto_sdk.commands.content_graph.strict_objects.common import (
 
 
 class Period(BaseStrictModel):
-    by: Optional[str] = None
-    from_value: Optional[int] = Field(None, alias="fromValue")
+    by: Optional[str] = Field(
+        None,
+        description="Time unit for the deduplication period (e.g. 'hours', 'days', 'minutes').",
+    )
+    from_value: Optional[int] = Field(
+        None,
+        alias="fromValue",
+        description="Number of time units for the deduplication period. Combined with 'by' to define the full period.",
+    )
 
 
 class _StrictPreProcessRule(BaseStrictModel):
-    action: str
-    enabled: bool
+    action: str = Field(
+        ...,
+        description="Action to take when this rule matches. Must be one of: 'link' (link to existing incident), 'drop' (discard the event), 'create' (create new incident).",
+    )
+    enabled: bool = Field(
+        ...,
+        description="When True, this pre-process rule is active and will be evaluated for incoming events.",
+    )
     existing_events_filters: List[Any] = Field(
-        default_factory=list, alias="existingEventsFilters"
+        default_factory=list,
+        alias="existingEventsFilters",
+        description="Filter conditions applied to existing incidents when searching for duplicates. Used with 'link' action.",
     )
-    from_version: str = Field(alias="fromVersion")
-    id_: str = Field(alias="id")
-    index: int
-    item_version: str = Field(alias="itemVersion")
-    link_to: str = Field(alias="linkTo")
-    locked: bool
-    name: str
-    description: Optional[str] = None
+    from_version: str = Field(
+        ...,
+        alias="fromVersion",
+        description="Minimum platform version required to use this pre-process rule (e.g. '6.0.0'). Required field.",
+    )
+    id_: str = Field(
+        ...,
+        alias="id",
+        description="Unique identifier of the pre-process rule. Used internally to reference this rule.",
+    )
+    index: int = Field(
+        ...,
+        description="Execution order of this rule relative to other pre-process rules. Lower index = higher priority.",
+    )
+    item_version: str = Field(
+        ...,
+        alias="itemVersion",
+        description="Version of the pack that contains this rule. Set automatically during pack installation.",
+    )
+    link_to: str = Field(
+        ...,
+        alias="linkTo",
+        description="Specifies which existing incident to link to when action is 'link'. References a field or expression.",
+    )
+    locked: bool = Field(
+        ...,
+        description="When True, this pre-process rule is locked and cannot be modified by users.",
+    )
+    name: str = Field(
+        ...,
+        description="Display name of the pre-process rule shown in the UI.",
+    )
+    description: Optional[str] = Field(
+        None,
+        description="Human-readable description of what this pre-process rule does and when it applies.",
+    )
     new_event_filters: List[List[Dict[str, Union[str, Dict[str, Any]]]]] = Field(
-        default_factory=list, alias="newEventFilters"
+        default_factory=list,
+        alias="newEventFilters",
+        description="Filter conditions applied to incoming events to determine if this rule should fire. Nested list structure supports AND/OR logic.",
     )
-    pack_id: str = Field(alias="packID")
-    period: Optional[Period] = None
+    pack_id: str = Field(
+        ...,
+        alias="packID",
+        description="ID of the pack that contains this pre-process rule.",
+    )
+    period: Optional[Period] = Field(
+        None,
+        description="Deduplication period configuration. Events matching within this period are considered duplicates.",
+    )
     ready_existing_events_filters: List[Any] = Field(
-        default_factory=list, alias="readyExistingEventsFilters"
+        default_factory=list,
+        alias="readyExistingEventsFilters",
+        description="Pre-compiled version of existingEventsFilters for runtime evaluation. Set automatically by the platform.",
     )
     ready_new_event_filters: List[Any] = Field(
-        default_factory=list, alias="readyNewEventFilters"
+        default_factory=list,
+        alias="readyNewEventFilters",
+        description="Pre-compiled version of newEventFilters for runtime evaluation. Set automatically by the platform.",
     )
-    script_name: str = Field(alias="scriptName")
-    search_closed: bool = Field(alias="searchClosed")
-    system: bool
-    to_server_version: str = Field(alias="toServerVersion")
-    version: int
+    script_name: str = Field(
+        ...,
+        alias="scriptName",
+        description="Name of the script to run when this rule matches. The script can modify the event or perform additional logic.",
+    )
+    search_closed: bool = Field(
+        ...,
+        alias="searchClosed",
+        description="When True, closed incidents are also searched when looking for duplicates to link to.",
+    )
+    system: bool = Field(
+        ...,
+        description="When True, this is a system-defined pre-process rule that cannot be deleted.",
+    )
+    to_server_version: str = Field(
+        ...,
+        alias="toServerVersion",
+        description="Maximum server version this pre-process rule is compatible with.",
+    )
+    version: int = Field(
+        ...,
+        description="Schema version of this pre-process rule. Used for conflict detection. Typically -1 for new items.",
+    )
 
 
 StrictPreProcessRule = create_model(

--- a/demisto_sdk/commands/content_graph/strict_objects/script.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/script.py
@@ -47,65 +47,209 @@ class CommonFieldsScript(CommonFields):  # type:ignore[misc,valid-type]
 
 
 class EngineInfo(BaseStrictModel):
-    engine: Optional[str] = None
+    engine: Optional[str] = Field(
+        None,
+        description="Name of the execution engine to use for this script (e.g. 'Agent'). Used for specialized execution environments.",
+    )
 
 
 class PromptConfig(BaseStrictModel):
     """Configuration for LLM prompt settings."""
 
-    temperature: Optional[float] = None
-    max_output_tokens: Optional[int] = Field(None, alias="maxOutputTokens")
-    web_search: Optional[bool] = Field(None, alias="webSearch")
+    temperature: Optional[float] = Field(
+        None,
+        description="LLM temperature parameter controlling randomness (0.0-1.0). Lower values produce more deterministic outputs.",
+    )
+    max_output_tokens: Optional[int] = Field(
+        None,
+        alias="maxOutputTokens",
+        description="Maximum number of tokens the LLM can generate in a single response.",
+    )
+    web_search: Optional[bool] = Field(
+        None,
+        alias="webSearch",
+        description="When True, the LLM can perform web searches to augment its responses.",
+    )
 
 
 class ContentItemFields(BaseStrictModel):
-    from_server_version: Optional[str] = Field(None, alias="fromServerVersion")
+    from_server_version: Optional[str] = Field(
+        None,
+        alias="fromServerVersion",
+        description="Minimum server version required for this content item's exportable fields.",
+    )
 
 
 class ContentItemExportableFields(BaseStrictModel):
     content_item_fields: Optional[ContentItemFields] = Field(
-        None, alias="contentitemfields"
+        None,
+        alias="contentitemfields",
+        description="Exportable content item fields configuration.",
     )
 
 
 class _StrictScript(BaseIntegrationScript):  # type:ignore[misc,valid-type]
-    common_fields: CommonFieldsScript = Field(..., alias="commonfields")
-    name_x2: Optional[str] = None
-    script: Optional[str] = None
-    type_: ScriptType = Field(..., alias="type")
-    tags: Optional[List[str]] = None
-    enabled: Optional[bool] = None
-    args: Optional[List[Argument]] = None  # type:ignore[valid-type]
-    script_target: Optional[int] = Field(None, alias="scripttarget")
-    timeout: Optional[str] = None
-    depends_on: dict = Field({}, alias="dependson")
-    outputs: Optional[List[Output]] = None
-    important: Optional[List[Important]] = None  # type:ignore[valid-type]
-    docker_image: str = Field(None, alias="dockerimage")
-    docker_image_45: str = Field(None, alias="dockerimage45")
-    alt_docker_images: Optional[List[str]] = Field(None, alias="alt_dockerimages")
-    native_image: Optional[List[str]] = Field(None, alias="nativeImage")
-    runonce: Optional[bool] = None
-    sensitive: Optional[bool] = None
-    run_as: Optional[str] = Field(None, alias="runas")
-    sub_type: Optional[ScriptSubType] = Field(None, alias="subtype")
-    engine_info: Optional[EngineInfo] = Field(None, alias="engineinfo")
-    content_item_exportable_fields: Optional[ContentItemExportableFields] = Field(
-        None, alias="contentitemexportablefields"
+    common_fields: CommonFieldsScript = Field(
+        ...,
+        alias="commonfields",
+        description="Common metadata fields including the script's unique ID and schema version.",
     )
-    polling: Optional[bool] = None
-    skip_prepare: Optional[List[SkipPrepare]] = Field(None, alias="skipprepare")
-    prettyname: Optional[str] = None
-    compliantpolicies: Optional[List[str]] = Field(None, alias="compliantpolicies")
-    is_llm: bool = Field(False, alias="isllm")
-    is_internal: bool = Field(False, alias="isInternal")
-    internal: bool = Field(False, alias="internal")
-    source: Optional[str] = None
-    model: Optional[str] = None
-    user_prompt: Optional[str] = Field(None, alias="userprompt")
-    system_prompt: Optional[str] = Field(None, alias="systemprompt")
-    few_shots: Optional[str] = Field(None, alias="fewshots")
-    prompt_config: Optional[PromptConfig] = Field(None, alias="promptConfig")
+    name_x2: Optional[str] = Field(
+        None,
+        description="Alternative name for the script in the X2 marketplace.",
+    )
+    script: Optional[str] = Field(
+        None,
+        description="The script source code. For Python scripts, this is the Python source. For unified scripts, this is '-'.",
+    )
+    type_: ScriptType = Field(
+        ...,
+        alias="type",
+        description="Script language type. Must be one of: 'python3', 'python2', 'powershell', 'javascript'.",
+    )
+    tags: Optional[List[str]] = Field(
+        None,
+        description="List of tags for categorizing and filtering this script in the marketplace.",
+    )
+    enabled: Optional[bool] = Field(
+        None,
+        description="When True, this script is enabled and can be executed. When False, the script is disabled.",
+    )
+    args: Optional[List[Argument]] = Field(  # type:ignore[valid-type]
+        None,
+        description="List of input arguments accepted by this script.",
+    )
+    script_target: Optional[int] = Field(
+        None,
+        alias="scripttarget",
+        description="Target environment for script execution. 0=XSOAR server, 1=Remote agent.",
+    )
+    timeout: Optional[str] = Field(
+        None,
+        description="Script execution timeout (e.g. '5m', '1h'). Script is terminated if it exceeds this duration.",
+    )
+    depends_on: dict = Field(
+        {},
+        alias="dependson",
+        description="Dictionary of commands this script depends on. Used for dependency resolution during pack installation.",
+    )
+    outputs: Optional[List[Output]] = Field(
+        None,
+        description="List of output fields returned by this script. Defines the context paths populated after execution.",
+    )
+    important: Optional[List[Important]] = Field(  # type:ignore[valid-type]
+        None,
+        description="List of important outputs to highlight in the UI. These outputs are shown prominently in the war room.",
+    )
+    docker_image: str = Field(
+        None,
+        alias="dockerimage",
+        description="Docker image used to run this script (e.g. 'demisto/python3:3.10.12.63474'). Must be a valid Docker image tag.",
+    )
+    docker_image_45: str = Field(
+        None,
+        alias="dockerimage45",
+        description="Docker image for XSOAR 4.5 compatibility. Used for backward compatibility with older platform versions.",
+    )
+    alt_docker_images: Optional[List[str]] = Field(
+        None,
+        alias="alt_dockerimages",
+        description="Alternative Docker images for different platforms. Used for multi-architecture support.",
+    )
+    native_image: Optional[List[str]] = Field(
+        None,
+        alias="nativeImage",
+        description="Native image configurations for running without Docker. Used for native execution environments.",
+    )
+    runonce: Optional[bool] = Field(
+        None,
+        description="When True, this script runs only once and then stops. Used for one-time setup scripts.",
+    )
+    sensitive: Optional[bool] = Field(
+        None,
+        description="When True, the script's output is treated as sensitive and masked in logs.",
+    )
+    run_as: Optional[str] = Field(
+        None,
+        alias="runas",
+        description="User context to run the script as (e.g. 'DBotWeakRole'). Controls script permissions.",
+    )
+    sub_type: Optional[ScriptSubType] = Field(
+        None,
+        alias="subtype",
+        description="Python sub-type. Must be 'python3' or 'python2'. Determines which Python version is used.",
+    )
+    engine_info: Optional[EngineInfo] = Field(
+        None,
+        alias="engineinfo",
+        description="Engine configuration for specialized execution environments.",
+    )
+    content_item_exportable_fields: Optional[ContentItemExportableFields] = Field(
+        None,
+        alias="contentitemexportablefields",
+        description="Exportable fields configuration for content item export.",
+    )
+    polling: Optional[bool] = Field(
+        None,
+        description="When True, this script supports polling mode for long-running operations.",
+    )
+    skip_prepare: Optional[List[SkipPrepare]] = Field(
+        None,
+        alias="skipprepare",
+        description="List of prepare steps to skip during content preparation. Currently only supports 'script-name'.",
+    )
+    prettyname: Optional[str] = Field(
+        None,
+        description="Human-readable display name of the script shown in the UI.",
+    )
+    compliantpolicies: Optional[List[str]] = Field(
+        None,
+        alias="compliantpolicies",
+        description="List of compliance policy names this script satisfies. Used for compliance reporting.",
+    )
+    is_llm: bool = Field(
+        False,
+        alias="isllm",
+        description="When True, this script is an LLM-based script. Requires userprompt and either model (legacy) or promptConfig (new format). Mutually exclusive with script code.",
+    )
+    is_internal: bool = Field(
+        False,
+        alias="isInternal",
+        description="When True, marks this script as internal and not intended for direct use by end users.",
+    )
+    internal: bool = Field(
+        False,
+        alias="internal",
+        description="When True, marks this script as internal.",
+    )
+    source: Optional[str] = Field(
+        None,
+        description="Source repository or origin of this script.",
+    )
+    model: Optional[str] = Field(
+        None,
+        description="LLM model name for legacy LLM scripts (toversion: 8.12.0). Required when isllm=True in legacy format.",
+    )
+    user_prompt: Optional[str] = Field(
+        None,
+        alias="userprompt",
+        description="User-facing prompt template for LLM scripts. Required when isllm=True. Defines the task the LLM performs.",
+    )
+    system_prompt: Optional[str] = Field(
+        None,
+        alias="systemprompt",
+        description="System-level instructions for the LLM. Defines the LLM's persona and behavior constraints.",
+    )
+    few_shots: Optional[str] = Field(
+        None,
+        alias="fewshots",
+        description="Few-shot examples for the LLM. Provides example inputs and outputs to guide the LLM's responses.",
+    )
+    prompt_config: Optional[PromptConfig] = Field(
+        None,
+        alias="promptConfig",
+        description="LLM prompt configuration for new-format LLM scripts (fromversion: 8.13.0). Mutually exclusive with legacy model field.",
+    )
 
     @root_validator
     def validate_llm_constraints(cls, values):

--- a/demisto_sdk/commands/content_graph/strict_objects/trigger.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/trigger.py
@@ -14,18 +14,55 @@ from demisto_sdk.commands.content_graph.strict_objects.common import (
 
 
 class _StrictTrigger(BaseStrictModel):
-    trigger_id: str
-    trigger_name: str
-    playbook_id: Optional[str]
-    description: str
-    suggestion_reason: str
-    alerts_filter: Optional[AlertsFilter] = None
-    automation_type: Optional[str]
-    automation_id: Optional[str]
-    supportedModules: Optional[list[str]] = Field(None, alias="supportedModules")
-    issilent: Optional[bool] = Field(default=False)
-    grouping_element: Optional[str] = None
-    is_auto_enabled: Optional[bool] = None
+    trigger_id: str = Field(
+        ...,
+        description="Unique identifier of the trigger. Used internally to reference this trigger.",
+    )
+    trigger_name: str = Field(
+        ...,
+        description="Display name of the trigger shown in the UI.",
+    )
+    playbook_id: Optional[str] = Field(
+        None,
+        description="ID of the playbook to run when this trigger fires. Mutually exclusive with automation_id/automation_type.",
+    )
+    description: str = Field(
+        ...,
+        description="Human-readable description of what this trigger does and when it fires.",
+    )
+    suggestion_reason: str = Field(
+        ...,
+        description="Explanation of why this trigger is suggested for the associated alert type. Shown to users in the trigger recommendation UI.",
+    )
+    alerts_filter: Optional[AlertsFilter] = Field(
+        None,
+        description="Filter conditions that determine which alerts activate this trigger. When the filter matches, the playbook or automation runs.",
+    )
+    automation_type: Optional[str] = Field(
+        None,
+        description="Type of automation to run. Must be 'command' or 'playbook'. Required when automation_id is set. Mutually exclusive with playbook_id.",
+    )
+    automation_id: Optional[str] = Field(
+        None,
+        description="ID of the automation (command or playbook) to run. Required when automation_type is set. Mutually exclusive with playbook_id.",
+    )
+    supportedModules: Optional[list[str]] = Field(
+        None,
+        alias="supportedModules",
+        description="Optional list of platform modules that support this trigger. Restricts availability to specific modules.",
+    )
+    issilent: Optional[bool] = Field(
+        default=False,
+        description="When True, the trigger runs silently without creating visible activity in the incident timeline. Defaults to False.",
+    )
+    grouping_element: Optional[str] = Field(
+        None,
+        description="Field used to group related alerts together when this trigger fires.",
+    )
+    is_auto_enabled: Optional[bool] = Field(
+        None,
+        description="When True, this trigger is automatically enabled when the associated pack is installed.",
+    )
 
     @root_validator
     def validate_automation_playbook_logic(cls, values):

--- a/demisto_sdk/commands/content_graph/strict_objects/widget.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/widget.py
@@ -18,20 +18,67 @@ from demisto_sdk.commands.content_graph.strict_objects.common import (
 
 
 class _StrictWidget(BaseStrictModel):
-    id_: str = Field(alias="id")
-    version: int
-    name: str
-    description: str
-    data_type: Optional[str] = Field(None, alias="dataType")
-    widget_type: str = Field(alias="widgetType")
-    query: Optional[str] = None
-    is_predefined: bool = Field(alias="isPredefined")
-    date_range: Optional[Dict[Any, Any]] = Field(None, alias="dateRange")
-    params: Optional[Dict[Any, Any]] = None
-    size: Optional[int] = None
-    sort: Optional[List[Any]] = None
-    category: Optional[str] = None
-    modified: Optional[str] = None
+    id_: str = Field(
+        ...,
+        alias="id",
+        description="Unique identifier of the widget. Used internally to reference this widget from dashboards.",
+    )
+    version: int = Field(
+        ...,
+        description="Schema version of this widget. Used for conflict detection. Typically -1 for new items.",
+    )
+    name: str = Field(
+        ...,
+        description="Display name of the widget shown in the UI and on dashboards.",
+    )
+    description: str = Field(
+        ...,
+        description="Human-readable description of what data this widget displays and how to interpret it.",
+    )
+    data_type: Optional[str] = Field(
+        None,
+        alias="dataType",
+        description="Type of data source for this widget (e.g. 'incidents', 'indicators', 'scripts'). Determines what data is queried.",
+    )
+    widget_type: str = Field(
+        ...,
+        alias="widgetType",
+        description="Visual type of the widget. Must be one of: 'bar', 'column', 'pie', 'line', 'text', 'number', 'table', 'trend', 'duration', 'list'.",
+    )
+    query: Optional[str] = Field(
+        None,
+        description="Query string used to fetch data for this widget. Format depends on the dataType.",
+    )
+    is_predefined: bool = Field(
+        ...,
+        alias="isPredefined",
+        description="When True, this is a system-provided widget that cannot be deleted.",
+    )
+    date_range: Optional[Dict[Any, Any]] = Field(
+        None,
+        alias="dateRange",
+        description="Date range configuration for the widget's data query. Defines the time window for displayed data.",
+    )
+    params: Optional[Dict[Any, Any]] = Field(
+        None,
+        description="Additional parameters for the widget's data query and visualization configuration.",
+    )
+    size: Optional[int] = Field(
+        None,
+        description="Display size of the widget on the dashboard grid.",
+    )
+    sort: Optional[List[Any]] = Field(
+        None,
+        description="Sort configuration for the widget's data. Defines the order in which data is displayed.",
+    )
+    category: Optional[str] = Field(
+        None,
+        description="Category of the widget used for filtering in the widget library.",
+    )
+    modified: Optional[str] = Field(
+        None,
+        description="ISO 8601 timestamp of when this widget was last modified. Set automatically by the platform.",
+    )
     marketplaces: Optional[List[MarketplaceVersions]] = Field(
         None,
         enum=[
@@ -39,8 +86,13 @@ class _StrictWidget(BaseStrictModel):
             MarketplaceVersions.XSOAR_SAAS,
             MarketplaceVersions.XSOAR_ON_PREM,
         ],
+        description="Marketplace(s) this widget is available in. Restricted to XSOAR marketplaces: xsoar, xsoar_saas, xsoar_on_prem.",
     )
-    supportedModules: Optional[List[str]] = Field(None, alias="supportedModules")
+    supportedModules: Optional[List[str]] = Field(
+        None,
+        alias="supportedModules",
+        description="Optional list of platform modules that support this widget. Restricts availability to specific modules.",
+    )
 
 
 StrictWidget = create_model(

--- a/demisto_sdk/commands/content_graph/strict_objects/xdrc_template.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/xdrc_template.py
@@ -13,13 +13,35 @@ from demisto_sdk.commands.content_graph.strict_objects.common import (
 
 
 class _StrictXDRCTemplate(BaseStrictModel):
-    os_type: str
-    profile_type: str
-    name: str
-    content_global_id: str
-    from_xdr_version: str
-    yaml_template: str
-    supportedModules: Optional[List[str]] = Field(None, alias="supportedModules")
+    os_type: str = Field(
+        ...,
+        description="Operating system type this template targets. Must be one of: 'Windows', 'Linux', 'macOS'.",
+    )
+    profile_type: str = Field(
+        ...,
+        description="Type of XDRC profile this template creates. Defines the configuration category (e.g. 'Endpoint Security', 'Firewall').",
+    )
+    name: str = Field(
+        ...,
+        description="Display name of the XDRC template shown in the UI.",
+    )
+    content_global_id: str = Field(
+        ...,
+        description="Globally unique identifier for this template content. Used to track the template across platform versions.",
+    )
+    from_xdr_version: str = Field(
+        ...,
+        description="Minimum XDR agent version required to apply this template (e.g. '7.5.0').",
+    )
+    yaml_template: str = Field(
+        ...,
+        description="YAML-formatted configuration template content. Defines the actual configuration applied to endpoints.",
+    )
+    supportedModules: Optional[List[str]] = Field(
+        None,
+        alias="supportedModules",
+        description="Optional list of platform modules that support this XDRC template. Restricts availability to specific modules.",
+    )
 
 
 StrictXDRCTemplate = create_model(

--- a/demisto_sdk/commands/get_schema/get_schema.py
+++ b/demisto_sdk/commands/get_schema/get_schema.py
@@ -1,0 +1,229 @@
+"""
+get-schema command: returns the JSON schema of a content item's strict (pydantic) model.
+"""
+
+import json
+from typing import Dict, Optional, Type
+
+from demisto_sdk.commands.common.logger import logger
+from demisto_sdk.commands.content_graph.strict_objects.agentix_action import (
+    AgentixAction,
+)
+from demisto_sdk.commands.content_graph.strict_objects.agentix_action_test import (
+    StrictAgentixActionTest,
+)
+from demisto_sdk.commands.content_graph.strict_objects.agentix_agent import (
+    AgentixAgent,
+)
+from demisto_sdk.commands.content_graph.strict_objects.asset_modeling_rule import (
+    StrictAssetsModelingRule,
+)
+from demisto_sdk.commands.content_graph.strict_objects.case_field import StrictCaseField
+from demisto_sdk.commands.content_graph.strict_objects.case_layout import (
+    StrictCaseLayout,
+)
+from demisto_sdk.commands.content_graph.strict_objects.case_layout_rule import (
+    StrictCaseLayoutRule,
+)
+from demisto_sdk.commands.content_graph.strict_objects.classifier import (
+    StrictClassifier,
+)
+from demisto_sdk.commands.content_graph.strict_objects.common import BaseStrictModel
+from demisto_sdk.commands.content_graph.strict_objects.correlation_rule import (
+    StrictCorrelationRule,
+)
+from demisto_sdk.commands.content_graph.strict_objects.dashboard import StrictDashboard
+from demisto_sdk.commands.content_graph.strict_objects.generic_definition import (
+    StrictGenericDefinition,
+)
+from demisto_sdk.commands.content_graph.strict_objects.generic_field import (
+    StrictGenericField,
+)
+from demisto_sdk.commands.content_graph.strict_objects.generic_module import (
+    StrictGenericModule,
+)
+from demisto_sdk.commands.content_graph.strict_objects.generic_type import (
+    StrictGenericType,
+)
+from demisto_sdk.commands.content_graph.strict_objects.incident_field import (
+    StrictIncidentField,
+)
+from demisto_sdk.commands.content_graph.strict_objects.incident_type import (
+    StrictIncidentType,
+)
+from demisto_sdk.commands.content_graph.strict_objects.indicator_field import (
+    StrictIndicatorField,
+)
+from demisto_sdk.commands.content_graph.strict_objects.indicator_type import (
+    StrictIndicatorType,
+)
+from demisto_sdk.commands.content_graph.strict_objects.integration import (
+    StrictIntegration,
+)
+from demisto_sdk.commands.content_graph.strict_objects.job import StrictJob
+from demisto_sdk.commands.content_graph.strict_objects.layout import StrictLayout
+from demisto_sdk.commands.content_graph.strict_objects.layout_rule import (
+    StrictLayoutRule,
+)
+from demisto_sdk.commands.content_graph.strict_objects.list import StrictList
+from demisto_sdk.commands.content_graph.strict_objects.mapper import StrictMapper
+from demisto_sdk.commands.content_graph.strict_objects.modeling_rule import (
+    StrictModelingRule,
+)
+from demisto_sdk.commands.content_graph.strict_objects.pack_meta_data import (
+    StrictPackMetadata,
+)
+from demisto_sdk.commands.content_graph.strict_objects.parsing_rule import (
+    StrictParsingRule,
+)
+from demisto_sdk.commands.content_graph.strict_objects.playbook import StrictPlaybook
+from demisto_sdk.commands.content_graph.strict_objects.pre_process_rule import (
+    StrictPreProcessRule,
+)
+from demisto_sdk.commands.content_graph.strict_objects.report import StrictReport
+from demisto_sdk.commands.content_graph.strict_objects.script import StrictScript
+from demisto_sdk.commands.content_graph.strict_objects.trigger import StrictTrigger
+from demisto_sdk.commands.content_graph.strict_objects.widget import StrictWidget
+from demisto_sdk.commands.content_graph.strict_objects.wizard import StrictWizard
+from demisto_sdk.commands.content_graph.strict_objects.xdrc_template import (
+    StrictXDRCTemplate,
+)
+from demisto_sdk.commands.content_graph.strict_objects.xsiam_dashboard import (
+    StrictXSIAMDashboard,
+)
+from demisto_sdk.commands.content_graph.strict_objects.xsiam_report import (
+    StrictXSIAMReport,
+)
+
+# Mapping from content item name (case-insensitive) to its strict pydantic model.
+# Both underscore-separated and concatenated variants are registered so that
+# e.g. both "agentix_action" and "agentixaction" resolve correctly.
+CONTENT_ITEM_NAME_TO_STRICT_OBJECT: Dict[str, Type[BaseStrictModel]] = {
+    "integration": StrictIntegration,
+    "script": StrictScript,
+    "playbook": StrictPlaybook,
+    "testplaybook": StrictPlaybook,
+    "test_playbook": StrictPlaybook,
+    "classifier": StrictClassifier,
+    "mapper": StrictMapper,
+    "incidentfield": StrictIncidentField,
+    "incident_field": StrictIncidentField,
+    "indicatorfield": StrictIndicatorField,
+    "indicator_field": StrictIndicatorField,
+    "incidenttype": StrictIncidentType,
+    "incident_type": StrictIncidentType,
+    "indicatortype": StrictIndicatorType,
+    "indicator_type": StrictIndicatorType,
+    "layout": StrictLayout,
+    "layoutrule": StrictLayoutRule,
+    "layout_rule": StrictLayoutRule,
+    "dashboard": StrictDashboard,
+    "report": StrictReport,
+    "widget": StrictWidget,
+    "job": StrictJob,
+    "list": StrictList,
+    "genericdefinition": StrictGenericDefinition,
+    "generic_definition": StrictGenericDefinition,
+    "genericfield": StrictGenericField,
+    "generic_field": StrictGenericField,
+    "genericmodule": StrictGenericModule,
+    "generic_module": StrictGenericModule,
+    "generictype": StrictGenericType,
+    "generic_type": StrictGenericType,
+    "correlationrule": StrictCorrelationRule,
+    "correlation_rule": StrictCorrelationRule,
+    "modelingrule": StrictModelingRule,
+    "modeling_rule": StrictModelingRule,
+    "assetsmodelrule": StrictAssetsModelingRule,
+    "assetsmodellingrule": StrictAssetsModelingRule,
+    "assets_modeling_rule": StrictAssetsModelingRule,
+    "parsingrule": StrictParsingRule,
+    "parsing_rule": StrictParsingRule,
+    "preprocessrule": StrictPreProcessRule,
+    "preprocess_rule": StrictPreProcessRule,
+    "pre_process_rule": StrictPreProcessRule,
+    "trigger": StrictTrigger,
+    "wizard": StrictWizard,
+    "xsiamdashboard": StrictXSIAMDashboard,
+    "xsiam_dashboard": StrictXSIAMDashboard,
+    "xsiamreport": StrictXSIAMReport,
+    "xsiam_report": StrictXSIAMReport,
+    "xdrctemplate": StrictXDRCTemplate,
+    "xdrc_template": StrictXDRCTemplate,
+    "casefield": StrictCaseField,
+    "case_field": StrictCaseField,
+    "caselayout": StrictCaseLayout,
+    "case_layout": StrictCaseLayout,
+    "caselayoutrule": StrictCaseLayoutRule,
+    "case_layout_rule": StrictCaseLayoutRule,
+    "agentixaction": AgentixAction,
+    "agentix_action": AgentixAction,
+    "agentixactiontest": StrictAgentixActionTest,
+    "agentix_action_test": StrictAgentixActionTest,
+    "agentixagent": AgentixAgent,
+    "agentix_agent": AgentixAgent,
+    "pack": StrictPackMetadata,
+    "pack_metadata": StrictPackMetadata,
+    "packmetadata": StrictPackMetadata,
+}
+
+
+def get_content_item_schema(content_item_name: str) -> Optional[dict]:
+    """
+    Returns the JSON schema of the strict pydantic model for the given content item name.
+
+    Args:
+        content_item_name: The name of the content item type (e.g. 'integration', 'script').
+
+    Returns:
+        A dict representing the JSON schema, or None if the content item name is not recognized.
+    """
+    # Normalise: lower-case, replace hyphens/spaces with underscores.
+    normalized = content_item_name.strip().lower().replace("-", "_").replace(" ", "_")
+    strict_model = CONTENT_ITEM_NAME_TO_STRICT_OBJECT.get(normalized)
+    if strict_model is None:
+        return None
+    return strict_model.schema()
+
+
+def print_schema(content_item_name: str, output_file: Optional[str] = None) -> int:
+    """
+    Retrieves and prints (or writes) the JSON schema for the given content item name.
+
+    Args:
+        content_item_name: The name of the content item type.
+        output_file: Optional path to write the schema JSON to. If None, prints to stdout.
+
+    Returns:
+        0 on success, 1 on failure.
+    """
+    schema = get_content_item_schema(content_item_name)
+    if schema is None:
+        available = sorted(
+            {
+                k
+                for k in CONTENT_ITEM_NAME_TO_STRICT_OBJECT
+                if "_" not in k
+                or k.replace("_", "") not in CONTENT_ITEM_NAME_TO_STRICT_OBJECT
+            }
+        )
+        logger.error(
+            f"Unknown content item type: '{content_item_name}'.\n"
+            f"Available content item types: {', '.join(available)}"
+        )
+        return 1
+
+    schema_json = json.dumps(schema, indent=2)
+
+    if output_file:
+        try:
+            with open(output_file, "w", encoding="utf-8") as f:
+                f.write(schema_json)
+            logger.info(f"Schema written to {output_file}")
+        except OSError as e:
+            logger.error(f"Failed to write schema to '{output_file}': {e}")
+            return 1
+    else:
+        print(schema_json)
+
+    return 0

--- a/demisto_sdk/commands/get_schema/get_schema_setup.py
+++ b/demisto_sdk/commands/get_schema/get_schema_setup.py
@@ -1,0 +1,99 @@
+import sys
+from typing import Optional
+
+import typer
+
+from demisto_sdk.commands.common.logger import logging_setup_decorator
+from demisto_sdk.commands.get_schema.get_schema import (
+    CONTENT_ITEM_NAME_TO_STRICT_OBJECT,
+    print_schema,
+)
+
+
+# Canonical names: prefer the underscore-separated form when it exists,
+# otherwise fall back to the concatenated form.  Deduplicate by strict model.
+def _build_canonical_names() -> list[str]:
+    seen_models: set = set()
+    canonical: list[str] = []
+    # First pass: collect underscore-separated names (most readable).
+    for k, model in sorted(CONTENT_ITEM_NAME_TO_STRICT_OBJECT.items()):
+        if "_" in k and id(model) not in seen_models:
+            seen_models.add(id(model))
+            canonical.append(k)
+    # Second pass: add concatenated names for models not yet covered.
+    for k, model in sorted(CONTENT_ITEM_NAME_TO_STRICT_OBJECT.items()):
+        if "_" not in k and id(model) not in seen_models:
+            seen_models.add(id(model))
+            canonical.append(k)
+    return sorted(canonical)
+
+
+_AVAILABLE_TYPES = _build_canonical_names()
+
+
+@logging_setup_decorator
+def get_schema(
+    ctx: typer.Context,
+    input: Optional[str] = typer.Option(
+        None,
+        "-i",
+        "--input",
+        help=(
+            "The content item type name to retrieve the schema for "
+            "(e.g. 'integration', 'script', 'agentix_action'). "
+            "Use --list-types to see all supported values."
+        ),
+    ),
+    list_types: bool = typer.Option(
+        False,
+        "-l",
+        "--list-types",
+        help="Print all supported content item type names and exit.",
+    ),
+    output: Optional[str] = typer.Option(
+        None,
+        "-o",
+        "--output",
+        help="Path to a file where the JSON schema will be written. If not provided, prints to stdout.",
+    ),
+    console_log_threshold: str = typer.Option(
+        None,
+        "--console-log-threshold",
+        help="Minimum logging threshold for console output. Possible values: DEBUG, INFO, SUCCESS, WARNING, ERROR.",
+    ),
+    file_log_threshold: str = typer.Option(
+        None,
+        "--file-log-threshold",
+        help="Minimum logging threshold for file output.",
+    ),
+    log_file_path: str = typer.Option(
+        None,
+        "--log-file-path",
+        help="Path to save log files.",
+    ),
+):
+    """
+    Returns the JSON schema of a content item type based on its strict pydantic model.
+
+    Example usage:\n
+        demisto-sdk get-schema -i integration\n
+        demisto-sdk get-schema -i agentix_action\n
+        demisto-sdk get-schema -i script -o /tmp/script_schema.json\n
+        demisto-sdk get-schema --list-types
+    """
+    if list_types:
+        typer.echo("Supported content item types:")
+        for name in _AVAILABLE_TYPES:
+            typer.echo(f"  {name}")
+        raise typer.Exit(0)
+
+    if not input:
+        typer.echo(
+            "Error: Missing option '-i' / '--input'. "
+            "Provide a content item type name or use --list-types to see all supported values.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    result = print_schema(content_item_name=input, output_file=output)
+    sys.exit(result)


### PR DESCRIPTION
## Summary

Adds `Field(description=...)` to every field across all strict pydantic models so that `demisto-sdk get-schema` outputs a schema where every key carries a human-readable description explaining its purpose and restrictions.

## Changes

### `common.py`
- Extended `create_dynamic_model()` to accept a `description` parameter
- Added descriptions to all dynamic models (`DESCRIPTION_DYNAMIC_MODEL`, `NAME_DYNAMIC_MODEL`, `ID_DYNAMIC_MODEL`, `IS_FETCH_DYNAMIC_MODEL`, etc.) — these generate marketplace-suffixed fields like `description:xsoar`, `isfetch:marketplacev2`

### `base_strict_model.py`
- Added descriptions to `_CommonFields`, `_Argument`, `Output`, `_Important`, `BaseOptionalVersionYaml`, `BaseOptionalVersionJson`, `_BaseIntegrationScript`, `AgentixBase`

### Strict object files (23 files)
- `agentix_action.py`, `agentix_agent.py`
- `integration.py`, `script.py`
- `classifier.py`, `mapper.py`
- `indicator_field.py`, `indicator_type.py`
- `layout_rule.py`, `widget.py`
- `correlation_rule.py`, `modeling_rule.py`, `parsing_rule.py`
- `pre_process_rule.py`, `trigger.py`, `xdrc_template.py`
- `case_layout_rule.py`, `pack_meta_data.py`
- `generic_definition.py`, `generic_module.py`, `generic_type.py`

## Example output

```json
{
  "display": {
    "title": "Display",
    "description": "Human-readable display name of the action shown in the UI and to the AI agent.",
    "type": "string"
  },
  "requiresuserapproval": {
    "description": "When True, the action requires explicit user approval before execution. Use for destructive or sensitive operations.",
    "default": false,
    "type": "boolean"
  }
}
```