### PR TITLE
CO200: Validate xsoar-integration-id matches referenced integration ID

### DIFF
--- a/demisto_sdk/commands/validate/tests/CO_validators_test.py
+++ b/demisto_sdk/commands/validate/tests/CO_validators_test.py
@@ -143,6 +143,10 @@ from demisto_sdk.commands.validate.validators.CO_validators.CO190_no_reserved_pa
 from demisto_sdk.commands.validate.validators.CO_validators.CO194_is_sub_capability_title_derived import (
     IsSubCapabilityTitleDerivedValidator,
 )
+from demisto_sdk.commands.validate.validators.CO_validators.CO200_is_matching_integration_exist import (
+    IsMatchingIntegrationExistValidator,
+)
+
 
 VALID_CONNECTION_DESCRIPTION = (
     "Enter the credentials to securely authorize the connection"
@@ -14013,3 +14017,100 @@ class TestCO183NoGroupedFlagFlipped:
         assert len(results) == 1
         assert results[0].path is not None
         assert results[0].path == connector.path
+class TestIsMatchingIntegrationExistValidator:
+    """Tests for CO200 IsMatchingIntegrationExistValidator."""
+
+    def _connector_with_handlers(self, handlers):
+        """Build a Connector-shaped SimpleNamespace with the given handlers."""
+        return SimpleNamespace(
+            object_id="TestConnector",
+            xsoar_handlers=handlers,
+        )
+
+    def test_no_problems_returns_empty(self):
+        """A connector whose handlers all match should produce no results."""
+        integration = SimpleNamespace(object_id="TestIntegration")
+        handler = SimpleNamespace(
+            id="h1",
+            xsoar_integration_id="TestIntegration",
+            related_integration=integration,
+        )
+        connector = self._connector_with_handlers([handler])
+
+        results = IsMatchingIntegrationExistValidator().obtain_invalid_content_items(
+            [connector]
+        )
+
+        assert results == []
+
+    def test_missing_label_is_flagged(self):
+        """A handler with no xsoar-integration-id label is a case-1 failure."""
+        handler = SimpleNamespace(
+            id="h1",
+            xsoar_integration_id=None,
+            related_integration=None,
+        )
+        connector = self._connector_with_handlers([handler])
+
+        results = IsMatchingIntegrationExistValidator().obtain_invalid_content_items(
+            [connector]
+        )
+
+        assert len(results) == 1
+        assert "missing xsoar-integration-id" in results[0].message
+
+    def test_unresolved_integration_is_flagged(self):
+        """Label present but integration not found is a case-2 failure."""
+        handler = SimpleNamespace(
+            id="h1",
+            xsoar_integration_id="MissingIntegration",
+            related_integration=None,
+        )
+        connector = self._connector_with_handlers([handler])
+
+        results = IsMatchingIntegrationExistValidator().obtain_invalid_content_items(
+            [connector]
+        )
+
+        assert len(results) == 1
+        assert "MissingIntegration" in results[0].message
+        assert "not found" in results[0].message
+
+    def test_mismatched_id_is_flagged(self):
+        """Label resolved to an integration but label != YML id is case-3."""
+        integration = SimpleNamespace(object_id="TestIntegration")
+        handler = SimpleNamespace(
+            id="h1",
+            xsoar_integration_id="testintegration",  # wrong case
+            related_integration=integration,
+        )
+        connector = self._connector_with_handlers([handler])
+
+        results = IsMatchingIntegrationExistValidator().obtain_invalid_content_items(
+            [connector]
+        )
+
+        assert len(results) == 1
+        assert "match verbatim" in results[0].message
+
+    def test_multiple_handler_problems_aggregated_in_one_result(self):
+        """Multiple bad handlers on one connector emit a single ValidationResult."""
+        bad_missing_label = SimpleNamespace(
+            id="h1", xsoar_integration_id=None, related_integration=None
+        )
+        bad_unresolved = SimpleNamespace(
+            id="h2",
+            xsoar_integration_id="Missing",
+            related_integration=None,
+        )
+        connector = self._connector_with_handlers(
+            [bad_missing_label, bad_unresolved]
+        )
+
+        results = IsMatchingIntegrationExistValidator().obtain_invalid_content_items(
+            [connector]
+        )
+
+        assert len(results) == 1
+        assert "h1" in results[0].message
+        assert "h2" in results[0].message

--- a/demisto_sdk/commands/validate/validators/CO_validators/CO200_is_matching_integration_exist.py
+++ b/demisto_sdk/commands/validate/validators/CO_validators/CO200_is_matching_integration_exist.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from demisto_sdk.commands.content_graph.objects.connector import Connector
+from demisto_sdk.commands.validate.validators.base_validator import (
+    ConnectorsValidator,
+    ValidationResult,
+)
+
+ContentTypes = Connector
+
+
+class IsMatchingIntegrationExistValidator(ConnectorsValidator[ContentTypes]):
+    error_code = "CO200"
+    description = (
+        "Validates that each XSOAR handler in a connector has an "
+        "xsoar-integration-id label AND that the label equals the "
+        "referenced integration's YML id verbatim."
+    )
+    rationale = (
+        "Every XSOAR handler must declare an xsoar-integration-id in its "
+        "triggering.labels so the platform knows which integration to invoke. "
+        "The label MUST equal the integration YML id verbatim (case-sensitive, "
+        "no slugification). This invariant is what lets CO122/CO139 compare "
+        "view_group.id against integration.object_id verbatim - if this "
+        "validator passes, `xsoar-integration-id` and `integration.object_id` "
+        "are interchangeable."
+    )
+    error_message = (
+        "Connector '{connector_id}' has XSOAR handlers with integration "
+        "problems: {handler_details}"
+    )
+    related_field = "triggering.labels"
+    is_auto_fixable = False
+
+    def obtain_invalid_content_items(
+        self,
+        content_items: Iterable[ContentTypes],
+    ) -> List[ValidationResult]:
+        """Check that each XSOAR handler has a valid integration reference.
+
+        Three failure cases:
+        1. Handler has no ``xsoar_integration_id`` at all - the handler YAML is
+           missing the ``xsoar-integration-id`` triggering label.
+        2. Handler has ``xsoar_integration_id`` but ``related_integration`` is
+           None - the referenced integration was not found in the content repo.
+        3. Handler has ``xsoar_integration_id`` that resolved to an integration
+           (via graph fallback) but does NOT equal that integration's
+           ``object_id`` verbatim - the label is drifted from the YML id.
+        """
+        results: List[ValidationResult] = []
+
+        for connector in content_items:
+            problems: List[str] = []
+            for h in connector.xsoar_handlers:
+                # Case 1: no xsoar-integration-id label at all.
+                if not h.xsoar_integration_id:
+                    problems.append(
+                        f"handler '{h.id}' is missing "
+                        f"xsoar-integration-id in triggering.labels"
+                    )
+                    continue
+                # Case 2: label present but no resolved integration.
+                if h.related_integration is None:
+                    problems.append(
+                        f"handler '{h.id}' -> integration-id "
+                        f"'{h.xsoar_integration_id}' not found"
+                    )
+                    continue
+                # Case 3: resolved (via graph fallback) but the label does
+                # NOT equal the integration YML id verbatim.
+                actual = h.related_integration.object_id
+                if h.xsoar_integration_id != actual:
+                    problems.append(
+                        f"handler '{h.id}' has xsoar-integration-id "
+                        f"'{h.xsoar_integration_id}' but the resolved "
+                        f"integration's YML id is '{actual}' - they must "
+                        f"match verbatim (case-sensitive, no slugification)"
+                    )
+
+            if problems:
+                results.append(
+                    ValidationResult(
+                        validator=self,
+                        message=self.error_message.format(
+                            connector_id=connector.object_id,
+                            handler_details="\n".join(problems),
+                        ),
+                        content_object=connector,
+                    )
+                )
+
+        return results


### PR DESCRIPTION
## What

Adds a new content-graph validator, **CO200 `IsMatchingIntegrationExistValidator`**, that catches out-of-sync `xsoar-integration-id` labels on Connector XSOAR handlers before they reach the platform.

## Why

Every XSOAR handler declares which integration to invoke via an `xsoar-integration-id` label in `triggering.labels`. That label must equal the integration YML `object_id` verbatim (case-sensitive, no slugification) — otherwise the platform silently routes to the wrong integration, or fails at runtime instead of at content-build time.

This invariant is already assumed by **CO122 / CO139**, which compare `view_group.id` against `integration.object_id` verbatim. CO200 makes the invariant explicit and enforced at content-graph validation time, so those downstream validators can trust their inputs.

## Failure cases caught

The validator flags three distinct problems on any Connector XSOAR handler:

| Case | Condition | Example message |
|---|---|---|
| 1 | Handler has no `xsoar_integration_id` at all | `handler 'h1' is missing xsoar-integration-id in triggering.labels` |
| 2 | Label present but `related_integration is None` | `handler 'h1' -> integration-id 'MissingIntegration' not found` |
| 3 | Label present, integration exists, but label ≠ YML `object_id` verbatim | `handler 'h1' has xsoar-integration-id 'testintegration' but the resolved integration's YML id is 'TestIntegration' - they must match verbatim (case-sensitive, no slugification)` |

Multiple bad handlers on one connector are aggregated into a single `ValidationResult` so the human reviewer sees the whole picture per-connector, not per-handler.

## Test coverage

Adds `TestIsMatchingIntegrationExistValidator` in `demisto_sdk/commands/validate/tests/CO_validators_test.py`:

- ✅ Happy path (all handlers valid) → no results
- ✅ Case 1 (missing label) → single flagged result
- ✅ Case 2 (label unresolved) → single flagged result
- ✅ Case 3 (case-mismatched label) → single flagged result
- ✅ Aggregation (two bad handlers on one connector) → single result mentioning both

## Related ticket

