### PR TITLE
fix: register all commands before attempting to dump the API

### DIFF
--- a/.changelog/5389.yml
+++ b/.changelog/5389.yml
@@ -1,0 +1,4 @@
+changes:
+- description: 'fix: register all commands before attempting to dump the API'
+  type: fix
+pr_number: 5389

--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -153,7 +153,8 @@ def register_commands(_args: list[str] = []):  # noqa: C901
 
     is_test = not _args
     is_help = "-h" in _args or "--help" in _args
-    register_all = any([is_test, is_help])
+    is_export_api = command_name == "export-api"
+    register_all = any([is_test, is_help, is_export_api])
 
     # Pre-commit runs a few commands as hooks.
     is_pre_commit = "pre-commit" == command_name


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues

## Description
The `export-api` command is supposed to [dump the API for every registered command](https://github.com/demisto/demisto-sdk/blob/3e6da00a37840d188bfb9ad418e64de50f1ddbee/demisto_sdk/commands/dump_api/dump_api_setup.py#L22), but only the `export-api` command is registered before the dump runs, so the output describes only export-api command itself.

My proposed fix is to include `export-api` in the list of scenarios which require all commands to be registered - treating `export-api ` the same as `--help` and test mode. This causes every command to be registered for an `export-api` command, and fixes the bug.

My first contribution to the project - open to feedback. Wanted to start with something small. Will sign the CLA as soon as the bot sends it to me, and will try the `poetry run sdk-changelog --init` command as well as soon as the PR is up, per the [Contributing to Demisto SDK](https://xsoar.pan.dev/docs/contributing/sdk) guide.

relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-16935