### PR TITLE
fix: `--help` produces a confusing and unhelpful error when run outside a content repository

### DIFF
--- a/.changelog/5390.yml
+++ b/.changelog/5390.yml
@@ -1,0 +1,4 @@
+changes:
+- description: "fix: --help produces a confusing and unhelpful error when run outside a content repository"
+  type: fix
+pr_number: 5390

--- a/demisto_sdk/commands/validate/validators/PB_validators/PB134_playbook_test_use_case_config.py
+++ b/demisto_sdk/commands/validate/validators/PB_validators/PB134_playbook_test_use_case_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import cache
 from typing import Iterable, List, Tuple
 
 from demisto_sdk.commands.common.constants import GitStatuses
@@ -15,7 +16,13 @@ from demisto_sdk.commands.validate.validators.base_validator import (
     ValidationResult,
 )
 
-ALL_PACK_IDS = get_all_repo_pack_ids()
+
+@cache
+def _all_pack_ids() -> list:
+    # Lazy: scanning ./Packs at import time breaks any `demisto-sdk`
+    # invocation made outside a content repo (e.g. `--help`).
+    return get_all_repo_pack_ids()
+
 
 ContentTypes = Playbook
 
@@ -90,10 +97,11 @@ class PlaybookTestUseCaseConfigValidator(BaseValidator[ContentTypes]):
             return False, "Invalid object schema"
 
         # Step 3: Check pack IDs
+        all_pack_ids = _all_pack_ids()
         invalid_pack_ids = {
             pack_id
             for pack_id in additional_needed_packs.keys()
-            if pack_id not in ALL_PACK_IDS
+            if pack_id not in all_pack_ids
         }
         if invalid_pack_ids:
             return False, f"Unknown packs: {', '.join(invalid_pack_ids)}"


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-16938

```bash
graeme@:/users/graeme/Code$ demisto-sdk --help
Please run demisto-sdk in a content repository. Set the DEMISTO_SDK_IGNORE_CONTENT_WARNING environment variable to suppress this warning.
Traceback (most recent call last):
  File "/home/graeme/.local/bin/demisto-sdk", line 3, in <module>
    from demisto_sdk.__main__ import app
  File "/users/graeme/Code/demisto-sdk/demisto_sdk/__main__.py", line 509, in <module>
    register_commands(args)
  File "/users/graeme/Code/demisto-sdk/demisto_sdk/__main__.py", line 371, in register_commands
    from demisto_sdk.commands.validate.validate_setup import validate
  File "/users/graeme/Code/demisto-sdk/demisto_sdk/commands/validate/validate_setup.py", line 23, in <module>
    from demisto_sdk.commands.validate.validate_manager import ValidateManager
  File "/users/graeme/Code/demisto-sdk/demisto_sdk/commands/validate/validate_manager.py", line 15, in <module>
    from demisto_sdk.commands.validate.validation_results import (
  File "/users/graeme/Code/demisto-sdk/demisto_sdk/commands/validate/validation_results.py", line 9, in <module>
    from demisto_sdk.commands.validate.validators.base_validator import (
  File "/users/graeme/Code/demisto-sdk/demisto_sdk/commands/validate/validators/__init__.py", line 23, in <module>
    module = importlib.import_module(module_name)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/users/graeme/Code/demisto-sdk/demisto_sdk/commands/validate/validators/PB_validators/PB134_playbook_test_use_case_config.py", line 18, in <module>
    ALL_PACK_IDS = get_all_repo_pack_ids()
                   ^^^^^^^^^^^^^^^^^^^^^^^
  File "/users/graeme/Code/demisto-sdk/demisto_sdk/commands/common/tools.py", line 4166, in get_all_repo_pack_ids
    return [path.name for path in (Path(get_content_path()) / PACKS_DIR).iterdir()]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/pathlib.py", line 1058, in iterdir
    for name in os.listdir(self):
                ^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'Packs'
```

## Description
The PB134 PlaybookTestUseCaseConfigValidator runs get_all_repo_pack_ids when the module is imported, rather than when it's called, meaning it triggers the validation even for simple `--help` commands if run in the wrong directory. The error message output is unnecessarily confusing, as there's no obvious reason a specific playbook validator should run for such commands.

My proposed fix is to replace the module-level constant with an `@cache`'d `_all_pack_ids()` helper, which is called by the `validate_config_docstring` function when needed, rather than when the module is imported. This maintains the current behaviour of "pack IDs are computed once when the validator is first run". I have deliberately chosen not to propose the obvious alternative of running get_all_repo_pack_ids directly in the validator, as that would be a behavioural change that could introduce issues downstream - the list of pack IDs might change mid-way through in e.g. testing scenarios.

@cache is a pattern seen elsewhere in the SDK, so it seems consistent with the existing code.

Happy to take feedback. It's a minor issue, but it's extremely off-putting for new users of the SDK, as it gives the impression that even basic functionality like `--help` is broken.