### PR TITLE
Avoid loguru color-tag crash when logging content item…

### DIFF
--- a/demisto_sdk/commands/content_graph/tests/pack_level_ignore_test.py
+++ b/demisto_sdk/commands/content_graph/tests/pack_level_ignore_test.py
@@ -331,6 +331,52 @@ class TestIsErrorIgnoredPackLevel:
             is_error_ignored("RM104", ALLOWED, item, [RelatedFileType.README]) is False
         )
 
+    def test_missing_related_file_attribute_does_not_crash_on_debug_log(self):
+        """
+        Given a content item that does NOT expose the related-file attribute
+        (so `getattr(content_item, related_file.value)` raises AttributeError),
+        and whose repr contains angle-bracket text (e.g. "<number>") that
+        loguru interprets as color markup,
+        When is_error_ignored is called with the related_file_type while a
+        colorized loguru sink is active (as in CI),
+        Then the AttributeError is swallowed, the debug log does not raise a
+        loguru ValueError ("Tag ... does not correspond to any known color
+        directive"), and evaluation falls through to the main content's
+        per-file ignore list.
+
+        This reproduces the CI crash: logging the full model repr under a
+        colorized sink previously blew up the whole `validate` run.
+        """
+        from demisto_sdk.commands.common.logger import logger
+
+        class _AngleBracketReprItem(_FakeContentItem):
+            def __repr__(self) -> str:
+                # Mimics a Pydantic model repr, which contains "<...>" text
+                # that loguru misreads as an (unknown) color tag.
+                return "Pack(some_field=<number>)"
+
+        # No `related_file` is set, so accessing RelatedFileType.README.value
+        # ("readme") raises AttributeError inside is_error_ignored.
+        item = _AngleBracketReprItem(pack=None, ignored_errors=["RM104"])
+
+        # Activate a colorized DEBUG sink so the loguru color parser runs on
+        # the debug message, exactly as it does in CI.
+        logger.enable(None)
+        sink_id = logger.add(
+            lambda _msg: None,
+            level="DEBUG",
+            colorize=True,
+        )
+        try:
+            # Must not raise; falls through to the main content's
+            # ignored_errors and returns True.
+            assert (
+                is_error_ignored("RM104", ALLOWED, item, [RelatedFileType.README])
+                is True
+            )
+        finally:
+            logger.remove(sink_id)
+
 
 # ---------------------------------------------------------------------------
 # Slice 3: extract_error_codes_from_file (PA137 coverage)

--- a/demisto_sdk/commands/validate/validators/base_validator.py
+++ b/demisto_sdk/commands/validate/validators/base_validator.py
@@ -517,8 +517,15 @@ def is_error_ignored(
                 ):
                     return True
             except Exception as e:
+                # Log only a safe identifier of the content item rather than
+                # its full repr. A Pydantic model repr can contain angle-bracket
+                # text (e.g. "<number>"), which loguru interprets as color
+                # markup and raises a ValueError on unknown tags.
+                content_item_id = getattr(content_item, "object_id", None) or type(
+                    content_item
+                ).__name__
                 logger.debug(
-                    f"is_error_ignored: skipped related_file={related_file.value!r} on {content_item!r}: {e!r}"
+                    f"is_error_ignored: skipped related_file={related_file.value!r} on {content_item_id}: {e}"
                 )
                 continue
         # None of the related files carried the ignore (e.g. the related file


### PR DESCRIPTION
… repr

The debug log added in #5478 inside is_error_ignored's except block interpolated the full content item repr ({content_item!r}). A Pydantic model repr (e.g. Pack) can contain angle-bracket text such as '<number>', which loguru parses as color markup and raises a ValueError on unknown tags, crashing the entire 'validate' run.

Log a safe identifier (object_id, falling back to the class name) instead of the full repr, and drop the !r on the exception. Add a regression test that reproduces the crash under a colorized loguru sink.

<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes:

## Description

## SDK Nightly
<!--
If the SDK Nightly Gate flags this PR (see the bot comment below):
  1. Run the SDK Nightly pipeline against this branch.
  2. Paste the link to the nightly run here.
  3. Apply either `nightly-run-passed` or `nightly-run-skipped`
     (skipped is only allowed for the recommended tier, with reviewer
     approval). The gate re-runs automatically when labels change.
-->
SDK Nightly link:
