### PR TITLE
gr107 false positive fix

### DIFF
--- a/demisto_sdk/commands/content_graph/commands/update.py
+++ b/demisto_sdk/commands/content_graph/commands/update.py
@@ -302,7 +302,7 @@ def _update_content_graph_inner(
     # fails, which currently tears down the whole import via "Creating from
     # scratch". The env-var path is the single source of truth in that case.
     explicit_changes_provided = bool(packs_to_update or connectors_to_update)
-    logger.debug(
+    logger.info(
         f"[graph-update] initial packs_to_update={packs_to_update}, "
         f"connectors_to_update={connectors_to_update}, "
         f"explicit_changes_provided={explicit_changes_provided}"
@@ -313,7 +313,7 @@ def _update_content_graph_inner(
     # from DEMISTO_SDK_DIFF_FILES (and vice versa).
     if not packs_to_update or not connectors_to_update:
         diff_files_env = os.getenv(DEMISTO_SDK_DIFF_FILES_ENV, "")
-        logger.debug(
+        logger.info(
             f"[graph-update] {DEMISTO_SDK_DIFF_FILES_ENV}="
             f"{repr(diff_files_env[:200]) if diff_files_env else '(not set)'}"
         )
@@ -347,7 +347,7 @@ def _update_content_graph_inner(
     changed_pack_ids: Set[str] = set()
     changed_connector_ids: Set[str] = set()
     git_diff_failed = False
-    logger.debug(
+    logger.info(
         f"[graph-update] use_git={use_git}, "
         f"commit={getattr(content_graph_interface, 'commit', 'N/A')}, "
         f"is_external_repo={is_external_repo}, "
@@ -359,10 +359,10 @@ def _update_content_graph_inner(
         and not is_external_repo
         and not explicit_changes_provided
     ):
-        logger.debug(f"[graph-update] Running git diff from commit={commit}")
+        logger.info(f"[graph-update] Running git diff from commit={commit}")
         try:
             changed_pack_ids = git_util.get_all_changed_pack_ids(commit)
-            logger.debug(
+            logger.info(
                 f"[graph-update] git diff found changed_pack_ids={sorted(changed_pack_ids)}"
             )
         except Exception as e:
@@ -373,11 +373,11 @@ def _update_content_graph_inner(
         if not git_diff_failed:
             # Best-effort: _changed_connectors_from_git never raises.
             changed_connector_ids = _changed_connectors_from_git(git_util, commit)
-            logger.debug(
+            logger.info(
                 f"[graph-update] git diff found changed_connector_ids={sorted(changed_connector_ids)}"
             )
     else:
-        logger.debug(
+        logger.info(
             f"[graph-update] Skipping git diff "
             f"(use_git={use_git}, has_commit={bool(getattr(content_graph_interface, 'commit', None))}, "
             f"is_external_repo={is_external_repo}, explicit_changes_provided={explicit_changes_provided})"
@@ -464,7 +464,7 @@ def _update_content_graph_inner(
     connectors_tuple: Optional[Tuple[str, ...]] = (
         tuple(sorted(set(connectors_to_update))) if connectors_to_update else None
     )
-    logger.debug(
+    logger.info(
         f"[graph-update] Calling builder.update_graph with "
         f"packs_to_update={packs_tuple}, connectors_to_update={connectors_tuple}"
     )
@@ -478,7 +478,7 @@ def _update_content_graph_inner(
         packs_to_update=packs_tuple,
         connectors_to_update=connectors_tuple,
     )
-    logger.debug("[graph-update] builder.update_graph completed")
+    logger.info("[graph-update] builder.update_graph completed")
 
     if dependencies:
         content_graph_interface.create_pack_dependencies()

--- a/demisto_sdk/commands/content_graph/commands/update.py
+++ b/demisto_sdk/commands/content_graph/commands/update.py
@@ -302,12 +302,21 @@ def _update_content_graph_inner(
     # fails, which currently tears down the whole import via "Creating from
     # scratch". The env-var path is the single source of truth in that case.
     explicit_changes_provided = bool(packs_to_update or connectors_to_update)
+    logger.debug(
+        f"[graph-update] initial packs_to_update={packs_to_update}, "
+        f"connectors_to_update={connectors_to_update}, "
+        f"explicit_changes_provided={explicit_changes_provided}"
+    )
 
     # Read env var if either list is still empty - the two are independent so a
     # caller that passed --packs only should still pick up connector entries
     # from DEMISTO_SDK_DIFF_FILES (and vice versa).
     if not packs_to_update or not connectors_to_update:
         diff_files_env = os.getenv(DEMISTO_SDK_DIFF_FILES_ENV, "")
+        logger.debug(
+            f"[graph-update] {DEMISTO_SDK_DIFF_FILES_ENV}="
+            f"{repr(diff_files_env[:200]) if diff_files_env else '(not set)'}"
+        )
         if diff_files_env:
             if not packs_to_update:
                 env_pack_ids = extract_pack_ids_from_diff_files(diff_files_env)
@@ -338,14 +347,24 @@ def _update_content_graph_inner(
     changed_pack_ids: Set[str] = set()
     changed_connector_ids: Set[str] = set()
     git_diff_failed = False
+    logger.debug(
+        f"[graph-update] use_git={use_git}, "
+        f"commit={getattr(content_graph_interface, 'commit', 'N/A')}, "
+        f"is_external_repo={is_external_repo}, "
+        f"explicit_changes_provided={explicit_changes_provided}"
+    )
     if (
         use_git
         and (commit := content_graph_interface.commit)
         and not is_external_repo
         and not explicit_changes_provided
     ):
+        logger.debug(f"[graph-update] Running git diff from commit={commit}")
         try:
             changed_pack_ids = git_util.get_all_changed_pack_ids(commit)
+            logger.debug(
+                f"[graph-update] git diff found changed_pack_ids={sorted(changed_pack_ids)}"
+            )
         except Exception as e:
             logger.warning(
                 f"Failed to get changed packs from git. Creating from scratch. Error: {e}"
@@ -354,6 +373,15 @@ def _update_content_graph_inner(
         if not git_diff_failed:
             # Best-effort: _changed_connectors_from_git never raises.
             changed_connector_ids = _changed_connectors_from_git(git_util, commit)
+            logger.debug(
+                f"[graph-update] git diff found changed_connector_ids={sorted(changed_connector_ids)}"
+            )
+    else:
+        logger.debug(
+            f"[graph-update] Skipping git diff "
+            f"(use_git={use_git}, has_commit={bool(getattr(content_graph_interface, 'commit', None))}, "
+            f"is_external_repo={is_external_repo}, explicit_changes_provided={explicit_changes_provided})"
+        )
 
     builder = ContentGraphBuilder(content_graph_interface)
     if not should_update_graph(
@@ -436,10 +464,21 @@ def _update_content_graph_inner(
     connectors_tuple: Optional[Tuple[str, ...]] = (
         tuple(sorted(set(connectors_to_update))) if connectors_to_update else None
     )
+    logger.debug(
+        f"[graph-update] Calling builder.update_graph with "
+        f"packs_to_update={packs_tuple}, connectors_to_update={connectors_tuple}"
+    )
+    if not packs_tuple and not connectors_tuple:
+        logger.warning(
+            "[graph-update] WARNING: packs_to_update and connectors_to_update are both empty/None. "
+            "builder.update_graph will return early without updating the graph. "
+            "The graph retains the bucket state (deprecated values from master)."
+        )
     builder.update_graph(
         packs_to_update=packs_tuple,
         connectors_to_update=connectors_tuple,
     )
+    logger.debug("[graph-update] builder.update_graph completed")
 
     if dependencies:
         content_graph_interface.create_pack_dependencies()

--- a/demisto_sdk/commands/content_graph/interface/neo4j/neo4j_graph.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/neo4j_graph.py
@@ -372,6 +372,7 @@ class Neo4jContentGraphInterface(ContentGraphInterface):
     def create_nodes(self, nodes: Dict[ContentType, List[Dict[str, Any]]]) -> None:
         logger.info("Creating graph nodes...")
         pack_ids = [p.get("object_id") for p in nodes.get(ContentType.PACK, [])]
+        logger.debug(f"[graph-update] create_nodes called for pack_ids={pack_ids}")
         with self.driver.session() as session:
             self._rels_to_preserve = session.execute_read(
                 get_relationships_to_preserve, pack_ids
@@ -379,6 +380,20 @@ class Neo4jContentGraphInterface(ContentGraphInterface):
             session.execute_write(remove_packs_before_creation, pack_ids)
             session.execute_write(create_nodes, nodes)
             session.execute_write(remove_empty_properties)
+        # Log the deprecated state of all integrations in the updated packs
+        if pack_ids:
+            with self.driver.session() as session:
+                result = session.run(
+                    "MATCH (n:Integration)-[:IN_PACK]->(p:Pack) "
+                    "WHERE p.object_id IN $pack_ids "
+                    "RETURN n.object_id AS id, n.deprecated AS deprecated",
+                    pack_ids=pack_ids,
+                )
+                for record in result:
+                    logger.debug(
+                        f"[graph-update] After create_nodes: integration "
+                        f"object_id={record['id']}, deprecated={record['deprecated']}"
+                    )
 
     def get_relationships_by_path(
         self,

--- a/demisto_sdk/commands/content_graph/interface/neo4j/neo4j_graph.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/neo4j_graph.py
@@ -372,7 +372,7 @@ class Neo4jContentGraphInterface(ContentGraphInterface):
     def create_nodes(self, nodes: Dict[ContentType, List[Dict[str, Any]]]) -> None:
         logger.info("Creating graph nodes...")
         pack_ids = [p.get("object_id") for p in nodes.get(ContentType.PACK, [])]
-        logger.debug(f"[graph-update] create_nodes called for pack_ids={pack_ids}")
+        logger.info(f"[graph-update] create_nodes called for pack_ids={pack_ids}")
         with self.driver.session() as session:
             self._rels_to_preserve = session.execute_read(
                 get_relationships_to_preserve, pack_ids
@@ -390,7 +390,7 @@ class Neo4jContentGraphInterface(ContentGraphInterface):
                     pack_ids=pack_ids,
                 )
                 for record in result:
-                    logger.debug(
+                    logger.info(
                         f"[graph-update] After create_nodes: integration "
                         f"object_id={record['id']}, deprecated={record['deprecated']}"
                     )

--- a/demisto_sdk/commands/content_graph/interface/neo4j/queries/validations.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/queries/validations.py
@@ -113,13 +113,13 @@ RETURN content_item_from, collect(r) as relationships, collect(n) as nodes_to"""
 def get_items_using_deprecated(
     tx: Transaction, file_paths: List[str]
 ) -> List[Tuple[str, List[graph.Node]]]:
-    logger.debug(
+    logger.info(
         f"[GR107] get_items_using_deprecated called with file_paths={file_paths}"
     )
     results = get_items_using_deprecated_commands(
         tx, file_paths
     ) + get_items_using_deprecated_content_items(tx, file_paths)
-    logger.debug(
+    logger.info(
         f"[GR107] get_items_using_deprecated returned {len(results)} deprecated item(s): "
         f"{[dep_id for dep_id, _ in results]}"
     )
@@ -165,13 +165,13 @@ WITH p, c, i2
 WHERE i2 IS NULL
 {files_filter}
 RETURN c.object_id AS deprecated_command, collect(p) AS object_using_deprecated"""
-    logger.debug(
+    logger.info(
         f"[GR107-commands] Running query with files_filter={repr(files_filter)}"
     )
-    logger.debug(
+    logger.info(
         f"[GR107-commands] BROKEN files_filter would have been={repr(broken_files_filter)}"
     )
-    logger.debug(f"[GR107-commands] Full query:\n{command_query}")
+    logger.info(f"[GR107-commands] Full query:\n{command_query}")
     results = [
         (
             item.get("deprecated_command"),
@@ -179,7 +179,7 @@ RETURN c.object_id AS deprecated_command, collect(p) AS object_using_deprecated"
         )
         for item in run_query(tx, command_query)
     ]
-    logger.debug(
+    logger.info(
         f"[GR107-commands] Query returned {len(results)} row(s): "
         f"{[(dep_id, [n.get('object_id', '?') for n in nodes]) for dep_id, nodes in results]}"
     )
@@ -226,13 +226,13 @@ WHERE c1 IS NULL
 {files_filter}
 RETURN d.object_id AS deprecated_content, collect(p) AS object_using_deprecated
     """
-    logger.debug(
+    logger.info(
         f"[GR107-content-items] Running query with files_filter={repr(files_filter)}"
     )
-    logger.debug(
+    logger.info(
         f"[GR107-content-items] BROKEN files_filter would have been={repr(broken_files_filter)}"
     )
-    logger.debug(f"[GR107-content-items] Full query:\n{query}")
+    logger.info(f"[GR107-content-items] Full query:\n{query}")
     results = [
         (
             item.get("deprecated_content"),
@@ -240,7 +240,7 @@ RETURN d.object_id AS deprecated_content, collect(p) AS object_using_deprecated
         )
         for item in run_query(tx, query)
     ]
-    logger.debug(
+    logger.info(
         f"[GR107-content-items] Query returned {len(results)} row(s): "
         f"{[(dep_id, [n.get('object_id', '?') for n in nodes]) for dep_id, nodes in results]}"
     )

--- a/demisto_sdk/commands/content_graph/interface/neo4j/queries/validations.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/queries/validations.py
@@ -9,6 +9,7 @@ from demisto_sdk.commands.common.constants import (
     MarketplaceVersions,
     PlatformSupportedModules,
 )
+from demisto_sdk.commands.common.logger import logger
 from demisto_sdk.commands.common.tools import replace_alert_to_incident
 from demisto_sdk.commands.content_graph.common import (
     ContentType,
@@ -112,9 +113,17 @@ RETURN content_item_from, collect(r) as relationships, collect(n) as nodes_to"""
 def get_items_using_deprecated(
     tx: Transaction, file_paths: List[str]
 ) -> List[Tuple[str, List[graph.Node]]]:
-    return get_items_using_deprecated_commands(
+    logger.debug(
+        f"[GR107] get_items_using_deprecated called with file_paths={file_paths}"
+    )
+    results = get_items_using_deprecated_commands(
         tx, file_paths
     ) + get_items_using_deprecated_content_items(tx, file_paths)
+    logger.debug(
+        f"[GR107] get_items_using_deprecated returned {len(results)} deprecated item(s): "
+        f"{[dep_id for dep_id, _ in results]}"
+    )
+    return results
 
 
 def get_items_using_deprecated_commands(
@@ -143,6 +152,10 @@ def get_items_using_deprecated_commands(
     files_filter = (
         f"AND (p.path IN {file_paths} OR c.path IN {file_paths})" if file_paths else ""
     )
+    # For comparison: what the BROKEN filter (before the parentheses fix) would have been
+    broken_files_filter = (
+        f"AND p.path IN {file_paths} OR c.path IN {file_paths}" if file_paths else ""
+    )
 
     command_query = f"""// Returning all the items which using deprecated commands
 MATCH (p{{deprecated: false}})-[:USES]->(c:Command)<-[:HAS_COMMAND{{deprecated: true}}]-(i:Integration) WHERE NOT p.is_test
@@ -152,13 +165,25 @@ WITH p, c, i2
 WHERE i2 IS NULL
 {files_filter}
 RETURN c.object_id AS deprecated_command, collect(p) AS object_using_deprecated"""
-    return [
+    logger.debug(
+        f"[GR107-commands] Running query with files_filter={repr(files_filter)}"
+    )
+    logger.debug(
+        f"[GR107-commands] BROKEN files_filter would have been={repr(broken_files_filter)}"
+    )
+    logger.debug(f"[GR107-commands] Full query:\n{command_query}")
+    results = [
         (
             item.get("deprecated_command"),
             item.get("object_using_deprecated"),
         )
         for item in run_query(tx, command_query)
     ]
+    logger.debug(
+        f"[GR107-commands] Query returned {len(results)} row(s): "
+        f"{[(dep_id, [n.get('object_id', '?') for n in nodes]) for dep_id, nodes in results]}"
+    )
+    return results
 
 
 def get_items_using_deprecated_content_items(
@@ -187,6 +212,10 @@ def get_items_using_deprecated_content_items(
     files_filter = (
         f"AND (p.path IN {file_paths} OR d.path IN {file_paths})" if file_paths else ""
     )
+    # For comparison: what the BROKEN filter (before the parentheses fix) would have been
+    broken_files_filter = (
+        f"AND p.path IN {file_paths} OR d.path IN {file_paths}" if file_paths else ""
+    )
 
     query = f"""
     MATCH (p{{deprecated: false}})-[:USES]->(d{{deprecated: true}}) WHERE not p.is_test
@@ -197,13 +226,25 @@ WHERE c1 IS NULL
 {files_filter}
 RETURN d.object_id AS deprecated_content, collect(p) AS object_using_deprecated
     """
-    return [
+    logger.debug(
+        f"[GR107-content-items] Running query with files_filter={repr(files_filter)}"
+    )
+    logger.debug(
+        f"[GR107-content-items] BROKEN files_filter would have been={repr(broken_files_filter)}"
+    )
+    logger.debug(f"[GR107-content-items] Full query:\n{query}")
+    results = [
         (
             item.get("deprecated_content"),
             item.get("object_using_deprecated"),
         )
         for item in run_query(tx, query)
     ]
+    logger.debug(
+        f"[GR107-content-items] Query returned {len(results)} row(s): "
+        f"{[(dep_id, [n.get('object_id', '?') for n in nodes]) for dep_id, nodes in results]}"
+    )
+    return results
 
 
 def validate_marketplaces(tx: Transaction, pack_ids: List[str]):

--- a/demisto_sdk/commands/content_graph/interface/neo4j/queries/validations.py
+++ b/demisto_sdk/commands/content_graph/interface/neo4j/queries/validations.py
@@ -141,7 +141,7 @@ def get_items_using_deprecated_commands(
     """
     # find items for both sides of the relationship where a non-deprecated item uses deprecated item.
     files_filter = (
-        f"AND p.path IN {file_paths} OR c.path IN {file_paths}" if file_paths else ""
+        f"AND (p.path IN {file_paths} OR c.path IN {file_paths})" if file_paths else ""
     )
 
     command_query = f"""// Returning all the items which using deprecated commands
@@ -185,7 +185,7 @@ def get_items_using_deprecated_content_items(
     """
     # find items for both sides of the relationship where a non-deprecated item uses deprecated item.
     files_filter = (
-        f"AND p.path IN {file_paths} OR d.path IN {file_paths}" if file_paths else ""
+        f"AND (p.path IN {file_paths} OR d.path IN {file_paths})" if file_paths else ""
     )
 
     query = f"""

--- a/demisto_sdk/commands/validate/tests/GR_validators_test.py
+++ b/demisto_sdk/commands/validate/tests/GR_validators_test.py
@@ -1052,6 +1052,65 @@ demisto.execute_command("AnotherDeprecatedScript", dArgs)
     assert len(validation_results) == 1
 
 
+def test_GR107_no_false_positive_when_un_deprecating_integration(
+    graph_repo: Repo,
+):
+    """
+    Regression test for the Cypher files_filter operator-precedence bug.
+
+    Given:
+    - A repository where a non-deprecated integration is used by a non-deprecated playbook.
+      The integration was previously deprecated (bucket state) but is now deprecated=false (PR state).
+
+    When:
+    - Running GR107_IsDeprecatedContentItemInUsageValidatorListFiles with the integration
+      as the changed content item (simulating USE_GIT / list_files mode).
+
+    Then:
+    - No validation errors are returned.
+      Before the fix the broken files_filter
+      "AND p.path IN [...] OR d.path IN [...]" (missing parentheses) caused the playbook
+      to be reported as a violator because the OR arm bypassed the c1 IS NULL guard.
+      After the fix "AND (p.path IN [...] OR d.path IN [...])" the query is correct.
+    """
+    pack_1 = graph_repo.create_pack("PackWithIntegration")
+    integration = pack_1.create_integration("NonDeprecatedIntegration")
+    integration.set_commands(["non-deprecated-command"])
+
+    pack_2 = graph_repo.create_pack("PackWithPlaybook")
+    pack_2.create_playbook(
+        "PlaybookUsingIntegration",
+        yml={
+            "id": "PlaybookUsingIntegration",
+            "name": "PlaybookUsingIntegration",
+            "tasks": {
+                "0": {
+                    "id": "0",
+                    "taskid": "0",
+                    "task": {
+                        "id": "0",
+                        "script": "|||non-deprecated-command",
+                    },
+                }
+            },
+        },
+    )
+
+    graph_interface = graph_repo.create_graph()
+    BaseValidator.graph_interface = graph_interface
+
+    # Simulate list_files mode: the changed content item is the integration itself
+    integration_graph_obj = pack_1.integrations[0].get_graph_object(graph_interface)
+    validation_results = GR107_IsDeprecatedContentItemInUsageValidatorListFiles().obtain_invalid_content_items(
+        [integration_graph_obj]
+    )
+
+    assert len(validation_results) == 0, (
+        "GR107 must not report a false positive when the changed item (integration) "
+        "is not deprecated and the playbook using it is also not deprecated."
+    )
+
+
 def test_GR107_IsDeprecatedContentItemInUsageValidatorAllFiles_is_invalid(
     repo_for_test_gr_107: Repo,
 ):

--- a/demisto_sdk/commands/validate/tests/GR_validators_test.py
+++ b/demisto_sdk/commands/validate/tests/GR_validators_test.py
@@ -1052,44 +1052,61 @@ demisto.execute_command("AnotherDeprecatedScript", dArgs)
     assert len(validation_results) == 1
 
 
-def test_GR107_no_false_positive_when_un_deprecating_integration(
+def test_GR107_no_false_positive_command_usage_bypasses_c1_is_null_guard(
     graph_repo: Repo,
 ):
     """
-    Regression test for the Cypher files_filter operator-precedence bug.
+    Regression test for the Cypher files_filter operator-precedence bug in
+    get_items_using_deprecated_content_items.
+
+    The query excludes USES relationships that are caused by a command (c1 IS NOT NULL)
+    because those are handled by the dedicated get_items_using_deprecated_commands query.
+    The broken files_filter:
+        AND p.path IN {file_paths} OR d.path IN {file_paths}
+    is evaluated (due to AND > OR precedence) as:
+        (c1 IS NULL AND p.path IN {file_paths}) OR (d.path IN {file_paths})
+    The second arm has no c1 IS NULL guard, so when d.path is in file_paths the row
+    is returned even when c1 IS NOT NULL - i.e. the integration is also reported as a
+    deprecated content item in the error message, even though the relationship is via a
+    command and should be excluded from the content-items query.
 
     Given:
-    - A repository where a non-deprecated integration is used by a non-deprecated playbook.
-      The integration was previously deprecated (bucket state) but is now deprecated=false (PR state).
+    - A deprecated integration d with a deprecated command.
+    - A non-deprecated playbook p that uses the deprecated command (c1 IS NOT NULL).
+    - file_paths contains d.path (the deprecated integration is the changed file).
 
     When:
-    - Running GR107_IsDeprecatedContentItemInUsageValidatorListFiles with the integration
-      as the changed content item (simulating USE_GIT / list_files mode).
+    - Running GR107_IsDeprecatedContentItemInUsageValidatorListFiles with the deprecated
+      integration as the changed content item.
 
     Then:
-    - No validation errors are returned.
-      Before the fix the broken files_filter
-      "AND p.path IN [...] OR d.path IN [...]" (missing parentheses) caused the playbook
-      to be reported as a violator because the OR arm bypassed the c1 IS NULL guard.
-      After the fix "AND (p.path IN [...] OR d.path IN [...])" the query is correct.
+    - Exactly 1 validation result is returned for the playbook.
+    - The error message mentions only the deprecated command, NOT the integration itself.
+      Before the fix the content-items query also fired (bypassing c1 IS NULL via the
+      broken OR arm), so the integration ID was also added to the deprecated_items set,
+      producing a message like "deprecated-command, DeprecatedIntegration".
+      After the fix the content-items query correctly excludes the row (c1 IS NOT NULL),
+      so only "deprecated-command" appears in the message.
     """
-    pack_1 = graph_repo.create_pack("PackWithIntegration")
-    integration = pack_1.create_integration("NonDeprecatedIntegration")
-    integration.set_commands(["non-deprecated-command"])
+    pack_1 = graph_repo.create_pack("PackWithDeprecatedIntegration")
+    integration = pack_1.create_integration("DeprecatedIntegration")
+    integration.set_commands(["deprecated-command"])
+    # Mark the integration and its command as deprecated
+    integration.set_data(**{"deprecated": True, "script.commands[0].deprecated": True})
 
     pack_2 = graph_repo.create_pack("PackWithPlaybook")
     pack_2.create_playbook(
-        "PlaybookUsingIntegration",
+        "PlaybookUsingDeprecatedCommand",
         yml={
-            "id": "PlaybookUsingIntegration",
-            "name": "PlaybookUsingIntegration",
+            "id": "PlaybookUsingDeprecatedCommand",
+            "name": "PlaybookUsingDeprecatedCommand",
             "tasks": {
                 "0": {
                     "id": "0",
                     "taskid": "0",
                     "task": {
                         "id": "0",
-                        "script": "|||non-deprecated-command",
+                        "script": "|||deprecated-command",
                     },
                 }
             },
@@ -1099,16 +1116,23 @@ def test_GR107_no_false_positive_when_un_deprecating_integration(
     graph_interface = graph_repo.create_graph()
     BaseValidator.graph_interface = graph_interface
 
-    # Simulate list_files mode: the changed content item is the integration itself
+    # Simulate list_files mode: the changed content item is the deprecated integration
+    # (d.path is in file_paths - this is the exact condition that triggers the bug)
     integration_graph_obj = pack_1.integrations[0].get_graph_object(graph_interface)
     validation_results = GR107_IsDeprecatedContentItemInUsageValidatorListFiles().obtain_invalid_content_items(
         [integration_graph_obj]
     )
 
-    assert len(validation_results) == 0, (
-        "GR107 must not report a false positive when the changed item (integration) "
-        "is not deprecated and the playbook using it is also not deprecated."
+    assert len(validation_results) == 1
+    # The error must only mention the deprecated command, not the integration itself.
+    # Before the fix the content-items query also fired (bypassing c1 IS NULL), so the
+    # integration ID "DeprecatedIntegration" was also included in the message.
+    assert "DeprecatedIntegration" not in validation_results[0].message, (
+        "The integration must not appear as a deprecated item in the error message. "
+        "Only the deprecated command should be reported (via the commands query). "
+        "The content-items query must exclude this row because c1 IS NOT NULL."
     )
+    assert "deprecated-command" in validation_results[0].message
 
 
 def test_GR107_IsDeprecatedContentItemInUsageValidatorAllFiles_is_invalid(


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: oncall

## Description
The bucket graph has `GoogleDriveStandardConnector.deprecated = true (master state). `
The broken `files_filter` `AND p.path IN [...] OR d.path IN [...] `- without parentheses - evaluates as (`c1 IS NULL AND p.path IN [...]) OR (d.path IN [...])`. The second arm `d.path IN [connector_path]` fires independently, bypassing the `c1 IS NULL` guard, and returns all items using the integration as violators even though the integration is no longer deprecated in the PR.

[run-validations job pass](https://gitlab.xdr.pan.local/xdr/cortex-content/content/-/jobs/65588313)
[run-validations job fail](https://gitlab.xdr.pan.local/xdr/cortex-content/content/-/jobs/65391853)