### PR TITLE
fix(git_util): derive pack first-created date from the add commit

### DIFF
--- a/.changelog/5498.yml
+++ b/.changelog/5498.yml
@@ -1,0 +1,7 @@
+changes:
+- description: Fixed an issue where the pack **First Created** (`firstCreated`) date
+    could be inaccurate. The date is now derived from the commit that first added the
+    pack metadata file (following renames), and a warning is logged when the result
+    may be unreliable (for example, in a shallow clone).
+  type: fix
+pr_number: '5498'

--- a/.changelog/5504.yml
+++ b/.changelog/5504.yml
@@ -4,4 +4,4 @@ changes:
     pack metadata file (following renames), and a warning is logged when the result
     may be unreliable (for example, in a shallow clone).
   type: fix
-pr_number: '5498'
+pr_number: '5504'

--- a/demisto_sdk/commands/common/git_util.py
+++ b/demisto_sdk/commands/common/git_util.py
@@ -1,6 +1,6 @@
 import os
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import lru_cache
 from pathlib import Path
 from typing import List, Optional, Sequence, Set, Tuple, Union
@@ -1264,8 +1264,62 @@ class GitUtil:
         else:
             logger.error(f"File '{file_path}' doesn't exist. Not adding.")
 
+    @staticmethod
+    def _normalize_iso_date(iso_date: str) -> str:
+        """
+        Convert a strict-ISO git date (``%aI``) into a UTC `ISO_TIMESTAMP_FORMAT` string.
+
+        Args:
+        - `iso_date` (``str``): The strict ISO 8601 date, e.g. `2020-11-04T10:20:30+02:00`.
+
+        Returns:
+        - `str`: The date normalized to UTC, in `ISO_TIMESTAMP_FORMAT`.
+        """
+        parsed = datetime.fromisoformat(iso_date.strip())
+        if parsed.tzinfo is not None:
+            parsed = parsed.astimezone(timezone.utc)
+        return parsed.strftime(ISO_TIMESTAMP_FORMAT)
+
     def get_file_creation_date(self, file_path: Path) -> str:
+        """
+        Get the date the file was first added to the repository, following renames.
+
+        Note that in a shallow clone the full history isn't available, so the returned
+        date may be later than the actual creation date. In such a case a warning is
+        logged and the best-effort date is still returned.
+
+        Args:
+        - `file_path` (``Path``): The file to get the creation date for.
+
+        Returns:
+        - `str`: The creation date in `ISO_TIMESTAMP_FORMAT`.
+        """
+        try:
+            if self.repo.git.rev_parse("--is-shallow-repository").strip() == "true":
+                logger.warning(
+                    f"The repository is a shallow clone, the first-created date of '{file_path}' may be inaccurate. "
+                    "Clone with the full history (for example, 'fetch-depth: 0') for an accurate date."
+                )
+        except GitError as e:
+            logger.debug(f"Could not determine whether the repository is shallow: {e}")
+
+        try:
+            # The log is ordered newest-first and '--follow' follows renames,
+            # so the last line is the commit that originally added the file.
+            log_output = self.repo.git.log(
+                "--follow", "--format=%aI", "--", str(file_path)
+            )
+            if add_dates := [line for line in log_output.splitlines() if line.strip()]:
+                return self._normalize_iso_date(add_dates[-1])
+        except (GitError, ValueError) as e:
+            logger.debug(f"Could not get the add-commit date of '{file_path}': {e}")
+
         if commits := list(self.repo.iter_commits(paths=file_path)):
+            logger.warning(
+                f"Could not find the commit that added '{file_path}', "
+                "falling back to the oldest reachable commit. The date may be inaccurate."
+            )
             first_commit = commits[-1]
-            return first_commit.authored_datetime.strftime(ISO_TIMESTAMP_FORMAT)
+            return self._normalize_iso_date(first_commit.authored_datetime.isoformat())
+
         return datetime.now().strftime(ISO_TIMESTAMP_FORMAT)

--- a/demisto_sdk/commands/common/git_util.py
+++ b/demisto_sdk/commands/common/git_util.py
@@ -1327,4 +1327,4 @@ class GitUtil:
             first_commit = commits[-1]
             return self._normalize_iso_date(first_commit.authored_datetime.isoformat())
 
-        return datetime.now().strftime(ISO_TIMESTAMP_FORMAT)
+        return self._normalize_iso_date(datetime.now(timezone.utc).isoformat())

--- a/demisto_sdk/commands/common/git_util.py
+++ b/demisto_sdk/commands/common/git_util.py
@@ -1275,7 +1275,12 @@ class GitUtil:
         Returns:
         - `str`: The date normalized to UTC, in `ISO_TIMESTAMP_FORMAT`.
         """
-        parsed = datetime.fromisoformat(iso_date.strip())
+        # Newer git versions render a UTC offset as a 'Z' suffix, which
+        # `datetime.fromisoformat` only supports from Python 3.11 onwards.
+        normalized = iso_date.strip()
+        if normalized.endswith(("Z", "z")):
+            normalized = f"{normalized[:-1]}+00:00"
+        parsed = datetime.fromisoformat(normalized)
         if parsed.tzinfo is not None:
             parsed = parsed.astimezone(timezone.utc)
         return parsed.strftime(ISO_TIMESTAMP_FORMAT)

--- a/demisto_sdk/commands/common/tests/git_util_test.py
+++ b/demisto_sdk/commands/common/tests/git_util_test.py
@@ -2,10 +2,24 @@ import stat
 from datetime import datetime
 from pathlib import Path
 
+import pytest
 from git import Blob
 
 from demisto_sdk.commands.common.constants import ISO_TIMESTAMP_FORMAT
+from demisto_sdk.commands.common.git_util import GitUtil
 from TestSuite.repo import Repo
+
+# ``TestSuite.repo.Repo.create_pack`` replaces ``GitUtil.get_file_creation_date``
+# with a ``MagicMock`` on the class and never restores it, so a test that ran
+# earlier can leak the mock into this module. Keep a reference to the real
+# implementation, captured on import (before any test could patch it).
+_REAL_GET_FILE_CREATION_DATE = GitUtil.get_file_creation_date
+
+
+@pytest.fixture
+def unmocked_get_file_creation_date(monkeypatch):
+    """Ensure the real ``get_file_creation_date`` is used, not a leaked mock."""
+    monkeypatch.setattr(GitUtil, "get_file_creation_date", _REAL_GET_FILE_CREATION_DATE)
 
 
 def test_find_primary_branch():
@@ -148,7 +162,7 @@ def test_git_util_with_repo():
     assert git_util.repo.working_dir == repo.working_dir
 
 
-def test_get_file_creation_date(git_repo: Repo):
+def test_get_file_creation_date(git_repo: Repo, unmocked_get_file_creation_date):
     """
     Given:
     - A git repo and a file in it.
@@ -195,7 +209,9 @@ def _commit_file(git_repo: Repo, file: Path, content: str, message: str, date: s
     )
 
 
-def test_get_file_creation_date_uses_add_commit_not_latest(git_repo: Repo):
+def test_get_file_creation_date_uses_add_commit_not_latest(
+    git_repo: Repo, unmocked_get_file_creation_date
+):
     """
     Given:
     - A file that was added in one commit and modified in a later commit.
@@ -221,7 +237,9 @@ def test_get_file_creation_date_uses_add_commit_not_latest(git_repo: Repo):
     assert git_repo.git_util.get_file_creation_date(file) == "2020-11-04T10:00:00Z"
 
 
-def test_get_file_creation_date_follows_renames(git_repo: Repo):
+def test_get_file_creation_date_follows_renames(
+    git_repo: Repo, unmocked_get_file_creation_date
+):
     """
     Given:
     - A file that was added and later renamed.
@@ -254,7 +272,9 @@ def test_get_file_creation_date_follows_renames(git_repo: Repo):
     assert git_repo.git_util.get_file_creation_date(renamed) == "2020-11-04T10:00:00Z"
 
 
-def test_get_file_creation_date_shallow_clone_warns(git_repo: Repo, mocker, caplog):
+def test_get_file_creation_date_shallow_clone_warns(
+    git_repo: Repo, mocker, caplog, unmocked_get_file_creation_date
+):
     """
     Given:
     - A shallow cloned repo.
@@ -284,7 +304,9 @@ def test_get_file_creation_date_shallow_clone_warns(git_repo: Repo, mocker, capl
     assert "shallow clone" in caplog.text
 
 
-def test_get_file_creation_date_no_history_returns_now(git_repo: Repo):
+def test_get_file_creation_date_no_history_returns_now(
+    git_repo: Repo, unmocked_get_file_creation_date
+):
     """
     Given:
     - A file path that has no git history.

--- a/demisto_sdk/commands/common/tests/git_util_test.py
+++ b/demisto_sdk/commands/common/tests/git_util_test.py
@@ -304,6 +304,28 @@ def test_get_file_creation_date_shallow_clone_warns(
     assert "shallow clone" in caplog.text
 
 
+@pytest.mark.parametrize(
+    "iso_date, expected",
+    [
+        ("2020-11-04T10:00:00Z", "2020-11-04T10:00:00Z"),  # newer git versions
+        ("2020-11-04T10:00:00+00:00", "2020-11-04T10:00:00Z"),
+        ("2020-11-04T12:00:00+02:00", "2020-11-04T10:00:00Z"),
+    ],
+)
+def test_normalize_iso_date(iso_date: str, expected: str):
+    """
+    Given:
+    - A strict-ISO git date, with either a 'Z' or a numeric UTC offset.
+
+    When:
+    - Normalizing it.
+
+    Then:
+    - The date is converted to UTC, in the expected format.
+    """
+    assert GitUtil._normalize_iso_date(iso_date) == expected
+
+
 def test_get_file_creation_date_no_history_returns_now(
     git_repo: Repo, unmocked_get_file_creation_date
 ):

--- a/demisto_sdk/commands/common/tests/git_util_test.py
+++ b/demisto_sdk/commands/common/tests/git_util_test.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from pathlib import Path
 
 import pytest
+from freezegun import freeze_time
 from git import Blob
 
 from demisto_sdk.commands.common.constants import ISO_TIMESTAMP_FORMAT
@@ -326,6 +327,7 @@ def test_normalize_iso_date(iso_date: str, expected: str):
     assert GitUtil._normalize_iso_date(iso_date) == expected
 
 
+@freeze_time("2020-11-04T10:00:00Z")
 def test_get_file_creation_date_no_history_returns_now(
     git_repo: Repo, unmocked_get_file_creation_date
 ):
@@ -343,4 +345,4 @@ def test_get_file_creation_date_no_history_returns_now(
         Path("no_such_file.json")
     )
 
-    datetime.strptime(file_creation_date, ISO_TIMESTAMP_FORMAT)  # raises if invalid
+    assert file_creation_date == "2020-11-04T10:00:00Z"

--- a/demisto_sdk/commands/common/tests/git_util_test.py
+++ b/demisto_sdk/commands/common/tests/git_util_test.py
@@ -166,3 +166,123 @@ def test_get_file_creation_date(git_repo: Repo):
     file_creation_date = git_repo.git_util.get_file_creation_date(file)
 
     datetime.strptime(file_creation_date, ISO_TIMESTAMP_FORMAT)  # raises if invalid
+
+
+# Distinctive content, so git's rename detection won't match other files in the repo.
+METADATA_CONTENT = '{"name": "MyPack", "support": "xsoar", "currentVersion": "1.0.0"}'
+
+
+def _commit_file(git_repo: Repo, file: Path, content: str, message: str, date: str):
+    """Create/update `file` with `content` and commit it with a fixed author/commit date."""
+    git_repo.make_file(str(file), content)
+    git_repo.git_util.repo.git.add(str(file))
+    git_repo.git_util.repo.git.commit(
+        "-m", message, "--date", date, env={"GIT_COMMITTER_DATE": date}
+    )
+
+
+def test_get_file_creation_date_uses_add_commit_not_latest(git_repo: Repo):
+    """
+    Given:
+    - A file that was added in one commit and modified in a later commit.
+
+    When:
+    - Retrieving the creation time of the given file.
+
+    Then:
+    - The date of the commit that added the file is returned, not the latest one.
+    """
+    file = Path("pack_metadata.json")
+    _commit_file(
+        git_repo, file, METADATA_CONTENT, f"added {file}", "2020-11-04T10:00:00+00:00"
+    )
+    _commit_file(
+        git_repo,
+        file,
+        METADATA_CONTENT.replace("1.0.0", "1.0.1"),
+        f"modified {file}",
+        "2025-03-29T10:00:00+00:00",
+    )
+
+    assert git_repo.git_util.get_file_creation_date(file) == "2020-11-04T10:00:00Z"
+
+
+def test_get_file_creation_date_follows_renames(git_repo: Repo):
+    """
+    Given:
+    - A file that was added and later renamed.
+
+    When:
+    - Retrieving the creation time of the file using its new path.
+
+    Then:
+    - The date of the commit that originally added the file is returned.
+    """
+    original = Path("pack_metadata.json")
+    renamed = Path("renamed_pack_metadata.json")
+    _commit_file(
+        git_repo,
+        original,
+        METADATA_CONTENT,
+        f"added {original}",
+        "2020-11-04T10:00:00+00:00",
+    )
+
+    git_repo.git_util.repo.git.mv(str(original), str(renamed))
+    git_repo.git_util.repo.git.commit(
+        "-m",
+        f"renamed {original}",
+        "--date",
+        "2025-03-29T10:00:00+00:00",
+        env={"GIT_COMMITTER_DATE": "2025-03-29T10:00:00+00:00"},
+    )
+
+    assert git_repo.git_util.get_file_creation_date(renamed) == "2020-11-04T10:00:00Z"
+
+
+def test_get_file_creation_date_shallow_clone_warns(git_repo: Repo, mocker, caplog):
+    """
+    Given:
+    - A shallow cloned repo.
+
+    When:
+    - Retrieving the creation time of a file in it.
+
+    Then:
+    - A warning is logged and the derived date is still returned.
+    """
+    file = Path("pack_metadata.json")
+    _commit_file(
+        git_repo, file, METADATA_CONTENT, f"added {file}", "2020-11-04T10:00:00+00:00"
+    )
+    # 'rev_parse' is resolved dynamically by GitPython, so it's patched on the class.
+    mocker.patch.object(
+        type(git_repo.git_util.repo.git),
+        "rev_parse",
+        create=True,
+        return_value="true",
+    )
+
+    caplog.set_level("WARNING")
+    file_creation_date = git_repo.git_util.get_file_creation_date(file)
+
+    assert file_creation_date == "2020-11-04T10:00:00Z"
+    assert "shallow clone" in caplog.text
+
+
+def test_get_file_creation_date_no_history_returns_now(git_repo: Repo):
+    """
+    Given:
+    - A file path that has no git history.
+
+    When:
+    - Retrieving the creation time of the given file.
+
+    Then:
+    - The current time is returned, in the expected format.
+    """
+    file_creation_date = git_repo.git_util.get_file_creation_date(
+        Path("no_such_file.json")
+    )
+
+    datetime.strptime(file_creation_date, ISO_TIMESTAMP_FORMAT)  # raises if invalid

--- a/demisto_sdk/commands/common/tests/git_util_test.py
+++ b/demisto_sdk/commands/common/tests/git_util_test.py
@@ -171,13 +171,27 @@ def test_get_file_creation_date(git_repo: Repo):
 # Distinctive content, so git's rename detection won't match other files in the repo.
 METADATA_CONTENT = '{"name": "MyPack", "support": "xsoar", "currentVersion": "1.0.0"}'
 
+# An explicit identity, as the git CLI fails to commit when one isn't configured
+# (for example, on a CI runner).
+GIT_IDENTITY_ENV = {
+    "GIT_AUTHOR_NAME": "demisto-sdk-test",
+    "GIT_AUTHOR_EMAIL": "demisto-sdk-test@example.com",
+    "GIT_COMMITTER_NAME": "demisto-sdk-test",
+    "GIT_COMMITTER_EMAIL": "demisto-sdk-test@example.com",
+}
+
+
+def _commit_env(date: str) -> dict:
+    """The environment to commit with, using a fixed identity and commit date."""
+    return {**GIT_IDENTITY_ENV, "GIT_COMMITTER_DATE": date}
+
 
 def _commit_file(git_repo: Repo, file: Path, content: str, message: str, date: str):
     """Create/update `file` with `content` and commit it with a fixed author/commit date."""
     git_repo.make_file(str(file), content)
     git_repo.git_util.repo.git.add(str(file))
     git_repo.git_util.repo.git.commit(
-        "-m", message, "--date", date, env={"GIT_COMMITTER_DATE": date}
+        "-m", message, "--date", date, env=_commit_env(date)
     )
 
 
@@ -234,7 +248,7 @@ def test_get_file_creation_date_follows_renames(git_repo: Repo):
         f"renamed {original}",
         "--date",
         "2025-03-29T10:00:00+00:00",
-        env={"GIT_COMMITTER_DATE": "2025-03-29T10:00:00+00:00"},
+        env=_commit_env("2025-03-29T10:00:00+00:00"),
     )
 
     assert git_repo.git_util.get_file_creation_date(renamed) == "2020-11-04T10:00:00Z"


### PR DESCRIPTION

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CRTX-221269

## Description
Derive the file creation date from the commit that first added the file (following renames) instead of the oldest reachable commit, and log a warning when the result may be unreliable (for example, a shallow clone).

