### PR TITLE
feat(script): support promptConfig.modelTier for AI prompts

### DIFF
--- a/.changelog/5492.yml
+++ b/.changelog/5492.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Added the **modelTier** field under the **promptConfig** object in the Script schema, allowing AI Tasks to pin an LLM tier (Flash, Thinking or Pro) instead of a concrete model id. An absent tier remains valid and resolves to the default model.
+  type: feature
+pr_number: 5492

--- a/demisto_sdk/commands/common/schemas/script.yml
+++ b/demisto_sdk/commands/common/schemas/script.yml
@@ -156,6 +156,9 @@ mapping:
         type: int
       webSearch:
         type: bool
+      modelTier:
+        type: str
+        enum: ['Flash', 'Thinking', 'Pro']
 
   compliantpolicies:
     type: seq

--- a/demisto_sdk/commands/content_graph/objects/script.py
+++ b/demisto_sdk/commands/content_graph/objects/script.py
@@ -16,6 +16,7 @@ class PromptConfig(BaseModel):
     temperature: Optional[float] = None
     max_output_tokens: Optional[int] = Field(None, alias="maxOutputTokens")
     web_search: Optional[bool] = Field(None, alias="webSearch")
+    model_tier: Optional[str] = Field(None, alias="modelTier")
 
 
 class Script(BaseScript, content_type=ContentType.SCRIPT):  # type: ignore[call-arg]

--- a/demisto_sdk/commands/content_graph/strict_objects/script.py
+++ b/demisto_sdk/commands/content_graph/strict_objects/script.py
@@ -41,6 +41,20 @@ class ScriptSubType(StrEnum):
     PYTHON2 = TYPE_PYTHON2
 
 
+class ModelTier(StrEnum):
+    """The LLM model tiers advertised by agentix-hub.
+
+    The concrete model backing each tier is resolved at runtime by the server
+    from the agentix-hub models cache, so the tier - not a model id - is what
+    content pins. An absent tier is valid and resolves to the hub-advertised
+    default model.
+    """
+
+    FLASH = "Flash"
+    THINKING = "Thinking"
+    PRO = "Pro"
+
+
 class CommonFieldsScript(CommonFields):  # type:ignore[misc,valid-type]
     id_x2: Optional[str] = None
     id_xpanse: Optional[str] = Field(None, alias="id:xpanse")
@@ -56,6 +70,7 @@ class PromptConfig(BaseStrictModel):
     temperature: Optional[float] = None
     max_output_tokens: Optional[int] = Field(None, alias="maxOutputTokens")
     web_search: Optional[bool] = Field(None, alias="webSearch")
+    model_tier: Optional[ModelTier] = Field(None, alias="modelTier")
 
 
 class ContentItemFields(BaseStrictModel):

--- a/demisto_sdk/commands/content_graph/tests/parsers_and_models_test.py
+++ b/demisto_sdk/commands/content_graph/tests/parsers_and_models_test.py
@@ -1391,6 +1391,78 @@ class TestParsersAndModels:
         model = Script.from_orm(parser)
         assert model.auto_update_docker_image is expected_value
 
+    def test_script_parser_prompt_config_model_tier(self, pack: Pack):
+        """
+        Given:
+            - An LLM script whose promptConfig pins a model tier.
+        When:
+            - Creating the content item's parser and model.
+        Then:
+            - Verify the modelTier is parsed onto the model's promptConfig.
+        """
+        from demisto_sdk.commands.content_graph.objects.script import Script
+        from demisto_sdk.commands.content_graph.parsers.script import ScriptParser
+
+        # given
+        script = pack.create_script()
+        script.create_default_script()
+        script.yml.update(
+            {
+                "promptConfig": {
+                    "temperature": 0.1,
+                    "maxOutputTokens": 12000,
+                    "webSearch": False,
+                    "modelTier": "Thinking",
+                }
+            }
+        )
+
+        # when
+        parser = ScriptParser(
+            Path(script.path), list(MarketplaceVersions), pack_supported_modules=[]
+        )
+        model = Script.from_orm(parser)
+
+        # then
+        assert model.prompt_config is not None
+        assert model.prompt_config.model_tier == "Thinking"
+
+    def test_script_parser_prompt_config_without_model_tier(self, pack: Pack):
+        """
+        Given:
+            - An LLM script whose promptConfig omits the model tier.
+        When:
+            - Creating the content item's parser and model.
+        Then:
+            - Verify the model is parsed and the tier is None, since an absent
+              tier is valid and resolves to the hub-advertised default model.
+        """
+        from demisto_sdk.commands.content_graph.objects.script import Script
+        from demisto_sdk.commands.content_graph.parsers.script import ScriptParser
+
+        # given
+        script = pack.create_script()
+        script.create_default_script()
+        script.yml.update(
+            {
+                "promptConfig": {
+                    "temperature": 0.1,
+                    "maxOutputTokens": 12000,
+                    "webSearch": False,
+                }
+            }
+        )
+
+        # when
+        parser = ScriptParser(
+            Path(script.path), list(MarketplaceVersions), pack_supported_modules=[]
+        )
+        model = Script.from_orm(parser)
+
+        # then
+        assert model.prompt_config is not None
+        assert model.prompt_config.model_tier is None
+
     def test_test_playbook_parser(self, pack: Pack):
         """
         Given:

--- a/demisto_sdk/commands/validate/tests/ST_validators_test.py
+++ b/demisto_sdk/commands/validate/tests/ST_validators_test.py
@@ -139,6 +139,98 @@ def test_SchemaValidator_extra_field(pack: Pack):
     )
 
 
+def test_SchemaValidator_prompt_config_valid_model_tier(pack: Pack):
+    """
+    Given:
+        - an LLM script whose promptConfig pins a supported model tier
+    When:
+        - execute the SchemaValidator (ST110 validation) on the script
+    Then:
+        - Ensure the validation passes
+    """
+    # given
+    script = pack.create_script(yml=load_yaml("script.yml"))
+    script.yml.update(
+        {
+            "isllm": True,
+            "userprompt": "Summarize ${issue}",
+            "script": "",
+            "promptConfig": {"modelTier": "Thinking"},
+        }
+    )
+    script_parser = ScriptParser(
+        Path(script.path), list(MarketplaceVersions), pack_supported_modules=[]
+    )
+
+    # when
+    results = SchemaValidator().obtain_invalid_content_items([script_parser])
+
+    # then
+    assert len(results) == 0
+
+
+def test_SchemaValidator_prompt_config_invalid_model_tier(pack: Pack):
+    """
+    Given:
+        - an LLM script whose promptConfig pins an unsupported model tier
+    When:
+        - execute the SchemaValidator (ST110 validation) on the script
+    Then:
+        - Ensure the validation fails on the modelTier field
+    """
+    # given
+    script = pack.create_script(yml=load_yaml("script.yml"))
+    script.yml.update(
+        {
+            "isllm": True,
+            "userprompt": "Summarize ${issue}",
+            "script": "",
+            "promptConfig": {"modelTier": "NotATier"},
+        }
+    )
+    script_parser = ScriptParser(
+        Path(script.path), list(MarketplaceVersions), pack_supported_modules=[]
+    )
+
+    # when
+    results = SchemaValidator().obtain_invalid_content_items([script_parser])
+
+    # then
+    assert len(results) == 1
+    assert "modelTier" in results[0].message
+
+
+def test_SchemaValidator_prompt_config_without_model_tier(pack: Pack):
+    """
+    Given:
+        - an LLM script whose promptConfig omits the model tier
+    When:
+        - execute the SchemaValidator (ST110 validation) on the script
+    Then:
+        - Ensure the validation passes, since an absent tier is valid and
+          resolves to the hub-advertised default model at run time
+    """
+    # given
+    script = pack.create_script(yml=load_yaml("script.yml"))
+    script.yml.update(
+        {
+            "isllm": True,
+            "userprompt": "Summarize ${issue}",
+            "script": "",
+            "promptConfig": {"temperature": 0.1, "maxOutputTokens": 12000},
+        }
+    )
+    script_parser = ScriptParser(
+        Path(script.path), list(MarketplaceVersions), pack_supported_modules=[]
+    )
+
+    # when
+    results = SchemaValidator().obtain_invalid_content_items([script_parser])
+
+    # then
+    assert len(results) == 0
+
+
 def test_modeling_rule_parser_sanity_check(pack: Pack):
     """
     Given:


### PR DESCRIPTION
Add the modelTier field to the Script promptConfig object, so AI prompt content can pin an LLM tier instead of a concrete model id.

The server resolves the tier at run time against the agentix-hub models cache (ServiceAI.resolveModel), which means content pins the tier and the backing model can change without a content release. The legacy top-level `model` field is deprecated server-side and is left untouched here.

Valid tiers are Flash, Thinking and Pro. An absent tier stays valid and resolves to the hub-advertised default model, so existing AI prompts are unaffected.

Changes:
- schemas/script.yml: modelTier under promptConfig.mapping, enum-constrained
- content_graph/objects/script.py: model_tier on PromptConfig
- content_graph/strict_objects/script.py: ModelTier StrEnum + model_tier on PromptConfig, so an unsupported tier surfaces as an ST110 error

Note: the SDK is stricter than the server on casing. The server matches tiers with strings.EqualFold, while this enum requires the canonical form.

Tests: parser round-trip with and without a tier, plus ST110 coverage for valid, invalid and absent tiers.

<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes:

## Description

## SDK Nightly
<!--
If the SDK Nightly Gate flags this PR (see the bot comment below):
  1. Run the SDK Nightly pipeline against this branch.
  2. Paste the link to the nightly run here.
  3. Apply either `nightly-run-passed` or `nightly-run-skipped`
     (skipped is only allowed for the recommended tier, with reviewer
     approval). The gate re-runs automatically when labels change.
-->
SDK Nightly link:
