### PR TITLE
[XSUP-74505] - Fixed the download command dup prefix bug

### DIFF
--- a/.changelog/5493.yml
+++ b/.changelog/5493.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where re-running the **download** command with `--force` would duplicate the type prefix in file names (e.g. `indicatorfield-indicatorfield-<name>.json`) for incident fields, indicator fields, incident types, and layouts containers.
+  type: fix
+pr_number: '5493'

--- a/demisto_sdk/commands/download/downloader.py
+++ b/demisto_sdk/commands/download/downloader.py
@@ -1579,9 +1579,11 @@ class Downloader:
                 FileType.INDICATOR_FIELD,
                 FileType.LAYOUTS_CONTAINER,
             ):
-                expected_prefix = f"{content_item_type.value}"
+                expected_prefix = f"{content_item_type.value}-"
                 if not content_item_file_name.startswith(expected_prefix):
-                    content_item_file_name = f"{expected_prefix}-{content_item_file_name}"
+                    content_item_file_name = (
+                        f"{expected_prefix}{content_item_file_name}"
+                    )
 
             temp_download_path = (
                 temp_dir / content_item_entity_directory / content_item_file_name

--- a/demisto_sdk/commands/download/downloader.py
+++ b/demisto_sdk/commands/download/downloader.py
@@ -1573,13 +1573,15 @@ class Downloader:
                     )
 
         else:  # Non-unified content item
-            if content_item_type in [
-                "incidenttype",
-                "incidentfield",
-                "indicatorfield",
-                "layoutscontainer",
-            ]:
-                content_item_file_name = f"{content_item_type}-{content_item_file_name}"
+            if content_item_type in (
+                FileType.INCIDENT_TYPE,
+                FileType.INCIDENT_FIELD,
+                FileType.INDICATOR_FIELD,
+                FileType.LAYOUTS_CONTAINER,
+            ):
+                expected_prefix = f"{content_item_type.value}"
+                if not content_item_file_name.startswith(expected_prefix):
+                    content_item_file_name = f"{expected_prefix}-{content_item_file_name}"
 
             temp_download_path = (
                 temp_dir / content_item_entity_directory / content_item_file_name

--- a/demisto_sdk/commands/download/tests/downloader_test.py
+++ b/demisto_sdk/commands/download/tests/downloader_test.py
@@ -867,11 +867,12 @@ class TestDownloadExistingFile:
         # The correctly-prefixed file must exist, and no double-prefixed file may be created.
         assert (entity_path / prefixed_file_name).is_file()
         double_prefixed = (
-            entity_path / f"{file_type.value}-{file_type.value}-{content_item_name}.json"
+            entity_path
+            / f"{file_type.value}-{file_type.value}-{content_item_name}.json"
         )
-        assert not double_prefixed.exists(), (
-            f"Prefix was duplicated: {double_prefixed.name} was created."
-        )
+        assert (
+            not double_prefixed.exists()
+        ), f"Prefix was duplicated: {double_prefixed.name} was created."
 
     def test_update_data_yml(self, tmp_path):
         env = Environment(tmp_path)

--- a/demisto_sdk/commands/download/tests/downloader_test.py
+++ b/demisto_sdk/commands/download/tests/downloader_test.py
@@ -800,6 +800,79 @@ class TestDownloadExistingFile:
         assert "fromVersion" in data and data["fromVersion"] == "5.0.0"
         assert "toVersion" in data and data["toVersion"] == "5.9.9"
 
+    @pytest.mark.parametrize(
+        "file_type, entity_dir",
+        [
+            (FileType.INDICATOR_FIELD, "IndicatorFields"),
+            (FileType.INCIDENT_FIELD, "IncidentFields"),
+            (FileType.INCIDENT_TYPE, "IncidentTypes"),
+            (FileType.LAYOUTS_CONTAINER, "Layouts"),
+        ],
+    )
+    def test_download_existing_file_no_duplicate_prefix(
+        self, tmp_path, file_type, entity_dir
+    ):
+        """
+        Given: An existing content item whose file name on disk is already prefixed
+               (e.g. 'indicatorfield-MyTest.json'), which is the actual
+               format returned by the server's custom-content bundle.
+        When:  Re-downloading the same item with `force=True`, hitting
+               `download_existing_content_items`.
+        Then:  The file must be written as '<type>-<name>.json' exactly once - the
+               prefix must NOT be compounded to '<type>-<type>-<name>.json'.
+               (Regression test for XSUP-74505).
+        """
+        content_item_name = "MyTest"
+        prefixed_file_name = f"{file_type.value}-{content_item_name}.json"
+        item_data = {"id": content_item_name, "name": content_item_name}
+
+        output_path = tmp_path / "TestPack"
+        entity_path = output_path / entity_dir
+        entity_path.mkdir(parents=True)
+        # Seed the pack with an already-prefixed file (simulating a prior download).
+        (entity_path / prefixed_file_name).write_text(json.dumps(item_data))
+
+        content_object = {
+            "id": content_item_name,
+            "name": content_item_name,
+            "entity": entity_dir,
+            "type": file_type,
+            "file_extension": "json",
+            "file_name": prefixed_file_name,  # As stored by create_content_item_object.
+            "file": StringIO(json.dumps(item_data)),
+            "data": item_data,
+        }
+        existing_pack_structure = {
+            entity_dir: {
+                content_item_name: [
+                    {
+                        "name": content_item_name,
+                        "id": content_item_name,
+                        "path": entity_path / prefixed_file_name,
+                        "file_extension": "json",
+                    }
+                ]
+            }
+        }
+
+        downloader = Downloader(force=True)
+        with TemporaryDirectory() as temp_dir_str:
+            downloader.download_existing_content_items(
+                content_object=content_object,
+                existing_pack_structure=existing_pack_structure,
+                output_path=output_path,
+                temp_dir=Path(temp_dir_str),
+            )
+
+        # The correctly-prefixed file must exist, and no double-prefixed file may be created.
+        assert (entity_path / prefixed_file_name).is_file()
+        double_prefixed = (
+            entity_path / f"{file_type.value}-{file_type.value}-{content_item_name}.json"
+        )
+        assert not double_prefixed.exists(), (
+            f"Prefix was duplicated: {double_prefixed.name} was created."
+        )
+
     def test_update_data_yml(self, tmp_path):
         env = Environment(tmp_path)
         downloader = Downloader()


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: [XSUP-74505](https://jira-dc.paloaltonetworks.com/browse/XSUP-74505).

## Description
Fixed an issue where re-running the **download** command with `--force` would duplicate the type prefix in file names (e.g. `indicatorfield-indicatorfield-<name>.json`) for incident fields, indicator fields, incident types, and layouts containers.

## SDK Nightly
<!--
If the SDK Nightly Gate flags this PR (see the bot comment below):
  1. Run the SDK Nightly pipeline against this branch.
  2. Paste the link to the nightly run here.
  3. Apply either `nightly-run-passed` or `nightly-run-skipped`
     (skipped is only allowed for the recommended tier, with reviewer
     approval). The gate re-runs automatically when labels change.
-->
SDK Nightly link:
