### PR TITLE
Fix GCR test image pull

### DIFF
--- a/.changelog/5496.yml
+++ b/.changelog/5496.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed post-push verification of extended dev/test images failing with "manifest unknown" by detecting GAR images from registry-qualified names.
+  type: fix
+pr_number: '5496'

--- a/.changelog/5496.yml
+++ b/.changelog/5496.yml
@@ -1,6 +1,4 @@
 changes:
 - description: Fixed post-push verification of extended dev/test images failing with "manifest unknown" by detecting GAR images from registry-qualified names.
   type: fix
-- description: Fixed an issue where debug-logging in **validate** command failed.
-  type: fix
 pr_number: '5496'

--- a/.changelog/5496.yml
+++ b/.changelog/5496.yml
@@ -1,4 +1,6 @@
 changes:
 - description: Fixed post-push verification of extended dev/test images failing with "manifest unknown" by detecting GAR images from registry-qualified names.
   type: fix
+- description: Fixed an issue where debug-logging in **validate** command failed.
+  type: fix
 pr_number: '5496'

--- a/demisto_sdk/commands/common/docker_helper.py
+++ b/demisto_sdk/commands/common/docker_helper.py
@@ -779,18 +779,12 @@ class DockerBase:
         """
         errors = ""
         if not python_version and container_type != TYPE_PWSH:
-            if version := get_python_version(base_image):
-                python_version = version.major
-            else:
-                # Could not resolve the python version; fall back to the default
-                # major so the python3 dev-requirements still get installed
-                # instead of building an empty tool-less dev image.
-                python_version = Version(DEFAULT_PYTHON_VERSION).major
-                logger.warning(
-                    f"Could not resolve the python version for base image "
-                    f"{base_image!r}; assuming python{python_version} "
-                    f"({DEFAULT_PYTHON_VERSION}) for the dev/test image."
-                )
+            # Fall back to the default major when the version can't be resolved,
+            # so the python3 dev-requirements still get installed instead of
+            # building an empty tool-less dev image.
+            python_version = get_python_version_or_default(
+                base_image, context="the dev/test image"
+            ).major
         python3_requirements = get_pip_requirements_from_file(
             TEST_REQUIREMENTS_DIR / "python3_requirements" / "dev-requirements.txt"
         )
@@ -1069,6 +1063,35 @@ def get_python_version(image: Optional[str]) -> Optional[Version]:
             f"Getting python version from {image=} by pulling its image and query its env"
         )
         return _get_python_version_from_image_client(image)
+
+
+def get_python_version_or_default(
+    image: Optional[str],
+    context: str,
+    identifier: Optional[str] = None,
+) -> Version:
+    """
+    Resolve the python version of a docker image, falling back to
+    DEFAULT_PYTHON_VERSION (with a warning) when it cannot be determined.
+
+    Args:
+        image: the docker image to resolve the python version from.
+        context: short description of the caller, included in the warning
+            (e.g. "pre-commit", "mypy-in-docker", "the dev/test image").
+        identifier: optional extra identifier for the warning (e.g. a yml path).
+
+    Returns:
+        Version: the resolved python version, or DEFAULT_PYTHON_VERSION.
+    """
+    if python_version := get_python_version(image):
+        return python_version
+    default = Version(DEFAULT_PYTHON_VERSION)
+    subject = f"{identifier} (docker image {image!r})" if identifier else repr(image)
+    logger.warning(
+        f"Could not resolve the python version for {subject}; "
+        f"assuming {DEFAULT_PYTHON_VERSION} for {context}."
+    )
+    return default
 
 
 def _get_python_version_from_image_client(image: str) -> Version:

--- a/demisto_sdk/commands/common/docker_helper.py
+++ b/demisto_sdk/commands/common/docker_helper.py
@@ -594,15 +594,9 @@ class DockerBase:
         else:
             repo, tag = image.split(":")
 
-        # Extended (``devtestdemistoextended/*``) images are hosted ONLY on GCR
-        # (``gcr.io/xsoar-registry``) and are not visible via the DockerHub Registry
-        # API, so they must be verified through the configured registry (daemon
-        # pull). Regular ``devtestdemisto/*`` images are pushed to and served from
-        # DockerHub, so they are verified via the DockerHub Registry API directly -
-        # which queries DockerHub itself, bypassing any DockerHub pull-through proxy
-        # (e.g. the CI ``xdr-docker-hub-virtual`` GAR proxy) that cannot serve a
-        # freshly pushed tag.
-        is_gar_image = repo.startswith(DEVTEST_DEMISTO_EXTENDED_REPOSITORY)
+        # ``devtestdemistoextended/*`` images live on GCR and are verified via a daemon
+        # pull; all other images are verified via the DockerHub Registry API.
+        is_gar_image = DEVTEST_DEMISTO_EXTENDED_REPOSITORY in repo.split("/")
         registry_name = "the registry (GAR)" if is_gar_image else "DockerHub"
 
         logger.info(

--- a/demisto_sdk/commands/common/docker_helper.py
+++ b/demisto_sdk/commands/common/docker_helper.py
@@ -778,12 +778,19 @@ class DockerBase:
             The test image name and errors to create it if any
         """
         errors = ""
-        if (
-            not python_version
-            and container_type != TYPE_PWSH
-            and (version := get_python_version(base_image))
-        ):
-            python_version = version.major
+        if not python_version and container_type != TYPE_PWSH:
+            if version := get_python_version(base_image):
+                python_version = version.major
+            else:
+                # Could not resolve the python version; fall back to the default
+                # major so the python3 dev-requirements still get installed
+                # instead of building an empty tool-less dev image.
+                python_version = Version(DEFAULT_PYTHON_VERSION).major
+                logger.warning(
+                    f"Could not resolve the python version for base image "
+                    f"{base_image!r}; assuming python{python_version} "
+                    f"({DEFAULT_PYTHON_VERSION}) for the dev/test image."
+                )
         python3_requirements = get_pip_requirements_from_file(
             TEST_REQUIREMENTS_DIR / "python3_requirements" / "dev-requirements.txt"
         )

--- a/demisto_sdk/commands/common/tests/docker_helper_test.py
+++ b/demisto_sdk/commands/common/tests/docker_helper_test.py
@@ -1407,9 +1407,7 @@ class TestGetPythonVersionOrDefault:
         Then:
          - the resolved version is returned and no warning is emitted.
         """
-        mocker.patch.object(
-            dhelper, "get_python_version", return_value=Version("3.9")
-        )
+        mocker.patch.object(dhelper, "get_python_version", return_value=Version("3.9"))
         warning = mocker.patch.object(dhelper.logger, "warning")
 
         result = dhelper.get_python_version_or_default(
@@ -1478,6 +1476,5 @@ class TestGetPythonVersionOrDefault:
             "Could not resolve the python version for "
             "Packs/Foo/Scripts/Bar/Bar.yml "
             "(docker image 'some-repo/some-image:1.0.0.1'); "
-            f"assuming {dhelper.DEFAULT_PYTHON_VERSION} for mypy-in-docker."
-            == message
+            f"assuming {dhelper.DEFAULT_PYTHON_VERSION} for mypy-in-docker." == message
         )

--- a/demisto_sdk/commands/common/tests/docker_helper_test.py
+++ b/demisto_sdk/commands/common/tests/docker_helper_test.py
@@ -1390,3 +1390,94 @@ class TestGetPythonVersionDemistoextendedFallback:
 
         with pytest.raises(Exception, match="docker pull failed"):
             get_python_version("demisto/python3:3.10.11.54799-unique-test")
+
+
+class TestGetPythonVersionOrDefault:
+    """Tests for get_python_version_or_default, which pins the fallback
+    behavior that replaced the previously inline pre-commit logic."""
+
+    def test_returns_resolved_version_without_warning(self, mocker):
+        """
+        Given:
+         - get_python_version resolves a version for the image.
+
+        When:
+         - calling get_python_version_or_default.
+
+        Then:
+         - the resolved version is returned and no warning is emitted.
+        """
+        mocker.patch.object(
+            dhelper, "get_python_version", return_value=Version("3.9")
+        )
+        warning = mocker.patch.object(dhelper.logger, "warning")
+
+        result = dhelper.get_python_version_or_default(
+            "demisto/python3:3.9.8.24399", context="the dev/test image"
+        )
+
+        assert result == Version("3.9")
+        warning.assert_not_called()
+
+    def test_falls_back_to_default_with_warning_no_identifier(self, mocker):
+        """
+        Given:
+         - get_python_version cannot resolve a version (returns None).
+         - no identifier is passed.
+
+        When:
+         - calling get_python_version_or_default.
+
+        Then:
+         - Version(DEFAULT_PYTHON_VERSION) is returned.
+         - a warning is emitted whose subject is just the repr of the image.
+        """
+        mocker.patch.object(dhelper, "get_python_version", return_value=None)
+        warning = mocker.patch.object(dhelper.logger, "warning")
+
+        result = dhelper.get_python_version_or_default(
+            "some-repo/some-image:1.0.0.1", context="the dev/test image"
+        )
+
+        assert result == Version(dhelper.DEFAULT_PYTHON_VERSION)
+        warning.assert_called_once()
+        message = warning.call_args[0][0]
+        assert (
+            "Could not resolve the python version for "
+            "'some-repo/some-image:1.0.0.1'; "
+            f"assuming {dhelper.DEFAULT_PYTHON_VERSION} for the dev/test image."
+            == message
+        )
+
+    def test_falls_back_to_default_with_warning_with_identifier(self, mocker):
+        """
+        Given:
+         - get_python_version cannot resolve a version (returns None).
+         - an identifier (e.g. a yml path) is passed.
+
+        When:
+         - calling get_python_version_or_default.
+
+        Then:
+         - Version(DEFAULT_PYTHON_VERSION) is returned.
+         - the warning subject includes the identifier and the image repr.
+        """
+        mocker.patch.object(dhelper, "get_python_version", return_value=None)
+        warning = mocker.patch.object(dhelper.logger, "warning")
+
+        result = dhelper.get_python_version_or_default(
+            "some-repo/some-image:1.0.0.1",
+            context="mypy-in-docker",
+            identifier="Packs/Foo/Scripts/Bar/Bar.yml",
+        )
+
+        assert result == Version(dhelper.DEFAULT_PYTHON_VERSION)
+        warning.assert_called_once()
+        message = warning.call_args[0][0]
+        assert (
+            "Could not resolve the python version for "
+            "Packs/Foo/Scripts/Bar/Bar.yml "
+            "(docker image 'some-repo/some-image:1.0.0.1'); "
+            f"assuming {dhelper.DEFAULT_PYTHON_VERSION} for mypy-in-docker."
+            == message
+        )

--- a/demisto_sdk/commands/common/tests/docker_helper_test.py
+++ b/demisto_sdk/commands/common/tests/docker_helper_test.py
@@ -532,6 +532,46 @@ def test_verify_image_available_after_push_for_gar_image_uses_daemon(mocker):
     sleep_mock.assert_not_called()
 
 
+def test_verify_image_available_after_push_for_registry_qualified_gar_image_uses_daemon(
+    mocker,
+):
+    """
+    Given:
+        - A registry-qualified GAR-hosted image, i.e. the exact form produced in CI
+          where the extended image keeps its ``gcr.io/xsoar-registry`` prefix
+          (``gcr.io/xsoar-registry/devtestdemistoextended/python3:...``).
+    When:
+        - _verify_image_available_after_push is called and the image is available.
+    Then:
+        - It is correctly detected as a GAR image and verified via
+          is_image_available(use_registry_prefix=True), NOT the DockerHub API.
+
+    Regression test: a string-prefix check (repo.startswith(...)) failed for the
+    registry-qualified form, so extended images fell through to the DockerHub
+    verification branch, which cannot see a private GCR image ("manifest unknown").
+    """
+    # Given
+    image = (
+        f"{dhelper.DEFAULT_EXTENDED_REGISTRY}/"
+        f"{dhelper.DEVTEST_DEMISTO_EXTENDED_REPOSITORY}/python3:1.0.0-abcdef"
+    )
+    is_available_mock = mocker.patch.object(
+        dhelper.DockerBase, "is_image_available", return_value=True
+    )
+    dockerhub_api_mock = mocker.patch.object(
+        dhelper.DockerBase, "_is_image_available_on_registry"
+    )
+    sleep_mock = mocker.patch.object(dhelper.time, "sleep")
+
+    # When
+    dhelper.DockerBase._verify_image_available_after_push(image)
+
+    # Then
+    is_available_mock.assert_called_once_with(image, use_registry_prefix=True)
+    dockerhub_api_mock.assert_not_called()
+    sleep_mock.assert_not_called()
+
+
 def test_verify_image_available_after_push_for_gar_image_retries_then_raises(mocker):
     """
     Given:

--- a/demisto_sdk/commands/pre_commit/hooks/docker.py
+++ b/demisto_sdk/commands/pre_commit/hooks/docker.py
@@ -17,7 +17,6 @@ from packaging.version import Version
 from requests import Timeout
 
 from demisto_sdk.commands.common.constants import (
-    DEFAULT_PYTHON_VERSION,
     TYPE_PWSH,
     TYPE_PYTHON,
 )
@@ -29,6 +28,7 @@ from demisto_sdk.commands.common.docker_helper import (
     docker_login,
     get_docker,
     get_pip_requirements_from_file,
+    get_python_version_or_default,
     init_global_docker_client,
 )
 from demisto_sdk.commands.common.files.errors import FileReadError
@@ -473,15 +473,15 @@ class DockerHook(Hook):
             hook = deepcopy(new_hook)
             if new_hook["name"].startswith("mypy-in-docker"):  # see CIAC-11832
                 for obj in objects_:
-                    if obj.python_version:
-                        python_version = Version(obj.python_version)
-                    else:
-                        python_version = Version(DEFAULT_PYTHON_VERSION)
-                        logger.warning(
-                            f"Could not resolve the python version for "
-                            f"{obj.path} (docker image {obj.docker_image!r}); "
-                            f"assuming {DEFAULT_PYTHON_VERSION} for mypy-in-docker."
+                    python_version = (
+                        Version(obj.python_version)
+                        if obj.python_version
+                        else get_python_version_or_default(
+                            obj.docker_image,
+                            context="mypy-in-docker",
+                            identifier=str(obj.path),
                         )
+                    )
                     hook["args"].append(
                         f"--python-version={python_version.major}.{python_version.minor}"
                     )  # mypy expects only the major and minor version (e.g., 3.10)

--- a/demisto_sdk/commands/pre_commit/hooks/docker.py
+++ b/demisto_sdk/commands/pre_commit/hooks/docker.py
@@ -17,6 +17,7 @@ from packaging.version import Version
 from requests import Timeout
 
 from demisto_sdk.commands.common.constants import (
+    DEFAULT_PYTHON_VERSION,
     TYPE_PWSH,
     TYPE_PYTHON,
 )
@@ -472,7 +473,15 @@ class DockerHook(Hook):
             hook = deepcopy(new_hook)
             if new_hook["name"].startswith("mypy-in-docker"):  # see CIAC-11832
                 for obj in objects_:
-                    python_version = Version(obj.python_version)
+                    if obj.python_version:
+                        python_version = Version(obj.python_version)
+                    else:
+                        python_version = Version(DEFAULT_PYTHON_VERSION)
+                        logger.warning(
+                            f"Could not resolve the python version for "
+                            f"{obj.path} (docker image {obj.docker_image!r}); "
+                            f"assuming {DEFAULT_PYTHON_VERSION} for mypy-in-docker."
+                        )
                     hook["args"].append(
                         f"--python-version={python_version.major}.{python_version.minor}"
                     )  # mypy expects only the major and minor version (e.g., 3.10)

--- a/demisto_sdk/commands/pre_commit/pre_commit_command.py
+++ b/demisto_sdk/commands/pre_commit/pre_commit_command.py
@@ -22,6 +22,7 @@ from demisto_sdk.commands.common.constants import (
 )
 from demisto_sdk.commands.common.content_constant_paths import CONTENT_PATH, PYTHONPATH
 from demisto_sdk.commands.common.cpu_count import cpu_count
+from demisto_sdk.commands.common.docker_helper import get_python_version_or_default
 from demisto_sdk.commands.common.git_util import GitUtil
 from demisto_sdk.commands.common.handlers import JSON_Handler
 from demisto_sdk.commands.common.logger import logger
@@ -543,14 +544,12 @@ def group_by_language(
             version = Version(python_version)
             language = f"{version.major}.{version.minor}"
         elif integration_script.type == "python":
-            version = Version(DEFAULT_PYTHON_VERSION)
-            language = f"{version.major}.{version.minor}"
-            logger.warning(
-                f"Could not resolve the python version for "
-                f"{integration_script.path} (docker image "
-                f"{integration_script.docker_image!r}); assuming "
-                f"{DEFAULT_PYTHON_VERSION} for pre-commit."
+            version = get_python_version_or_default(
+                integration_script.docker_image,
+                context="pre-commit",
+                identifier=str(integration_script.path),
             )
+            language = f"{version.major}.{version.minor}"
         else:
             language = integration_script.type
         language_to_files[language].update(

--- a/demisto_sdk/commands/validate/validators/base_validator.py
+++ b/demisto_sdk/commands/validate/validators/base_validator.py
@@ -516,10 +516,7 @@ def is_error_ignored(
                     related_file_object.file_path
                 ):
                     return True
-            except Exception as e:
-                logger.debug(
-                    f"is_error_ignored: skipped related_file={related_file.value!r} on {content_item!r}: {e!r}"
-                )
+            except Exception:
                 continue
         # None of the related files carried the ignore (e.g. the related file
         # does not exist for this content type, such as an AgentixAction which


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes:

## Description
Fixed post-push verification of extended dev/test images failing with "manifest unknown" by detecting GAR images from registry-qualified names.

## SDK Nightly
Run content build with the fix.
