### PR TITLE
fix: Download of custom content now tries both JSON and YAML parsing

### DIFF
--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -148,6 +148,9 @@ from demisto_sdk.commands.common.handlers import (
     XSOAR_Handler,
     YAML_Handler,
 )
+from demisto_sdk.commands.common.handlers.xsoar_handler import (
+    JSONDecodeError,
+)
 from demisto_sdk.commands.common.logger import logger
 from demisto_sdk.commands.common.string_to_bool import (
     # all files, except for the logger setup, import from tools, so we import it here (makes more sense than having all other files import from string_to_bool.py)
@@ -638,7 +641,12 @@ def get_file_details(
     if not file_content:
         return {}
     if full_file_path.endswith("json"):
-        file_details = json.loads(file_content)
+        try:
+            file_details = json.loads(file_content)
+        except JSONDecodeError:
+            logger.error(f"{full_file_path} not valid json, trying YAML file types")
+            file_details = yaml.load(file_content)
+
     elif full_file_path.endswith(("yml", "yaml")):
         file_details = yaml.load(file_content)
     elif full_file_path.endswith(".pack-ignore"):


### PR DESCRIPTION
## Description

This fixes an issue caused by the presence of bad JSON data tracked back to Agentix items

This PR changes the handling to attempt both JSON and YAML file decoding for a given item, even if the file suffix is `json`. 

## Failing environment

Cortex XSIAM with Agentix items deployed

## Error
```
Fetching custom content bundle from server (https://api-coe-combined.xdr.us.paloaltonetworks.com/xsoar)...
Parsing downloaded custom content data...
Error while parsing 'agentixaction-xxx.json': .
...  TRUNCATED OUTPUT ...
error: Expected object or value
```

relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-16790