### PR TITLE
fix(validate): fix debug-logging failure & Python 3.14 'return' in 'finally' SyntaxWarning

### DIFF
--- a/.changelog/5497.yml
+++ b/.changelog/5497.yml
@@ -1,0 +1,7 @@
+changes:
+- description: Fixed an issue where debug-logging in **validate** command failed.
+  type: fix
+- description: Fixed an issue where a **SyntaxWarning** was raised in Python 3.14 due
+    to a 'return' statement inside a 'finally' block.
+  type: fix
+pr_number: 5497

--- a/demisto_sdk/commands/common/tools.py
+++ b/demisto_sdk/commands/common/tools.py
@@ -2733,9 +2733,9 @@ def open_id_set_file(id_set_path):
             id_set = json.load(id_set_file)
     except OSError:
         logger.info("<yellow>Could not open id_set file</yellow>")
-        raise
-    finally:
-        return id_set
+    except Exception:
+        pass
+    return id_set
 
 
 def get_demisto_version(client: demisto_client) -> Version:

--- a/demisto_sdk/commands/validate/validators/base_validator.py
+++ b/demisto_sdk/commands/validate/validators/base_validator.py
@@ -516,11 +516,7 @@ def is_error_ignored(
                     related_file_object.file_path
                 ):
                     return True
-            except Exception as e:
-                logger.debug(  # noqa: PLE1205
-                    "{}",
-                    f"<yellow>is_error_ignored: skipped related_file={related_file.value!r} on {content_item!r}: {e!r}</yellow>",
-                )
+            except Exception:
                 continue
         # None of the related files carried the ignore (e.g. the related file
         # does not exist for this content type, such as an AgentixAction which

--- a/demisto_sdk/commands/validate/validators/base_validator.py
+++ b/demisto_sdk/commands/validate/validators/base_validator.py
@@ -517,8 +517,9 @@ def is_error_ignored(
                 ):
                     return True
             except Exception as e:
-                logger.debug(
-                    f"is_error_ignored: skipped related_file={related_file.value!r} on {content_item!r}: {e!r}"
+                logger.debug(  # noqa: PLE1205
+                    "{}",
+                    f"<yellow>is_error_ignored: skipped related_file={related_file.value!r} on {content_item!r}: {e!r}</yellow>",
                 )
                 continue
         # None of the related files carried the ignore (e.g. the related file


### PR DESCRIPTION
## Description
1. Fixed an issue where a **SyntaxWarning** was raised in Python 3.14 due
    to a 'return' statement inside a 'finally' block.
    ```
    demisto-sdk/demisto_sdk/commands/common/tools.py:2738: SyntaxWarning: 'return' in a 'finally' block
    return id_set
    ```
    
 2. Fixed an issue where debug-logging in **validate** command failed.
 ```
   File "/builds/xdr/cortex-content/content/.venv/lib/python3.10/site-packages/demisto_sdk/commands/validate/validators/base_validator.py", line 520, in is_error_ignored
    logger.debug(
  File "/builds/xdr/cortex-content/content/.venv/lib/python3.10/site-packages/loguru/_logger.py", line 2074, in debug
    __self._log("DEBUG", False, __self._options, __message, args, kwargs)
  File "/builds/xdr/cortex-content/content/.venv/lib/python3.10/site-packages/loguru/_logger.py", line 2051, in _log
    colored_message = Colorizer.prepare_simple_message(str(message))
  File "/builds/xdr/cortex-content/content/.venv/lib/python3.10/site-packages/loguru/_colorizer.py", line 378, in prepare_simple_message
    parser.feed(string)
  File "/builds/xdr/cortex-content/content/.venv/lib/python3.10/site-packages/loguru/_colorizer.py", line 260, in feed
    raise ValueError(
ValueError: Tag "<br>" does not correspond to any known color directive, make sure you did not misspelled it (or prepend '\' to escape it)
```



## SDK Nightly
<!--
If the SDK Nightly Gate flags this PR (see the bot comment below):
  1. Run the SDK Nightly pipeline against this branch.
  2. Paste the link to the nightly run here.
  3. Apply either `nightly-run-passed` or `nightly-run-skipped`
     (skipped is only allowed for the recommended tier, with reviewer
     approval). The gate re-runs automatically when labels change.
-->
SDK Nightly link:
