### PR TITLE
remove job from platform and sdk upload

### DIFF
--- a/.changelog/5329.yml
+++ b/.changelog/5329.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Jobs are now blocked from being uploaded as part of a pack.
+  type: feature
+pr_number: 5329

--- a/demisto_sdk/commands/content_graph/objects/pack.py
+++ b/demisto_sdk/commands/content_graph/objects/pack.py
@@ -64,6 +64,7 @@ from demisto_sdk.commands.prepare_content.markdown_images_handler import (
 )
 from demisto_sdk.commands.upload.constants import (
     CONTENT_TYPES_EXCLUDED_FROM_UPLOAD,
+    CONTENT_TYPES_NOT_SUPPORTED_IN_UPLOAD,
     MULTIPLE_ZIPPED_PACKS_FILE_NAME,
     MULTIPLE_ZIPPED_PACKS_FILE_STEM,
 )
@@ -527,6 +528,18 @@ class Pack(BaseContent, PackMetadata, content_type=ContentType.PACK):
             content_types_excluded_from_upload.discard(ContentType.TEST_PLAYBOOK)
 
         for item in self.content_items:
+            if item.content_type in CONTENT_TYPES_NOT_SUPPORTED_IN_UPLOAD:
+                upload_failures.append(
+                    FailedUploadException(
+                        item.path,
+                        response_body={},
+                        additional_info=(
+                            f"{item.content_type} is not a content item and therefore cannot be uploaded as part of a pack"
+                        ),
+                    )
+                )
+                continue
+
             if item.content_type in content_types_excluded_from_upload:
                 logger.debug(
                     f"SKIPPING upload of {item.content_type} {item.object_id}: type is skipped"

--- a/demisto_sdk/commands/upload/constants.py
+++ b/demisto_sdk/commands/upload/constants.py
@@ -8,3 +8,9 @@ CONTENT_TYPES_EXCLUDED_FROM_UPLOAD = {
     ContentType.TEST_SCRIPT,
     ContentType.AGENTIX_ACTION_TEST,
 }
+
+# Content types that are not supported by the platform and should cause the upload to fail
+# with a clear error message when found in a pack.
+CONTENT_TYPES_NOT_SUPPORTED_IN_UPLOAD = {
+    ContentType.JOB,
+}

--- a/demisto_sdk/commands/upload/tests/uploader_test.py
+++ b/demisto_sdk/commands/upload/tests/uploader_test.py
@@ -456,6 +456,39 @@ def test_upload_pack_with_tpb(demisto_client_configure, mocker, tmpdir):
     assert mocked_upload_method.call_count == len(expected_names)
 
 
+def test_upload_pack_with_job_fails(mocker, repo, tmpdir):
+    """
+    Given
+        - A pack that contains a Job content item
+
+    When
+        - Uploading the pack (item-by-item, without -z flag)
+
+    Then
+        - Ensure the upload fails with ERROR_RETURN_CODE
+        - Ensure the Job is reported as a failed upload with a clear error message
+          indicating that Job is not a content item and cannot be uploaded as part of a pack
+    """
+    mock_api_client(mocker)
+    mocker.patch.object(
+        IntegrationScript, "get_supported_native_images", return_value=[]
+    )
+    # Prevent actual network calls for non-Job content items (e.g. the playbook created alongside the job)
+    mocker.patch.object(ContentItem, "upload")
+
+    pack = repo.create_pack("PackWithJob")
+    pack.create_job(is_feed=False, name="MyJob")
+
+    uploader = Uploader(Path(pack.path), destination_zip_dir=Path(tmpdir))
+    assert uploader.upload() == ERROR_RETURN_CODE
+
+    assert len(uploader._failed_upload_content_items) == 1
+    failed_item, error_msg = uploader._failed_upload_content_items[0]
+    assert "Job" in error_msg
+    assert "not a content item" in error_msg
+    assert "cannot be uploaded as part of a pack" in error_msg
+
+
 def test_upload_packs_from_configfile(demisto_client_configure, mocker):
     """
     Given


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: [XSUP-67572](https://jira-dc.paloaltonetworks.com/browse/XSUP-67572)

## Description
Added a new CONTENT_TYPES_NOT_SUPPORTED_IN_UPLOAD set containing ContentType.JOB

Modified `upload_item_by_item()` to check each content item against CONTENT_TYPES_NOT_SUPPORTED_IN_UPLOAD before the existing exclusion check. 
When a Job is found, a FailedUploadException is appended with the message:
"Job is not a content item and therefore cannot be uploaded as part of a pack"