### PR TITLE
fix(pre-commit): preserve ApiModule non-code files and pull sibling R…

### DIFF
--- a/.changelog/5405.yml
+++ b/.changelog/5405.yml
@@ -1,4 +1,4 @@
 changes:
-- description: Fixed an issue where `pre-commit` silently skipped hooks targeting non-code files (e.g. `markdownlint-cli2` on `README.md`) sitting inside an `ApiModules` pack folder.
+- description: Fixed an issue where `pre-commit` silently skipped hooks targeting non-code files (e.g. `markdownlint-cli2` on `README.md`).
   type: fix
 pr_number: '5405'

--- a/.changelog/5405.yml
+++ b/.changelog/5405.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where `pre-commit` silently skipped hooks targeting non-code files (e.g. `markdownlint-cli2` on `README.md`) sitting inside an `ApiModules` pack folder.
+  type: fix
+pr_number: '5405'

--- a/demisto_sdk/commands/pre_commit/pre_commit_command.py
+++ b/demisto_sdk/commands/pre_commit/pre_commit_command.py
@@ -481,6 +481,32 @@ def group_by_language(
             )
         for api_module in api_modules:
             assert isinstance(api_module, Script)
+
+            # Rescue non-code files (e.g. README.md, description.md, images,
+            # json) that the user explicitly passed inside the ApiModule folder.
+            # The API-module-expansion block below only copies .py/.yml/.ps1
+            # files (via `add_related_files`) into the per-integration mapping,
+            # and the second loop in `group_by_language` skips the ApiModules
+            # pack entirely - so without this rescue, anything that isn't
+            # source code would be silently dropped before reaching pre-commit.
+            # Keys in `integrations_scripts_mapping` are `CONTENT_PATH /
+            # <relative path>` (see code_file_path above), so prefer that
+            # absolute form; also try the relative form as a fallback.
+            if api_module.path.is_absolute():
+                absolute_api_folder = api_module.path.parent
+                relative_api_folder = api_module.path.parent.relative_to(
+                    CONTENT_PATH
+                )
+            else:
+                relative_api_folder = api_module.path.parent
+                absolute_api_folder = CONTENT_PATH / relative_api_folder
+            api_module_files = integrations_scripts_mapping.get(
+                absolute_api_folder
+            ) or integrations_scripts_mapping.get(relative_api_folder, set())
+            for f in api_module_files:
+                if f.suffix.lower() not in {".py", ".yml", ".ps1"}:
+                    infra_files.append(f)
+
             for imported_by in api_module.imported_by:
                 # we need to add the api module for each integration that uses it, so it will execute the api module check
                 integrations_scripts.add(imported_by)
@@ -709,6 +735,13 @@ def add_related_files(file: Path) -> Set[Path]:
             files_to_run.add(py_file_path)
         elif ps1_file_path.exists():
             files_to_run.add(ps1_file_path)
+
+        # Pull in the sibling README.md so README-targeting hooks
+        # (e.g. markdownlint-cli2 with `files: "^(.*/)?README\\.md$"`)
+        # fire whenever the integration/script manifest is touched.
+        readme_path = file.with_name("README.md")
+        if readme_path.exists():
+            files_to_run.add(readme_path)
 
     # Identifying test files
 

--- a/demisto_sdk/commands/pre_commit/pre_commit_command.py
+++ b/demisto_sdk/commands/pre_commit/pre_commit_command.py
@@ -88,9 +88,9 @@ class PreCommitRunner:
         for hook_id in hooks.copy():
             if hook_id in custom_hooks_to_classes:
                 PreCommitRunner.original_hook_id_to_generated_hook_ids[hook_id] = (
-                    custom_hooks_to_classes[hook_id](
-                        **hooks.pop(hook_id), context=pre_commit_context
-                    ).prepare_hook()
+                    custom_hooks_to_classes[
+                        hook_id
+                    ](**hooks.pop(hook_id), context=pre_commit_context).prepare_hook()
                 )
             elif hook_id.endswith("in-docker"):
                 PreCommitRunner.original_hook_id_to_generated_hook_ids[hook_id] = (

--- a/demisto_sdk/commands/pre_commit/pre_commit_command.py
+++ b/demisto_sdk/commands/pre_commit/pre_commit_command.py
@@ -88,9 +88,9 @@ class PreCommitRunner:
         for hook_id in hooks.copy():
             if hook_id in custom_hooks_to_classes:
                 PreCommitRunner.original_hook_id_to_generated_hook_ids[hook_id] = (
-                    custom_hooks_to_classes[
-                        hook_id
-                    ](**hooks.pop(hook_id), context=pre_commit_context).prepare_hook()
+                    custom_hooks_to_classes[hook_id](
+                        **hooks.pop(hook_id), context=pre_commit_context
+                    ).prepare_hook()
                 )
             elif hook_id.endswith("in-docker"):
                 PreCommitRunner.original_hook_id_to_generated_hook_ids[hook_id] = (
@@ -494,14 +494,12 @@ def group_by_language(
             # absolute form; also try the relative form as a fallback.
             if api_module.path.is_absolute():
                 absolute_api_folder = api_module.path.parent
-                relative_api_folder = api_module.path.parent.relative_to(
-                    CONTENT_PATH
-                )
+                relative_api_folder = api_module.path.parent.relative_to(CONTENT_PATH)
             else:
                 relative_api_folder = api_module.path.parent
                 absolute_api_folder = CONTENT_PATH / relative_api_folder
-            api_module_files = integrations_scripts_mapping.get(
-                absolute_api_folder
+            api_module_files: Set[Path] = integrations_scripts_mapping.get(
+                absolute_api_folder, set()
             ) or integrations_scripts_mapping.get(relative_api_folder, set())
             for f in api_module_files:
                 if f.suffix.lower() not in {".py", ".yml", ".ps1"}:

--- a/demisto_sdk/commands/pre_commit/tests/pre_commit_test.py
+++ b/demisto_sdk/commands/pre_commit/tests/pre_commit_test.py
@@ -25,6 +25,7 @@ from demisto_sdk.commands.pre_commit.pre_commit_command import (
     GitUtil,
     PreCommitContext,
     PreCommitRunner,
+    add_related_files,
     group_by_language,
     pre_commit_manager,
     preprocess_files,
@@ -261,6 +262,77 @@ def test_handle_api_modules(mocker, git_repo: Repo):
         Path(integration.yml.path).relative_to(git_repo.path),
         integration.object.path.relative_to(git_repo.path),
     ) in files_to_run
+
+
+def test_api_module_readme_is_preserved(mocker, git_repo: Repo):
+    """
+    Given:
+        - A repository with an ApiModules pack containing an API module that
+          ships with a README.md, and a downstream pack with an integration
+          that imports the API module.
+
+    When:
+        - Calling ``group_by_language`` with the API module's README.md as the
+          only input file (mirroring ``demisto-sdk pre-commit -i <README>``).
+
+    Then:
+        - The README.md must end up in the returned ``language_to_files``
+          mapping (under the default Python version bucket, with
+          ``IntegrationScript=None``) instead of being silently dropped before
+          pre-commit is invoked. Without this, the markdownlint-cli2 hook (and
+          any other ``.md``-targeting hook) is "Skipped: no files to check".
+    """
+    pack1 = git_repo.create_pack("ApiModules")
+    script = pack1.create_script("TestApiModule")
+    pack2 = git_repo.create_pack("Pack2")
+    pack2.create_integration("integration1", code="from TestApiModule import *")
+
+    readme_path = Path(script.readme.path).relative_to(git_repo.path)
+
+    mocker.patch.object(pre_commit_command, "CONTENT_PATH", Path(git_repo.path))
+    with ChangeCWD(git_repo.path):
+        git_repo.create_graph()
+        language_to_files, _ = group_by_language({readme_path})
+
+    # The README should reach the per-language bucket with no IntegrationScript
+    # attached (it is an infra/doc file from the ApiModule folder).
+    bucket_paths = {
+        path for path, _ in language_to_files.get(DEFAULT_PYTHON_VERSION, set())
+    }
+    assert readme_path in bucket_paths
+
+
+def test_yml_change_pulls_readme(tmp_path):
+    """
+    Given:
+        - An integration folder on disk containing both a ``.yml`` manifest and
+          a sibling ``README.md`` file.
+
+    When:
+        - Calling ``add_related_files`` on the ``.yml`` file (as happens when
+          the user runs ``demisto-sdk pre-commit -i Foo.yml`` or when the
+          API-module-expansion block rebuilds the per-integration file set).
+
+    Then:
+        - The sibling ``README.md`` must be included in the returned set so
+          that README-targeting hooks (e.g. markdownlint-cli2 with
+          ``files: "^(.*/)?README\\.md$"``) actually fire instead of being
+          reported as Skipped.
+    """
+    integration_dir = tmp_path / "Foo"
+    integration_dir.mkdir()
+    yml_file = integration_dir / "Foo.yml"
+    yml_file.write_text("name: Foo\n")
+    py_file = integration_dir / "Foo.py"
+    py_file.write_text("# code\n")
+    readme_file = integration_dir / "README.md"
+    readme_file.write_text("# Foo\n")
+
+    related = add_related_files(yml_file)
+
+    assert readme_file in related
+    assert yml_file in related
+    assert py_file in related
 
 
 @pytest.mark.parametrize("github_actions", [True, False])

--- a/demisto_sdk/commands/pre_commit/tests/pre_commit_test.py
+++ b/demisto_sdk/commands/pre_commit/tests/pre_commit_test.py
@@ -466,6 +466,9 @@ class TestPreprocessFiles:
             - Running demisto-sdk pre-commit -i file1.yml.
         Then:
             - Check that the associated python file was gathered correctly.
+            - Check that the sibling README.md is also gathered, so that
+              README-targeting hooks (e.g. markdownlint-cli2) fire whenever
+              the integration manifest is touched.
         """
         pack1 = repo.create_pack("Pack1")
         mocker.patch.object(pre_commit_command, "CONTENT_PATH", Path(repo.path))
@@ -481,6 +484,7 @@ class TestPreprocessFiles:
             Path(integration.yml.rel_path),
             Path(integration.code.rel_path),
             Path(integration.test.rel_path),
+            Path(integration.readme.rel_path),
         }
         mocker.patch.object(GitUtil, "get_all_files", return_value=relative_paths)
         output = preprocess_files(input_files=input_files)


### PR DESCRIPTION
Summary

Fixes demisto-sdk pre-commit silently skipping hooks targeting non-code files (e.g. markdownlint-cli2 on README.md) when the file lives inside an ApiModules pack folder. Affects both -i and --use-git flows.

Before: markdownlint-cli2 ....(no files to check) Skipped
After: markdownlint-cli2 ....Passed (or Failed if the file has violations)

Root cause
In group_by_language(), files under Packs/ApiModules/Scripts/<X>/ are stored in integrations_scripts_mapping. The API-module-expansion block only re-emits .py/.yml/.ps1 via add_related_files() into downstream integrations, and the second loop skips the ApiModules pack entirely — so any README/description/image/json sitting in an ApiModule folder is dropped before reaching pre-commit.

Changes
group_by_language() — rescue non-.py/.yml/.ps1 files inside an ApiModule folder onto infra_files, so they survive and land in language_to_files. Source-agnostic (works for -i, --use-git, --staged-only, --all-files).

add_related_files() — when the input is a .yml, also include the sibling README.md, so README-targeting hooks fire whenever an integration manifest is touched.

Tests
test_api_module_readme_is_preserved — repro of the bug report.
test_yml_change_pulls_readme — covers the symmetric fix.
Updated test_preprocess_files_with_input_yml_files to expect the README in the result.

## Related Issues
fixes:

## Description
