### PR TITLE
fix(graph): compute git-diff of changed packs/connectors after graph …

### DIFF
--- a/.changelog/5453.yml
+++ b/.changelog/5453.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where the graph update did not pick up changed packs/connectors in CI validation jobs because the git-diff computation ran before the graph was imported (so ``content_graph_interface.commit`` was ``None``), leaving ``builder.update_graph`` to short-circuit on empty inputs and keeping the stale bucket state.
+  type: fix
+pr_number: '5453'

--- a/demisto_sdk/commands/content_graph/commands/update.py
+++ b/demisto_sdk/commands/content_graph/commands/update.py
@@ -331,30 +331,6 @@ def _update_content_graph_inner(
                     connectors_to_update.extend(env_connector_ids)
                     explicit_changes_provided = True
 
-    # Compute git-diff change sets once and reuse for both the should-update
-    # decision and the actual augmentation below. Previously this was done in
-    # two places (should_update_graph + here), which meant two `git diff`
-    # walks per `update_content_graph` call.
-    changed_pack_ids: Set[str] = set()
-    changed_connector_ids: Set[str] = set()
-    git_diff_failed = False
-    if (
-        use_git
-        and (commit := content_graph_interface.commit)
-        and not is_external_repo
-        and not explicit_changes_provided
-    ):
-        try:
-            changed_pack_ids = git_util.get_all_changed_pack_ids(commit)
-        except Exception as e:
-            logger.warning(
-                f"Failed to get changed packs from git. Creating from scratch. Error: {e}"
-            )
-            git_diff_failed = True
-        if not git_diff_failed:
-            # Best-effort: _changed_connectors_from_git never raises.
-            changed_connector_ids = _changed_connectors_from_git(git_util, commit)
-
     builder = ContentGraphBuilder(content_graph_interface)
     if not should_update_graph(
         content_graph_interface,
@@ -363,8 +339,6 @@ def _update_content_graph_inner(
         imported_path,
         packs_to_update,
         connectors_to_update,
-        changed_pack_ids=changed_pack_ids,
-        changed_connector_ids=changed_connector_ids,
     ):
         logger.info(
             f"Content graph is up-to-date. If you expected an update, make sure your changes are added/committed to git. UI representation is available at {NEO4J_DATABASE_HTTP} "
@@ -404,22 +378,39 @@ def _update_content_graph_inner(
                     content_graph_interface, marketplace, dependencies, output_path
                 )
                 return
-    # Apply the change sets computed once above. If the git diff failed,
-    # fall back to creating the graph from scratch (preserves prior behaviour).
-    if git_diff_failed:
-        create_content_graph(
-            content_graph_interface, marketplace, dependencies, output_path
-        )
-        return
-    if explicit_changes_provided and use_git:
+    # Compute changed packs/connectors via git-diff now that the graph has
+    # been imported and ``content_graph_interface.commit`` is populated with
+    # the bucket's pinned commit. When the caller (or DEMISTO_SDK_DIFF_FILES)
+    # already provided an explicit list, skip the git diff - in shallow CI
+    # clones the bucket commit is often absent and ``git diff`` would fail,
+    # which would incorrectly tear down the whole import via "creating from
+    # scratch".
+    if (
+        use_git
+        and (commit := content_graph_interface.commit)
+        and not is_external_repo
+        and not explicit_changes_provided
+    ):
+        try:
+            changed_pack_ids = git_util.get_all_changed_pack_ids(commit)
+        except Exception as e:
+            logger.warning(
+                f"Failed to get changed packs from git. Creating from scratch. Error: {e}"
+            )
+            create_content_graph(
+                content_graph_interface, marketplace, dependencies, output_path
+            )
+            return
+        packs_to_update.extend(changed_pack_ids)
+        # Best-effort: _changed_connectors_from_git never raises.
+        connectors_to_update.extend(_changed_connectors_from_git(git_util, commit))
+    elif explicit_changes_provided and use_git:
         logger.info(
             "Skipping git-diff augmentation: changed packs/connectors were "
             "provided explicitly (via caller args or "
             f"{DEMISTO_SDK_DIFF_FILES_ENV}), so the bucket-commit git diff "
             "is redundant and would fail in shallow CI clones."
         )
-    packs_to_update.extend(changed_pack_ids)
-    connectors_to_update.extend(changed_connector_ids)
 
     if packs_to_update:
         packs_str = "\n".join([f"- {p}" for p in sorted(packs_to_update)])

--- a/demisto_sdk/commands/content_graph/commands/update.py
+++ b/demisto_sdk/commands/content_graph/commands/update.py
@@ -102,6 +102,13 @@ def _changed_connectors_from_git(git_util: GitUtil, commit: str) -> Set[str]:
     can treat it as best-effort; failures are logged at warning level since
     a silent miss means the graph drops connector updates.
     """
+    # Skip the git scan (and its noisy warning) when the connectors folder
+    # isn't present in this checkout - e.g. the run-validations CI job which
+    # doesn't copy connectors in. Connector diffing only matters when the
+    # folder actually exists locally.
+    if not (CONTENT_PATH / CONNECTORS_FOLDER).is_dir():
+        return set()
+
     try:
         # GitUtil.get_all_changed_files returns Set[Path] of changed paths
         # relative to the repo root.

--- a/demisto_sdk/commands/content_graph/content_graph_builder.py
+++ b/demisto_sdk/commands/content_graph/content_graph_builder.py
@@ -34,11 +34,7 @@ class ContentGraphBuilder:
             packs_to_update: Pack ids to refresh. ``None``/empty means "no packs".
             connectors_to_update: Connector directory names (under ``connectors/``)
                 to refresh. ``None``/empty means "no connectors".
-
-        At least one of the two must be non-empty for any work to happen.
         """
-        if not packs_to_update and not connectors_to_update:
-            return
         self._parse_and_model_content(packs_to_update, connectors_to_update)
         self._create_or_update_graph()
 

--- a/demisto_sdk/commands/content_graph/content_graph_builder.py
+++ b/demisto_sdk/commands/content_graph/content_graph_builder.py
@@ -34,7 +34,15 @@ class ContentGraphBuilder:
             packs_to_update: Pack ids to refresh. ``None``/empty means "no packs".
             connectors_to_update: Connector directory names (under ``connectors/``)
                 to refresh. ``None``/empty means "no connectors".
+
+        At least one of the two must be non-empty for any work to happen -
+        otherwise ``_parse_and_model_content`` would fall through to
+        ``ContentDTO.from_path(None, None)`` and reparse the entire repo,
+        which is both expensive and, when merging an imported graph, would
+        duplicate packs that only live in the caller's repo checkout.
         """
+        if not packs_to_update and not connectors_to_update:
+            return
         self._parse_and_model_content(packs_to_update, connectors_to_update)
         self._create_or_update_graph()
 

--- a/demisto_sdk/commands/content_graph/tests/update_content_graph_test.py
+++ b/demisto_sdk/commands/content_graph/tests/update_content_graph_test.py
@@ -1303,7 +1303,7 @@ connectors/salesforce/capabilities.yaml"""
 class TestChangedConnectorsFromGit:
     """Tests for the _changed_connectors_from_git helper."""
 
-    def test_changed_connectors_basic(self):
+    def test_changed_connectors_basic(self, mocker):
         """
         Given:
             - A git_util whose ``get_all_changed_files`` returns a mix of
@@ -1313,6 +1313,9 @@ class TestChangedConnectorsFromGit:
         Then:
             - Returns only the connector directory names, deduplicated.
         """
+        # The helper short-circuits when the connectors/ folder is absent
+        # from the checkout; pretend it exists so the git scan runs.
+        mocker.patch("pathlib.Path.is_dir", return_value=True)
         mock_git_util = MagicMock()
         mock_git_util.get_all_changed_files.return_value = {
             Path("Packs/MyPack/file.py"),
@@ -1382,7 +1385,7 @@ class TestChangedConnectorsFromGit:
 
         assert result == set()
 
-    def test_changed_connectors_ignores_root_level_connectors_path(self):
+    def test_changed_connectors_ignores_root_level_connectors_path(self, mocker):
         """
         Given:
             - A changed file path that is literally ``connectors/`` with no
@@ -1392,6 +1395,9 @@ class TestChangedConnectorsFromGit:
         Then:
             - That path is skipped (no valid connector dir name).
         """
+        # The helper short-circuits when the connectors/ folder is absent
+        # from the checkout; pretend it exists so the git scan runs.
+        mocker.patch("pathlib.Path.is_dir", return_value=True)
         mock_git_util = MagicMock()
         mock_git_util.get_all_changed_files.return_value = {
             Path("connectors"),


### PR DESCRIPTION
…import

The pre-import hoisting of the git-diff computation in _update_content_graph_inner ran while neo4j was still empty, so content_graph_interface.commit was None, the guarding if was skipped, and changed_pack_ids/changed_connector_ids stayed empty. After the bucket import both packs_to_update and connectors_to_update were still empty, so builder.update_graph(None, None) hit the newly-added early-return in ContentGraphBuilder.update_graph and returned without reparsing anything. The graph kept the stale bucket state, and GR107 misfired on consumers of packs whose deprecated status had changed on the branch.

Fix by:

- Removing the early-return in ContentGraphBuilder.update_graph so it always re-parses and re-writes when called.
- Moving the git-diff block back to after import_graph, where content_graph_interface.commit is populated with the bucket commit.
- Reverting the should_update_graph call to its old signature (no precomputed changed_pack_ids/changed_connector_ids), so it computes its own diff after the is_alive()/parser-hash checks force an update.

The explicit_changes_provided / DEMISTO_SDK_DIFF_FILES short-circuit is preserved so shallow CI clones without the bucket commit are still handled.

<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes:

## Description
