### PR TITLE
add pb-runner-v2 to validation CO162_is_valid_workloads

### DIFF
--- a/.changelog/5507.yml
+++ b/.changelog/5507.yml
@@ -1,0 +1,3 @@
+changes:
+- description: add pb-runner-v2 workload to validation CO162_is_valid_workloads
+pr_number: 5507

--- a/.changelog/5507.yml
+++ b/.changelog/5507.yml
@@ -1,3 +1,4 @@
 changes:
 - description: add pb-runner-v2 workload to validation CO162_is_valid_workloads
+  type: internal
 pr_number: 5507

--- a/demisto_sdk/commands/validate/tests/CO_validators_test.py
+++ b/demisto_sdk/commands/validate/tests/CO_validators_test.py
@@ -11168,7 +11168,7 @@ def _cap_with_actions(cap_id: str, action_types: list, **extras):
         "auth_options": [
             {
                 "id": "plain.test",
-                "workloads": ["xsoar-pod", "xsoar-automationhub-runner"],
+                "workloads": ["xsoar-pod", "xsoar-automationhub-runner", "pb-runner-v2"],
             }
         ],
         "actions": [{"type": t} for t in action_types],
@@ -11517,7 +11517,7 @@ def _cap_with_workloads(
 
 class TestCO162IsValidWorkloads:
     """Tests for CO162: every auth_options[].workloads must equal the
-    canonical set {xsoar-automationhub-runner, xsoar-pod} (order-insensitive),
+    canonical set {xsoar-automationhub-runner, xsoar-pod, pb-runner-v2} (order-insensitive),
     and no capability may declare the anonymous capability-level workloads
     shape.
     """
@@ -11530,7 +11530,7 @@ class TestCO162IsValidWorkloads:
                     "capabilities": [
                         _cap_with_workloads(
                             "fetch-issues",
-                            [["xsoar-pod", "xsoar-automationhub-runner"]],
+                            [["xsoar-pod", "xsoar-automationhub-runner", "pb-runner-v2"]],
                         )
                     ],
                 }
@@ -11548,7 +11548,7 @@ class TestCO162IsValidWorkloads:
                     "capabilities": [
                         _cap_with_workloads(
                             "fetch-issues",
-                            [["xsoar-automationhub-runner", "xsoar-pod"]],
+                            [["xsoar-automationhub-runner", "xsoar-pod", "pb-runner-v2"]],
                         )
                     ],
                 }
@@ -11574,6 +11574,7 @@ class TestCO162IsValidWorkloads:
         assert "fetch-issues" in msg
         assert "plain.0" in msg
         assert "xsoar-automationhub-runner" in msg
+        assert "pb-runner-v2" in msg
 
     def test_extra_workload_fails(self):
         connector = create_connector_object(
@@ -11587,6 +11588,7 @@ class TestCO162IsValidWorkloads:
                                 [
                                     "xsoar-pod",
                                     "xsoar-automationhub-runner",
+                                    "pb-runner-v2",
                                     "xsoar-extra",
                                 ]
                             ],

--- a/demisto_sdk/commands/validate/tests/CO_validators_test.py
+++ b/demisto_sdk/commands/validate/tests/CO_validators_test.py
@@ -11168,7 +11168,11 @@ def _cap_with_actions(cap_id: str, action_types: list, **extras):
         "auth_options": [
             {
                 "id": "plain.test",
-                "workloads": ["xsoar-pod", "xsoar-automationhub-runner", "pb-runner-v2"],
+                "workloads": [
+                    "xsoar-pod",
+                    "xsoar-automationhub-runner",
+                    "pb-runner-v2",
+                ],
             }
         ],
         "actions": [{"type": t} for t in action_types],
@@ -11530,7 +11534,13 @@ class TestCO162IsValidWorkloads:
                     "capabilities": [
                         _cap_with_workloads(
                             "fetch-issues",
-                            [["xsoar-pod", "xsoar-automationhub-runner", "pb-runner-v2"]],
+                            [
+                                [
+                                    "xsoar-pod",
+                                    "xsoar-automationhub-runner",
+                                    "pb-runner-v2",
+                                ]
+                            ],
                         )
                     ],
                 }
@@ -11548,7 +11558,13 @@ class TestCO162IsValidWorkloads:
                     "capabilities": [
                         _cap_with_workloads(
                             "fetch-issues",
-                            [["xsoar-automationhub-runner", "xsoar-pod", "pb-runner-v2"]],
+                            [
+                                [
+                                    "xsoar-automationhub-runner",
+                                    "xsoar-pod",
+                                    "pb-runner-v2",
+                                ]
+                            ],
                         )
                     ],
                 }

--- a/demisto_sdk/commands/validate/validators/CO_validators/CO162_is_valid_workloads.py
+++ b/demisto_sdk/commands/validate/validators/CO_validators/CO162_is_valid_workloads.py
@@ -11,7 +11,9 @@ from demisto_sdk.commands.validate.validators.base_validator import (
 
 ContentTypes = Connector
 
-CANONICAL_WORKLOADS = frozenset({"xsoar-automationhub-runner", "xsoar-pod", "pb-runner-v2"})
+CANONICAL_WORKLOADS = frozenset(
+    {"xsoar-automationhub-runner", "xsoar-pod", "pb-runner-v2"}
+)
 
 
 class IsValidWorkloadsValidator(ConnectorsValidator[ContentTypes]):

--- a/demisto_sdk/commands/validate/validators/CO_validators/CO162_is_valid_workloads.py
+++ b/demisto_sdk/commands/validate/validators/CO_validators/CO162_is_valid_workloads.py
@@ -11,14 +11,14 @@ from demisto_sdk.commands.validate.validators.base_validator import (
 
 ContentTypes = Connector
 
-CANONICAL_WORKLOADS = frozenset({"xsoar-automationhub-runner", "xsoar-pod"})
+CANONICAL_WORKLOADS = frozenset({"xsoar-automationhub-runner", "xsoar-pod", "pb-runner-v2"})
 
 
 class IsValidWorkloadsValidator(ConnectorsValidator[ContentTypes]):
     error_code = "CO162"
     description = (
         "Validates that every auth_option's workloads list equals the "
-        "canonical set {xsoar-automationhub-runner, xsoar-pod} (order "
+        "canonical set {xsoar-automationhub-runner, xsoar-pod, pb-runner-v2} (order "
         "insensitive), and that no capability declares the anonymous "
         "capability-level workloads shape."
     )
@@ -48,7 +48,7 @@ class IsValidWorkloadsValidator(ConnectorsValidator[ContentTypes]):
            ``auth_options``. A non-empty capability-level workloads list is
            a hard fail.
         2. Every ``auth_options[].workloads`` must equal the canonical set
-           ``{xsoar-automationhub-runner, xsoar-pod}`` (order-insensitive).
+           ``{xsoar-automationhub-runner, xsoar-pod, pb-runner-v2}`` (order-insensitive).
            Missing / empty lists fail, mismatched sets fail.
 
         Per-handler aggregated result. Path points at the offending


### PR DESCRIPTION
add pb-runner-v2 workload to validation CO162_is_valid_workloads
See ticket:https://jira-dc.paloaltonetworks.com/browse/CRTX-275889