### PR TITLE
fix(content_graph): compute git-diff after import so interface.commit…

### DIFF
--- a/.changelog/5451.yml
+++ b/.changelog/5451.yml
@@ -1,0 +1,10 @@
+changes:
+- description: >-
+    Fixed an issue where **validate -g** silently skipped applying git-diff
+    updates to the content graph when the imported graph had no pinned
+    commit yet (e.g. fresh CI runner). The diff is now computed after
+    **import_graph** populates the commit, and a full-rebuild fallback
+    protects against the same silent no-op if the commit is still unknown
+    post-import.
+  type: fix
+pr_number: 5451

--- a/demisto_sdk/commands/content_graph/commands/update.py
+++ b/demisto_sdk/commands/content_graph/commands/update.py
@@ -331,29 +331,18 @@ def _update_content_graph_inner(
                     connectors_to_update.extend(env_connector_ids)
                     explicit_changes_provided = True
 
-    # Compute git-diff change sets once and reuse for both the should-update
-    # decision and the actual augmentation below. Previously this was done in
-    # two places (should_update_graph + here), which meant two `git diff`
-    # walks per `update_content_graph` call.
+    # Placeholders for the git-diff change sets. We DO NOT compute them yet:
+    # ``content_graph_interface.commit`` is read from the ``metadata.json`` that
+    # is only written to the import directory when ``import_graph`` runs below.
+    # Computing the diff here (as we used to) means that on a fresh CI runner
+    # with an empty import dir, ``commit`` is ``None``, the diff is silently
+    # skipped, and ``builder.update_graph`` is called with empty lists - which
+    # after the connectors refactor became a hard no-op, leaving the graph at
+    # the bucket's master state. Instead, we compute the diff post-import,
+    # once ``interface.commit`` is populated.
     changed_pack_ids: Set[str] = set()
     changed_connector_ids: Set[str] = set()
     git_diff_failed = False
-    if (
-        use_git
-        and (commit := content_graph_interface.commit)
-        and not is_external_repo
-        and not explicit_changes_provided
-    ):
-        try:
-            changed_pack_ids = git_util.get_all_changed_pack_ids(commit)
-        except Exception as e:
-            logger.warning(
-                f"Failed to get changed packs from git. Creating from scratch. Error: {e}"
-            )
-            git_diff_failed = True
-        if not git_diff_failed:
-            # Best-effort: _changed_connectors_from_git never raises.
-            changed_connector_ids = _changed_connectors_from_git(git_util, commit)
 
     builder = ContentGraphBuilder(content_graph_interface)
     if not should_update_graph(
@@ -363,8 +352,8 @@ def _update_content_graph_inner(
         imported_path,
         packs_to_update,
         connectors_to_update,
-        changed_pack_ids=changed_pack_ids,
-        changed_connector_ids=changed_connector_ids,
+        changed_pack_ids=None,
+        changed_connector_ids=None,
     ):
         logger.info(
             f"Content graph is up-to-date. If you expected an update, make sure your changes are added/committed to git. UI representation is available at {NEO4J_DATABASE_HTTP} "
@@ -404,13 +393,60 @@ def _update_content_graph_inner(
                     content_graph_interface, marketplace, dependencies, output_path
                 )
                 return
-    # Apply the change sets computed once above. If the git diff failed,
-    # fall back to creating the graph from scratch (preserves prior behaviour).
+    # Post-import: the bucket import (or the caller-provided ``imported_path``)
+    # has now populated ``metadata.json`` under the import directory, so
+    # ``content_graph_interface.commit`` finally returns the pinned commit.
+    # THIS is the only safe moment to compute the git diff.
+    if (
+        use_git
+        and (commit := content_graph_interface.commit)
+        and not is_external_repo
+        and not explicit_changes_provided
+    ):
+        try:
+            changed_pack_ids = git_util.get_all_changed_pack_ids(commit)
+        except Exception as e:
+            logger.warning(
+                f"Failed to get changed packs from git. Creating from scratch. Error: {e}"
+            )
+            git_diff_failed = True
+        if not git_diff_failed:
+            # Best-effort: _changed_connectors_from_git never raises.
+            changed_connector_ids = _changed_connectors_from_git(git_util, commit)
+
+    # If the git diff failed, fall back to creating the graph from scratch
+    # (preserves prior behaviour).
     if git_diff_failed:
         create_content_graph(
             content_graph_interface, marketplace, dependencies, output_path
         )
         return
+
+    # Safety net: if we were asked to sync from git but the imported graph
+    # has no pinned ``commit`` in its metadata, we cannot perform a valid
+    # git-diff at all. Without this guard we would silently fall through
+    # to ``builder.update_graph`` with empty lists (which is now a hard
+    # no-op after the connectors refactor), and return a stale graph that
+    # still reflects the bucket's master state. Rebuild from scratch to
+    # guarantee correctness. This mirrors the ``git_diff_failed`` branch
+    # above.
+    if (
+        use_git
+        and not is_external_repo
+        and not explicit_changes_provided
+        and content_graph_interface.commit is None
+    ):
+        logger.warning(
+            "use_git=True but the imported graph has no pinned commit in its "
+            "metadata (interface.commit is None), so we cannot compute a "
+            "git-diff. Falling back to a full rebuild to avoid returning a "
+            "stale graph."
+        )
+        create_content_graph(
+            content_graph_interface, marketplace, dependencies, output_path
+        )
+        return
+
     if explicit_changes_provided and use_git:
         logger.info(
             "Skipping git-diff augmentation: changed packs/connectors were "

--- a/demisto_sdk/commands/content_graph/content_graph_builder.py
+++ b/demisto_sdk/commands/content_graph/content_graph_builder.py
@@ -1,6 +1,7 @@
 import gc
 from typing import Optional, Tuple
 
+from demisto_sdk.commands.common.logger import logger
 from demisto_sdk.commands.content_graph.common import Nodes, Relationships
 from demisto_sdk.commands.content_graph.interface.graph import ContentGraphInterface
 from demisto_sdk.commands.content_graph.objects.repository import (
@@ -38,6 +39,18 @@ class ContentGraphBuilder:
         At least one of the two must be non-empty for any work to happen.
         """
         if not packs_to_update and not connectors_to_update:
+            # Intentional no-op. Callers that reach here with empty inputs
+            # under ``use_git`` should have already been redirected to a
+            # full rebuild by ``_update_content_graph_inner`` (see the
+            # ``interface.commit is None`` safety-net there); this branch
+            # is now reserved for callers that explicitly asked for no
+            # changes (e.g. connector-only refreshes with no matching
+            # entries in this repo). Log at debug so unexpected hits are
+            # still visible when debug logging is enabled.
+            logger.debug(
+                "ContentGraphBuilder.update_graph called with no packs and no "
+                "connectors - returning without touching the graph."
+            )
             return
         self._parse_and_model_content(packs_to_update, connectors_to_update)
         self._create_or_update_graph()

--- a/demisto_sdk/commands/content_graph/tests/update_content_graph_test.py
+++ b/demisto_sdk/commands/content_graph/tests/update_content_graph_test.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Optional
 from unittest.mock import MagicMock, PropertyMock
 from zipfile import ZipFile
 
@@ -1045,6 +1045,178 @@ class TestUpdateContentGraphCommitHandling:
         assert (
             True not in commit_args
         ), "get_all_changed_pack_ids should not be called with boolean True"
+
+    def test_git_diff_computed_after_import_populates_commit(self, mocker):
+        """
+        Regression test for the "diff computed before import" bug.
+
+        Given:
+            - use_git=True, no explicit packs/connectors provided.
+            - A content graph interface whose ``commit`` returns None BEFORE
+              ``import_graph`` is called (simulating a fresh CI runner where
+              the import directory has no metadata.json yet) and returns a
+              real commit hash AFTER ``import_graph`` succeeds.
+            - GitUtil would report a changed pack if consulted with the
+              real commit.
+        When:
+            - _update_content_graph_inner runs with use_git=True.
+        Then:
+            - get_all_changed_pack_ids IS called (post-import), with the
+              post-import commit hash.
+            - builder.update_graph is called with a non-empty packs tuple
+              (i.e. the diff was applied), NOT with (None, None) which was
+              the silent-no-op bug.
+        """
+        commit_hash = "postimportcommit1234567890abcdefabcdef12"
+
+        # Simulate metadata.json not existing until import_graph runs.
+        commit_state: Dict[str, Optional[str]] = {"value": None}
+
+        def commit_getter():
+            return commit_state["value"]
+
+        mock_interface = MagicMock()
+        # Use PropertyMock with a callable via side_effect so each access
+        # re-evaluates against commit_state.
+        type(mock_interface).commit = PropertyMock(side_effect=commit_getter)
+        mock_interface.is_alive.return_value = True
+        type(mock_interface).content_parser_latest_hash = PropertyMock(
+            return_value="hash1"
+        )
+        # Force should_update_graph to return True via parser-hash mismatch,
+        # so we actually reach the import/diff path.
+        mock_interface._get_latest_content_parser_hash.return_value = "hash2"
+
+        def flip_commit_after_import(*args, **kwargs):
+            commit_state["value"] = commit_hash
+            return True
+
+        mock_interface.import_graph.side_effect = flip_commit_after_import
+
+        mock_git_util = MagicMock()
+        mock_git_util.get_all_changed_pack_ids.return_value = {"MyChangedPack"}
+        mock_git_util.get_all_changed_files.return_value = set()
+
+        mocker.patch(
+            "demisto_sdk.commands.content_graph.commands.update.GitUtil",
+            return_value=mock_git_util,
+        )
+        mocker.patch(
+            "demisto_sdk.commands.content_graph.commands.update.is_external_repository",
+            return_value=False,
+        )
+        mock_builder_cls = mocker.patch(
+            "demisto_sdk.commands.content_graph.commands.update.ContentGraphBuilder"
+        )
+
+        from demisto_sdk.commands.content_graph.commands.update import (
+            _update_content_graph_inner,
+        )
+
+        _update_content_graph_inner(
+            content_graph_interface=mock_interface,
+            use_git=True,
+            dependencies=False,
+        )
+
+        # get_all_changed_pack_ids must have been called with the POST-import
+        # commit hash, not skipped due to a None pre-import commit.
+        calls = mock_git_util.get_all_changed_pack_ids.call_args_list
+        commit_args = [call.args[0] for call in calls if call.args]
+        assert commit_hash in commit_args, (
+            "Expected get_all_changed_pack_ids to be called with the "
+            f"post-import commit hash '{commit_hash}', but was called with: "
+            f"{commit_args}. This indicates the diff is still being computed "
+            "before import_graph populates interface.commit."
+        )
+
+        # builder.update_graph must have been called with the changed pack.
+        # The bug manifested as update_graph(packs_to_update=None,
+        # connectors_to_update=None) - a silent no-op.
+        mock_builder_instance = mock_builder_cls.return_value
+        update_calls = mock_builder_instance.update_graph.call_args_list
+        assert len(update_calls) == 1, (
+            f"Expected exactly one call to builder.update_graph, got "
+            f"{len(update_calls)}"
+        )
+        kwargs = update_calls[0].kwargs
+        assert kwargs.get("packs_to_update") == ("MyChangedPack",), (
+            "builder.update_graph was called with "
+            f"packs_to_update={kwargs.get('packs_to_update')!r}; expected "
+            "('MyChangedPack',). The silent-no-op regression is back."
+        )
+
+    def test_full_rebuild_when_use_git_and_no_commit_after_import(self, mocker):
+        """
+        Safety-net regression test.
+
+        Given:
+            - use_git=True, no explicit packs/connectors provided.
+            - A content graph interface whose ``commit`` returns None even
+              AFTER import_graph runs (simulating a corrupted/empty
+              metadata.json, or shallow clone where the pinned commit is
+              unknown to the local repo).
+        When:
+            - _update_content_graph_inner runs.
+        Then:
+            - We fall back to create_content_graph (full rebuild) instead
+              of silently no-op'ing with a stale bucket graph.
+            - builder.update_graph is NEVER called (we returned early via
+              the safety-net).
+        """
+        mock_interface = MagicMock()
+        # commit stays None throughout - simulates the failure mode.
+        type(mock_interface).commit = PropertyMock(return_value=None)
+        mock_interface.is_alive.return_value = True
+        type(mock_interface).content_parser_latest_hash = PropertyMock(
+            return_value="hash1"
+        )
+        # Force should_update_graph -> True via parser-hash mismatch so we
+        # actually reach the import + safety-net path.
+        mock_interface._get_latest_content_parser_hash.return_value = "hash2"
+        mock_interface.import_graph.return_value = True
+
+        mock_git_util = MagicMock()
+        # Should never be called - safety-net triggers before diff.
+        mock_git_util.get_all_changed_pack_ids.return_value = set()
+
+        mocker.patch(
+            "demisto_sdk.commands.content_graph.commands.update.GitUtil",
+            return_value=mock_git_util,
+        )
+        mocker.patch(
+            "demisto_sdk.commands.content_graph.commands.update.is_external_repository",
+            return_value=False,
+        )
+        mock_builder_cls = mocker.patch(
+            "demisto_sdk.commands.content_graph.commands.update.ContentGraphBuilder"
+        )
+        mock_create = mocker.patch(
+            "demisto_sdk.commands.content_graph.commands.update.create_content_graph"
+        )
+
+        from demisto_sdk.commands.content_graph.commands.update import (
+            _update_content_graph_inner,
+        )
+
+        _update_content_graph_inner(
+            content_graph_interface=mock_interface,
+            use_git=True,
+            dependencies=False,
+        )
+
+        # Safety net must have triggered the full rebuild.
+        assert mock_create.call_count == 1, (
+            "Expected create_content_graph to be called exactly once as the "
+            f"safety-net fallback, got {mock_create.call_count} calls."
+        )
+        # And builder.update_graph must NOT have been called (we returned
+        # early after the safety-net).
+        mock_builder_instance = mock_builder_cls.return_value
+        assert mock_builder_instance.update_graph.call_count == 0, (
+            "builder.update_graph must not be called when the safety-net "
+            "fallback fires - we returned early."
+        )
 
 
 class TestExtractPackIdsFromDiffFiles:


### PR DESCRIPTION
… is populated

Fixes a silent no-op in validate -g where a modified pack (e.g. deprecation flip on an integration) was ignored by the graph, causing graph validations such as GR107 to fire against unrelated content items with stale deprecated=false values inherited from the bucket's master state.

Root cause
----------
_update_content_graph_inner computed the git-diff BEFORE calling import_graph. ContentGraphInterface.commit reads the pinned commit from metadata.json under the import directory - a file only written by import_graph. On a fresh CI runner with an empty import dir, interface.commit therefore returned None at diff time, the diff was skipped, and after the connectors refactor added a hard early-return on empty inputs to ContentGraphBuilder.update_graph, the whole update pipeline silently returned without touching the graph.

Fix
---
1. Move the git-diff computation to AFTER import_graph populates metadata.json (and therefore interface.commit).
2. Add a safety-net: if use_git=True and interface.commit is still None post-import (corrupted metadata, shallow clone where the pinned commit is unknown, etc.), fall back to create_content_graph (full rebuild) instead of no-op'ing with a stale bucket graph. Mirrors the existing git_diff_failed handler.
3. Add a debug log in ContentGraphBuilder.update_graph's empty-input early-return so future silent no-ops are visible in debug logs.
4. Add regression tests covering both the post-import diff and the safety-net fallback.

<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes:

## Description
