### PR TITLE
Demisto-sdk release 1.39.4

### DIFF
--- a/.changelog/5442.yml
+++ b/.changelog/5442.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Renamed the Connector's ``metadata.category`` field to ``metadata.categories`` (a list of strings, at least one required) to match the updated Connector schema.
-  type: breaking
-pr_number: '5442'

--- a/.changelog/5443.yml
+++ b/.changelog/5443.yml
@@ -1,4 +1,0 @@
-changes:
-- description: Move MC101 validation to warning level as it is a broken validation
-  type: internal
-pr_number: 5443

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## 1.39.4 (2026-07-12)
+### Breaking
+* Renamed the Connector's ``metadata.category`` field to ``metadata.categories`` (a list of strings, at least one required) to match the updated Connector schema. [#5442](https://github.com/demisto/demisto-sdk/pull/5442)
+
+### Internal
+* Move MC101 validation to warning level as it is a broken validation [#5443](https://github.com/demisto/demisto-sdk/pull/5443)
+
+
 ## 1.39.3 (2026-07-06)
 ### Feature
 * Added support for skill action dependencies. [#5411](https://github.com/demisto/demisto-sdk/pull/5411)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ exclude = "tests/.*|demisto_sdk/commands/init/templates/.*"
 
 [tool.poetry]
 name = "demisto-sdk"
-version = "1.39.3"
+version = "1.39.4"
 description = "\"A Python library for the Demisto SDK\""
 authors = ["Demisto"]
 license = "MIT"


### PR DESCRIPTION
### Breaking
* Renamed the Connector's ``metadata.category`` field to ``metadata.categories`` (a list of strings, at least one required) to match the updated Connector schema. [#5442](https://github.com/demisto/demisto-sdk/pull/5442)

### Internal
* Move MC101 validation to warning level as it is a broken validation [#5443](https://github.com/demisto/demisto-sdk/pull/5443)
