### PR TITLE
feat(prepare-content): support per-marketplace hidden values on integ…

### DIFF
--- a/.changelog/5430.yml
+++ b/.changelog/5430.yml
@@ -1,4 +1,4 @@
 changes:
 - description: "Added support for hiding integration commands per marketplace. The command-level `hidden` field now accepts a list of marketplace names (mirroring the existing parameter-level behavior); listed marketplaces resolve to `hidden=true` for that marketplace during unify, while others resolve to `hidden=false`. Pre-existing boolean `hidden` values are left untouched."
   type: feature
-pr_number: 'TBD'
+pr_number: 5430

--- a/.changelog/hidden-commands-per-marketplace.yml
+++ b/.changelog/hidden-commands-per-marketplace.yml
@@ -1,0 +1,4 @@
+changes:
+- description: "Added support for hiding integration commands per marketplace. The command-level `hidden` field now accepts a list of marketplace names (mirroring the existing parameter-level behavior); listed marketplaces resolve to `hidden=true` for that marketplace during unify, while others resolve to `hidden=false`. Pre-existing boolean `hidden` values are left untouched."
+  type: feature
+pr_number: 'TBD'

--- a/demisto_sdk/commands/common/schemas/integration.yml
+++ b/demisto_sdk/commands/common/schemas/integration.yml
@@ -368,7 +368,9 @@ schema;command_schema:
     timeout:
       type: int
     hidden:
-      type: bool
+      # Either a bool, or a list of marketplace names where the command is hidden.
+      # Mirrors the same shape allowed on integration parameters (see _configuration_schema).
+      type: any
     hidden_x2:
       type: bool
     polling:

--- a/demisto_sdk/commands/content_graph/objects/integration.py
+++ b/demisto_sdk/commands/content_graph/objects/integration.py
@@ -72,7 +72,10 @@ class Command(BaseNode, content_type=ContentType.COMMAND):  # type: ignore[call-
     outputs: List[IntegrationOutput] = Field([], exclude=True)
 
     deprecated: bool = Field(False)
-    hidden: bool = Field(False)
+    # `hidden` may be a bool, or a list of marketplace names where the command
+    # should be hidden. Mirrors the same shape allowed on integration parameters
+    # (see `Parameter.hidden`).
+    hidden: Any = Field(False)
     description: Optional[str] = Field("")
     supportedModules: Optional[List[str]] = Field([])
 

--- a/demisto_sdk/commands/content_graph/parsers/integration.py
+++ b/demisto_sdk/commands/content_graph/parsers/integration.py
@@ -23,7 +23,9 @@ from demisto_sdk.commands.prepare_content.integration_script_unifier import (
 class CommandParser:
     name: str
     deprecated: bool
-    hidden: bool
+    # `hidden` may be a bool, or a list of marketplace names where the command
+    # should be hidden. Mirrors the same shape allowed on integration parameters.
+    hidden: Any
     description: str
     args: List[dict]
     outputs: List[dict]

--- a/demisto_sdk/commands/content_graph/strict_objects/integration.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/integration.py
@@ -104,6 +104,11 @@ class _Command(BaseStrictModel):
     polling: Optional[bool] = None
     prettyname: Optional[str] = None
     compliantpolicies: Optional[List[str]] = None
+    # `hidden` may be a bool, or a list of marketplace names where the command
+    # should be hidden. Mirrors the same shape allowed on integration parameters
+    # (see `_Configuration.hidden`). The explicit declaration here overrides the
+    # `hidden: Optional[bool]` that HIDDEN_DYNAMIC_MODEL would otherwise add.
+    hidden: Optional[Any] = None
     supportedModules: Optional[
         Annotated[
             List[PlatformSupportedModules],

--- a/demisto_sdk/commands/prepare_content/integration_script_unifier.py
+++ b/demisto_sdk/commands/prepare_content/integration_script_unifier.py
@@ -86,6 +86,7 @@ class IntegrationScriptUnifier(Unifier):
         if not is_script_package:  # integration
             # Change data in place
             IntegrationScriptUnifier.update_hidden_parameters_value(data, marketplace)
+            IntegrationScriptUnifier.update_hidden_commands_value(data, marketplace)
             IntegrationScriptUnifier.remove_mirroring_commands_and_settings(
                 data, marketplace
             )
@@ -172,6 +173,44 @@ class IntegrationScriptUnifier(Unifier):
                     data["configuration"][i].pop("hidden")
                 else:  # type-4 param
                     data["configuration"][i]["hidden"] = marketplace in hidden
+
+    @staticmethod
+    def update_hidden_commands_value(
+        data: dict, marketplace: MarketplaceVersions = None
+    ) -> None:
+        """
+        The `hidden` attribute of each command may be a bool (hiding the command across all
+        marketplaces), or a list of marketplaces where the command should be hidden.
+
+        This method replaces a list-typed `hidden` value with a boolean that matches the
+        current marketplace. Boolean values are left untouched.
+
+        The XSOAR family aliases (`xsoar`, `xsoar_saas`, `xsoar_on_prem`) are expanded
+        in the same way as for integration parameters, so a single `xsoar` entry hides
+        the command on all XSOAR-flavored marketplaces.
+
+        Args:
+            data (dict): The integration data.
+            marketplace (MarketplaceVersions): The current marketplace.
+        """
+        if not marketplace:
+            return
+
+        commands = data.get("script", {}).get("commands") or []
+        for i, command in enumerate(commands):
+            if isinstance(hidden := command.get("hidden"), list):
+                # converts list to bool, mirroring update_hidden_parameters_value
+                if MarketplaceVersions.XSOAR.value in hidden:
+                    hidden.extend(
+                        [
+                            MarketplaceVersions.XSOAR_SAAS,
+                            MarketplaceVersions.XSOAR_ON_PREM,
+                        ]
+                    )
+                if MarketplaceVersions.XSOAR_ON_PREM.value in hidden:
+                    hidden.append(MarketplaceVersions.XSOAR)
+
+                data["script"]["commands"][i]["hidden"] = marketplace in hidden
 
     @staticmethod
     def remove_mirroring_commands_and_settings(

--- a/demisto_sdk/commands/prepare_content/tests/yml_unifier_test.py
+++ b/demisto_sdk/commands/prepare_content/tests/yml_unifier_test.py
@@ -992,6 +992,120 @@ class TestMergeScriptPackageToYMLIntegration:
                     marketplace == MarketplaceVersions.XSOAR
                 )
 
+    @pytest.mark.parametrize(
+        "marketplace, expected_hidden",
+        [
+            (
+                MarketplaceVersions.XSOAR,
+                {
+                    "cmd-always-visible": None,
+                    "cmd-bool-true": True,
+                    "cmd-bool-false": False,
+                    "cmd-hidden-on-xsiam": False,
+                    "cmd-hidden-on-xsoar-family": True,
+                    "cmd-hidden-on-xsoar-and-xsiam": True,
+                    "cmd-hidden-on-platform": False,
+                },
+            ),
+            (
+                MarketplaceVersions.MarketplaceV2,
+                {
+                    "cmd-always-visible": None,
+                    "cmd-bool-true": True,
+                    "cmd-bool-false": False,
+                    "cmd-hidden-on-xsiam": True,
+                    "cmd-hidden-on-xsoar-family": False,
+                    "cmd-hidden-on-xsoar-and-xsiam": True,
+                    "cmd-hidden-on-platform": False,
+                },
+            ),
+            # PLATFORM marketplace is intentionally not exercised here:
+            # `prepare_for_upload` for PLATFORM accesses self.pack.supportedModules,
+            # but the lightweight `create_test_package` fixture used by this test
+            # class does not set up a parent pack object - this is an existing
+            # limitation of the fixture, not of the per-marketplace hidden feature.
+            # The PLATFORM resolution path is covered by the direct unit tests
+            # for `update_hidden_commands_value` further down in this module.
+            (
+                MarketplaceVersions.XSOAR_SAAS,
+                {
+                    "cmd-always-visible": None,
+                    "cmd-bool-true": True,
+                    "cmd-bool-false": False,
+                    "cmd-hidden-on-xsiam": False,
+                    "cmd-hidden-on-xsoar-family": True,
+                    "cmd-hidden-on-xsoar-and-xsiam": True,
+                    "cmd-hidden-on-platform": False,
+                },
+            ),
+        ],
+    )
+    def test_unify_integration__hidden_command(
+        self,
+        marketplace: MarketplaceVersions,
+        expected_hidden: dict,
+        mocker,
+        monkeypatch,
+    ):
+        """
+        Given:
+            - An integration YAML whose `script.commands` contains a mix of:
+                * a command with no `hidden` attribute,
+                * a command with `hidden: true`,
+                * a command with `hidden: false`,
+                * commands with `hidden: [<marketplace>]` lists.
+
+        When:
+            - Running the full prepare-content (unify) pipeline for a specific
+              marketplace.
+
+        Then:
+            - The list-typed `hidden` values are resolved to a boolean reflecting
+              whether the current marketplace appears in the list.
+            - The `xsoar` alias expands to also cover `xsoar_saas` and
+              `xsoar_on_prem` (mirroring the parameter-level behavior).
+            - Pre-existing boolean values are preserved.
+            - This is the end-to-end gate proving the feature works through the
+              YAML schema validation, the strict pydantic model, the parser, and
+              the unifier - not just the unifier helper in isolation.
+        """
+        create_test_package(
+            test_dir=self.test_dir_path,
+            package_name=self.package_name,
+            base_yml=(
+                "demisto_sdk/tests/test_files/Unifier/SampleIntegPackage/"
+                "SampleIntegPackageHiddenCommands.yml"
+            ),
+            script_code=TEST_VALID_CODE,
+            detailed_description=TEST_VALID_DETAILED_DESCRIPTION,
+            image_file=(
+                "demisto_sdk/tests/test_files/Unifier/SampleIntegPackage/"
+                "SampleIntegPackage_image.png"
+            ),
+        )
+
+        mocker.patch.object(
+            IntegrationScript, "get_supported_native_images", return_value=[]
+        )
+        with TemporaryDirectory() as artifact_dir:
+            monkeypatch.setenv("DEMISTO_SDK_CONTENT_PATH", artifact_dir)
+            monkeypatch.setenv("ARTIFACTS_FOLDER", artifact_dir)
+            unified_yml = PrepareUploadManager.prepare_for_upload(
+                input=Path(self.export_dir_path),
+                output=Path(self.test_dir_path),
+                marketplace=marketplace,
+            )
+
+        unified_commands = {
+            cmd["name"]: cmd.get("hidden")
+            for cmd in get_yaml(unified_yml)["script"]["commands"]
+        }
+        for cmd_name, expected in expected_hidden.items():
+            assert unified_commands[cmd_name] is expected, (
+                f"command {cmd_name!r} expected hidden={expected} for "
+                f"marketplace {marketplace.value!r}, got {unified_commands[cmd_name]!r}"
+            )
+
     def test_unify_integration__detailed_description_with_special_char(
         self, mocker, monkeypatch
     ):

--- a/demisto_sdk/commands/prepare_content/tests/yml_unifier_test.py
+++ b/demisto_sdk/commands/prepare_content/tests/yml_unifier_test.py
@@ -1776,6 +1776,166 @@ def test_update_hidden_parameters_value():
 
 
 @pytest.mark.parametrize(
+    "marketplace, expected_hidden",
+    [
+        # cmd-bool-true: bool stays bool regardless of marketplace
+        # cmd-platform-only: hidden on platform marketplace only
+        # cmd-xsoar-family: hidden across all XSOAR-flavored marketplaces
+        # cmd-xsoar-and-xsiam: hidden on xsoar family + marketplacev2
+        (
+            MarketplaceVersions.XSOAR,
+            {
+                "cmd-bool-true": True,
+                "cmd-platform-only": False,
+                "cmd-xsoar-family": True,
+                "cmd-xsoar-and-xsiam": True,
+            },
+        ),
+        (
+            MarketplaceVersions.XSOAR_SAAS,
+            {
+                "cmd-bool-true": True,
+                "cmd-platform-only": False,
+                "cmd-xsoar-family": True,
+                "cmd-xsoar-and-xsiam": True,
+            },
+        ),
+        (
+            MarketplaceVersions.XSOAR_ON_PREM,
+            {
+                "cmd-bool-true": True,
+                "cmd-platform-only": False,
+                "cmd-xsoar-family": True,
+                "cmd-xsoar-and-xsiam": True,
+            },
+        ),
+        (
+            MarketplaceVersions.MarketplaceV2,
+            {
+                "cmd-bool-true": True,
+                "cmd-platform-only": False,
+                "cmd-xsoar-family": False,
+                "cmd-xsoar-and-xsiam": True,
+            },
+        ),
+        (
+            MarketplaceVersions.PLATFORM,
+            {
+                "cmd-bool-true": True,
+                "cmd-platform-only": True,
+                "cmd-xsoar-family": False,
+                "cmd-xsoar-and-xsiam": False,
+            },
+        ),
+        (
+            MarketplaceVersions.XPANSE,
+            {
+                "cmd-bool-true": True,
+                "cmd-platform-only": False,
+                "cmd-xsoar-family": False,
+                "cmd-xsoar-and-xsiam": False,
+            },
+        ),
+    ],
+)
+def test_update_hidden_commands_value(
+    marketplace: MarketplaceVersions, expected_hidden: dict
+):
+    """
+    Given:
+        - An integration yml dict whose commands have a mix of:
+            * `hidden: true` (always-hidden)
+            * `hidden: [<marketplace>]` for various marketplaces
+            * `hidden: [xsoar, marketplacev2]` listing several marketplaces
+
+    When:
+        - Calling IntegrationScriptUnifier.update_hidden_commands_value for a specific
+          marketplace.
+
+    Then:
+        - List-typed `hidden` values are converted to a boolean reflecting whether the
+          current marketplace appears in the list.
+        - The `xsoar` entry expands to also cover xsoar_saas and xsoar_on_prem
+          (and xsoar_on_prem expands to also cover xsoar) - matching the existing
+          parameter-level behavior.
+        - Pre-existing boolean values are left untouched.
+    """
+    yml_data = {
+        "script": {
+            "commands": [
+                {"name": "cmd-bool-true", "hidden": True},
+                {"name": "cmd-platform-only", "hidden": ["platform"]},
+                {"name": "cmd-xsoar-family", "hidden": ["xsoar"]},
+                {
+                    "name": "cmd-xsoar-and-xsiam",
+                    "hidden": ["xsoar", "marketplacev2"],
+                },
+                {"name": "cmd-no-hidden"},
+            ]
+        }
+    }
+
+    IntegrationScriptUnifier.update_hidden_commands_value(yml_data, marketplace)
+
+    resolved = {
+        cmd["name"]: cmd.get("hidden") for cmd in yml_data["script"]["commands"]
+    }
+    for cmd_name, expected in expected_hidden.items():
+        assert resolved[cmd_name] is expected, (
+            f"command {cmd_name!r} expected hidden={expected} for "
+            f"marketplace {marketplace.value!r}, got {resolved[cmd_name]!r}"
+        )
+    # commands without a `hidden` attribute are left untouched
+    assert "hidden" not in yml_data["script"]["commands"][-1]
+
+
+def test_update_hidden_commands_value__no_marketplace_is_noop():
+    """
+    Given:
+        - An integration yml dict whose first command has `hidden: [platform]`.
+
+    When:
+        - Calling update_hidden_commands_value without a marketplace argument
+          (e.g. during a non-marketplace-aware prepare).
+
+    Then:
+        - The data is left untouched (list-typed hidden values are preserved),
+          mirroring the no-op behavior of update_hidden_parameters_value.
+    """
+    yml_data = {
+        "script": {
+            "commands": [
+                {"name": "cmd-platform-only", "hidden": ["platform"]},
+            ]
+        }
+    }
+
+    IntegrationScriptUnifier.update_hidden_commands_value(yml_data, None)
+
+    assert yml_data["script"]["commands"][0]["hidden"] == ["platform"]
+
+
+def test_update_hidden_commands_value__missing_commands_is_safe():
+    """
+    Given:
+        - An integration yml dict whose `script` block has no `commands` key.
+
+    When:
+        - Calling update_hidden_commands_value for any marketplace.
+
+    Then:
+        - No exception is raised and the data is left untouched.
+    """
+    yml_data = {"script": {}}
+
+    IntegrationScriptUnifier.update_hidden_commands_value(
+        yml_data, MarketplaceVersions.PLATFORM
+    )
+
+    assert yml_data == {"script": {}}
+
+
+@pytest.mark.parametrize(
     argnames="marketplace, expected_commands_count, expected_mirroring_enabled",
     argvalues=PREPARE_CONTENT_MARKETPLACE_MIRRORING,
 )

--- a/demisto_sdk/commands/validate/tests/IN_validators_test.py
+++ b/demisto_sdk/commands/validate/tests/IN_validators_test.py
@@ -21,7 +21,7 @@ from demisto_sdk.commands.common.constants import (
     MarketplaceVersions,
     ParameterType,
 )
-from demisto_sdk.commands.content_graph.objects.integration import Integration
+from demisto_sdk.commands.content_graph.objects.integration import Command, Integration
 from demisto_sdk.commands.validate.tests.test_tools import (
     REPO,
     create_integration_object,
@@ -4577,6 +4577,112 @@ def test_IsValidHiddenValueValidator_obtain_invalid_content_items(
             result.message == expected_msg
             for result, expected_msg in zip(results, expected_msgs)
         ]
+    )
+
+
+@pytest.mark.parametrize(
+    "hidden_value, expected_invalid",
+    [
+        # valid shapes -> not in invalid_commands
+        (None, False),
+        (False, False),
+        (True, False),
+        ([MarketplaceVersions.XSOAR.value], False),
+        (
+            [
+                MarketplaceVersions.XSOAR.value,
+                MarketplaceVersions.MarketplaceV2.value,
+                MarketplaceVersions.PLATFORM.value,
+            ],
+            False,
+        ),
+        ("true", False),
+        ("false", False),
+        # invalid shapes -> reported
+        ("yes", True),
+        ("flase", True),
+        (1, True),
+        ([False], True),
+        (["not-a-marketplace"], True),
+        (
+            [MarketplaceVersions.XSOAR.value, "bogus"],
+            True,
+        ),
+    ],
+)
+def test_IsValidHiddenValueValidator_command_level_hidden(
+    hidden_value, expected_invalid
+):
+    """
+    Given:
+        - An integration whose script.commands contains a single command with a
+          `hidden` field set to a variety of valid and invalid shapes (bool,
+          string, int, list of marketplace names, list with bogus values, etc.).
+
+    When:
+        - Running IN156's `get_invalid_commands` against that integration's
+          commands.
+
+    Then:
+        - Valid shapes (bool, None, list of valid marketplace names, the
+          strings "true"/"false") are NOT reported.
+        - Invalid shapes (arbitrary strings, ints, lists of non-marketplace
+          strings) ARE reported.
+        - This mirrors the existing parameter-level coverage so that the same
+          set of `hidden` values is allowed/rejected on commands too.
+    """
+    integration = create_integration_object()
+    command = Command(name="my-cmd", description="desc", hidden=hidden_value)
+    integration.commands = [command]
+
+    invalid = IsValidHiddenValueValidator().get_invalid_commands(integration.commands)
+
+    assert ("my-cmd" in invalid) is expected_invalid
+
+
+def test_IsValidHiddenValueValidator_reports_both_params_and_commands():
+    """
+    Given:
+        - An integration with one invalid parameter `hidden` value AND one
+          invalid command `hidden` value.
+
+    When:
+        - Running IN156's `obtain_invalid_content_items` against it.
+
+    Then:
+        - A single ValidationResult is emitted for the integration whose message
+          lists BOTH the invalid param and the invalid command, so authors get
+          one consolidated error per integration rather than two duplicates.
+    """
+    integration = create_integration_object(
+        paths=["configuration"],
+        values=[
+            [
+                {
+                    "name": "bad-param",
+                    "type": 8,
+                    "display": "bad",
+                    "required": False,
+                    "hidden": "yes",
+                }
+            ]
+        ],
+    )
+    integration.commands = [
+        Command(name="bad-cmd", description="desc", hidden="yes"),
+    ]
+
+    results = IsValidHiddenValueValidator().obtain_invalid_content_items([integration])
+
+    assert len(results) == 1
+    message = results[0].message
+    assert (
+        "The param bad-param contains the following invalid hidden value: yes"
+        in message
+    )
+    assert (
+        "The command bad-cmd contains the following invalid hidden value: yes"
+        in message
     )
 
 

--- a/demisto_sdk/commands/validate/validators/IN_validators/IN156_is_valid_hidden_value.py
+++ b/demisto_sdk/commands/validate/validators/IN_validators/IN156_is_valid_hidden_value.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import Iterable, List
+from typing import Any, Iterable, List
 
 from demisto_sdk.commands.common.constants import MarketplaceVersions
 from demisto_sdk.commands.content_graph.objects.integration import (
+    Command,
     Integration,
     Parameter,
 )
@@ -28,40 +29,59 @@ class IsValidHiddenValueValidator(BaseValidator[ContentTypes]):
     def obtain_invalid_content_items(
         self, content_items: Iterable[ContentTypes]
     ) -> List[ValidationResult]:
-        return [
-            ValidationResult(
-                validator=self,
-                message=self.error_message.format(
-                    "\n".join(
-                        [
-                            f"The param {key} contains the following invalid hidden value: {val}"
-                            for key, val in invalid_params.items()
-                        ]
+        results: List[ValidationResult] = []
+        for content_item in content_items:
+            invalid_params = self.get_invalid_params(content_item.params)
+            invalid_commands = self.get_invalid_commands(content_item.commands)
+            if not invalid_params and not invalid_commands:
+                continue
+
+            lines = [
+                f"The param {key} contains the following invalid hidden value: {val}"
+                for key, val in invalid_params.items()
+            ] + [
+                f"The command {key} contains the following invalid hidden value: {val}"
+                for key, val in invalid_commands.items()
+            ]
+            results.append(
+                ValidationResult(
+                    validator=self,
+                    message=self.error_message.format(
+                        "\n".join(lines),
+                        ", ".join(MarketplaceVersions),
                     ),
-                    ", ".join(MarketplaceVersions),
-                ),
-                content_object=content_item,
+                    content_object=content_item,
+                )
             )
-            for content_item in content_items
-            if (invalid_params := self.get_invalid_params(content_item.params))
-        ]
+        return results
+
+    @staticmethod
+    def _is_invalid_hidden_value(hidden: Any) -> bool:
+        """Return True if the given `hidden` value is neither a bool/None nor a
+        list of valid marketplace names (or the strings "true"/"false")."""
+        if not hidden:
+            return False
+        return all(
+            [
+                not isinstance(hidden, (type(None), bool)),
+                not (isinstance(hidden, str) and hidden in ["true", "false"]),
+                not (
+                    isinstance(hidden, list)
+                    and not set(hidden).difference(MarketplaceVersions)
+                ),
+            ]
+        )
 
     def get_invalid_params(self, params: List[Parameter]) -> dict:
         return {
             param.name: param.hidden
             for param in params
-            if param.hidden
-            and all(
-                [
-                    not isinstance(param.hidden, (type(None), bool)),
-                    not (
-                        isinstance(param.hidden, str)
-                        and param.hidden in ["true", "false"]
-                    ),
-                    not (
-                        isinstance(param.hidden, list)
-                        and not set(param.hidden).difference(MarketplaceVersions)
-                    ),
-                ]
-            )
+            if self._is_invalid_hidden_value(param.hidden)
+        }
+
+    def get_invalid_commands(self, commands: List[Command]) -> dict:
+        return {
+            command.name: command.hidden
+            for command in commands
+            if self._is_invalid_hidden_value(command.hidden)
         }

--- a/demisto_sdk/tests/test_files/Unifier/SampleIntegPackage/SampleIntegPackageHiddenCommands.yml
+++ b/demisto_sdk/tests/test_files/Unifier/SampleIntegPackage/SampleIntegPackageHiddenCommands.yml
@@ -1,0 +1,49 @@
+category: Authentication
+commonfields:
+  id: TestIntegPackageHiddenCommands
+  version: -1
+provider: Test Provider
+configuration:
+- defaultvalue: https://example.net
+  display: Server URL (e.g. https://example.net)
+  name: url
+  required: true
+  type: 0
+description: Sample integration used to exercise per-marketplace hidden on commands.
+display: TestIntegPackageHiddenCommands
+name: TestIntegPackageHiddenCommands
+script:
+  commands:
+  - name: cmd-always-visible
+    description: No hidden attribute - should remain visible everywhere.
+  - name: cmd-bool-true
+    description: hidden=true - hidden on every marketplace.
+    hidden: true
+  - name: cmd-bool-false
+    description: hidden=false - visible on every marketplace.
+    hidden: false
+  - name: cmd-hidden-on-xsiam
+    description: Hidden only on the XSIAM marketplace.
+    hidden:
+      - marketplacev2
+  - name: cmd-hidden-on-xsoar-family
+    description: Hidden on all XSOAR-flavored marketplaces.
+    hidden:
+      - xsoar
+  - name: cmd-hidden-on-xsoar-and-xsiam
+    description: Hidden on xsoar + marketplacev2.
+    hidden:
+      - xsoar
+      - marketplacev2
+  - name: cmd-hidden-on-platform
+    description: Hidden only on the platform marketplace.
+    hidden:
+      - platform
+  isfetch: false
+  runonce: false
+  script: '-'
+  type: python
+  subtype: python3
+  dockerimage: demisto/python3:3.9.9.25564
+tests:
+- No tests (auto formatted)


### PR DESCRIPTION
…ration commands

Mirror the existing parameter-level behavior on commands: the command-level `hidden` field now accepts a list of marketplace names in addition to a plain boolean. At unify time, list-typed values are resolved to a boolean that matches the current marketplace - listed marketplaces become `hidden: true`, others become `hidden: false`. Pre-existing boolean values are left untouched.

The `xsoar` family aliases (`xsoar`, `xsoar_saas`, `xsoar_on_prem`) are expanded using the same rules as parameter-level hiding, so a single `xsoar` entry hides the command on all XSOAR-flavored marketplaces.

Adds 8 parametrized unit tests covering all six marketplaces plus the no-marketplace and missing-commands edge cases.

<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CRTX-260035

## Description
