### PR TITLE
fix(validate): honor per-file .pack-ignore for related-file validators

### DIFF
--- a/.changelog/5478.yml
+++ b/.changelog/5478.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where a validator that declares a related_file_type (such as AG112) checked only the related-file ignore section and not the file's own per-file ignore section in `.pack-ignore`.
+  type: fix
+pr_number: '5478'

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -21,7 +21,6 @@ from demisto_sdk.commands.common.handlers import DEFAULT_JSON_HANDLER as json
 from demisto_sdk.commands.common.logger import logger
 from demisto_sdk.commands.content_graph.common import ContentType
 from demisto_sdk.commands.content_graph.objects.base_content import BaseContent
-from demisto_sdk.commands.content_graph.parsers.related_files import RelatedFileType
 from demisto_sdk.commands.content_graph.objects.integration import Integration
 from demisto_sdk.commands.content_graph.objects.script import Script
 from demisto_sdk.commands.content_graph.parsers.related_files import RelatedFileType
@@ -700,9 +699,7 @@ def test_is_error_ignored_not_ignored_anywhere():
     Then:
     - The code is not ignored (returns False).
     """
-    item = _FakeContentItem(
-        own_ignored=[], related_ignored=[], has_related_file=False
-    )
+    item = _FakeContentItem(own_ignored=[], related_ignored=[], has_related_file=False)
     assert (
         is_error_ignored(
             "AG112",

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -21,6 +21,7 @@ from demisto_sdk.commands.common.handlers import DEFAULT_JSON_HANDLER as json
 from demisto_sdk.commands.common.logger import logger
 from demisto_sdk.commands.content_graph.common import ContentType
 from demisto_sdk.commands.content_graph.objects.base_content import BaseContent
+from demisto_sdk.commands.content_graph.parsers.related_files import RelatedFileType
 from demisto_sdk.commands.content_graph.objects.integration import Integration
 from demisto_sdk.commands.content_graph.objects.script import Script
 from demisto_sdk.commands.content_graph.tests.test_tools import load_yaml
@@ -52,6 +53,7 @@ from demisto_sdk.commands.validate.validators.base_validator import (
     FixResult,
     ValidationResult,
     get_all_validators,
+    is_error_ignored,
 )
 from demisto_sdk.commands.validate.validators.BC_validators.BC100_breaking_backwards_subtype import (
     BreakingBackwardsSubtypeValidator,
@@ -602,6 +604,112 @@ def test_should_run_api_module():
     validator = DockerImageTagIsNotOutdated()
     assert not validator.should_run(
         script, [], {}, running_execution_mode=ExecutionMode.USE_GIT
+    )
+
+
+class _FakeRelatedFile:
+    def __init__(self, file_path: str):
+        self.file_path = file_path
+
+
+class _FakeContentItem:
+    """Minimal stand-in for a ContentItem for is_error_ignored tests.
+
+    Emulates the two lookup paths used by is_error_ignored:
+    - per-file ignore on the item itself via ``ignored_errors``
+    - per-related-file ignore via ``ignored_errors_related_files``
+    The related-file attribute (e.g. ``skill_content``) is only present when
+    ``has_related_file`` is True, mirroring an AgentixSkill; an AgentixAction
+    has no such attribute so the getattr raises AttributeError.
+    """
+
+    def __init__(
+        self,
+        own_ignored,
+        related_ignored=None,
+        has_related_file=False,
+    ):
+        self.ignored_errors = list(own_ignored)
+        self._related_ignored = list(related_ignored or [])
+        if has_related_file:
+            self.skill_content = _FakeRelatedFile("skill_body.md")
+
+    def ignored_errors_related_files(self, _file_path):
+        return self._related_ignored
+
+
+def test_is_error_ignored_falls_through_to_main_when_related_file_missing():
+    """
+    Given:
+    - A validator error code that declares a related_file_type (SKILL_CONTENT).
+    - A content item that has NO related file (like an AgentixAction) but does
+      list the code under its own per-file `[file:...]` ignore section.
+    When:
+    - Calling is_error_ignored with the related_file_type.
+    Then:
+    - The main content per-file ignore is honored (returns True), because the
+      lookup falls through when no related file matches.
+    """
+    item = _FakeContentItem(
+        own_ignored=["AG112"], related_ignored=[], has_related_file=False
+    )
+    assert (
+        is_error_ignored(
+            "AG112",
+            ["AG112"],
+            item,
+            related_file_type=[RelatedFileType.SKILL_CONTENT],
+        )
+        is True
+    )
+
+
+def test_is_error_ignored_related_file_still_matches():
+    """
+    Given:
+    - A content item that has a related file which lists the code to ignore
+      (like an AgentixSkill using the SKILL_CONTENT section).
+    When:
+    - Calling is_error_ignored with the related_file_type.
+    Then:
+    - The related-file ignore is honored (returns True), preserving prior
+      behavior.
+    """
+    item = _FakeContentItem(
+        own_ignored=[], related_ignored=["AG112"], has_related_file=True
+    )
+    assert (
+        is_error_ignored(
+            "AG112",
+            ["AG112"],
+            item,
+            related_file_type=[RelatedFileType.SKILL_CONTENT],
+        )
+        is True
+    )
+
+
+def test_is_error_ignored_not_ignored_anywhere():
+    """
+    Given:
+    - A content item that lists the code in neither its own per-file section nor
+      any related file section.
+    When:
+    - Calling is_error_ignored with the related_file_type.
+    Then:
+    - The code is not ignored (returns False).
+    """
+    item = _FakeContentItem(
+        own_ignored=[], related_ignored=[], has_related_file=False
+    )
+    assert (
+        is_error_ignored(
+            "AG112",
+            ["AG112"],
+            item,
+            related_file_type=[RelatedFileType.SKILL_CONTENT],
+        )
+        is False
     )
 
 

--- a/demisto_sdk/commands/validate/validators/base_validator.py
+++ b/demisto_sdk/commands/validate/validators/base_validator.py
@@ -297,10 +297,13 @@ def is_error_ignored(
         3. If ``err_code`` is listed under the new ``[pack]`` section of the
            pack's ``.pack-ignore`` file -> ignore for every item in the pack
            (and for related files of those items).
-        4. If a ``related_file_type`` is provided -> ignore only when the
-           code is listed under the related file's per-file section.
-        5. Otherwise -> ignore only when the code is listed under the
-           content item's per-file section.
+        4. If a ``related_file_type`` is provided -> ignore when the code is
+           listed under any of the related files' per-file sections. If none
+           of the related files match (e.g. the related file does not exist
+           for this content type, such as an AgentixAction which has no
+           SKILL_CONTENT), fall through to rule 5.
+        5. Ignore when the code is listed under the content item's own
+           per-file section.
 
     Args:
         err_code: The validation's error code.
@@ -340,10 +343,13 @@ def is_error_ignored(
                     return True
             except Exception:
                 continue
-        return False
-    else:
-        # If the validation should run on the main content, will check if the validation's error code is ignored by the file.
-        return err_code in content_item.ignored_errors
+        # None of the related files carried the ignore (e.g. the related file
+        # does not exist for this content type, such as an AgentixAction which
+        # has no SKILL_CONTENT). Fall through to the main content's per-file
+        # ignore so a `[file:...]` section on the item itself is still honored.
+
+    # If the validation should run on the main content, will check if the validation's error code is ignored by the file.
+    return err_code in content_item.ignored_errors
 
 
 class ValidationResult(BaseResult, BaseModel):

--- a/demisto_sdk/commands/validate/validators/base_validator.py
+++ b/demisto_sdk/commands/validate/validators/base_validator.py
@@ -456,8 +456,7 @@ def is_error_ignored(
         4. If a ``related_file_type`` is provided -> ignore when the code is
            listed under any of the related files' per-file sections. If none
            of the related files match (e.g. the related file does not exist
-           for this content type, such as an AgentixAction which has no
-           SKILL_CONTENT), fall through to rule 5.
+           for this content type), fall through to rule 5.
         5. Ignore when the code is listed under the content item's own
            per-file section.
 
@@ -497,7 +496,10 @@ def is_error_ignored(
                     related_file_object.file_path
                 ):
                     return True
-            except Exception:
+            except Exception as e:
+                logger.debug(
+                    f"is_error_ignored: skipped related_file={related_file.value!r} on {content_item!r}: {e!r}"
+                )
                 continue
         # None of the related files carried the ignore (e.g. the related file
         # does not exist for this content type, such as an AgentixAction which


### PR DESCRIPTION
is_error_ignored returned False for any validator declaring related_file_type as soon as none of the related files matched, so it never consulted the content item's own [file:...] per-file ignore section. For AgentixActions (which have no SKILL_CONTENT related file) this made AG112 impossible to ignore via .pack-ignore.

Fall through to the main content per-file ignore when no related file matches. Add is_error_ignored regression tests.

<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes:

## Description

test MR - [link](https://gitlab.xdr.pan.local/xdr/cortex-content/content-private/-/merge_requests/584/pipelines)
failure before the fix -[link](https://gitlab.xdr.pan.local/xdr/cortex-content/content/-/jobs/69649672)
AG112 passing with the fix -  [link](https://gitlab.xdr.pan.local/xdr/cortex-content/content/-/jobs/69614984)

## SDK Nightly
<!--
If the SDK Nightly Gate flags this PR (see the bot comment below):
  1. Run the SDK Nightly pipeline against this branch.
  2. Paste the link to the nightly run here.
  3. Apply either `nightly-run-passed` or `nightly-run-skipped`
     (skipped is only allowed for the recommended tier, with reviewer
     approval). The gate re-runs automatically when labels change.
-->
SDK Nightly link:
