### PR TITLE
Added pack level validations to filter validation results

### DIFF
--- a/.changelog/5503.yml
+++ b/.changelog/5503.yml
@@ -1,0 +1,4 @@
+changes:
+- description: Fixed an issue where the pack-level `[pack]` section of `.pack-ignore` was not honored for validators listed in `ALWAYS_RUN_ON_ERROR_CODE`. `ValidateManager.filter_validation_results` now consults both the content item's per-file `ignored_errors` and the pack's `pack_level_ignored_errors`.
+  type: fix
+pr_number: '5503'

--- a/demisto_sdk/commands/validate/tests/validators_test.py
+++ b/demisto_sdk/commands/validate/tests/validators_test.py
@@ -2269,6 +2269,83 @@ class TestConnectorHandlerIgnoreFiltering:
 
         assert result in filtered
 
+    def test_filter_drops_result_ignored_via_pack_level_ignore(self, mocker):
+        """
+        Given: A ContentItem result whose error code (e.g. GR109) is listed
+               under the pack's ``[pack]`` section of ``.pack-ignore`` (exposed
+               as ``in_pack.pack_level_ignored_errors``), and NOT in the item's
+               own per-file ``ignored_errors``.
+        When: filter_validation_results runs (the post-hoc path taken for
+              ``ALWAYS_RUN_ON_ERROR_CODE`` codes such as GR107/GR109).
+        Then: The result is dropped - the pack-level ignore is honored.
+        """
+        from types import SimpleNamespace
+
+        manager = get_validate_manager(mocker)
+
+        pack = SimpleNamespace(pack_level_ignored_errors=["GR109"])
+        result = SimpleNamespace(
+            validator=SimpleNamespace(error_code="GR109", related_file_type=None),
+            path=Path("/repo/Packs/Foo/Integrations/Foo/Foo.yml"),
+            content_object=SimpleNamespace(ignored_errors=[], in_pack=pack),
+        )
+
+        filtered = manager.filter_validation_results([result])
+
+        assert filtered == []
+
+    def test_filter_drops_result_when_content_object_is_pack_with_pack_level_ignore(
+        self, mocker
+    ):
+        """
+        Given: A result whose content_object IS the ``Pack`` itself (as with
+               PA-validators), and the code is listed in the pack's
+               ``pack_level_ignored_errors``.
+        When: filter_validation_results runs.
+        Then: The result is dropped - the duck-typed pack lookup uses
+              ``pack_level_ignored_errors`` directly on the content_object.
+        """
+        from types import SimpleNamespace
+
+        manager = get_validate_manager(mocker)
+
+        pack = SimpleNamespace(
+            ignored_errors=[],
+            pack_level_ignored_errors=["GR107"],
+        )
+        result = SimpleNamespace(
+            validator=SimpleNamespace(error_code="GR107", related_file_type=None),
+            path=Path("/repo/Packs/Foo/pack_metadata.json"),
+            content_object=pack,
+        )
+
+        filtered = manager.filter_validation_results([result])
+
+        assert filtered == []
+
+    def test_filter_keeps_result_when_neither_file_nor_pack_ignore_match(self, mocker):
+        """
+        Given: A result whose error code is neither in the content item's
+               per-file ``ignored_errors`` nor in the pack's
+               ``pack_level_ignored_errors``.
+        When: filter_validation_results runs.
+        Then: The result is kept.
+        """
+        from types import SimpleNamespace
+
+        manager = get_validate_manager(mocker)
+
+        pack = SimpleNamespace(pack_level_ignored_errors=["PB100"])
+        result = SimpleNamespace(
+            validator=SimpleNamespace(error_code="GR109", related_file_type=None),
+            path=Path("/repo/Packs/Foo/Integrations/Foo/Foo.yml"),
+            content_object=SimpleNamespace(ignored_errors=["BA101"], in_pack=pack),
+        )
+
+        filtered = manager.filter_validation_results([result])
+
+        assert result in filtered
+
 
 class TestImplicitGraphInitialization:
     """Tests for the connectors-flow graph initialization.

--- a/demisto_sdk/commands/validate/validate_manager.py
+++ b/demisto_sdk/commands/validate/validate_manager.py
@@ -219,7 +219,8 @@ class ValidateManager:
           ``.connector-ignore`` - so ignoring one handler does not suppress the
           others.
         * All other validations are filtered against the content object's main
-          ``ignored_errors`` list (the general case).
+          ``ignored_errors`` list AND the pack's ``pack_level_ignored_errors``
+          list (the general case).
 
         Returns:
         List[ValidationResult]: Filtered validation results excluding ignored error codes
@@ -236,12 +237,39 @@ class ValidateManager:
                 if not self._is_connector_handler_result_ignored(result)
             ]
 
-        # General case: filter against the content item's main ignored_errors.
+        # General case: filter against the content item's main ignored_errors
+        # AND the pack's pack_level_ignored_errors (from `[pack]` in
+        # `.pack-ignore`).
         return [
             result
             for result in validation_results
-            if result.validator.error_code not in result.content_object.ignored_errors
+            if not self._is_result_ignored_by_pack_or_file(result)
         ]
+
+    @staticmethod
+    def _is_result_ignored_by_pack_or_file(result: ValidationResult) -> bool:
+        """Whether a single validation result is ignored by the content item's own
+        ``ignored_errors`` (per-file ``[file:...]`` section) or by the pack's
+        ``pack_level_ignored_errors`` (the ``[pack]`` section of
+        ``.pack-ignore``).
+        """
+        err_code = result.validator.error_code
+        content_object = result.content_object
+
+        if err_code in getattr(content_object, "ignored_errors", []):
+            return True
+
+        pack = (
+            content_object
+            if hasattr(content_object, "pack_level_ignored_errors")
+            else getattr(content_object, "in_pack", None)
+        )
+        if pack is not None and err_code in getattr(
+            pack, "pack_level_ignored_errors", []
+        ):
+            return True
+
+        return False
 
     @staticmethod
     def _is_connector_handler_validation(result: ValidationResult) -> bool:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO; DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Related Issues
fixes: [CIAC-17704](https://jira-dc.paloaltonetworks.com/browse/CIAC-17704).

## Description
Honor pack-level .pack-ignore for `ALWAYS_RUN_ON_ERROR_CODE` validators (GR107, GR109) by adding the pack level validation check to the `filter_validation_results` function. 

Tested on this content-private branch - [link](https://gitlab.xdr.pan.local/xdr/cortex-content/content-private/-/merge_requests/621/diffs).

Before the fix - [link to run validation failure](https://gitlab.xdr.pan.local/xdr/cortex-content/content/-/pipelines/11990858) - run validation failed on GR109. 

After the fix - [link to run validation](https://gitlab.xdr.pan.local/xdr/cortex-content/content/-/pipelines/12064765) -  run validation doesn't fail on GR109 anymore. 

## SDK Nightly
<!--
If the SDK Nightly Gate flags this PR (see the bot comment below):
  1. Run the SDK Nightly pipeline against this branch.
  2. Paste the link to the nightly run here.
  3. Apply either `nightly-run-passed` or `nightly-run-skipped`
     (skipped is only allowed for the recommended tier, with reviewer
     approval). The gate re-runs automatically when labels change.
-->
SDK Nightly link:
